### PR TITLE
Move ccipReader interface from cl-common

### DIFF
--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -30,7 +30,7 @@ type Plugin struct {
 	nodeID            commontypes.OracleID
 	oracleIDToP2pID   map[commontypes.OracleID]libocrtypes.PeerID
 	cfg               cciptypes.CommitPluginConfig
-	ccipReader        cciptypes.CCIPReader
+	ccipReader        reader.CCIP
 	tokenPricesReader cciptypes.TokenPricesReader
 	reportCodec       cciptypes.CommitPluginCodec
 	msgHasher         cciptypes.MessageHasher
@@ -44,7 +44,7 @@ func NewPlugin(
 	nodeID commontypes.OracleID,
 	oracleIDToP2pID map[commontypes.OracleID]libocrtypes.PeerID,
 	cfg cciptypes.CommitPluginConfig,
-	ccipReader cciptypes.CCIPReader,
+	ccipReader reader.CCIP,
 	tokenPricesReader cciptypes.TokenPricesReader,
 	reportCodec cciptypes.CommitPluginCodec,
 	msgHasher cciptypes.MessageHasher,

--- a/commit/plugin_functions.go
+++ b/commit/plugin_functions.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/slicelib"
+	"github.com/smartcontractkit/chainlink-ccip/internal/reader"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
@@ -23,7 +24,7 @@ import (
 func observeLatestCommittedSeqNums(
 	ctx context.Context,
 	lggr logger.Logger,
-	ccipReader cciptypes.CCIPReader,
+	ccipReader reader.CCIP,
 	readableChains mapset.Set[cciptypes.ChainSelector],
 	destChain cciptypes.ChainSelector,
 	knownSourceChains []cciptypes.ChainSelector,
@@ -53,7 +54,7 @@ func observeLatestCommittedSeqNums(
 func observeNewMsgs(
 	ctx context.Context,
 	lggr logger.Logger,
-	ccipReader cciptypes.CCIPReader,
+	ccipReader reader.CCIP,
 	msgHasher cciptypes.MessageHasher,
 	readableChains mapset.Set[cciptypes.ChainSelector],
 	latestCommittedSeqNums []cciptypes.SeqNumChain,
@@ -138,7 +139,7 @@ func observeTokenPrices(
 
 func observeGasPrices(
 	ctx context.Context,
-	ccipReader cciptypes.CCIPReader,
+	ccipReader reader.CCIP,
 	chains []cciptypes.ChainSelector,
 ) ([]cciptypes.GasPriceChain, error) {
 	if len(chains) == 0 {
@@ -590,7 +591,7 @@ func validateMerkleRootsState(
 	ctx context.Context,
 	lggr logger.Logger,
 	report cciptypes.CommitPluginReport,
-	reader cciptypes.CCIPReader,
+	reader reader.CCIP,
 ) (bool, error) {
 	reportChains := make([]cciptypes.ChainSelector, 0)
 	reportMinSeqNums := make(map[cciptypes.ChainSelector]cciptypes.SeqNum)

--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -11,10 +11,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
+	"github.com/smartcontractkit/chainlink-ccip/internal/reader"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/slicelib"
 )
@@ -27,7 +31,7 @@ const SentinelRoot = "0x289502ebf164ea87871e19cd9c8734016e954539fffc8c789ac4dadc
 type Plugin struct {
 	reportingCfg    ocr3types.ReportingPluginConfig
 	cfg             cciptypes.ExecutePluginConfig
-	ccipReader      cciptypes.CCIPReader
+	ccipReader      reader.CCIP
 	reportCodec     cciptypes.ExecutePluginCodec
 	msgHasher       cciptypes.MessageHasher
 	tokenDataReader TokenDataReader
@@ -40,7 +44,7 @@ type Plugin struct {
 func NewPlugin(
 	reportingCfg ocr3types.ReportingPluginConfig,
 	cfg cciptypes.ExecutePluginConfig,
-	ccipReader cciptypes.CCIPReader,
+	ccipReader reader.CCIP,
 	reportCodec cciptypes.ExecutePluginCodec,
 	msgHasher cciptypes.MessageHasher,
 	lggr logger.Logger,
@@ -66,7 +70,7 @@ func (p *Plugin) Query(ctx context.Context, outctx ocr3types.OutcomeContext) (ty
 }
 
 func getPendingExecutedReports(
-	ctx context.Context, ccipReader cciptypes.CCIPReader, dest cciptypes.ChainSelector, ts time.Time,
+	ctx context.Context, ccipReader reader.CCIP, dest cciptypes.ChainSelector, ts time.Time,
 ) (cciptypes.ExecutePluginCommitObservations, time.Time, error) {
 	latestReportTS := time.Time{}
 	commitReports, err := ccipReader.CommitReportsGTETimestamp(ctx, dest, ts, 1000)

--- a/internal/mocks/ccipreader.go
+++ b/internal/mocks/ccipreader.go
@@ -51,10 +51,12 @@ func (r CCIPReader) GasPrices(ctx context.Context, chains []cciptypes.ChainSelec
 	return args.Get(0).([]cciptypes.BigInt), args.Error(1)
 }
 
+func (r CCIPReader) Sync(ctx context.Context) (bool, error) {
+	args := r.Called(ctx)
+	return args.Bool(0), args.Error(1)
+}
+
 func (r CCIPReader) Close(ctx context.Context) error {
 	args := r.Called(ctx)
 	return args.Error(0)
 }
-
-// Interface compatibility check.
-var _ cciptypes.CCIPReader = (*CCIPReader)(nil)


### PR DESCRIPTION
The original idea was to keep types used in plugins in a centralized location (cl-common).
But it's proven to slow us down, since merging changes on cl-common is slow since it depends on different teams working on different timezones.

The ccip reader interface is something safe to move under ccip repo since it won't be used by anyone else.