### PR TITLE
exec: use checkMessage for isExecuted and preparing token data.

### DIFF
--- a/execute/report/errors.go
+++ b/execute/report/errors.go
@@ -3,3 +3,4 @@ package report
 import "errors"
 
 var ErrEmptyReport = errors.New("no messages can fit in the report")
+var ErrNotReady = errors.New("token data not ready")

--- a/execute/report/report.go
+++ b/execute/report/report.go
@@ -15,13 +15,13 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/plugintypes"
 )
 
-// buildSingleChainReportHelper converts the on-chain event data stored in
-// cciptypes.ExecutePluginCommitDataWithMessages into the final on-chain report format.
+// buildSingleChainReportHelper converts the on-chain event data stored in cciptypes.ExecutePluginCommitData into the
+// final on-chain report format. Messages in the report are selected based on the readyMessages argument. If
+// readyMessages is empty all messages will be included. This allows the caller to create smaller reports if needed.
+//
+// Before calling this function all messages should have been checked and processed by the checkMessage function.
 //
 // The hasher and encoding codec are provided as arguments to allow for chain-specific formats to be used.
-//
-// The readyMessages argument indicates which messages should be included in the report. If readyMessages is empty
-// all messages will be included. This allows the caller to create smaller reports if needed.
 func buildSingleChainReportHelper(
 	ctx context.Context,
 	lggr logger.Logger,

--- a/execute/report/report.go
+++ b/execute/report/report.go
@@ -20,21 +20,21 @@ import (
 //
 // The hasher and encoding codec are provided as arguments to allow for chain-specific formats to be used.
 //
-// The messages argument indicates which messages should be included in the report. If messages is empty
+// The readyMessages argument indicates which messages should be included in the report. If readyMessages is empty
 // all messages will be included. This allows the caller to create smaller reports if needed.
 func buildSingleChainReportHelper(
 	ctx context.Context,
 	lggr logger.Logger,
 	hasher cciptypes.MessageHasher,
 	report plugintypes.ExecutePluginCommitData,
-	messages map[int]struct{},
+	readyMessages map[int]struct{},
 ) (cciptypes.ExecutePluginReportSingleChain, error) {
-	if len(messages) == 0 {
-		if messages == nil {
-			messages = make(map[int]struct{})
+	if len(readyMessages) == 0 {
+		if readyMessages == nil {
+			readyMessages = make(map[int]struct{})
 		}
 		for i := 0; i < len(report.Messages); i++ {
-			messages[i] = struct{}{}
+			readyMessages[i] = struct{}{}
 		}
 	}
 
@@ -75,7 +75,7 @@ func buildSingleChainReportHelper(
 	var offchainTokenData [][][]byte
 	var msgInRoot []cciptypes.Message
 	for i, msg := range report.Messages {
-		if _, ok := messages[i]; ok {
+		if _, ok := readyMessages[i]; ok {
 			offchainTokenData = append(offchainTokenData, report.TokenData[i])
 			toExecute = append(toExecute, i)
 			msgInRoot = append(msgInRoot, msg)

--- a/execute/report/report.go
+++ b/execute/report/report.go
@@ -245,7 +245,7 @@ func (b *execReportBuilder) buildSingleChainReport(
 		return execReport, commitReport, nil
 	}
 
-	// Check which messages are ready to execute
+	// Check which messages are ready to execute, and update report with any additional metadata needed for execution.
 	readyMessages := make(map[int]struct{})
 	for i := 0; i < len(report.Messages); i++ {
 		updatedReport, status, err := b.checkMessage(ctx, i, report)

--- a/execute/report/report.go
+++ b/execute/report/report.go
@@ -120,7 +120,7 @@ type messageStatus string
 const (
 	ReadyToExecute      messageStatus = "ready_to_execute"
 	AlreadyExecuted     messageStatus = "already_executed"
-	TokenDataNotReady   messageStatus = "token_data_not_ready"
+	TokenDataNotReady   messageStatus = "token_data_not_ready" //nolint:gosec // this is not a password
 	TokenDataFetchError messageStatus = "token_data_fetch_error"
 	/*
 		SenderAlreadySkipped                 messageStatus = "sender_already_skipped"

--- a/execute/report/report.go
+++ b/execute/report/report.go
@@ -178,6 +178,7 @@ func (b *execReportBuilder) checkMessage(
 				"sourceChain", execReport.SourceChain,
 				"seqNum", msg.Header.SequenceNumber,
 				"error", err)
+			return execReport, TokenDataFetchError, nil
 		}
 
 		// pad token data if needed

--- a/execute/report/report_test.go
+++ b/execute/report/report_test.go
@@ -290,10 +290,20 @@ func Test_buildSingleChainReport_Errors(t *testing.T) {
 		wantErr string
 	}{
 		{
+			name:    "token data mismatch",
+			wantErr: "token data length mismatch: got 2, expected 0",
+			args: args{
+				report: plugintypes.ExecutePluginCommitData{
+					TokenData: make([][][]byte, 2),
+				},
+			},
+		},
+		{
 			name:    "wrong number of messages",
 			wantErr: "unexpected number of messages: expected 1, got 2",
 			args: args{
 				report: plugintypes.ExecutePluginCommitData{
+					TokenData:           make([][][]byte, 2),
 					SequenceNumberRange: cciptypes.NewSeqNumRange(cciptypes.SeqNum(100), cciptypes.SeqNum(100)),
 					Messages: []cciptypes.Message{
 						{Header: cciptypes.RampMessageHeader{}},
@@ -307,6 +317,7 @@ func Test_buildSingleChainReport_Errors(t *testing.T) {
 			wantErr: "sequence number 102 outside of report range [100 -> 101]",
 			args: args{
 				report: plugintypes.ExecutePluginCommitData{
+					TokenData:           make([][][]byte, 2),
 					SequenceNumberRange: cciptypes.NewSeqNumRange(cciptypes.SeqNum(100), cciptypes.SeqNum(101)),
 					Messages: []cciptypes.Message{
 						{
@@ -328,13 +339,16 @@ func Test_buildSingleChainReport_Errors(t *testing.T) {
 			wantErr: "unexpected source chain: expected 1111, got 2222",
 			args: args{
 				report: plugintypes.ExecutePluginCommitData{
+					TokenData:           make([][][]byte, 1),
 					SourceChain:         1111,
 					SequenceNumberRange: cciptypes.NewSeqNumRange(cciptypes.SeqNum(100), cciptypes.SeqNum(100)),
 					Messages: []cciptypes.Message{
-						{Header: cciptypes.RampMessageHeader{
-							SourceChainSelector: 2222,
-							SequenceNumber:      cciptypes.SeqNum(100),
-						}},
+						{
+							Header: cciptypes.RampMessageHeader{
+								SourceChainSelector: 2222,
+								SequenceNumber:      cciptypes.SeqNum(100),
+							},
+						},
 					},
 				},
 				hasher: badHasher{},
@@ -345,13 +359,16 @@ func Test_buildSingleChainReport_Errors(t *testing.T) {
 			wantErr: "unable to hash message (1234567, 100): bad hasher",
 			args: args{
 				report: plugintypes.ExecutePluginCommitData{
+					TokenData:           make([][][]byte, 1),
 					SourceChain:         1234567,
 					SequenceNumberRange: cciptypes.NewSeqNumRange(cciptypes.SeqNum(100), cciptypes.SeqNum(100)),
 					Messages: []cciptypes.Message{
-						{Header: cciptypes.RampMessageHeader{
-							SourceChainSelector: 1234567,
-							SequenceNumber:      cciptypes.SeqNum(100),
-						}},
+						{
+							Header: cciptypes.RampMessageHeader{
+								SourceChainSelector: 1234567,
+								SequenceNumber:      cciptypes.SeqNum(100),
+							},
+						},
 					},
 				},
 				hasher: badHasher{},
@@ -362,13 +379,16 @@ func Test_buildSingleChainReport_Errors(t *testing.T) {
 			wantErr: "unable to read token data for message 100: bad token data reader",
 			args: args{
 				report: plugintypes.ExecutePluginCommitData{
+					TokenData:           make([][][]byte, 1),
 					SourceChain:         1234567,
 					SequenceNumberRange: cciptypes.NewSeqNumRange(cciptypes.SeqNum(100), cciptypes.SeqNum(100)),
 					Messages: []cciptypes.Message{
-						{Header: cciptypes.RampMessageHeader{
-							SourceChainSelector: 1234567,
-							SequenceNumber:      cciptypes.SeqNum(100),
-						}},
+						{
+							Header: cciptypes.RampMessageHeader{
+								SourceChainSelector: 1234567,
+								SequenceNumber:      cciptypes.SeqNum(100),
+							},
+						},
 					},
 				},
 				tokenDataReader: badTokenDataReader{},

--- a/execute/report/report_test.go
+++ b/execute/report/report_test.go
@@ -252,9 +252,8 @@ func Test_buildSingleChainReport_Errors(t *testing.T) {
 	lggr := logger.Test(t)
 
 	type args struct {
-		report          plugintypes.ExecutePluginCommitData
-		hasher          cciptypes.MessageHasher
-		tokenDataReader types.TokenDataReader
+		report plugintypes.ExecutePluginCommitData
+		hasher cciptypes.MessageHasher
 	}
 	tests := []struct {
 		name    string
@@ -659,11 +658,8 @@ func (bc badCodec) Decode(ctx context.Context, bytes []byte) (cciptypes.ExecuteP
 func Test_execReportBuilder_verifyReport(t *testing.T) {
 	type fields struct {
 		encoder            cciptypes.ExecutePluginCodec
-		hasher             cciptypes.MessageHasher
 		maxReportSizeBytes uint64
-		maxGas             uint64
 		accumulated        validationMetadata
-		execReports        []cciptypes.ExecutePluginReportSingleChain
 	}
 	type args struct {
 		execReport cciptypes.ExecutePluginReportSingleChain
@@ -837,7 +833,6 @@ func (t tdr) ReadTokenData(
 
 func Test_execReportBuilder_checkMessage(t *testing.T) {
 	type fields struct {
-		lggr            logger.Logger
 		tokenDataReader types.TokenDataReader
 	}
 	type args struct {

--- a/execute/report/report_test.go
+++ b/execute/report/report_test.go
@@ -672,3 +672,72 @@ func Test_Builder_Build(t *testing.T) {
 		})
 	}
 }
+
+func Test_execReportBuilder_verifyReport(t *testing.T) {
+	type fields struct {
+		//ctx                context.Context
+		//lggr               logger.Logger
+		//tokenDataReader    types.TokenDataReader
+		encoder            cciptypes.ExecutePluginCodec
+		hasher             cciptypes.MessageHasher
+		maxReportSizeBytes uint64
+		maxGas             uint64
+		accumulated        validationMetadata
+		execReports        []cciptypes.ExecutePluginReportSingleChain
+	}
+	type args struct {
+		execReport cciptypes.ExecutePluginReportSingleChain
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    bool
+		want1   validationMetadata
+		wantErr assert.ErrorAssertionFunc
+	}{
+		// TODO: Add test cases.
+		{
+			name: "simple",
+			args: args{
+				execReport: cciptypes.ExecutePluginReportSingleChain{},
+			},
+			fields: fields{},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		lggr := logger.Test(t)
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Select token data reader mock.
+			var resolvedEncoder cciptypes.ExecutePluginCodec
+			if tt.fields.encoder != nil {
+				resolvedEncoder = tt.fields.encoder
+			} else {
+				resolvedEncoder = mocks.NewExecutePluginJSONReportCodec()
+			}
+
+			b := &execReportBuilder{
+				ctx:  context.Background(),
+				lggr: lggr,
+				//ctx:                tt.fields.ctx,
+				//lggr:               tt.fields.lggr,
+				//tokenDataReader:    tt.fields.tokenDataReader,
+				encoder: resolvedEncoder,
+				//hasher:             tt.fields.hasher,
+				maxReportSizeBytes: tt.fields.maxReportSizeBytes,
+				//maxGas:             tt.fields.maxGas,
+				accumulated: tt.fields.accumulated,
+				//execReports:        tt.fields.execReports,
+			}
+			got, got1, err := b.verifyReport(tt.args.ctx, tt.args.execReport)
+			if !tt.wantErr(t, err, fmt.Sprintf("verifyReport(%v, %v)", tt.args.ctx, tt.args.execReport)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "verifyReport(%v, %v)", tt.args.ctx, tt.args.execReport)
+			assert.Equalf(t, tt.want1, got1, "verifyReport(%v, %v)", tt.args.ctx, tt.args.execReport)
+		})
+	}
+}

--- a/execute/report/report_test.go
+++ b/execute/report/report_test.go
@@ -827,7 +827,7 @@ func (t tdr) ReadTokenData(
 	case notReady:
 		return nil, ErrNotReady
 	default:
-		panic("mode should be 1, 2 or 3")
+		panic("mode should be one of the valid ones.")
 	}
 }
 
@@ -918,7 +918,53 @@ func Test_execReportBuilder_checkMessage(t *testing.T) {
 				Messages: []cciptypes.Message{
 					makeMessage(1, 100, 0),
 				},
-				TokenData: [][][]byte{{{0x01, 0x02, 0x03}}},
+				TokenData: [][][]byte{
+					{{0x01, 0x02, 0x03}},
+				},
+			},
+		},
+		{
+			name: "good - no token data - 1 msg",
+			args: args{
+				idx: 0,
+				execReport: plugintypes.ExecutePluginCommitData{
+					Messages: []cciptypes.Message{
+						makeMessage(1, 100, 0),
+					},
+				},
+			},
+			fields: fields{
+				tokenDataReader: tdr{mode: noop},
+			},
+			expectedStatus: ReadyToExecute,
+			expectedData: plugintypes.ExecutePluginCommitData{
+				Messages: []cciptypes.Message{
+					makeMessage(1, 100, 0),
+				},
+				TokenData: [][][]byte{nil},
+			},
+		},
+		{
+			name: "good - no token data - 2nd msg pads slice",
+			args: args{
+				idx: 1,
+				execReport: plugintypes.ExecutePluginCommitData{
+					Messages: []cciptypes.Message{
+						makeMessage(1, 100, 0),
+						makeMessage(1, 101, 0),
+					},
+				},
+			},
+			fields: fields{
+				tokenDataReader: tdr{mode: noop},
+			},
+			expectedStatus: ReadyToExecute,
+			expectedData: plugintypes.ExecutePluginCommitData{
+				Messages: []cciptypes.Message{
+					makeMessage(1, 100, 0),
+					makeMessage(1, 101, 0),
+				},
+				TokenData: [][][]byte{nil, nil},
 			},
 		},
 	}

--- a/execute/report/report_test.go
+++ b/execute/report/report_test.go
@@ -364,9 +364,16 @@ func Test_buildSingleChainReport_Errors(t *testing.T) {
 			for i := 0; i < len(tt.args.report.Messages); i++ {
 				msgs[i] = struct{}{}
 			}
-			_, err := buildSingleChainReportHelper(ctx, lggr, resolvedHasher, tt.args.report, msgs)
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tt.wantErr)
+
+			test := func(readyMessages map[int]struct{}) {
+				_, err := buildSingleChainReportHelper(ctx, lggr, resolvedHasher, tt.args.report, readyMessages)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+
+			// Test with pre-built and all messages.
+			test(msgs)
+			test(nil)
 		})
 	}
 }

--- a/execute/report/report_test.go
+++ b/execute/report/report_test.go
@@ -651,7 +651,6 @@ func Test_Builder_Build(t *testing.T) {
 	}
 }
 
-// TODO: Use this to test the verifyReport function.
 type badCodec struct{}
 
 func (bc badCodec) Encode(ctx context.Context, report cciptypes.ExecutePluginReport) ([]byte, error) {
@@ -807,7 +806,6 @@ func Test_execReportBuilder_verifyReport(t *testing.T) {
 	}
 }
 
-// TODO: better than this
 type tdr struct {
 	mode tokenDataMode
 }

--- a/execute/report/report_test.go
+++ b/execute/report/report_test.go
@@ -374,26 +374,6 @@ func Test_buildSingleChainReport_Errors(t *testing.T) {
 				hasher: badHasher{},
 			},
 		},
-		{
-			name:    "bad token data reader",
-			wantErr: "unable to read token data for message 100: bad token data reader",
-			args: args{
-				report: plugintypes.ExecutePluginCommitData{
-					TokenData:           make([][][]byte, 1),
-					SourceChain:         1234567,
-					SequenceNumberRange: cciptypes.NewSeqNumRange(cciptypes.SeqNum(100), cciptypes.SeqNum(100)),
-					Messages: []cciptypes.Message{
-						{
-							Header: cciptypes.RampMessageHeader{
-								SourceChainSelector: 1234567,
-								SequenceNumber:      cciptypes.SeqNum(100),
-							},
-						},
-					},
-				},
-				tokenDataReader: badTokenDataReader{},
-			},
-		},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -408,21 +388,12 @@ func Test_buildSingleChainReport_Errors(t *testing.T) {
 				resolvedHasher = mocks.NewMessageHasher()
 			}
 
-			// Select token data reader mock.
-			var resolvedTokenDataReader types.TokenDataReader
-			if tt.args.tokenDataReader != nil {
-				resolvedTokenDataReader = tt.args.tokenDataReader
-			} else {
-				resolvedTokenDataReader = tdr{}
-			}
-
 			ctx := context.Background()
 			msgs := make(map[int]struct{})
 			for i := 0; i < len(tt.args.report.Messages); i++ {
 				msgs[i] = struct{}{}
 			}
-			_, err := buildSingleChainReportHelper(
-				ctx, lggr, resolvedHasher, resolvedTokenDataReader, tt.args.report, msgs)
+			_, err := buildSingleChainReportHelper(ctx, lggr, resolvedHasher, tt.args.report, msgs)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
 		})

--- a/execute/report/report_test.go
+++ b/execute/report/report_test.go
@@ -375,7 +375,7 @@ func Test_Builder_Build(t *testing.T) {
 	hasher := mocks.NewMessageHasher()
 	codec := mocks.NewExecutePluginJSONReportCodec()
 	lggr := logger.Test(t)
-	var tokenDataReader tdr
+	tokenDataReader := tdr{mode: good}
 
 	type args struct {
 		reports       []plugintypes.ExecutePluginCommitData

--- a/plugintypes/execute.go
+++ b/plugintypes/execute.go
@@ -31,9 +31,8 @@ type ExecutePluginCommitData struct {
 	// ExecutedMessages are the messages in this report that have already been executed.
 	ExecutedMessages []cciptypes.SeqNum `json:"executedMessages"`
 
-	// TODO: cache for token data.
 	// TokenData for each message.
-	// TokenData [][][]byte `json:"-"`
+	TokenData [][][]byte `json:"-"`
 }
 
 type ExecutePluginCommitObservations map[cciptypes.ChainSelector][]ExecutePluginCommitData


### PR DESCRIPTION
Move logic for checking if a message is executed and preparing token data into the new checkMessage function.

Add tests for checkMessage and verifyReport.