### PR TITLE
exec: Skip messages that do not fit

### DIFF
--- a/execute/report/builder.go
+++ b/execute/report/builder.go
@@ -79,7 +79,7 @@ func (b *execReportBuilder) Add(
 		return commitReport, nil
 	}
 	if err != nil {
-		return commitReport, fmt.Errorf("unable to build single chain report: %w", err)
+		return commitReport, fmt.Errorf("unable to add a single chain report: %w", err)
 	}
 
 	b.execReports = append(b.execReports, execReport)

--- a/execute/report/builder.go
+++ b/execute/report/builder.go
@@ -72,7 +72,7 @@ type execReportBuilder struct {
 func (b *execReportBuilder) Add(
 	commitReport plugintypes.ExecutePluginCommitDataWithMessages,
 ) (plugintypes.ExecutePluginCommitDataWithMessages, error) {
-	execReport, updatedReport, err := b.buildSingleChainReportMaxSize(b.ctx, commitReport)
+	execReport, updatedReport, err := b.buildSingleChainReport(b.ctx, commitReport)
 
 	// No messages fit into the report, move to next report
 	if errors.Is(err, ErrEmptyReport) {

--- a/execute/report/builder.go
+++ b/execute/report/builder.go
@@ -41,6 +41,14 @@ func NewBuilder(
 	}
 }
 
+// validationMetadata contains all metadata needed to accumulate results across multiple reports and messages.
+type validationMetadata struct {
+	encodedSizeBytes uint64
+
+	// TODO: gas limit
+	//gas             uint64
+}
+
 type execReportBuilder struct {
 	ctx  context.Context // TODO: remove context from builder so that it can be pure?
 	lggr logger.Logger
@@ -55,9 +63,7 @@ type execReportBuilder struct {
 	maxGas             uint64
 
 	// State
-	reportSizeBytes uint64
-	// TODO: gas limit
-	//gas             uint64
+	accumulated validationMetadata
 
 	// Result
 	execReports []cciptypes.ExecutePluginReportSingleChain
@@ -66,11 +72,7 @@ type execReportBuilder struct {
 func (b *execReportBuilder) Add(
 	commitReport plugintypes.ExecutePluginCommitDataWithMessages,
 ) (plugintypes.ExecutePluginCommitDataWithMessages, error) {
-	// TODO: buildSingleChainReportMaxSize needs to be part of the builder in order to access state.
-	execReport, encodedSize, updatedReport, err :=
-		buildSingleChainReportMaxSize(b.ctx, b.lggr, b.hasher, b.tokenDataReader, b.encoder,
-			commitReport,
-			int(b.maxReportSizeBytes-b.reportSizeBytes))
+	execReport, updatedReport, err := b.buildSingleChainReportMaxSize(b.ctx, commitReport)
 
 	// No messages fit into the report, move to next report
 	if errors.Is(err, ErrEmptyReport) {
@@ -80,7 +82,6 @@ func (b *execReportBuilder) Add(
 		return commitReport, fmt.Errorf("unable to build single chain report: %w", err)
 	}
 
-	b.reportSizeBytes += uint64(encodedSize)
 	b.execReports = append(b.execReports, execReport)
 
 	return updatedReport, nil
@@ -90,7 +91,7 @@ func (b *execReportBuilder) Build() ([]cciptypes.ExecutePluginReportSingleChain,
 	b.lggr.Infow(
 		"selected commit reports for execution report",
 		"numReports", len(b.execReports),
-		"size", b.reportSizeBytes,
+		"sizeBytes", b.accumulated.encodedSizeBytes,
 		"maxSize", b.maxReportSizeBytes)
 	return b.execReports, nil
 }

--- a/execute/report/report.go
+++ b/execute/report/report.go
@@ -16,15 +16,15 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/plugintypes"
 )
 
-// buildSingleChainReport converts the on-chain event data stored in cciptypes.ExecutePluginCommitDataWithMessages into
-// the final on-chain report format.
+// buildSingleChainReportHelper converts the on-chain event data stored in
+// cciptypes.ExecutePluginCommitDataWithMessages into the final on-chain report format.
 //
 // The hasher and encoding codec are provided as arguments to allow for chain-specific formats to be used.
 //
 // The messages argument indicates which messages should be included in the report. If messages is empty
 // all messages will be included. This allows the caller to create smaller reports if needed. Executed messages
 // are skipped automatically.
-func buildSingleChainReport(
+func buildSingleChainReportHelper(
 	ctx context.Context,
 	lggr logger.Logger,
 	hasher cciptypes.MessageHasher,
@@ -204,7 +204,7 @@ func (b *execReportBuilder) buildSingleChainReport(
 	}
 	// Attempt to include all messages in the report.
 	finalReport, err :=
-		buildSingleChainReport(b.ctx, b.lggr, b.hasher, b.tokenDataReader, report, nil)
+		buildSingleChainReportHelper(b.ctx, b.lggr, b.hasher, b.tokenDataReader, report, nil)
 	if err != nil {
 		return cciptypes.ExecutePluginReportSingleChain{},
 			plugintypes.ExecutePluginCommitDataWithMessages{},
@@ -236,7 +236,7 @@ func (b *execReportBuilder) buildSingleChainReport(
 		msgs[i] = struct{}{}
 
 		finalReport2, err :=
-			buildSingleChainReport(b.ctx, b.lggr, b.hasher, b.tokenDataReader, report, msgs)
+			buildSingleChainReportHelper(b.ctx, b.lggr, b.hasher, b.tokenDataReader, report, msgs)
 		if err != nil {
 			return cciptypes.ExecutePluginReportSingleChain{},
 				plugintypes.ExecutePluginCommitDataWithMessages{},

--- a/execute/report/report.go
+++ b/execute/report/report.go
@@ -187,9 +187,9 @@ func (b *execReportBuilder) verifyReport(
 	}, nil
 }
 
-// buildSingleChainReportMaxSize generates the largest report which fits into maxSizeBytes.
+// buildSingleChainReport generates the largest report which fits into maxSizeBytes.
 // See buildSingleChainReport for more details about how a report is built.
-func (b *execReportBuilder) buildSingleChainReportMaxSize(
+func (b *execReportBuilder) buildSingleChainReport(
 	ctx context.Context,
 	report plugintypes.ExecutePluginCommitDataWithMessages,
 ) (cciptypes.ExecutePluginReportSingleChain, plugintypes.ExecutePluginCommitDataWithMessages, error) {

--- a/execute/report/report.go
+++ b/execute/report/report.go
@@ -217,6 +217,8 @@ func (b *execReportBuilder) buildSingleChainReport(
 			plugintypes.ExecutePluginCommitDataWithMessages{},
 			fmt.Errorf("unable to verify report: %w", err)
 	} else if validReport {
+		b.lggr.Debugw("optimistic full single chain report build is successful",
+			"root", report.MerkleRoot.String())
 		return finalize(finalReport, report, meta)
 	}
 

--- a/execute/report/report_test.go
+++ b/execute/report/report_test.go
@@ -413,7 +413,7 @@ func Test_buildSingleChainReport_Errors(t *testing.T) {
 			for i := 0; i < len(tt.args.report.Messages); i++ {
 				msgs[i] = struct{}{}
 			}
-			_, err := buildSingleChainReport(
+			_, err := buildSingleChainReportHelper(
 				ctx, lggr, resolvedHasher, resolvedTokenDataReader, tt.args.report, msgs)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)

--- a/execute/report/report_test.go
+++ b/execute/report/report_test.go
@@ -208,8 +208,12 @@ func Test_buildSingleChainReport_Errors(t *testing.T) {
 			}
 
 			ctx := context.Background()
+			msgs := make(map[int]struct{})
+			for i := 0; i < len(tt.args.report.Messages); i++ {
+				msgs[i] = struct{}{}
+			}
 			execReport, size, err := buildSingleChainReport(
-				ctx, lggr, resolvedHasher, resolvedTokenDataReader, resolvedCodec, tt.args.report, 0)
+				ctx, lggr, resolvedHasher, resolvedTokenDataReader, resolvedCodec, tt.args.report, msgs)
 			if tt.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr)

--- a/execute/report/report_test.go
+++ b/execute/report/report_test.go
@@ -3,18 +3,244 @@ package report
 import (
 	"context"
 	"fmt"
+	"math/rand"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/hashutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/merklemulti"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	"github.com/smartcontractkit/chainlink-ccip/execute/types"
+	"github.com/smartcontractkit/chainlink-ccip/internal/libs/slicelib"
 	"github.com/smartcontractkit/chainlink-ccip/internal/mocks"
 	"github.com/smartcontractkit/chainlink-ccip/plugintypes"
 )
+
+// mustMakeBytes parses a given string into a byte array, any error causes a panic. Pass in an empty string for a
+// random byte array.
+// nolint:unparam // surly this will be useful at some point...
+func mustMakeBytes(byteStr string) cciptypes.Bytes32 {
+	if byteStr == "" {
+		var randomBytes cciptypes.Bytes32
+		n, err := rand.New(rand.NewSource(0)).Read(randomBytes[:])
+		if n != 32 {
+			panic(fmt.Sprintf("Unexpected number of bytes read for placeholder id: want 32, got %d", n))
+		}
+		if err != nil {
+			panic(fmt.Sprintf("Error reading random bytes: %v", err))
+		}
+		return randomBytes
+	}
+	b, err := cciptypes.NewBytes32FromString(byteStr)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func TestMustMakeBytes(t *testing.T) {
+	type args struct {
+		byteStr string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		want      cciptypes.Bytes32
+		willPanic bool
+	}{
+		{
+			name: "empty - deterministic random",
+			args: args{byteStr: ""},
+			want: cciptypes.Bytes32{
+				0x01, 0x94, 0xfd, 0xc2, 0xfa, 0x2f, 0xfc, 0xc0, 0x41, 0xd3, 0xff, 0x12, 0x4, 0x5b, 0x73, 0xc8,
+				0x6e, 0x4f, 0xf9, 0x5f, 0xf6, 0x62, 0xa5, 0xee, 0xe8, 0x2a, 0xbd, 0xf4, 0x4a, 0x2d, 0xb, 0x75,
+			},
+		},
+		{
+			name: "constant",
+			args: args{byteStr: "0x0000000000000000000000000000000000000000000000000000000000000000"},
+			want: cciptypes.Bytes32{},
+		},
+		{
+			name: "constant2",
+			args: args{byteStr: "0x0102030405060708090102030405060708090102030405060708090102030405"},
+			want: cciptypes.Bytes32{
+				0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7,
+				0x8, 0x9, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0x1, 0x2, 0x3, 0x4, 0x5,
+			},
+		},
+		{
+			name:      "panic - wrong size",
+			args:      args{byteStr: "0x00000"},
+			willPanic: true,
+		},
+		{
+			name:      "panic - wrong format",
+			args:      args{byteStr: "lorem ipsum"},
+			willPanic: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if tt.willPanic {
+				assert.Panics(t, func() {
+					mustMakeBytes(tt.args.byteStr)
+				})
+				return
+			}
+
+			got := mustMakeBytes(tt.args.byteStr)
+			assert.Equal(t, tt.want, got, "mustMakeBytes() = %v, want %v", got, tt.want)
+			fmt.Println(got)
+		})
+	}
+}
+
+// assertMerkleRoot computes the source messages merkle root, then computes a verification with the proof, then compares
+// the roots.
+func assertMerkleRoot(
+	t *testing.T,
+	hasher cciptypes.MessageHasher,
+	execReport cciptypes.ExecutePluginReportSingleChain,
+	commitReport plugintypes.ExecutePluginCommitDataWithMessages,
+) {
+	keccak := hashutil.NewKeccak()
+	// Generate merkle root from commit report messages
+	var leafHashes [][32]byte
+	for _, msg := range commitReport.Messages {
+		hash, err := hasher.Hash(context.Background(), msg)
+		require.NoError(t, err)
+		leafHashes = append(leafHashes, hash)
+	}
+	tree, err := merklemulti.NewTree(keccak, leafHashes)
+	require.NoError(t, err)
+	merkleRoot := tree.Root()
+
+	// Generate merkle root from exec report messages and proof
+	ctx := context.Background()
+	var leaves [][32]byte
+	for _, msg := range execReport.Messages {
+		hash, err := hasher.Hash(ctx, msg)
+		require.NoError(t, err)
+		leaves = append(leaves, hash)
+	}
+	proofCast := make([][32]byte, len(execReport.Proofs))
+	for i, p := range execReport.Proofs {
+		copy(proofCast[i][:], p[:32])
+	}
+	var proof merklemulti.Proof[[32]byte]
+	proof.Hashes = proofCast
+	proof.SourceFlags = slicelib.BitFlagsToBools(execReport.ProofFlagBits.Int, len(leaves)+len(proofCast)-1)
+	recomputedMerkleRoot, err := merklemulti.VerifyComputeRoot(hashutil.NewKeccak(),
+		leaves,
+		proof)
+	assert.NoError(t, err)
+	assert.NotNil(t, recomputedMerkleRoot)
+
+	// Compare them
+	assert.Equal(t, merkleRoot, recomputedMerkleRoot)
+}
+
+// makeMessage creates a message deterministically derived from the given inputs.
+func makeMessage(src cciptypes.ChainSelector, num cciptypes.SeqNum, nonce uint64) cciptypes.Message {
+	var placeholderID cciptypes.Bytes32
+	n, err := rand.New(rand.NewSource(int64(src) * int64(num) * int64(nonce))).Read(placeholderID[:])
+	if n != 32 {
+		panic(fmt.Sprintf("Unexpected number of bytes read for placeholder id: want 32, got %d", n))
+	}
+	if err != nil {
+		panic(fmt.Sprintf("Error reading random bytes: %v", err))
+	}
+
+	return cciptypes.Message{
+		Header: cciptypes.RampMessageHeader{
+			MessageID:           placeholderID,
+			SourceChainSelector: src,
+			SequenceNumber:      num,
+			MsgHash:             cciptypes.Bytes32{},
+		},
+	}
+}
+
+// makeTestCommitReport creates a basic commit report with messages given different parameters. This function
+// will panic if the input parameters are inconsistent.
+func makeTestCommitReport(
+	hasher cciptypes.MessageHasher,
+	numMessages,
+	srcChain,
+	firstSeqNum,
+	block int,
+	timestamp int64,
+	rootOverride cciptypes.Bytes32,
+	executed []cciptypes.SeqNum,
+) plugintypes.ExecutePluginCommitDataWithMessages {
+	sequenceNumberRange :=
+		cciptypes.NewSeqNumRange(cciptypes.SeqNum(firstSeqNum), cciptypes.SeqNum(firstSeqNum+numMessages-1))
+
+	for _, e := range executed {
+		if !sequenceNumberRange.Contains(e) {
+			panic("executed message out of range")
+		}
+	}
+	var messages []cciptypes.Message
+	for i := 0; i < numMessages; i++ {
+		messages = append(messages, makeMessage(
+			cciptypes.ChainSelector(srcChain),
+			cciptypes.SeqNum(i+firstSeqNum),
+			uint64(i)))
+	}
+
+	commitReport := plugintypes.ExecutePluginCommitDataWithMessages{
+		ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
+			//MerkleRoot:          root,
+			SourceChain:         cciptypes.ChainSelector(srcChain),
+			SequenceNumberRange: sequenceNumberRange,
+			Timestamp:           time.UnixMilli(timestamp),
+			BlockNum:            uint64(block),
+			ExecutedMessages:    executed,
+		},
+		Messages: messages,
+	}
+
+	// calculate merkle root
+	root := rootOverride
+	if root.IsEmpty() {
+		tree, err := ConstructMerkleTree(context.Background(), hasher, commitReport)
+		if err != nil {
+			panic(fmt.Sprintf("unable to construct merkle tree: %s", err))
+		}
+		commitReport.MerkleRoot = tree.Root()
+	}
+
+	return commitReport
+}
+
+// breakCommitReport by adding an extra message. This causes the report to have an unexpected number of messages.
+func breakCommitReport(
+	commitReport plugintypes.ExecutePluginCommitDataWithMessages,
+) plugintypes.ExecutePluginCommitDataWithMessages {
+	commitReport.Messages = append(commitReport.Messages, cciptypes.Message{})
+	return commitReport
+}
+
+// SetMessageData at the given index to the given size. This function will panic if the index is out of range.
+func SetMessageData(
+	idx int, size uint64, commitReport plugintypes.ExecutePluginCommitDataWithMessages,
+) plugintypes.ExecutePluginCommitDataWithMessages {
+	if len(commitReport.Messages) < idx {
+		panic("message index out of range")
+	}
+	commitReport.Messages[idx].Data = make([]byte, size)
+	return commitReport
+}
 
 // TODO: better than this
 type tdr struct{}
@@ -191,6 +417,247 @@ func Test_buildSingleChainReport_Errors(t *testing.T) {
 				ctx, lggr, resolvedHasher, resolvedTokenDataReader, tt.args.report, msgs)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func Test_Builder_Build(t *testing.T) {
+	hasher := mocks.NewMessageHasher()
+	codec := mocks.NewExecutePluginJSONReportCodec()
+	lggr := logger.Test(t)
+	var tokenDataReader tdr
+
+	type args struct {
+		reports       []plugintypes.ExecutePluginCommitDataWithMessages
+		maxReportSize uint64
+	}
+	tests := []struct {
+		name                  string
+		args                  args
+		expectedExecReports   int
+		expectedCommitReports int
+		expectedExecThings    []int
+		lastReportExecuted    []cciptypes.SeqNum
+		wantErr               string
+	}{
+		{
+			name: "empty report",
+			args: args{
+				reports: []plugintypes.ExecutePluginCommitDataWithMessages{},
+			},
+			expectedExecReports:   0,
+			expectedCommitReports: 0,
+		},
+		{
+			name: "half report",
+			args: args{
+				maxReportSize: 2300,
+				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
+					makeTestCommitReport(hasher, 10, 1, 100, 999, 10101010101,
+						cciptypes.Bytes32{}, // generate a correct root.
+						nil),
+				},
+			},
+			expectedExecReports:   1,
+			expectedCommitReports: 1,
+			expectedExecThings:    []int{5},
+			lastReportExecuted:    []cciptypes.SeqNum{100, 101, 102, 103, 104},
+		},
+		{
+			name: "full report",
+			args: args{
+				maxReportSize: 10000,
+				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
+					makeTestCommitReport(hasher, 10, 1, 100, 999, 10101010101,
+						cciptypes.Bytes32{}, // generate a correct root.
+						nil),
+				},
+			},
+			expectedExecReports:   1,
+			expectedCommitReports: 0,
+			expectedExecThings:    []int{10},
+		},
+		{
+			name: "two reports",
+			args: args{
+				maxReportSize: 15000,
+				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
+					makeTestCommitReport(hasher, 10, 1, 100, 999, 10101010101,
+						cciptypes.Bytes32{}, // generate a correct root.
+						nil),
+					makeTestCommitReport(hasher, 20, 2, 100, 999, 10101010101,
+						cciptypes.Bytes32{}, // generate a correct root.
+						nil),
+				},
+			},
+			expectedExecReports:   2,
+			expectedCommitReports: 0,
+			expectedExecThings:    []int{10, 20},
+		},
+		{
+			name: "one and half reports",
+			args: args{
+				maxReportSize: 8500,
+				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
+					makeTestCommitReport(hasher, 10, 1, 100, 999, 10101010101,
+						cciptypes.Bytes32{}, // generate a correct root.
+						nil),
+					makeTestCommitReport(hasher, 20, 2, 100, 999, 10101010101,
+						cciptypes.Bytes32{}, // generate a correct root.
+						nil),
+				},
+			},
+			expectedExecReports:   2,
+			expectedCommitReports: 1,
+			expectedExecThings:    []int{10, 10},
+			lastReportExecuted:    []cciptypes.SeqNum{100, 101, 102, 103, 104, 105, 106, 107, 108, 109},
+		},
+		{
+			name: "exactly one report",
+			args: args{
+				maxReportSize: 4200,
+				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
+					makeTestCommitReport(hasher, 10, 1, 100, 999, 10101010101,
+						cciptypes.Bytes32{}, // generate a correct root.
+						nil),
+					makeTestCommitReport(hasher, 20, 2, 100, 999, 10101010101,
+						cciptypes.Bytes32{}, // generate a correct root.
+						nil),
+				},
+			},
+			expectedExecReports:   1,
+			expectedCommitReports: 1,
+			expectedExecThings:    []int{10},
+			lastReportExecuted:    []cciptypes.SeqNum{},
+		},
+		{
+			name: "execute remainder of partially executed report",
+			args: args{
+				maxReportSize: 2500,
+				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
+					makeTestCommitReport(hasher, 10, 1, 100, 999, 10101010101,
+						cciptypes.Bytes32{}, // generate a correct root.
+						[]cciptypes.SeqNum{100, 101, 102, 103, 104}),
+				},
+			},
+			expectedExecReports:   1,
+			expectedCommitReports: 0,
+			expectedExecThings:    []int{5},
+		},
+		{
+			name: "partially execute remainder of partially executed report",
+			args: args{
+				maxReportSize: 2050,
+				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
+					makeTestCommitReport(hasher, 10, 1, 100, 999, 10101010101,
+						cciptypes.Bytes32{}, // generate a correct root.
+						[]cciptypes.SeqNum{100, 101, 102, 103, 104}),
+				},
+			},
+			expectedExecReports:   1,
+			expectedCommitReports: 1,
+			expectedExecThings:    []int{4},
+			lastReportExecuted:    []cciptypes.SeqNum{100, 101, 102, 103, 104, 105, 106, 107, 108},
+		},
+		{
+			name: "execute remainder of sparsely executed report",
+			args: args{
+				maxReportSize: 3500,
+				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
+					makeTestCommitReport(hasher, 10, 1, 100, 999, 10101010101,
+						cciptypes.Bytes32{}, // generate a correct root.
+						[]cciptypes.SeqNum{100, 102, 104, 106, 108}),
+				},
+			},
+			expectedExecReports:   1,
+			expectedCommitReports: 0,
+			expectedExecThings:    []int{5},
+		},
+		{
+			name: "partially execute remainder of partially executed sparse report",
+			args: args{
+				maxReportSize: 2050,
+				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
+					makeTestCommitReport(hasher, 10, 1, 100, 999, 10101010101,
+						cciptypes.Bytes32{}, // generate a correct root.
+						[]cciptypes.SeqNum{100, 102, 104, 106, 108}),
+				},
+			},
+			expectedExecReports:   1,
+			expectedCommitReports: 1,
+			expectedExecThings:    []int{4},
+			lastReportExecuted:    []cciptypes.SeqNum{100, 101, 102, 103, 104, 105, 106, 107, 108},
+		},
+		{
+			name: "broken report",
+			args: args{
+				maxReportSize: 10000,
+				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
+					breakCommitReport(makeTestCommitReport(hasher, 10, 1, 101, 1000, 10101010102,
+						cciptypes.Bytes32{}, // generate a correct root.
+						nil)),
+				},
+			},
+			wantErr: "unable to add a single chain report",
+		},
+		{
+			name: "invalid merkle root",
+			args: args{
+				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
+					makeTestCommitReport(hasher, 10, 1, 100, 999, 10101010101,
+						mustMakeBytes(""), // random root
+						nil),
+				},
+			},
+			wantErr: "merkle root mismatch: expected 0x00000000000000000",
+		},
+		// TODO: A test that requires skipping over a large message because only a smaller message fits in the report.
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			// look for error in Add or Build
+			foundError := false
+
+			builder := NewBuilder(ctx, lggr, hasher, tokenDataReader, codec, tt.args.maxReportSize, 0)
+			var updatedMessages []plugintypes.ExecutePluginCommitDataWithMessages
+			for _, report := range tt.args.reports {
+				updatedMessage, err := builder.Add(report)
+				if err != nil && tt.wantErr != "" {
+					if strings.Contains(err.Error(), tt.wantErr) {
+						foundError = true
+						break
+					}
+				}
+				require.NoError(t, err)
+				updatedMessages = append(updatedMessages, updatedMessage)
+			}
+			if foundError {
+				return
+			}
+			execReports, err := builder.Build()
+			if tt.wantErr != "" {
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, execReports, tt.expectedExecReports)
+			//require.Len(t, commitReports, tt.expectedCommitReports)
+			for i, execReport := range execReports {
+				require.Lenf(t, execReport.Messages, tt.expectedExecThings[i],
+					"Unexpected number of messages, iter %d", i)
+				require.Lenf(t, execReport.OffchainTokenData, tt.expectedExecThings[i],
+					"Unexpected number of token data, iter %d", i)
+				require.NotEmptyf(t, execReport.Proofs, "Proof should not be empty.")
+				assertMerkleRoot(t, hasher, execReport, tt.args.reports[i])
+			}
+			// If the last report is partially executed, the executed messages can be checked.
+			if len(updatedMessages) > 0 && len(tt.lastReportExecuted) > 0 {
+				lastReport := updatedMessages[len(updatedMessages)-1]
+				require.ElementsMatch(t, tt.lastReportExecuted, lastReport.ExecutedMessages)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Three main changes:
1. Rewrite `selectReport` test to use the report builder, move to report builder package.
2. Update `buildSingleChainReport` to select reports by index rather than by a maximum number of messages to select.
3. Introduce `checkMesssage` and `verifyReport` functions to contain business logic to determine whether messages are ready to be executed and if the final report is valid.