### PR TITLE
commit plugin - fix wrong assumption that nextSeqNums returns the committed seq nums

### DIFF
--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -176,7 +176,7 @@ func (p *Plugin) Observation(
 		p.ccipReader,
 		p.msgHasher,
 		supportedChains,
-		prevOutcome.MaxSeqNums, // TODO: Chainlink common PR to rename.
+		prevOutcome.MaxSeqNums,
 		p.cfg.NewMsgScanBatchSize,
 	)
 	if err != nil {

--- a/commit/plugin_e2e_test.go
+++ b/commit/plugin_e2e_test.go
@@ -275,11 +275,11 @@ func setupAllNodesReadAllChains(ctx context.Context, t *testing.T, lggr logger.L
 
 		// all nodes observe the same sequence numbers lastCommittedSeqNumA for chainA and lastCommittedSeqNumB for chainB
 		n.ccipReader.On("NextSeqNum", ctx, []cciptypes.ChainSelector{chainA, chainB}).
-			Return([]cciptypes.SeqNum{lastCommittedSeqNumA, lastCommittedSeqNumB}, nil)
+			Return([]cciptypes.SeqNum{lastCommittedSeqNumA + 1, lastCommittedSeqNumB + 1}, nil)
 
 		// transmission phase root staleness check passes
 		n.ccipReader.On("NextSeqNum", ctx, []cciptypes.ChainSelector{chainB}).
-			Return([]cciptypes.SeqNum{lastCommittedSeqNumB}, nil)
+			Return([]cciptypes.SeqNum{lastCommittedSeqNumB + 1}, nil)
 	}
 	require.NoError(t, homeChain.Close())
 	return nodes
@@ -302,7 +302,7 @@ func setupNodesDoNotAgreeOnMsgs(ctx context.Context, t *testing.T, lggr logger.L
 		nodes = append(nodes, n)
 		// all nodes observe the same sequence numbers lastCommittedSeqNumA for chainA and lastCommittedSeqNumB for chainB
 		n.ccipReader.On("NextSeqNum", ctx, []cciptypes.ChainSelector{chainA, chainB}).
-			Return([]cciptypes.SeqNum{lastCommittedSeqNumA, lastCommittedSeqNumB}, nil)
+			Return([]cciptypes.SeqNum{lastCommittedSeqNumA + 1, lastCommittedSeqNumB + 1}, nil)
 
 		// then they fetch new msgs, there is nothing new on chainA
 		mockMsgsBetweenSeqNums(ctx, n.ccipReader, chainA, seqNumA, emptyMsgs)
@@ -348,9 +348,9 @@ func setupNodesDoNotReportGasPrices(ctx context.Context, t *testing.T, lggr logg
 
 		// all nodes observe the same sequence numbers lastCommittedSeqNumA for chainA and lastCommittedSeqNumB for chainB
 		n.ccipReader.On("NextSeqNum", ctx, []cciptypes.ChainSelector{chainA, chainB}).
-			Return([]cciptypes.SeqNum{lastCommittedSeqNumA, lastCommittedSeqNumB}, nil)
+			Return([]cciptypes.SeqNum{lastCommittedSeqNumA + 1, lastCommittedSeqNumB + 1}, nil)
 		n.ccipReader.On("NextSeqNum", ctx, []cciptypes.ChainSelector{chainB}).
-			Return([]cciptypes.SeqNum{lastCommittedSeqNumB}, nil)
+			Return([]cciptypes.SeqNum{lastCommittedSeqNumB + 1}, nil)
 	}
 
 	require.NoError(t, homeChain.Close())

--- a/commit/plugin_functions.go
+++ b/commit/plugin_functions.go
@@ -35,14 +35,15 @@ func observeLatestCommittedSeqNums(
 	sort.Slice(knownSourceChains, func(i, j int) bool { return knownSourceChains[i] < knownSourceChains[j] })
 	latestCommittedSeqNumsObservation := make([]plugintypes.SeqNumChain, 0)
 	if readableChains.Contains(destChain) {
-		lggr.Debugw("reading sequence numbers", "chains", knownSourceChains)
-		onChainNextSeqNums, err := ccipReader.NextSeqNum(ctx, knownSourceChains)
+		lggr.Debugw("reading sequence numbers", "chains", knownSourceChains, "destChain", destChain)
+		expectedNextSeqNums, err := ccipReader.NextSeqNum(ctx, knownSourceChains)
 		if err != nil {
 			return latestCommittedSeqNumsObservation, fmt.Errorf("get next seq nums: %w", err)
 		}
-		lggr.Debugw("observing latest committed sequence numbers", "onChainNextSeqNums", onChainNextSeqNums)
+		lggr.Debugw("observing latest committed sequence numbers",
+			"onChainNextSeqNums", expectedNextSeqNums, "destChain", destChain)
 		for i, ch := range knownSourceChains {
-			committedSeqNum := onChainNextSeqNums[i] - 1
+			committedSeqNum := expectedNextSeqNums[i] - 1
 
 			latestCommittedSeqNumsObservation = append(
 				latestCommittedSeqNumsObservation,


### PR DESCRIPTION
There was a wrong assumption that `nextSeqNums` returns the committed seqNums.
