### PR TITLE
update chainlink-common

### DIFF
--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -120,7 +120,7 @@ func (p *Plugin) Observation(
 		return types.Observation{}, fmt.Errorf("error finding supported chains by node: %w", err)
 	}
 
-	msgBaseDetails := make([]cciptypes.CCIPMsgBaseDetails, 0)
+	msgBaseDetails := make([]cciptypes.RampMessageHeader, 0)
 	latestCommittedSeqNumsObservation, err := observeLatestCommittedSeqNums(
 		ctx, p.lggr, p.ccipReader, supportedChains, p.cfg.DestChain, p.knownSourceChainsSlice(),
 	)
@@ -191,7 +191,7 @@ func (p *Plugin) Observation(
 		"fChain", fChain)
 
 	for _, msg := range newMsgs {
-		msgBaseDetails = append(msgBaseDetails, msg.CCIPMsgBaseDetails)
+		msgBaseDetails = append(msgBaseDetails, msg.Header)
 	}
 
 	return plugintypes.NewCommitPluginObservation(

--- a/commit/plugin_e2e_test.go
+++ b/commit/plugin_e2e_test.go
@@ -467,12 +467,18 @@ var (
 	chainBDefaultMsgs = []cciptypes.Message{
 		{
 			Header: cciptypes.RampMessageHeader{
-				MsgHash: cciptypes.Bytes32{1}, MessageID: mustNewMessageID("0x01"), SourceChainSelector: chainB, SequenceNumber: seqNumB,
+				MsgHash:             cciptypes.Bytes32{1},
+				MessageID:           mustNewMessageID("0x01"),
+				SourceChainSelector: chainB,
+				SequenceNumber:      seqNumB,
 			},
 		},
 		{
 			Header: cciptypes.RampMessageHeader{
-				MsgHash: cciptypes.Bytes32{2}, MessageID: mustNewMessageID("0x02"), SourceChainSelector: chainB, SequenceNumber: 22,
+				MsgHash:             cciptypes.Bytes32{2},
+				MessageID:           mustNewMessageID("0x02"),
+				SourceChainSelector: chainB,
+				SequenceNumber:      22,
 			},
 		},
 	}

--- a/commit/plugin_functions_test.go
+++ b/commit/plugin_functions_test.go
@@ -145,17 +145,35 @@ func Test_observeNewMsgs(t *testing.T) {
 			msgScanBatchSize: 256,
 			newMsgs: map[cciptypes.ChainSelector][]cciptypes.Message{
 				1: {
-					{Header: cciptypes.RampMessageHeader{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}},
+					{Header: cciptypes.RampMessageHeader{
+						MessageID:           mustNewMessageID("0x01"),
+						SourceChainSelector: 1,
+						SequenceNumber:      11}},
 				},
 				2: {
-					{Header: cciptypes.RampMessageHeader{MessageID: mustNewMessageID("0x02"), SourceChainSelector: 2, SequenceNumber: 21}},
-					{Header: cciptypes.RampMessageHeader{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 2, SequenceNumber: 22}},
+					{Header: cciptypes.RampMessageHeader{
+						MessageID:           mustNewMessageID("0x02"),
+						SourceChainSelector: 2,
+						SequenceNumber:      21}},
+					{Header: cciptypes.RampMessageHeader{
+						MessageID:           mustNewMessageID("0x03"),
+						SourceChainSelector: 2,
+						SequenceNumber:      22}},
 				},
 			},
 			expMsgs: []cciptypes.Message{
-				{Header: cciptypes.RampMessageHeader{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}},
-				{Header: cciptypes.RampMessageHeader{MessageID: mustNewMessageID("0x02"), SourceChainSelector: 2, SequenceNumber: 21}},
-				{Header: cciptypes.RampMessageHeader{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 2, SequenceNumber: 22}},
+				{Header: cciptypes.RampMessageHeader{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      11}},
+				{Header: cciptypes.RampMessageHeader{
+					MessageID:           mustNewMessageID("0x02"),
+					SourceChainSelector: 2,
+					SequenceNumber:      21}},
+				{Header: cciptypes.RampMessageHeader{
+					MessageID:           mustNewMessageID("0x03"),
+					SourceChainSelector: 2,
+					SequenceNumber:      22}},
 			},
 			expErr: false,
 		},
@@ -169,13 +187,25 @@ func Test_observeNewMsgs(t *testing.T) {
 			msgScanBatchSize: 256,
 			newMsgs: map[cciptypes.ChainSelector][]cciptypes.Message{
 				2: {
-					{Header: cciptypes.RampMessageHeader{MessageID: mustNewMessageID("0x02"), SourceChainSelector: 2, SequenceNumber: 21}},
-					{Header: cciptypes.RampMessageHeader{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 2, SequenceNumber: 22}},
+					{Header: cciptypes.RampMessageHeader{
+						MessageID:           mustNewMessageID("0x02"),
+						SourceChainSelector: 2,
+						SequenceNumber:      21}},
+					{Header: cciptypes.RampMessageHeader{
+						MessageID:           mustNewMessageID("0x03"),
+						SourceChainSelector: 2,
+						SequenceNumber:      22}},
 				},
 			},
 			expMsgs: []cciptypes.Message{
-				{Header: cciptypes.RampMessageHeader{MessageID: mustNewMessageID("0x02"), SourceChainSelector: 2, SequenceNumber: 21}},
-				{Header: cciptypes.RampMessageHeader{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 2, SequenceNumber: 22}},
+				{Header: cciptypes.RampMessageHeader{
+					MessageID:           mustNewMessageID("0x02"),
+					SourceChainSelector: 2,
+					SequenceNumber:      21}},
+				{Header: cciptypes.RampMessageHeader{
+					MessageID:           mustNewMessageID("0x03"),
+					SourceChainSelector: 2,
+					SequenceNumber:      22}},
 			},
 			expErr: false,
 		},
@@ -455,9 +485,24 @@ func Test_validateObservedSequenceNumbers(t *testing.T) {
 		{
 			name: "dup msg hashes",
 			msgs: []cciptypes.RampMessageHeader{
-				{MsgHash: cciptypes.Bytes32{123}, MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 12},
-				{MsgHash: cciptypes.Bytes32{99}, MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 13},
-				{MsgHash: cciptypes.Bytes32{123}, MessageID: mustNewMessageID("0x01"), SourceChainSelector: 300, SequenceNumber: 23}, // dup hash
+				{
+					MsgHash:             cciptypes.Bytes32{123},
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      12,
+				},
+				{
+					MsgHash:             cciptypes.Bytes32{99},
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      13,
+				},
+				{
+					MsgHash:             cciptypes.Bytes32{123},
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 300,
+					SequenceNumber:      23,
+				}, // dup hash
 			},
 			maxSeqNums: []plugintypes.SeqNumChain{
 				{ChainSel: 1, SeqNum: 10},
@@ -692,9 +737,15 @@ func Test_newMsgsConsensusForChain(t *testing.T) {
 				{ChainSel: 1, SeqNum: 10},
 			},
 			observations: []plugintypes.CommitPluginObservation{
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1, SequenceNumber: 11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1, SequenceNumber: 11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1, SequenceNumber: 11}}},
 			},
 			expMerkleRoots: []cciptypes.MerkleRootChain{},
 			expErr:         false,
@@ -706,11 +757,26 @@ func Test_newMsgsConsensusForChain(t *testing.T) {
 			},
 			maxSeqNums: []plugintypes.SeqNumChain{{ChainSel: 1, SeqNum: 10}},
 			observations: []plugintypes.CommitPluginObservation{
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      11}}},
 			},
 			expMerkleRoots: []cciptypes.MerkleRootChain{
 				{
@@ -729,21 +795,66 @@ func Test_newMsgsConsensusForChain(t *testing.T) {
 				{ChainSel: 1, SeqNum: 10},
 			},
 			observations: []plugintypes.CommitPluginObservation{
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x02"), SourceChainSelector: 1, SequenceNumber: 12}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x02"), SourceChainSelector: 1, SequenceNumber: 12}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x02"), SourceChainSelector: 1, SequenceNumber: 12}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x02"), SourceChainSelector: 1, SequenceNumber: 12}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x02"), SourceChainSelector: 1, SequenceNumber: 12}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 1, SequenceNumber: 13}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 1, SequenceNumber: 13}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 1, SequenceNumber: 13}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 1, SequenceNumber: 13}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 1, SequenceNumber: 13}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x02"),
+					SourceChainSelector: 1,
+					SequenceNumber:      12}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x02"),
+					SourceChainSelector: 1,
+					SequenceNumber:      12}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x02"),
+					SourceChainSelector: 1,
+					SequenceNumber:      12}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x02"),
+					SourceChainSelector: 1,
+					SequenceNumber:      12}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x02"),
+					SourceChainSelector: 1,
+					SequenceNumber:      12}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x03"),
+					SourceChainSelector: 1,
+					SequenceNumber:      13}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x03"),
+					SourceChainSelector: 1,
+					SequenceNumber:      13}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x03"),
+					SourceChainSelector: 1,
+					SequenceNumber:      13}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x03"),
+					SourceChainSelector: 1,
+					SequenceNumber:      13}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x03"),
+					SourceChainSelector: 1,
+					SequenceNumber:      13}}},
 			},
 			expMerkleRoots: []cciptypes.MerkleRootChain{
 				{
@@ -762,21 +873,66 @@ func Test_newMsgsConsensusForChain(t *testing.T) {
 				{ChainSel: 1, SeqNum: 10},
 			},
 			observations: []plugintypes.CommitPluginObservation{
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 10}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 10}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 10}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 10}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 10}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x02"), SourceChainSelector: 1, SequenceNumber: 12}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x02"), SourceChainSelector: 1, SequenceNumber: 12}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x02"), SourceChainSelector: 1, SequenceNumber: 12}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x02"), SourceChainSelector: 1, SequenceNumber: 12}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x02"), SourceChainSelector: 1, SequenceNumber: 12}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 1, SequenceNumber: 13}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 1, SequenceNumber: 13}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 1, SequenceNumber: 13}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 1, SequenceNumber: 13}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 1, SequenceNumber: 13}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      10}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      10}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      10}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      10}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      10}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x02"),
+					SourceChainSelector: 1,
+					SequenceNumber:      12}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x02"),
+					SourceChainSelector: 1,
+					SequenceNumber:      12}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x02"),
+					SourceChainSelector: 1,
+					SequenceNumber:      12}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x02"),
+					SourceChainSelector: 1,
+					SequenceNumber:      12}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x02"),
+					SourceChainSelector: 1,
+					SequenceNumber:      12}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x03"),
+					SourceChainSelector: 1,
+					SequenceNumber:      13}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x03"),
+					SourceChainSelector: 1,
+					SequenceNumber:      13}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x03"),
+					SourceChainSelector: 1,
+					SequenceNumber:      13}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x03"),
+					SourceChainSelector: 1,
+					SequenceNumber:      13}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x03"),
+					SourceChainSelector: 1,
+					SequenceNumber:      13}}},
 			},
 			expMerkleRoots: []cciptypes.MerkleRootChain{
 				{
@@ -795,18 +951,54 @@ func Test_newMsgsConsensusForChain(t *testing.T) {
 				{ChainSel: 1, SeqNum: 10},
 			},
 			observations: []plugintypes.CommitPluginObservation{
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x02"), SourceChainSelector: 1, SequenceNumber: 12}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x02"), SourceChainSelector: 1, SequenceNumber: 12}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 1, SequenceNumber: 13}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 1, SequenceNumber: 13}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 1, SequenceNumber: 13}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 1, SequenceNumber: 13}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 1, SequenceNumber: 13}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x02"),
+					SourceChainSelector: 1,
+					SequenceNumber:      12}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x02"),
+					SourceChainSelector: 1,
+					SequenceNumber:      12}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x03"),
+					SourceChainSelector: 1,
+					SequenceNumber:      13}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x03"),
+					SourceChainSelector: 1,
+					SequenceNumber:      13}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x03"),
+					SourceChainSelector: 1,
+					SequenceNumber:      13}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x03"),
+					SourceChainSelector: 1,
+					SequenceNumber:      13}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x03"),
+					SourceChainSelector: 1,
+					SequenceNumber:      13}}},
 			},
 			expMerkleRoots: []cciptypes.MerkleRootChain{
 				{
@@ -827,17 +1019,50 @@ func Test_newMsgsConsensusForChain(t *testing.T) {
 				{ChainSel: 2, SeqNum: 20},
 			},
 			observations: []plugintypes.CommitPluginObservation{
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 2, SequenceNumber: 21}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 2, SequenceNumber: 21}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 2, SequenceNumber: 21}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x04"), SourceChainSelector: 2, SequenceNumber: 22}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x04"), SourceChainSelector: 2, SequenceNumber: 22}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x04"), SourceChainSelector: 2, SequenceNumber: 22}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x01"),
+					SourceChainSelector: 1,
+					SequenceNumber:      11}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x03"),
+					SourceChainSelector: 2,
+					SequenceNumber:      21}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x03"),
+					SourceChainSelector: 2,
+					SequenceNumber:      21}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x03"),
+					SourceChainSelector: 2,
+					SequenceNumber:      21}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x04"),
+					SourceChainSelector: 2,
+					SequenceNumber:      22}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x04"),
+					SourceChainSelector: 2,
+					SequenceNumber:      22}}},
+				{NewMsgs: []cciptypes.RampMessageHeader{{
+					MessageID:           mustNewMessageID("0x04"),
+					SourceChainSelector: 2,
+					SequenceNumber:      22}}},
 			},
 			expMerkleRoots: []cciptypes.MerkleRootChain{
 				{
@@ -860,21 +1085,96 @@ func Test_newMsgsConsensusForChain(t *testing.T) {
 				{ChainSel: 1, SeqNum: 10},
 			},
 			observations: []plugintypes.CommitPluginObservation{
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x01"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x10"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x10"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x1101"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x1101"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x03"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x02"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x02"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x02"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x02"), SourceChainSelector: 1, SequenceNumber: 11}}},
-				{NewMsgs: []cciptypes.RampMessageHeader{{MessageID: mustNewMessageID("0x02"), SourceChainSelector: 1, SequenceNumber: 11}}},
+				{
+					NewMsgs: []cciptypes.RampMessageHeader{
+						{
+							MessageID:           mustNewMessageID("0x01"),
+							SourceChainSelector: 1, SequenceNumber: 11,
+						}}},
+				{
+					NewMsgs: []cciptypes.RampMessageHeader{
+						{
+							MessageID:           mustNewMessageID("0x01"),
+							SourceChainSelector: 1, SequenceNumber: 11,
+						}}},
+				{
+					NewMsgs: []cciptypes.RampMessageHeader{
+						{
+							MessageID:           mustNewMessageID("0x01"),
+							SourceChainSelector: 1, SequenceNumber: 11,
+						}}},
+				{
+					NewMsgs: []cciptypes.RampMessageHeader{
+						{
+							MessageID:           mustNewMessageID("0x01"),
+							SourceChainSelector: 1, SequenceNumber: 11,
+						}}},
+				{
+					NewMsgs: []cciptypes.RampMessageHeader{
+						{
+							MessageID:           mustNewMessageID("0x01"),
+							SourceChainSelector: 1, SequenceNumber: 11,
+						}}},
+				{
+					NewMsgs: []cciptypes.RampMessageHeader{
+						{
+							MessageID:           mustNewMessageID("0x10"),
+							SourceChainSelector: 1, SequenceNumber: 11,
+						}}},
+				{
+					NewMsgs: []cciptypes.RampMessageHeader{
+						{
+							MessageID:           mustNewMessageID("0x10"),
+							SourceChainSelector: 1, SequenceNumber: 11,
+						}}},
+				{
+					NewMsgs: []cciptypes.RampMessageHeader{
+						{
+							MessageID:           mustNewMessageID("0x1101"),
+							SourceChainSelector: 1, SequenceNumber: 11,
+						}}},
+				{
+					NewMsgs: []cciptypes.RampMessageHeader{
+						{
+							MessageID:           mustNewMessageID("0x1101"),
+							SourceChainSelector: 1, SequenceNumber: 11,
+						}}},
+				{
+					NewMsgs: []cciptypes.RampMessageHeader{
+						{
+							MessageID:           mustNewMessageID("0x03"),
+							SourceChainSelector: 1, SequenceNumber: 11,
+						}}},
+				{
+					NewMsgs: []cciptypes.RampMessageHeader{
+						{
+							MessageID:           mustNewMessageID("0x02"),
+							SourceChainSelector: 1, SequenceNumber: 11,
+						}}},
+				{
+					NewMsgs: []cciptypes.RampMessageHeader{
+						{
+							MessageID:           mustNewMessageID("0x02"),
+							SourceChainSelector: 1, SequenceNumber: 11,
+						}}},
+				{
+					NewMsgs: []cciptypes.RampMessageHeader{
+						{
+							MessageID:           mustNewMessageID("0x02"),
+							SourceChainSelector: 1, SequenceNumber: 11,
+						}}},
+				{
+					NewMsgs: []cciptypes.RampMessageHeader{
+						{
+							MessageID:           mustNewMessageID("0x02"),
+							SourceChainSelector: 1, SequenceNumber: 11,
+						}}},
+				{
+					NewMsgs: []cciptypes.RampMessageHeader{
+						{
+							MessageID:           mustNewMessageID("0x02"),
+							SourceChainSelector: 1, SequenceNumber: 11,
+						}}},
 			},
 			expMerkleRoots: []cciptypes.MerkleRootChain{
 				{

--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -189,7 +189,7 @@ func (p *Plugin) Observation(
 					return nil, err
 				}
 				for _, msg := range msgs {
-					messages[selector][msg.SeqNum] = msg
+					messages[selector][msg.Header.SequenceNumber] = msg
 				}
 			}
 		}
@@ -330,7 +330,7 @@ func buildSingleChainReport(
 	// Iterate sequence range and executed messages to select messages to execute.
 	var toExecute []int
 	var offchainTokenData [][][]byte
-	var msgInRoot []cciptypes.CCIPMsg
+	var msgInRoot []cciptypes.Message
 	executedIdx := 0
 	for i := 0; i < numMsgs && len(toExecute) <= maxMessages; i++ {
 		seqNum := report.SequenceNumberRange.Start() + cciptypes.SeqNum(i)
@@ -339,23 +339,23 @@ func buildSingleChainReport(
 			executedIdx++
 		} else {
 			msg := report.Messages[i]
-			tokenData, err := tokenDataReader.ReadTokenData(context.Background(), report.SourceChain, msg.SeqNum)
+			tokenData, err := tokenDataReader.ReadTokenData(context.Background(), report.SourceChain, msg.Header.SequenceNumber)
 			if err != nil {
 				// TODO: skip message instead of failing the whole thing.
 				//       that might mean moving the token data reading out of the loop.
 				lggr.Infow(
 					"unable to read token data",
 					"sourceChain", report.SourceChain,
-					"seqNum", msg.SeqNum,
+					"seqNum", msg.Header.SequenceNumber,
 					"error", err)
 				return cciptypes.ExecutePluginReportSingleChain{}, 0, fmt.Errorf(
-					"unable to read token data for message %d: %w", msg.SeqNum, err)
+					"unable to read token data for message %d: %w", msg.Header.SequenceNumber, err)
 			}
 
 			lggr.Infow(
 				"read token data",
 				"sourceChain", report.SourceChain,
-				"seqNum", msg.SeqNum,
+				"seqNum", msg.Header.SequenceNumber,
 				"data", tokenData)
 			offchainTokenData = append(offchainTokenData, tokenData)
 			toExecute = append(toExecute, i)

--- a/execute/plugin_functions.go
+++ b/execute/plugin_functions.go
@@ -367,7 +367,9 @@ func constructMerkleTree(
 		}
 		leaf, err := hasher.Hash(ctx, msg)
 		if err != nil {
-			return nil, fmt.Errorf("unable to hash message (%d, %d): %w", msg.Header.SourceChainSelector, msg.Header.SequenceNumber, err)
+			return nil, fmt.Errorf(
+				"unable to hash message (%d, %d): %w",
+				msg.Header.SourceChainSelector, msg.Header.SequenceNumber, err)
 		}
 		treeLeaves = append(treeLeaves, leaf)
 	}

--- a/execute/plugin_test.go
+++ b/execute/plugin_test.go
@@ -309,15 +309,15 @@ func Test_selectReport(t *testing.T) {
 		{
 			name: "half report",
 			args: args{
-				maxReportSize: 2600,
+				maxReportSize: 2300,
 				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
 					makeTestCommitReport(10, 1, 100, 999, 10101010101, nil),
 				},
 			},
 			expectedExecReports:   1,
 			expectedCommitReports: 1,
-			expectedExecThings:    []int{8},
-			lastReportExecuted:    []cciptypes.SeqNum{100, 101, 102, 103, 104, 105, 106, 107},
+			expectedExecThings:    []int{5},
+			lastReportExecuted:    []cciptypes.SeqNum{100, 101, 102, 103, 104},
 		},
 		{
 			name: "full report",
@@ -355,16 +355,13 @@ func Test_selectReport(t *testing.T) {
 			},
 			expectedExecReports:   2,
 			expectedCommitReports: 1,
-			expectedExecThings:    []int{10, 19},
-			lastReportExecuted: []cciptypes.SeqNum{
-				100, 101, 102, 103, 104, 105, 106, 107, 108, 109,
-				110, 111, 112, 113, 114, 115, 116, 117, 118,
-			},
+			expectedExecThings:    []int{10, 10},
+			lastReportExecuted:    []cciptypes.SeqNum{100, 101, 102, 103, 104, 105, 106, 107, 108, 109},
 		},
 		{
 			name: "exactly one report",
 			args: args{
-				maxReportSize: 3200,
+				maxReportSize: 4200,
 				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
 					makeTestCommitReport(10, 1, 100, 999, 10101010101, nil),
 					makeTestCommitReport(20, 2, 100, 999, 10101010101, nil),
@@ -390,7 +387,7 @@ func Test_selectReport(t *testing.T) {
 		{
 			name: "partially execute remainder of partially executed report",
 			args: args{
-				maxReportSize: 1550,
+				maxReportSize: 2050,
 				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
 					makeTestCommitReport(10, 1, 100, 999, 10101010101, []cciptypes.SeqNum{100, 101, 102, 103, 104}),
 				},
@@ -415,7 +412,7 @@ func Test_selectReport(t *testing.T) {
 		{
 			name: "partially execute remainder of partially executed sparse report",
 			args: args{
-				maxReportSize: 1550,
+				maxReportSize: 2050,
 				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
 					makeTestCommitReport(10, 1, 100, 999, 10101010101, []cciptypes.SeqNum{100, 102, 104, 106, 108}),
 				},

--- a/execute/plugin_test.go
+++ b/execute/plugin_test.go
@@ -451,8 +451,10 @@ func Test_selectReport(t *testing.T) {
 			require.Len(t, execReports, tt.expectedExecReports)
 			require.Len(t, commitReports, tt.expectedCommitReports)
 			for i, execReport := range execReports {
-				require.Lenf(t, execReport.Messages, tt.expectedExecThings[i], "Unexpected number of messages, iter %d", i)
-				require.Lenf(t, execReport.OffchainTokenData, tt.expectedExecThings[i], "Unexpected number of token data, iter %d", i)
+				require.Lenf(t, execReport.Messages, tt.expectedExecThings[i],
+					"Unexpected number of messages, iter %d", i)
+				require.Lenf(t, execReport.OffchainTokenData, tt.expectedExecThings[i],
+					"Unexpected number of token data, iter %d", i)
 				require.NotEmptyf(t, execReport.Proofs, "Proof should not be empty.")
 				assertMerkleRoot(t, hasher, execReport, tt.args.reports[i])
 			}

--- a/execute/plugin_test.go
+++ b/execute/plugin_test.go
@@ -344,34 +344,37 @@ func Test_selectReport(t *testing.T) {
 			expectedCommitReports: 0,
 			expectedExecThings:    []int{10, 20},
 		},
-		// {
-		// 	name: "one and half reports",
-		// 	args: args{
-		// 		maxReportSize: 8500,
-		// 		reports: []plugintypes.ExecutePluginCommitDataWithMessages{
-		// 			makeTestCommitReport(10, 1, 100, 999, 10101010101, nil),
-		// 			makeTestCommitReport(20, 2, 100, 999, 10101010101, nil),
-		// 		},
-		// 	},
-		// 	expectedExecReports:   2,
-		// 	expectedCommitReports: 1,
-		// 	expectedExecThings:    []int{10, 10},
-		// 	lastReportExecuted:    []cciptypes.SeqNum{100, 101, 102, 103, 104, 105, 106, 107, 108, 109},
-		// },
-		// {
-		// 	name: "exactly one report",
-		// 	args: args{
-		// 		maxReportSize: 4200,
-		// 		reports: []plugintypes.ExecutePluginCommitDataWithMessages{
-		// 			makeTestCommitReport(10, 1, 100, 999, 10101010101, nil),
-		// 			makeTestCommitReport(20, 2, 100, 999, 10101010101, nil),
-		// 		},
-		// 	},
-		// 	expectedExecReports:   1,
-		// 	expectedCommitReports: 1,
-		// 	expectedExecThings:    []int{10},
-		// 	lastReportExecuted:    []cciptypes.SeqNum{},
-		// },
+		{
+			name: "one and half reports",
+			args: args{
+				maxReportSize: 8500,
+				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
+					makeTestCommitReport(10, 1, 100, 999, 10101010101, nil),
+					makeTestCommitReport(20, 2, 100, 999, 10101010101, nil),
+				},
+			},
+			expectedExecReports:   2,
+			expectedCommitReports: 1,
+			expectedExecThings:    []int{10, 19},
+			lastReportExecuted: []cciptypes.SeqNum{
+				100, 101, 102, 103, 104, 105, 106, 107, 108, 109,
+				110, 111, 112, 113, 114, 115, 116, 117, 118,
+			},
+		},
+		{
+			name: "exactly one report",
+			args: args{
+				maxReportSize: 3200,
+				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
+					makeTestCommitReport(10, 1, 100, 999, 10101010101, nil),
+					makeTestCommitReport(20, 2, 100, 999, 10101010101, nil),
+				},
+			},
+			expectedExecReports:   1,
+			expectedCommitReports: 1,
+			expectedExecThings:    []int{10},
+			lastReportExecuted:    []cciptypes.SeqNum{},
+		},
 		{
 			name: "execute remainder of partially executed report",
 			args: args{
@@ -384,19 +387,19 @@ func Test_selectReport(t *testing.T) {
 			expectedCommitReports: 0,
 			expectedExecThings:    []int{5},
 		},
-		// {
-		// 	name: "partially execute remainder of partially executed report",
-		// 	args: args{
-		// 		maxReportSize: 2050,
-		// 		reports: []plugintypes.ExecutePluginCommitDataWithMessages{
-		// 			makeTestCommitReport(10, 1, 100, 999, 10101010101, []cciptypes.SeqNum{100, 101, 102, 103, 104}),
-		// 		},
-		// 	},
-		// 	expectedExecReports:   1,
-		// 	expectedCommitReports: 1,
-		// 	expectedExecThings:    []int{4},
-		// 	lastReportExecuted:    []cciptypes.SeqNum{100, 101, 102, 103, 104, 105, 106, 107, 108},
-		// },
+		{
+			name: "partially execute remainder of partially executed report",
+			args: args{
+				maxReportSize: 1550,
+				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
+					makeTestCommitReport(10, 1, 100, 999, 10101010101, []cciptypes.SeqNum{100, 101, 102, 103, 104}),
+				},
+			},
+			expectedExecReports:   1,
+			expectedCommitReports: 1,
+			expectedExecThings:    []int{4},
+			lastReportExecuted:    []cciptypes.SeqNum{100, 101, 102, 103, 104, 105, 106, 107, 108},
+		},
 		{
 			name: "execute remainder of sparsely executed report",
 			args: args{
@@ -409,19 +412,19 @@ func Test_selectReport(t *testing.T) {
 			expectedCommitReports: 0,
 			expectedExecThings:    []int{5},
 		},
-		// {
-		// 	name: "partially execute remainder of partially executed sparse report",
-		// 	args: args{
-		// 		maxReportSize: 2050,
-		// 		reports: []plugintypes.ExecutePluginCommitDataWithMessages{
-		// 			makeTestCommitReport(10, 1, 100, 999, 10101010101, []cciptypes.SeqNum{100, 102, 104, 106, 108}),
-		// 		},
-		// 	},
-		// 	expectedExecReports:   1,
-		// 	expectedCommitReports: 1,
-		// 	expectedExecThings:    []int{4},
-		// 	lastReportExecuted:    []cciptypes.SeqNum{100, 101, 102, 103, 104, 105, 106, 107, 108},
-		// },
+		{
+			name: "partially execute remainder of partially executed sparse report",
+			args: args{
+				maxReportSize: 1550,
+				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
+					makeTestCommitReport(10, 1, 100, 999, 10101010101, []cciptypes.SeqNum{100, 102, 104, 106, 108}),
+				},
+			},
+			expectedExecReports:   1,
+			expectedCommitReports: 1,
+			expectedExecThings:    []int{4},
+			lastReportExecuted:    []cciptypes.SeqNum{100, 101, 102, 103, 104, 105, 106, 107, 108},
+		},
 		{
 			name: "broken report",
 			args: args{
@@ -448,15 +451,15 @@ func Test_selectReport(t *testing.T) {
 			require.Len(t, execReports, tt.expectedExecReports)
 			require.Len(t, commitReports, tt.expectedCommitReports)
 			for i, execReport := range execReports {
-				assert.Len(t, execReport.Messages, tt.expectedExecThings[i])
-				assert.Len(t, execReport.OffchainTokenData, tt.expectedExecThings[i])
-				assert.NotEmptyf(t, execReport.Proofs, "Proof should not be empty.")
+				require.Lenf(t, execReport.Messages, tt.expectedExecThings[i], "Unexpected number of messages, iter %d", i)
+				require.Lenf(t, execReport.OffchainTokenData, tt.expectedExecThings[i], "Unexpected number of token data, iter %d", i)
+				require.NotEmptyf(t, execReport.Proofs, "Proof should not be empty.")
 				assertMerkleRoot(t, hasher, execReport, tt.args.reports[i])
 			}
 			// If the last report is partially executed, the executed messages can be checked.
 			if len(execReports) > 0 && len(tt.lastReportExecuted) > 0 {
 				lastReport := commitReports[len(commitReports)-1]
-				assert.ElementsMatch(t, tt.lastReportExecuted, lastReport.ExecutedMessages)
+				require.ElementsMatch(t, tt.lastReportExecuted, lastReport.ExecutedMessages)
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.7
 
 require (
 	github.com/deckarep/golang-set/v2 v2.6.0
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705104354-fd870ba27159
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705152327-91b39e47607a
 	github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.24.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.7
 
 require (
 	github.com/deckarep/golang-set/v2 v2.6.0
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705152327-91b39e47607a
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240708093742-683c10b045f7
 	github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.24.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.7
 
 require (
 	github.com/deckarep/golang-set/v2 v2.6.0
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705081543-49649c975466
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705104354-fd870ba27159
 	github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5g
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705081543-49649c975466 h1:sM9QH5KpaM0LK+ZjqIrf5h3fVsvLf+l8kmg/lmQw7ts=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705081543-49649c975466/go.mod h1:fh9eBbrReCmv31bfz52ENCAMa7nTKQbdhb2B3+S2VGo=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705104354-fd870ba27159 h1:tLeyrqR4m8aDwGE3wAn/AP3Wj1JUnOP1WCtx73YI8p8=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705104354-fd870ba27159/go.mod h1:fh9eBbrReCmv31bfz52ENCAMa7nTKQbdhb2B3+S2VGo=
 github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c h1:lIyMbTaF2H0Q71vkwZHX/Ew4KF2BxiKhqEXwF8rn+KI=
 github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c/go.mod h1:fb1ZDVXACvu4frX3APHZaEBp0xi1DIm34DcA0CwTsZM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,10 @@ github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705081543-49649c97546
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705081543-49649c975466/go.mod h1:fh9eBbrReCmv31bfz52ENCAMa7nTKQbdhb2B3+S2VGo=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705104354-fd870ba27159 h1:tLeyrqR4m8aDwGE3wAn/AP3Wj1JUnOP1WCtx73YI8p8=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705104354-fd870ba27159/go.mod h1:fh9eBbrReCmv31bfz52ENCAMa7nTKQbdhb2B3+S2VGo=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705143754-e9f096cef1b3 h1:IvwpEib2LiutHZdzHAPyqjmm+UEEmNeWSaiYlyvuD7E=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705143754-e9f096cef1b3/go.mod h1:fh9eBbrReCmv31bfz52ENCAMa7nTKQbdhb2B3+S2VGo=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705152327-91b39e47607a h1:5jIa3o2rLJ8BUsttLj8lTrZr57gIVX6hFhFc1RTVSbc=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705152327-91b39e47607a/go.mod h1:fh9eBbrReCmv31bfz52ENCAMa7nTKQbdhb2B3+S2VGo=
 github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c h1:lIyMbTaF2H0Q71vkwZHX/Ew4KF2BxiKhqEXwF8rn+KI=
 github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c/go.mod h1:fb1ZDVXACvu4frX3APHZaEBp0xi1DIm34DcA0CwTsZM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -55,12 +55,6 @@ github.com/santhosh-tekuri/jsonschema/v5 v5.2.0 h1:WCcC4vZDS1tYNxjWlwRJZQy28r8CM
 github.com/santhosh-tekuri/jsonschema/v5 v5.2.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705081543-49649c975466 h1:sM9QH5KpaM0LK+ZjqIrf5h3fVsvLf+l8kmg/lmQw7ts=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705081543-49649c975466/go.mod h1:fh9eBbrReCmv31bfz52ENCAMa7nTKQbdhb2B3+S2VGo=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705104354-fd870ba27159 h1:tLeyrqR4m8aDwGE3wAn/AP3Wj1JUnOP1WCtx73YI8p8=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705104354-fd870ba27159/go.mod h1:fh9eBbrReCmv31bfz52ENCAMa7nTKQbdhb2B3+S2VGo=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705143754-e9f096cef1b3 h1:IvwpEib2LiutHZdzHAPyqjmm+UEEmNeWSaiYlyvuD7E=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705143754-e9f096cef1b3/go.mod h1:fh9eBbrReCmv31bfz52ENCAMa7nTKQbdhb2B3+S2VGo=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705152327-91b39e47607a h1:5jIa3o2rLJ8BUsttLj8lTrZr57gIVX6hFhFc1RTVSbc=
 github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705152327-91b39e47607a/go.mod h1:fh9eBbrReCmv31bfz52ENCAMa7nTKQbdhb2B3+S2VGo=
 github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c h1:lIyMbTaF2H0Q71vkwZHX/Ew4KF2BxiKhqEXwF8rn+KI=

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/santhosh-tekuri/jsonschema/v5 v5.2.0 h1:WCcC4vZDS1tYNxjWlwRJZQy28r8CM
 github.com/santhosh-tekuri/jsonschema/v5 v5.2.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705152327-91b39e47607a h1:5jIa3o2rLJ8BUsttLj8lTrZr57gIVX6hFhFc1RTVSbc=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240705152327-91b39e47607a/go.mod h1:fh9eBbrReCmv31bfz52ENCAMa7nTKQbdhb2B3+S2VGo=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240708093742-683c10b045f7 h1:obg6WdQpop0TnU4Ff0+eB/lGvidAsZ2Z2co43pg9kqc=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240708093742-683c10b045f7/go.mod h1:fh9eBbrReCmv31bfz52ENCAMa7nTKQbdhb2B3+S2VGo=
 github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c h1:lIyMbTaF2H0Q71vkwZHX/Ew4KF2BxiKhqEXwF8rn+KI=
 github.com/smartcontractkit/libocr v0.0.0-20240419185742-fd3cab206b2c/go.mod h1:fb1ZDVXACvu4frX3APHZaEBp0xi1DIm34DcA0CwTsZM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/mocks/ccipreader.go
+++ b/internal/mocks/ccipreader.go
@@ -37,9 +37,9 @@ func (r CCIPReader) ExecutedMessageRanges(
 
 func (r CCIPReader) MsgsBetweenSeqNums(
 	ctx context.Context, chain cciptypes.ChainSelector, seqNumRange cciptypes.SeqNumRange,
-) ([]cciptypes.CCIPMsg, error) {
+) ([]cciptypes.Message, error) {
 	args := r.Called(ctx, chain, seqNumRange)
-	return args.Get(0).([]cciptypes.CCIPMsg), args.Error(1)
+	return args.Get(0).([]cciptypes.Message), args.Error(1)
 }
 
 func (r CCIPReader) NextSeqNum(ctx context.Context, chains []cciptypes.ChainSelector) (

--- a/internal/mocks/messagehasher.go
+++ b/internal/mocks/messagehasher.go
@@ -12,9 +12,9 @@ func NewMessageHasher() *MessageHasher {
 	return &MessageHasher{}
 }
 
-func (m *MessageHasher) Hash(ctx context.Context, msg cciptypes.CCIPMsg) (cciptypes.Bytes32, error) {
+func (m *MessageHasher) Hash(ctx context.Context, msg cciptypes.Message) (cciptypes.Bytes32, error) {
 	// simply return the msg id as bytes32
 	var b32 [32]byte
-	copy(b32[:], msg.ID)
+	copy(b32[:], msg.Header.MessageID[:])
 	return b32, nil
 }

--- a/internal/reader/ccip.go
+++ b/internal/reader/ccip.go
@@ -41,7 +41,7 @@ type CCIP interface {
 		ctx context.Context,
 		chain cciptypes.ChainSelector,
 		seqNumRange cciptypes.SeqNumRange,
-	) ([]cciptypes.CCIPMsg, error)
+	) ([]cciptypes.Message, error)
 
 	// NextSeqNum reads the destination chain.
 	// Returns the next expected sequence number for each one of the provided chains.
@@ -104,7 +104,7 @@ func (r *CCIPChainReader) ExecutedMessageRanges(
 
 func (r *CCIPChainReader) MsgsBetweenSeqNums(
 	ctx context.Context, chain cciptypes.ChainSelector, seqNumRange cciptypes.SeqNumRange,
-) ([]cciptypes.CCIPMsg, error) {
+) ([]cciptypes.Message, error) {
 	if err := r.validateReaderExistence(chain); err != nil {
 		return nil, err
 	}
@@ -147,17 +147,17 @@ func (r *CCIPChainReader) MsgsBetweenSeqNums(
 				Count: uint64(seqNumRange.End() - seqNumRange.Start() + 1),
 			},
 		},
-		&cciptypes.CCIPMsg{},
+		&cciptypes.Message{},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query onRamp: %w", err)
 	}
 
-	msgs := make([]cciptypes.CCIPMsg, 0)
+	msgs := make([]cciptypes.Message, 0)
 	for _, item := range seq {
-		msg, ok := item.Data.(cciptypes.CCIPMsg)
+		msg, ok := item.Data.(cciptypes.Message)
 		if !ok {
-			return nil, fmt.Errorf("failed to cast %v to CCIPMsg", item.Data)
+			return nil, fmt.Errorf("failed to cast %v to Message", item.Data)
 		}
 		msgs = append(msgs, msg)
 	}

--- a/plugintypes/commit.go
+++ b/plugintypes/commit.go
@@ -11,7 +11,7 @@ import (
 // ---[ Observation ]-----------------------------------------------------------
 
 type CommitPluginObservation struct {
-	NewMsgs     []cciptypes.CCIPMsgBaseDetails  `json:"newMsgs"`
+	NewMsgs     []cciptypes.RampMessageHeader   `json:"newMsgs"`
 	GasPrices   []cciptypes.GasPriceChain       `json:"gasPrices"`
 	TokenPrices []cciptypes.TokenPrice          `json:"tokenPrices"`
 	MaxSeqNums  []SeqNumChain                   `json:"maxSeqNums"`
@@ -19,7 +19,7 @@ type CommitPluginObservation struct {
 }
 
 func NewCommitPluginObservation(
-	newMsgs []cciptypes.CCIPMsgBaseDetails,
+	newMsgs []cciptypes.RampMessageHeader,
 	gasPrices []cciptypes.GasPriceChain,
 	tokenPrices []cciptypes.TokenPrice,
 	maxSeqNums []SeqNumChain,

--- a/plugintypes/execute.go
+++ b/plugintypes/execute.go
@@ -14,7 +14,7 @@ import (
 
 type ExecutePluginCommitDataWithMessages struct {
 	ExecutePluginCommitData
-	Messages []cciptypes.CCIPMsg `json:"messages"`
+	Messages []cciptypes.Message `json:"messages"`
 }
 
 // ExecutePluginCommitData is the data that is committed to the chain.
@@ -34,7 +34,7 @@ type ExecutePluginCommitData struct {
 }
 
 type ExecutePluginCommitObservations map[cciptypes.ChainSelector][]ExecutePluginCommitDataWithMessages
-type ExecutePluginMessageObservations map[cciptypes.ChainSelector]map[cciptypes.SeqNum]cciptypes.CCIPMsg
+type ExecutePluginMessageObservations map[cciptypes.ChainSelector]map[cciptypes.SeqNum]cciptypes.Message
 
 // ExecutePluginObservation is the observation of the ExecutePlugin.
 // TODO: revisit observation types. The maps used here are more space efficient and easier to work


### PR DESCRIPTION
Update chainlink-common to use the family-agnostic types from https://github.com/smartcontractkit/chainlink-common/pull/639.