### PR TITLE
Add contract reader wrapper

### DIFF
--- a/pkg/contractreader/extended.go
+++ b/pkg/contractreader/extended.go
@@ -1,0 +1,88 @@
+package contractreader
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/smartcontractkit/chainlink-ccip/internal/libs/slicelib"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+)
+
+// Extended version of a ContractReader.
+type Extended interface {
+	types.ContractReader
+	GetBindings(contractName string) []ExtendedBoundContract
+}
+
+type ExtendedBoundContract struct {
+	BoundAt time.Time
+	Binding types.BoundContract
+}
+
+// extendedContractReader is an extended version of the contract reader.
+type extendedContractReader struct {
+	types.ContractReader
+	contractBindingsByName map[string][]ExtendedBoundContract
+	mu                     *sync.RWMutex
+}
+
+func NewExtendedContractReader(baseContractReader types.ContractReader) Extended {
+	return &extendedContractReader{
+		ContractReader:         baseContractReader,
+		contractBindingsByName: make(map[string][]ExtendedBoundContract),
+		mu:                     &sync.RWMutex{},
+	}
+}
+
+func (e *extendedContractReader) Bind(ctx context.Context, allBindings []types.BoundContract) error {
+	validBindings := slicelib.Filter(allBindings, func(b types.BoundContract) bool { return !e.bindingExists(b) })
+	if len(validBindings) == 0 {
+		return nil
+	}
+
+	err := e.ContractReader.Bind(ctx, validBindings)
+	if err != nil {
+		return fmt.Errorf("bind: %w", err)
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	for _, binding := range validBindings {
+		e.contractBindingsByName[binding.Name] = append(e.contractBindingsByName[binding.Name], ExtendedBoundContract{
+			BoundAt: time.Now(),
+			Binding: binding,
+		})
+	}
+
+	return nil
+}
+
+func (e *extendedContractReader) GetBindings(contractName string) []ExtendedBoundContract {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	bindings, exists := e.contractBindingsByName[contractName]
+	if !exists {
+		return []ExtendedBoundContract{}
+	}
+	return bindings
+}
+
+func (e *extendedContractReader) bindingExists(b types.BoundContract) bool {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	for _, boundContracts := range e.contractBindingsByName {
+		for _, boundContract := range boundContracts {
+			if boundContract.Binding.Key() == b.Key() {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Interface compliance check
+var _ Extended = (*extendedContractReader)(nil)

--- a/pkg/contractreader/extended_test.go
+++ b/pkg/contractreader/extended_test.go
@@ -1,0 +1,47 @@
+package contractreader
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/smartcontractkit/chainlink-ccip/internal/mocks"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+)
+
+func TestExtendedContractReader(t *testing.T) {
+	const contractName = "testContract"
+	cr := mocks.NewContractReaderMock()
+	extCr := NewExtendedContractReader(cr)
+
+	bindings := extCr.GetBindings(contractName)
+	assert.Len(t, bindings, 0)
+
+	cr.On("Bind", context.Background(),
+		[]types.BoundContract{{Name: contractName, Address: "0x123"}}).Return(nil)
+	cr.On("Bind", context.Background(),
+		[]types.BoundContract{{Name: contractName, Address: "0x124"}}).Return(nil)
+	cr.On("Bind", context.Background(),
+		[]types.BoundContract{{Name: contractName, Address: "0x125"}}).Return(fmt.Errorf("some err"))
+
+	err := extCr.Bind(context.Background(), []types.BoundContract{{Name: contractName, Address: "0x123"}})
+	assert.NoError(t, err)
+
+	// ignored since 0x123 already exists
+	err = extCr.Bind(context.Background(), []types.BoundContract{{Name: contractName, Address: "0x123"}})
+	assert.NoError(t, err)
+
+	err = extCr.Bind(context.Background(), []types.BoundContract{{Name: contractName, Address: "0x124"}})
+	assert.NoError(t, err)
+
+	// Bind fails
+	err = extCr.Bind(context.Background(), []types.BoundContract{{Name: contractName, Address: "0x125"}})
+	assert.Error(t, err)
+
+	bindings = extCr.GetBindings(contractName)
+	assert.Len(t, bindings, 2)
+	assert.Equal(t, "0x123", bindings[0].Binding.Address)
+	assert.Equal(t, "0x124", bindings[1].Binding.Address)
+}


### PR DESCRIPTION
We need to keep track of the contract addresses of bound contracts.
That's because of upcoming ContractReader changes that will require providing the contract address on each method.

I am adding an `ExtendedContractReader` that keeps track of this and which we can also extend with more functionality in the future.