### PR TITLE
Include security check and coverage info in gh workflow

### DIFF
--- a/.github/workflows/ccip-ocr3-build-lint-test.yml
+++ b/.github/workflows/ccip-ocr3-build-lint-test.yml
@@ -32,10 +32,6 @@ jobs:
         run: golangci-lint run -c .golangci.yml
       - name: Run tests
         run: go test -race -fullpath -shuffle on -count 20 -coverprofile=coverage.out ./...
-      - name: Install gosec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
-      - name: Run gosec
-        run: gosec ./...
       - name: Generate coverage report
         run: |
           go tool cover -func=coverage.out > coverage.txt

--- a/.github/workflows/ccip-ocr3-build-lint-test.yml
+++ b/.github/workflows/ccip-ocr3-build-lint-test.yml
@@ -33,7 +33,10 @@ jobs:
       - name: Run tests
         run: go test -race -fullpath -shuffle on -count 20 -coverprofile=coverage.out ./...
       - name: Generate coverage report
-        run: go tool cover -func=coverage.out > coverage.txt
+        run: |
+          go tool cover -func=coverage.out > coverage.txt
+          total=$(go tool cover -func=coverage.out | grep total | awk '{print $3}')
+          echo "coverage=$total" >> $GITHUB_ENV
       - name: Remove previous coverage comments
         uses: actions/github-script@v6
         with:
@@ -60,13 +63,12 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const fs = require('fs');
-            const coverageReport = fs.readFileSync('coverage.txt', 'utf8');
+            const coverage = process.env.coverage;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `### Go Coverage Report\n\`\`\`\n${coverageReport}\n\`\`\``
+              body: `### Go Coverage Report\n\`\`\`\n${coverage}\n\`\`\``
             });
       - name: Install gosec
         run: go install github.com/securego/gosec/v2/cmd/gosec@latest

--- a/.github/workflows/ccip-ocr3-build-lint-test.yml
+++ b/.github/workflows/ccip-ocr3-build-lint-test.yml
@@ -60,7 +60,7 @@ jobs:
               repo,
               issue_number
             });
-            const coverageCommentPrefix = "### Go Coverage Report";
+            const coverageCommentPrefix = "### Test Coverage";
             for (const comment of comments.data) {
               if (comment.body.startsWith(coverageCommentPrefix)) {
                 await github.rest.issues.deleteComment({
@@ -81,5 +81,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `### Go Coverage Report\nThis branch:${coverage}\nTarget branch:${coverage_target}`
+              body: `### Test Coverage\n\n| Branch          | Coverage        |\n|-----------------|-----------------|\n| ${{ process.env.branch_name }}  | ${coverage}           |\n| ${{ github.base_ref }}   | ${coverage_target}           |`
             });

--- a/.github/workflows/ccip-ocr3-build-lint-test.yml
+++ b/.github/workflows/ccip-ocr3-build-lint-test.yml
@@ -81,5 +81,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `### Test Coverage\n\n| Branch          | Coverage        |\n|-----------------|-----------------|\n| ${{ process.env.branch_name }}  | ${coverage}           |\n| ${{ github.base_ref }}   | ${coverage_target}           |`
+              body: `### Test Coverage\n\n| Branch          | Coverage        |\n|-----------------|-----------------|\n| ${{ github.head_ref }}  | ${coverage}           |\n| ${{ github.base_ref }}   | ${coverage_target}           |`
             });

--- a/.github/workflows/ccip-ocr3-build-lint-test.yml
+++ b/.github/workflows/ccip-ocr3-build-lint-test.yml
@@ -32,11 +32,23 @@ jobs:
         run: golangci-lint run -c .golangci.yml
       - name: Run tests
         run: go test -race -fullpath -shuffle on -count 20 -coverprofile=coverage.out ./...
+      - name: Install gosec
+        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+      - name: Run gosec
+        run: gosec ./...
       - name: Generate coverage report
         run: |
           go tool cover -func=coverage.out > coverage.txt
           total=$(go tool cover -func=coverage.out | grep total | awk '{print $3}')
           echo "coverage=$total" >> $GITHUB_ENV
+      - name: Coverage on target branch
+        run: |
+          git fetch origin ${{ github.base_ref }}
+          git checkout ${{ github.base_ref }}
+          go test -coverprofile=coverage_target.out ./...
+          go tool cover -func=coverage_target.out > coverage_target.txt
+          total=$(go tool cover -func=coverage_target.out | grep total | awk '{print $3}')
+          echo "coverage_target=$total" >> $GITHUB_ENV
       - name: Remove previous coverage comments
         uses: actions/github-script@v6
         with:
@@ -64,13 +76,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const coverage = process.env.coverage;
+            const coverage_target = process.env.coverage_target;
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `### Go Coverage Report\n\`\`\`\n${coverage}\n\`\`\``
+              body: `### Go Coverage Report\nThis branch:${coverage}\nTarget branch:${coverage_target}`
             });
-      - name: Install gosec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
-      - name: Run gosec
-        run: gosec ./...

--- a/.github/workflows/ccip-ocr3-build-lint-test.yml
+++ b/.github/workflows/ccip-ocr3-build-lint-test.yml
@@ -31,4 +31,44 @@ jobs:
       - name: Run linter
         run: golangci-lint run -c .golangci.yml
       - name: Run tests
-        run: go test -race -fullpath -shuffle on -count 20 ./...
+        run: go test -race -fullpath -shuffle on -count 20 -coverprofile=coverage.out ./...
+      - name: Generate coverage report
+        run: go tool cover -func=coverage.out > coverage.txt
+      - name: Remove previous coverage comments
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo, number: issue_number } = context.issue;
+            const comments = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number
+            });
+            const coverageCommentPrefix = "### Go Coverage Report";
+            for (const comment of comments.data) {
+              if (comment.body.startsWith(coverageCommentPrefix)) {
+                await github.rest.issues.deleteComment({
+                  owner,
+                  repo,
+                  comment_id: comment.id
+                });
+              }
+            }
+      - name: Display coverage in PR comment
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const coverageReport = fs.readFileSync('coverage.txt', 'utf8');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### Go Coverage Report\n\`\`\`\n${coverageReport}\n\`\`\``
+            });
+      - name: Install gosec
+        run: go install github.com/securego/gosec/v2/cmd/gosec@latest
+      - name: Run gosec
+        run: gosec ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,13 +15,12 @@ linters:
     - noctx
     - depguard
     - lll
+    - gosec
 linters-settings:
   exhaustive:
     default-signifies-exhaustive: true
   goimports:
     local-prefixes: "github.com/smartcontractkit/chainlink-ccip"
-  gosec:
-    excludes:
   errorlint:
     errorf: true # Disallow formatting of errors without %w
   revive:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - depguard
     - lll
     - gosec
+    - unparam
 linters-settings:
   exhaustive:
     default-signifies-exhaustive: true

--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -247,10 +247,7 @@ func (p *Plugin) Outcome(
 	}
 	p.lggr.Debugw("new messages consensus", "merkleRoots", merkleRoots)
 
-	tokenPrices, err := tokenPricesConsensus(decodedObservations, fChainDest)
-	if err != nil {
-		return ocr3types.Outcome{}, fmt.Errorf("token prices consensus: %w", err)
-	}
+	tokenPrices := tokenPricesConsensus(decodedObservations, fChainDest)
 
 	gasPrices := gasPricesConsensus(p.lggr, decodedObservations, fChainDest)
 	p.lggr.Debugw("gas prices consensus", "gasPrices", gasPrices)

--- a/commit/plugin_e2e_test.go
+++ b/commit/plugin_e2e_test.go
@@ -447,8 +447,8 @@ type nodeSetup struct {
 }
 
 func newNode(
-	ctx context.Context,
-	t *testing.T,
+	_ context.Context,
+	_ *testing.T,
 	lggr logger.Logger,
 	id int,
 	cfg cciptypes.CommitPluginConfig,

--- a/commit/plugin_functions.go
+++ b/commit/plugin_functions.go
@@ -383,10 +383,7 @@ func maxSeqNumsConsensus(
 }
 
 // tokenPricesConsensus returns the median price for tokens that have at least 2f_chain+1 observations.
-func tokenPricesConsensus(
-	observations []cciptypes.CommitPluginObservation,
-	fChain int,
-) ([]cciptypes.TokenPrice, error) {
+func tokenPricesConsensus(observations []cciptypes.CommitPluginObservation, fChain int) []cciptypes.TokenPrice {
 	pricesPerToken := make(map[types.Account][]cciptypes.BigInt)
 	for _, obs := range observations {
 		for _, price := range obs.TokenPrices {
@@ -407,7 +404,7 @@ func tokenPricesConsensus(
 	}
 
 	sort.Slice(consensusPrices, func(i, j int) bool { return consensusPrices[i].TokenID < consensusPrices[j].TokenID })
-	return consensusPrices, nil
+	return consensusPrices
 }
 
 func gasPricesConsensus(

--- a/commit/plugin_functions_test.go
+++ b/commit/plugin_functions_test.go
@@ -14,10 +14,11 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/slicelib"
 	"github.com/smartcontractkit/chainlink-ccip/internal/mocks"
 
-	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
@@ -1015,14 +1016,12 @@ func Test_tokenPricesConsensus(t *testing.T) {
 		observations []cciptypes.CommitPluginObservation
 		fChain       int
 		expPrices    []cciptypes.TokenPrice
-		expErr       bool
 	}{
 		{
 			name:         "empty",
 			observations: make([]cciptypes.CommitPluginObservation, 0),
 			fChain:       2,
 			expPrices:    make([]cciptypes.TokenPrice, 0),
-			expErr:       false,
 		},
 		{
 			name: "happy flow",
@@ -1063,7 +1062,6 @@ func Test_tokenPricesConsensus(t *testing.T) {
 				cciptypes.NewTokenPrice("0x1", big.NewInt(11)),
 				cciptypes.NewTokenPrice("0x2", big.NewInt(21)),
 			},
-			expErr: false,
 		},
 		{
 			name: "not enough observations for some token",
@@ -1102,18 +1100,12 @@ func Test_tokenPricesConsensus(t *testing.T) {
 			expPrices: []cciptypes.TokenPrice{
 				cciptypes.NewTokenPrice("0x2", big.NewInt(21)),
 			},
-			expErr: false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			prices, err := tokenPricesConsensus(tc.observations, tc.fChain)
-			if tc.expErr {
-				assert.Error(t, err)
-				return
-			}
-			assert.NoError(t, err)
+			prices := tokenPricesConsensus(tc.observations, tc.fChain)
 			assert.Equal(t, tc.expPrices, prices)
 		})
 	}

--- a/internal/libs/testhelpers/ocr3runner.go
+++ b/internal/libs/testhelpers/ocr3runner.go
@@ -2,15 +2,16 @@ package testhelpers
 
 import (
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"math/big"
 
 	"github.com/smartcontractkit/libocr/commontypes"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
-	"golang.org/x/exp/rand"
 
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/slicelib"
 )
@@ -170,7 +171,15 @@ func (r *OCR3Runner[RI]) selectLeader() ocr3types.ReportingPlugin[RI] {
 	if numNodes == 0 {
 		return nil
 	}
-	return r.nodes[rand.Intn(numNodes)]
+
+	idx, err := rand.Int(rand.Reader, big.NewInt(int64(numNodes)))
+	if err != nil {
+		panic(err)
+	}
+	if !idx.IsInt64() {
+		panic("index is not int64")
+	}
+	return r.nodes[idx.Int64()]
 }
 
 type RoundResult[RI any] struct {

--- a/internal/libs/testhelpers/ocr3runner.go
+++ b/internal/libs/testhelpers/ocr3runner.go
@@ -6,11 +6,11 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"math/rand"
 
 	"github.com/smartcontractkit/libocr/commontypes"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+	"golang.org/x/exp/rand"
 
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/slicelib"
 )

--- a/internal/reader/home_chain.go
+++ b/internal/reader/home_chain.go
@@ -8,11 +8,12 @@ import (
 
 	mapset "github.com/deckarep/golang-set/v2"
 
+	libocrtypes "github.com/smartcontractkit/libocr/ragep2p/types"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
-	libocrtypes "github.com/smartcontractkit/libocr/ragep2p/types"
 )
 
 type HomeChain interface {
@@ -123,12 +124,7 @@ func (r *homeChainPoller) fetchAndSetConfigs(ctx context.Context) error {
 		r.lggr.Warnw("no on chain configs found")
 		return nil
 	}
-	homeChainConfigs, err := convertOnChainConfigToHomeChainConfig(chainConfigInfos)
-	if err != nil {
-		r.lggr.Errorw("error converting OnChainConfigs to ChainConfig", "err", err)
-		return err
-	}
-	r.setState(homeChainConfigs)
+	r.setState(convertOnChainConfigToHomeChainConfig(chainConfigInfos))
 	return nil
 }
 
@@ -255,18 +251,16 @@ func createNodesSupportedChains(
 			if _, ok := nodeSupportedChains[p2pID]; !ok {
 				nodeSupportedChains[p2pID] = mapset.NewSet[cciptypes.ChainSelector]()
 			}
-			//add chain to SupportedChains
+			// add chain to SupportedChains
 			nodeSupportedChains[p2pID].Add(chainSelector)
 		}
 	}
 	return nodeSupportedChains
 }
 
-func convertOnChainConfigToHomeChainConfig(
-	capabilityConfigs []ChainConfigInfo,
-) (map[cciptypes.ChainSelector]ChainConfig, error) {
+func convertOnChainConfigToHomeChainConfig(capabilityCfgs []ChainConfigInfo) map[cciptypes.ChainSelector]ChainConfig {
 	chainConfigs := make(map[cciptypes.ChainSelector]ChainConfig)
-	for _, capabilityConfig := range capabilityConfigs {
+	for _, capabilityConfig := range capabilityCfgs {
 		chainSelector := capabilityConfig.ChainSelector
 		config := capabilityConfig.ChainConfig
 
@@ -275,7 +269,7 @@ func convertOnChainConfigToHomeChainConfig(
 			SupportedNodes: mapset.NewSet(config.Readers...),
 		}
 	}
-	return chainConfigs, nil
+	return chainConfigs
 }
 
 // HomeChainConfigMapper This is a 1-1 mapping between the config that we get from the contract to make

--- a/pkg/reader/home_chain.go
+++ b/pkg/reader/home_chain.go
@@ -15,6 +15,10 @@ type ChainConfig = reader_internal.ChainConfig
 
 type ChainConfigInfo = reader_internal.ChainConfigInfo
 
+type OCR3ConfigWithMeta = reader_internal.OCR3ConfigWithMeta
+
+type OCR3Config = reader_internal.OCR3Config
+
 func NewHomeChainReader(
 	homeChainReader types.ContractReader,
 	lggr logger.Logger,


### PR DESCRIPTION
Enable `gosec` for security-checks, enable `unparam` and display coverage info in a PR comment.

> e2e pipeline is kept ~40sec