### PR TITLE
exec: Simplify exec observation type.

### DIFF
--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -191,7 +191,7 @@ func (p *Plugin) Observation(
 		// No reports to execute.
 		// This is expected after a cold start.
 	} else {
-		commitReportCache := make(map[cciptypes.ChainSelector][]plugintypes.ExecutePluginCommitDataWithMessages)
+		commitReportCache := make(map[cciptypes.ChainSelector][]plugintypes.ExecutePluginCommitData)
 		for _, report := range previousOutcome.PendingCommitReports {
 			commitReportCache[report.SourceChain] = append(commitReportCache[report.SourceChain], report)
 		}
@@ -268,14 +268,14 @@ func selectReport(
 	hasher cciptypes.MessageHasher,
 	encoder cciptypes.ExecutePluginCodec,
 	tokenDataReader types2.TokenDataReader,
-	commitReports []plugintypes.ExecutePluginCommitDataWithMessages,
+	commitReports []plugintypes.ExecutePluginCommitData,
 	maxReportSizeBytes int,
-) ([]cciptypes.ExecutePluginReportSingleChain, []plugintypes.ExecutePluginCommitDataWithMessages, error) {
+) ([]cciptypes.ExecutePluginReportSingleChain, []plugintypes.ExecutePluginCommitData, error) {
 	// TODO: It may be desirable for this entire function to be an interface so that
 	//       different selection algorithms can be used.
 
 	builder := report.NewBuilder(ctx, lggr, hasher, tokenDataReader, encoder, uint64(maxReportSizeBytes), 99)
-	var stillPendingReports []plugintypes.ExecutePluginCommitDataWithMessages
+	var stillPendingReports []plugintypes.ExecutePluginCommitData
 	for i, report := range commitReports {
 		// Reports at the end may not have messages yet.
 		if len(report.Messages) == 0 {
@@ -337,7 +337,7 @@ func (p *Plugin) Outcome(
 		mergedMessageObservations)
 
 	// flatten commit reports and sort by timestamp.
-	var commitReports []plugintypes.ExecutePluginCommitDataWithMessages
+	var commitReports []plugintypes.ExecutePluginCommitData
 	for _, report := range observation.CommitReports {
 		commitReports = append(commitReports, report...)
 	}

--- a/execute/plugin_e2e_test.go
+++ b/execute/plugin_e2e_test.go
@@ -130,12 +130,10 @@ func setupSimpleTest(
 		makeMsg(105, srcSelector, dstSelector, false),
 	}
 
-	reportData := plugintypes.ExecutePluginCommitDataWithMessages{
-		ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-			SourceChain:         srcSelector,
-			SequenceNumberRange: cciptypes.NewSeqNumRange(100, 105),
-		},
-		Messages: slicelib.Map(messages, func(m inmem.MessagesWithMetadata) cciptypes.Message { return m.Message }),
+	reportData := plugintypes.ExecutePluginCommitData{
+		SourceChain:         srcSelector,
+		SequenceNumberRange: cciptypes.NewSeqNumRange(100, 105),
+		Messages:            slicelib.Map(messages, func(m inmem.MessagesWithMetadata) cciptypes.Message { return m.Message }),
 	}
 
 	tree, err := report.ConstructMerkleTree(context.Background(), msgHasher, reportData)

--- a/execute/plugin_e2e_test.go
+++ b/execute/plugin_e2e_test.go
@@ -130,10 +130,11 @@ func setupSimpleTest(
 		makeMsg(105, srcSelector, dstSelector, false),
 	}
 
+	mapped := slicelib.Map(messages, func(m inmem.MessagesWithMetadata) cciptypes.Message { return m.Message })
 	reportData := plugintypes.ExecutePluginCommitData{
 		SourceChain:         srcSelector,
 		SequenceNumberRange: cciptypes.NewSeqNumRange(100, 105),
-		Messages:            slicelib.Map(messages, func(m inmem.MessagesWithMetadata) cciptypes.Message { return m.Message }),
+		Messages:            mapped,
 	}
 
 	tree, err := report.ConstructMerkleTree(context.Background(), msgHasher, reportData)

--- a/execute/plugin_functions_test.go
+++ b/execute/plugin_functions_test.go
@@ -77,49 +77,41 @@ func Test_validateObserverReadingEligibility(t *testing.T) {
 func Test_validateObservedSequenceNumbers(t *testing.T) {
 	testCases := []struct {
 		name         string
-		observedData map[cciptypes.ChainSelector][]plugintypes.ExecutePluginCommitDataWithMessages
+		observedData map[cciptypes.ChainSelector][]plugintypes.ExecutePluginCommitData
 		expErr       bool
 	}{
 		{
 			name: "ValidData",
-			observedData: map[cciptypes.ChainSelector][]plugintypes.ExecutePluginCommitDataWithMessages{
+			observedData: map[cciptypes.ChainSelector][]plugintypes.ExecutePluginCommitData{
 				1: {
 					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							MerkleRoot:          cciptypes.Bytes32{1},
-							SequenceNumberRange: cciptypes.SeqNumRange{1, 10},
-							ExecutedMessages:    []cciptypes.SeqNum{1, 2, 3},
-						},
+						MerkleRoot:          cciptypes.Bytes32{1},
+						SequenceNumberRange: cciptypes.SeqNumRange{1, 10},
+						ExecutedMessages:    []cciptypes.SeqNum{1, 2, 3},
 					},
 				},
 				2: {
 					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							MerkleRoot:          cciptypes.Bytes32{2},
-							SequenceNumberRange: cciptypes.SeqNumRange{11, 20},
-							ExecutedMessages:    []cciptypes.SeqNum{11, 12, 13},
-						},
+						MerkleRoot:          cciptypes.Bytes32{2},
+						SequenceNumberRange: cciptypes.SeqNumRange{11, 20},
+						ExecutedMessages:    []cciptypes.SeqNum{11, 12, 13},
 					},
 				},
 			},
 		},
 		{
 			name: "DuplicateMerkleRoot",
-			observedData: map[cciptypes.ChainSelector][]plugintypes.ExecutePluginCommitDataWithMessages{
+			observedData: map[cciptypes.ChainSelector][]plugintypes.ExecutePluginCommitData{
 				1: {
 					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							MerkleRoot:          cciptypes.Bytes32{1},
-							SequenceNumberRange: cciptypes.SeqNumRange{1, 10},
-							ExecutedMessages:    []cciptypes.SeqNum{1, 2, 3},
-						},
+						MerkleRoot:          cciptypes.Bytes32{1},
+						SequenceNumberRange: cciptypes.SeqNumRange{1, 10},
+						ExecutedMessages:    []cciptypes.SeqNum{1, 2, 3},
 					},
 					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							MerkleRoot:          cciptypes.Bytes32{1},
-							SequenceNumberRange: cciptypes.SeqNumRange{11, 20},
-							ExecutedMessages:    []cciptypes.SeqNum{11, 12, 13},
-						},
+						MerkleRoot:          cciptypes.Bytes32{1},
+						SequenceNumberRange: cciptypes.SeqNumRange{11, 20},
+						ExecutedMessages:    []cciptypes.SeqNum{11, 12, 13},
 					},
 				},
 			},
@@ -127,21 +119,17 @@ func Test_validateObservedSequenceNumbers(t *testing.T) {
 		},
 		{
 			name: "OverlappingSequenceNumberRange",
-			observedData: map[cciptypes.ChainSelector][]plugintypes.ExecutePluginCommitDataWithMessages{
+			observedData: map[cciptypes.ChainSelector][]plugintypes.ExecutePluginCommitData{
 				1: {
 					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							MerkleRoot:          cciptypes.Bytes32{1},
-							SequenceNumberRange: cciptypes.SeqNumRange{1, 10},
-							ExecutedMessages:    []cciptypes.SeqNum{1, 2, 3},
-						},
+						MerkleRoot:          cciptypes.Bytes32{1},
+						SequenceNumberRange: cciptypes.SeqNumRange{1, 10},
+						ExecutedMessages:    []cciptypes.SeqNum{1, 2, 3},
 					},
 					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							MerkleRoot:          cciptypes.Bytes32{2},
-							SequenceNumberRange: cciptypes.SeqNumRange{5, 15},
-							ExecutedMessages:    []cciptypes.SeqNum{6, 7, 8},
-						},
+						MerkleRoot:          cciptypes.Bytes32{2},
+						SequenceNumberRange: cciptypes.SeqNumRange{5, 15},
+						ExecutedMessages:    []cciptypes.SeqNum{6, 7, 8},
 					},
 				},
 			},
@@ -149,14 +137,12 @@ func Test_validateObservedSequenceNumbers(t *testing.T) {
 		},
 		{
 			name: "ExecutedMessageOutsideObservedRange",
-			observedData: map[cciptypes.ChainSelector][]plugintypes.ExecutePluginCommitDataWithMessages{
+			observedData: map[cciptypes.ChainSelector][]plugintypes.ExecutePluginCommitData{
 				1: {
 					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							MerkleRoot:          cciptypes.Bytes32{1},
-							SequenceNumberRange: cciptypes.SeqNumRange{1, 10},
-							ExecutedMessages:    []cciptypes.SeqNum{1, 2, 11},
-						},
+						MerkleRoot:          cciptypes.Bytes32{1},
+						SequenceNumberRange: cciptypes.SeqNumRange{1, 10},
+						ExecutedMessages:    []cciptypes.SeqNum{1, 2, 11},
 					},
 				},
 			},
@@ -164,13 +150,13 @@ func Test_validateObservedSequenceNumbers(t *testing.T) {
 		},
 		{
 			name: "NoCommitData",
-			observedData: map[cciptypes.ChainSelector][]plugintypes.ExecutePluginCommitDataWithMessages{
+			observedData: map[cciptypes.ChainSelector][]plugintypes.ExecutePluginCommitData{
 				1: {},
 			},
 		},
 		{
 			name:         "EmptyObservedData",
-			observedData: map[cciptypes.ChainSelector][]plugintypes.ExecutePluginCommitDataWithMessages{},
+			observedData: map[cciptypes.ChainSelector][]plugintypes.ExecutePluginCommitData{},
 		},
 	}
 
@@ -188,7 +174,7 @@ func Test_validateObservedSequenceNumbers(t *testing.T) {
 
 func Test_computeRanges(t *testing.T) {
 	type args struct {
-		reports []plugintypes.ExecutePluginCommitDataWithMessages
+		reports []plugintypes.ExecutePluginCommitData
 	}
 
 	tests := []struct {
@@ -199,89 +185,63 @@ func Test_computeRanges(t *testing.T) {
 	}{
 		{
 			name: "empty",
-			args: args{reports: []plugintypes.ExecutePluginCommitDataWithMessages{}},
+			args: args{reports: []plugintypes.ExecutePluginCommitData{}},
 			want: nil,
 		},
 		{
 			name: "overlapping ranges",
-			args: args{reports: []plugintypes.ExecutePluginCommitDataWithMessages{
+			args: args{reports: []plugintypes.ExecutePluginCommitData{
 				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
-					},
+					SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
 				},
 				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(15, 25),
-					},
+					SequenceNumberRange: cciptypes.NewSeqNumRange(15, 25),
 				},
-			},
-			},
+			}},
 			err: errOverlappingRanges,
 		},
 		{
 			name: "simple ranges collapsed",
-			args: args{reports: []plugintypes.ExecutePluginCommitDataWithMessages{
+			args: args{reports: []plugintypes.ExecutePluginCommitData{
 				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
-					},
+					SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
 				},
 				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(21, 40),
-					},
+					SequenceNumberRange: cciptypes.NewSeqNumRange(21, 40),
 				},
 				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(41, 60),
-					},
+					SequenceNumberRange: cciptypes.NewSeqNumRange(41, 60),
 				},
-			},
-			},
+			}},
 			want: []cciptypes.SeqNumRange{{10, 60}},
 		},
 		{
 			name: "non-contiguous ranges",
-			args: args{reports: []plugintypes.ExecutePluginCommitDataWithMessages{
+			args: args{reports: []plugintypes.ExecutePluginCommitData{
 				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
-					},
+					SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
 				},
 				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40),
-					},
+					SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40),
 				},
 				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60)},
-				},
-			},
-			},
+					SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60)},
+			}},
 			want: []cciptypes.SeqNumRange{{10, 20}, {30, 40}, {50, 60}},
 		},
 		{
 			name: "contiguous and non-contiguous ranges",
-			args: args{reports: []plugintypes.ExecutePluginCommitDataWithMessages{
+			args: args{reports: []plugintypes.ExecutePluginCommitData{
 				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
-					},
+					SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
 				},
 				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(21, 40),
-					},
+					SequenceNumberRange: cciptypes.NewSeqNumRange(21, 40),
 				},
 				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60),
-					},
+					SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60),
 				},
-			},
-			},
+			}},
 			want: []cciptypes.SeqNumRange{{10, 40}, {50, 60}},
 		},
 	}
@@ -325,22 +285,16 @@ func Test_groupByChainSelector(t *testing.T) {
 			want: plugintypes.ExecutePluginCommitObservations{
 				1: {
 					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SourceChain:         1,
-							MerkleRoot:          cciptypes.Bytes32{1},
-							SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
-							ExecutedMessages:    nil,
-						},
+						SourceChain:         1,
+						MerkleRoot:          cciptypes.Bytes32{1},
+						SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
 					},
 				},
 				2: {
 					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SourceChain:         2,
-							MerkleRoot:          cciptypes.Bytes32{2},
-							SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40),
-							ExecutedMessages:    nil,
-						},
+						SourceChain:         2,
+						MerkleRoot:          cciptypes.Bytes32{2},
+						SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40),
 					},
 				},
 			},
@@ -357,13 +311,13 @@ func Test_groupByChainSelector(t *testing.T) {
 
 func Test_filterOutFullyExecutedMessages(t *testing.T) {
 	type args struct {
-		reports          []plugintypes.ExecutePluginCommitDataWithMessages
+		reports          []plugintypes.ExecutePluginCommitData
 		executedMessages []cciptypes.SeqNumRange
 	}
 	tests := []struct {
 		name    string
 		args    args
-		want    []plugintypes.ExecutePluginCommitDataWithMessages
+		want    []plugintypes.ExecutePluginCommitData
 		wantErr assert.ErrorAssertionFunc
 	}{
 		{
@@ -378,60 +332,36 @@ func Test_filterOutFullyExecutedMessages(t *testing.T) {
 		{
 			name: "empty2",
 			args: args{
-				reports:          []plugintypes.ExecutePluginCommitDataWithMessages{},
+				reports:          []plugintypes.ExecutePluginCommitData{},
 				executedMessages: nil,
 			},
-			want:    []plugintypes.ExecutePluginCommitDataWithMessages{},
+			want:    []plugintypes.ExecutePluginCommitData{},
 			wantErr: assert.NoError,
 		},
 		{
 			name: "no executed messages",
 			args: args{
-				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
-					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
-						},
-					},
-					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40),
-						},
-					},
-					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60),
-						},
-					},
+				reports: []plugintypes.ExecutePluginCommitData{
+					{SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20)},
+					{SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40)},
+					{SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60)},
 				},
 				executedMessages: nil,
 			},
-			want: []plugintypes.ExecutePluginCommitDataWithMessages{
-				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20)}},
-				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40)}},
-				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60)}},
+			want: []plugintypes.ExecutePluginCommitData{
+				{SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20)},
+				{SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40)},
+				{SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60)},
 			},
 			wantErr: assert.NoError,
 		},
 		{
 			name: "executed messages",
 			args: args{
-				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
-					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20)}},
-					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40)}},
-					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60)}},
+				reports: []plugintypes.ExecutePluginCommitData{
+					{SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20)},
+					{SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40)},
+					{SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60)},
 				},
 				executedMessages: []cciptypes.SeqNumRange{
 					cciptypes.NewSeqNumRange(0, 100),
@@ -443,41 +373,26 @@ func Test_filterOutFullyExecutedMessages(t *testing.T) {
 		{
 			name: "2 partially executed",
 			args: args{
-				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
-					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20)},
-					},
-					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40)},
-					},
-					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60)},
-					},
+				reports: []plugintypes.ExecutePluginCommitData{
+					{SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20)},
+					{SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40)},
+					{SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60)},
 				},
 				executedMessages: []cciptypes.SeqNumRange{
 					cciptypes.NewSeqNumRange(15, 35),
 				},
 			},
-			want: []plugintypes.ExecutePluginCommitDataWithMessages{
+			want: []plugintypes.ExecutePluginCommitData{
 				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
-						ExecutedMessages:    []cciptypes.SeqNum{15, 16, 17, 18, 19, 20},
-					},
+					SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
+					ExecutedMessages:    []cciptypes.SeqNum{15, 16, 17, 18, 19, 20},
 				},
 				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40),
-						ExecutedMessages:    []cciptypes.SeqNum{30, 31, 32, 33, 34, 35},
-					},
+					SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40),
+					ExecutedMessages:    []cciptypes.SeqNum{30, 31, 32, 33, 34, 35},
 				},
 				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60),
-					},
+					SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60),
 				},
 			},
 			wantErr: assert.NoError,
@@ -485,39 +400,23 @@ func Test_filterOutFullyExecutedMessages(t *testing.T) {
 		{
 			name: "2 partially executed 1 fully executed",
 			args: args{
-				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
-					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
-						},
-					},
-					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40),
-						},
-					},
-					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60),
-						},
-					},
+				reports: []plugintypes.ExecutePluginCommitData{
+					{SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20)},
+					{SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40)},
+					{SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60)},
 				},
 				executedMessages: []cciptypes.SeqNumRange{
 					cciptypes.NewSeqNumRange(15, 55),
 				},
 			},
-			want: []plugintypes.ExecutePluginCommitDataWithMessages{
+			want: []plugintypes.ExecutePluginCommitData{
 				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
-						ExecutedMessages:    []cciptypes.SeqNum{15, 16, 17, 18, 19, 20},
-					},
+					SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
+					ExecutedMessages:    []cciptypes.SeqNum{15, 16, 17, 18, 19, 20},
 				},
 				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60),
-						ExecutedMessages:    []cciptypes.SeqNum{50, 51, 52, 53, 54, 55},
-					},
+					SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60),
+					ExecutedMessages:    []cciptypes.SeqNum{50, 51, 52, 53, 54, 55},
 				},
 			},
 			wantErr: assert.NoError,
@@ -525,116 +424,64 @@ func Test_filterOutFullyExecutedMessages(t *testing.T) {
 		{
 			name: "first report executed",
 			args: args{
-				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
-					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
-						},
-					},
-					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40),
-						},
-					},
-					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60),
-						},
-					},
+				reports: []plugintypes.ExecutePluginCommitData{
+					{SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20)},
+					{SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40)},
+					{SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60)},
 				},
 				executedMessages: []cciptypes.SeqNumRange{
 					cciptypes.NewSeqNumRange(10, 20),
 				},
 			},
-			want: []plugintypes.ExecutePluginCommitDataWithMessages{
-				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40),
-					},
-				},
-				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60),
-					},
-				},
+			want: []plugintypes.ExecutePluginCommitData{
+				{SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40)},
+				{SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60)},
 			},
 			wantErr: assert.NoError,
 		},
 		{
 			name: "last report executed",
 			args: args{
-				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
-					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
-						},
-					},
-					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40),
-						},
-					},
-					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60),
-						},
-					},
+				reports: []plugintypes.ExecutePluginCommitData{
+					{SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20)},
+					{SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40)},
+					{SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60)},
 				},
 				executedMessages: []cciptypes.SeqNumRange{
 					cciptypes.NewSeqNumRange(50, 60),
 				},
 			},
-			want: []plugintypes.ExecutePluginCommitDataWithMessages{
-				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
-					},
-				},
-				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40),
-					},
-				},
+			want: []plugintypes.ExecutePluginCommitData{
+				{SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20)},
+				{SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40)},
 			},
 			wantErr: assert.NoError,
 		},
 		{
 			name: "sort-report",
 			args: args{
-				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
+				reports: []plugintypes.ExecutePluginCommitData{
 					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40),
-						},
+						SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40),
 					},
 					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60),
-						},
+						SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60),
 					},
 					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
-						},
+						SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
 					},
 				},
 				executedMessages: nil,
 			},
-			want: []plugintypes.ExecutePluginCommitDataWithMessages{
+			want: []plugintypes.ExecutePluginCommitData{
 				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
-					},
+					SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
 				},
 				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40),
-					},
+					SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40),
 				},
 				{
-					ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60),
-					},
+					SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60),
 				},
 			},
 			wantErr: assert.NoError,
@@ -642,21 +489,15 @@ func Test_filterOutFullyExecutedMessages(t *testing.T) {
 		{
 			name: "sort-executed",
 			args: args{
-				reports: []plugintypes.ExecutePluginCommitDataWithMessages{
+				reports: []plugintypes.ExecutePluginCommitData{
 					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
-						},
+						SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
 					},
 					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40),
-						},
+						SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40),
 					},
 					{
-						ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-							SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60),
-						},
+						SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60),
 					},
 				},
 				executedMessages: []cciptypes.SeqNumRange{
@@ -708,7 +549,7 @@ func Test_decodeAttributedObservations(t *testing.T) {
 					Observer: commontypes.OracleID(1),
 					Observation: mustEncode(plugintypes.ExecutePluginObservation{
 						CommitReports: plugintypes.ExecutePluginCommitObservations{
-							1: {{ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{MerkleRoot: cciptypes.Bytes32{1}}}},
+							1: {{MerkleRoot: cciptypes.Bytes32{1}}},
 						},
 					}),
 				},
@@ -718,7 +559,7 @@ func Test_decodeAttributedObservations(t *testing.T) {
 					Observer: commontypes.OracleID(1),
 					Observation: plugintypes.ExecutePluginObservation{
 						CommitReports: plugintypes.ExecutePluginCommitObservations{
-							1: {{ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{MerkleRoot: cciptypes.Bytes32{1}}}},
+							1: {{MerkleRoot: cciptypes.Bytes32{1}}},
 						},
 					},
 				},
@@ -732,7 +573,7 @@ func Test_decodeAttributedObservations(t *testing.T) {
 					Observer: commontypes.OracleID(1),
 					Observation: mustEncode(plugintypes.ExecutePluginObservation{
 						CommitReports: plugintypes.ExecutePluginCommitObservations{
-							1: {{ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{MerkleRoot: cciptypes.Bytes32{1}}}},
+							1: {{MerkleRoot: cciptypes.Bytes32{1}}},
 						},
 					}),
 				},
@@ -740,7 +581,7 @@ func Test_decodeAttributedObservations(t *testing.T) {
 					Observer: commontypes.OracleID(2),
 					Observation: mustEncode(plugintypes.ExecutePluginObservation{
 						CommitReports: plugintypes.ExecutePluginCommitObservations{
-							2: {{ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{MerkleRoot: cciptypes.Bytes32{2}}}},
+							2: {{MerkleRoot: cciptypes.Bytes32{2}}},
 						},
 					}),
 				},
@@ -750,7 +591,7 @@ func Test_decodeAttributedObservations(t *testing.T) {
 					Observer: commontypes.OracleID(1),
 					Observation: plugintypes.ExecutePluginObservation{
 						CommitReports: plugintypes.ExecutePluginCommitObservations{
-							1: {{ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{MerkleRoot: cciptypes.Bytes32{1}}}},
+							1: {{MerkleRoot: cciptypes.Bytes32{1}}},
 						},
 					},
 				},
@@ -758,7 +599,7 @@ func Test_decodeAttributedObservations(t *testing.T) {
 					Observer: commontypes.OracleID(2),
 					Observation: plugintypes.ExecutePluginObservation{
 						CommitReports: plugintypes.ExecutePluginCommitObservations{
-							2: {{ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{MerkleRoot: cciptypes.Bytes32{2}}}},
+							2: {{MerkleRoot: cciptypes.Bytes32{2}}},
 						},
 					},
 				},

--- a/execute/plugin_test.go
+++ b/execute/plugin_test.go
@@ -67,14 +67,13 @@ func Test_getPendingExecutedReports(t *testing.T) {
 				1: nil,
 			},
 			want: plugintypes.ExecutePluginCommitObservations{
-				1: []plugintypes.ExecutePluginCommitDataWithMessages{
-					{ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
+				1: []plugintypes.ExecutePluginCommitData{
+					{
 						SourceChain:         1,
 						SequenceNumberRange: cciptypes.NewSeqNumRange(1, 10),
-						ExecutedMessages:    nil,
 						Timestamp:           time.UnixMilli(10101010101),
 						BlockNum:            999,
-					}},
+					},
 				},
 			},
 			want1:   time.UnixMilli(10101010101),
@@ -103,14 +102,14 @@ func Test_getPendingExecutedReports(t *testing.T) {
 				},
 			},
 			want: plugintypes.ExecutePluginCommitObservations{
-				1: []plugintypes.ExecutePluginCommitDataWithMessages{
-					{ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
+				1: []plugintypes.ExecutePluginCommitData{
+					{
 						SourceChain:         1,
 						SequenceNumberRange: cciptypes.NewSeqNumRange(1, 10),
 						Timestamp:           time.UnixMilli(10101010101),
 						BlockNum:            999,
 						ExecutedMessages:    []cciptypes.SeqNum{1, 2, 3, 7, 8},
-					}},
+					},
 				},
 			},
 			want1:   time.UnixMilli(10101010101),
@@ -256,18 +255,10 @@ func TestPlugin_ValidateObservation_ValidateObservedSeqNum_Error(t *testing.T) {
 
 	// Reports with duplicate roots.
 	root := cciptypes.Bytes32{}
-	commitReports := map[cciptypes.ChainSelector][]plugintypes.ExecutePluginCommitDataWithMessages{
+	commitReports := map[cciptypes.ChainSelector][]plugintypes.ExecutePluginCommitData{
 		1: {
-			{
-				ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-					MerkleRoot: root,
-				},
-			},
-			{
-				ExecutePluginCommitData: plugintypes.ExecutePluginCommitData{
-					MerkleRoot: root,
-				},
-			},
+			{MerkleRoot: root},
+			{MerkleRoot: root},
 		},
 	}
 	observation := plugintypes.NewExecutePluginObservation(commitReports, nil)
@@ -352,7 +343,7 @@ func TestPlugin_Outcome_CommitReportsMergeError(t *testing.T) {
 		lggr:      logger.Test(t),
 	}
 
-	commitReports := map[cciptypes.ChainSelector][]plugintypes.ExecutePluginCommitDataWithMessages{
+	commitReports := map[cciptypes.ChainSelector][]plugintypes.ExecutePluginCommitData{
 		1: {},
 	}
 	observation, err := plugintypes.NewExecutePluginObservation(commitReports, nil).Encode()

--- a/execute/report/builder.go
+++ b/execute/report/builder.go
@@ -15,7 +15,7 @@ import (
 var _ ExecReportBuilder = &execReportBuilder{}
 
 type ExecReportBuilder interface {
-	Add(report plugintypes.ExecutePluginCommitDataWithMessages) (plugintypes.ExecutePluginCommitDataWithMessages, error)
+	Add(report plugintypes.ExecutePluginCommitData) (plugintypes.ExecutePluginCommitData, error)
 	Build() ([]cciptypes.ExecutePluginReportSingleChain, error)
 }
 
@@ -70,8 +70,8 @@ type execReportBuilder struct {
 }
 
 func (b *execReportBuilder) Add(
-	commitReport plugintypes.ExecutePluginCommitDataWithMessages,
-) (plugintypes.ExecutePluginCommitDataWithMessages, error) {
+	commitReport plugintypes.ExecutePluginCommitData,
+) (plugintypes.ExecutePluginCommitData, error) {
 	execReport, updatedReport, err := b.buildSingleChainReport(b.ctx, commitReport)
 
 	// No messages fit into the report, move to next report

--- a/execute/report/data.go
+++ b/execute/report/data.go
@@ -11,8 +11,8 @@ import (
 // markNewMessagesExecuted compares an execute plugin report with the commit report metadata and marks the new messages
 // as executed.
 func markNewMessagesExecuted(
-	execReport cciptypes.ExecutePluginReportSingleChain, report plugintypes.ExecutePluginCommitDataWithMessages,
-) plugintypes.ExecutePluginCommitDataWithMessages {
+	execReport cciptypes.ExecutePluginReportSingleChain, report plugintypes.ExecutePluginCommitData,
+) plugintypes.ExecutePluginCommitData {
 	// Mark new messages executed.
 	for i := 0; i < len(execReport.Messages); i++ {
 		report.ExecutedMessages =

--- a/execute/report/report.go
+++ b/execute/report/report.go
@@ -217,8 +217,6 @@ func (b *execReportBuilder) buildSingleChainReport(
 			plugintypes.ExecutePluginCommitDataWithMessages{},
 			fmt.Errorf("unable to verify report: %w", err)
 	} else if validReport {
-		b.lggr.Debugw("optimistic full single chain report build is successful",
-			"root", report.MerkleRoot.String())
 		return finalize(finalReport, report, meta)
 	}
 

--- a/execute/report/roots.go
+++ b/execute/report/roots.go
@@ -15,7 +15,7 @@ import (
 func ConstructMerkleTree(
 	ctx context.Context,
 	hasher cciptypes.MessageHasher,
-	report plugintypes.ExecutePluginCommitDataWithMessages,
+	report plugintypes.ExecutePluginCommitData,
 ) (*merklemulti.Tree[[32]byte], error) {
 	// Ensure we have the expected number of messages
 	numMsgs := int(report.SequenceNumberRange.End() - report.SequenceNumberRange.Start() + 1)

--- a/pluginconfig/execute.go
+++ b/pluginconfig/execute.go
@@ -15,14 +15,17 @@ type ExecutePluginConfig struct {
 	// ObserverInfo is a map of oracle IDs to ObserverInfo.
 	ObserverInfo map[commontypes.OracleID]ObserverInfo `json:"observerInfo"`
 
-	// MessageVisibilityInterval is the time interval for which the messages are visible by the plugin.
-	MessageVisibilityInterval time.Duration `json:"messageVisibilityInterval"`
-
 	// SyncTimeout is the timeout for syncing the commit plugin reader.
 	SyncTimeout time.Duration `json:"syncTimeout"`
 
 	// SyncFrequency is the frequency at which the commit plugin reader should sync.
 	SyncFrequency time.Duration `json:"syncFrequency"`
+
+	// MessageVisibilityInterval is the time interval for which the messages are visible by the plugin.
+	MessageVisibilityInterval time.Duration `json:"messageVisibilityInterval"`
+
+	// BatchGasLimit is the maximum sum of user callback gas we permit in one execution report.
+	BatchGasLimit uint32
 }
 
 type ObserverInfo struct {

--- a/pluginconfig/execute.go
+++ b/pluginconfig/execute.go
@@ -23,9 +23,6 @@ type ExecutePluginConfig struct {
 
 	// MessageVisibilityInterval is the time interval for which the messages are visible by the plugin.
 	MessageVisibilityInterval time.Duration `json:"messageVisibilityInterval"`
-
-	// BatchGasLimit is the maximum sum of user callback gas we permit in one execution report.
-	BatchGasLimit uint32
 }
 
 type ObserverInfo struct {

--- a/plugintypes/execute.go
+++ b/plugintypes/execute.go
@@ -12,11 +12,6 @@ import (
 // Execute Observation //
 // ///////////////////////
 
-type ExecutePluginCommitDataWithMessages struct {
-	ExecutePluginCommitData
-	Messages []cciptypes.Message `json:"messages"`
-}
-
 // ExecutePluginCommitData is the data that is committed to the chain.
 type ExecutePluginCommitData struct {
 	// SourceChain of the chain that contains the commit report.
@@ -29,11 +24,19 @@ type ExecutePluginCommitData struct {
 	MerkleRoot cciptypes.Bytes32 `json:"merkleRoot"`
 	// SequenceNumberRange of the messages that are in this commit report.
 	SequenceNumberRange cciptypes.SeqNumRange `json:"sequenceNumberRange"`
+
+	// Messages that are part of the commit report.
+	Messages []cciptypes.Message `json:"messages"`
+
 	// ExecutedMessages are the messages in this report that have already been executed.
-	ExecutedMessages []cciptypes.SeqNum `json:"executed"`
+	ExecutedMessages []cciptypes.SeqNum `json:"executedMessages"`
+
+	// TODO: cache for token data.
+	// TokenData for each message.
+	//TokenData [][][]byte `json:"-"`
 }
 
-type ExecutePluginCommitObservations map[cciptypes.ChainSelector][]ExecutePluginCommitDataWithMessages
+type ExecutePluginCommitObservations map[cciptypes.ChainSelector][]ExecutePluginCommitData
 type ExecutePluginMessageObservations map[cciptypes.ChainSelector]map[cciptypes.SeqNum]cciptypes.Message
 
 // ExecutePluginObservation is the observation of the ExecutePlugin.
@@ -77,14 +80,14 @@ func DecodeExecutePluginObservation(b []byte) (ExecutePluginObservation, error) 
 type ExecutePluginOutcome struct {
 	// PendingCommitReports are the oldest reports with pending commits. The slice is
 	// sorted from oldest to newest.
-	PendingCommitReports []ExecutePluginCommitDataWithMessages `json:"commitReports"`
+	PendingCommitReports []ExecutePluginCommitData `json:"commitReports"`
 
 	// Report is built from the oldest pending commit reports.
 	Report cciptypes.ExecutePluginReport `json:"report"`
 }
 
 func NewExecutePluginOutcome(
-	pendingCommits []ExecutePluginCommitDataWithMessages,
+	pendingCommits []ExecutePluginCommitData,
 	report cciptypes.ExecutePluginReport,
 ) ExecutePluginOutcome {
 	return ExecutePluginOutcome{


### PR DESCRIPTION
Merge `ExecutePluginCommitDataWithMessages` and `ExecutePluginCommitData`. This greatly simplifies many test cases which are harder to read and write because of the nested types with similar names.

No functionality changes in this PR.

Based on #40 