### PR TITLE
internal/reader: add bound contract ctor parameter

### DIFF
--- a/commit/plugin_e2e_test.go
+++ b/commit/plugin_e2e_test.go
@@ -16,6 +16,7 @@ import (
 	libocrtypes "github.com/smartcontractkit/libocr/ragep2p/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	"github.com/smartcontractkit/chainlink-ccip/chainconfig"
@@ -423,6 +424,10 @@ func setupHomeChainPoller(lggr logger.Logger, chainConfigInfos []reader.ChainCon
 		// to prevent linting error because of logging after finishing tests, we close the poller after each test, having
 		// lower polling interval make it catch up faster
 		10*time.Millisecond,
+		types.BoundContract{
+			Address: "0xCCIPConfigFakeAddress",
+			Name:    consts.ContractNameCCIPConfig,
+		},
 	)
 
 	return homeChain

--- a/execute/plugin_e2e_test.go
+++ b/execute/plugin_e2e_test.go
@@ -14,6 +14,7 @@ import (
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	"github.com/smartcontractkit/chainlink-ccip/chainconfig"
@@ -102,6 +103,10 @@ func setupHomeChainPoller(lggr logger.Logger, chainConfigInfos []reader.ChainCon
 		// to prevent linting error because of logging after finishing tests, we close the poller after each test, having
 		// lower polling interval make it catch up faster
 		time.Minute,
+		types.BoundContract{
+			Address: "0xCCIPConfigFakeAddress",
+			Name:    consts.ContractNameCCIPConfig,
+		},
 	)
 
 	return homeChain

--- a/internal/plugincommon/ccipreader_test.go
+++ b/internal/plugincommon/ccipreader_test.go
@@ -52,7 +52,7 @@ func TestBackgroundReaderSyncer(t *testing.T) {
 		assert.NoError(t, err, "start success")
 		assert.Eventually(t, func() bool {
 			return mockReader.AssertExpectations(t)
-		}, time.Second, 10*time.Millisecond)
+		}, 3*time.Second, 10*time.Millisecond)
 		err = readerSyncer.Close()
 		assert.NoError(t, err, "closing a started syncer")
 	})

--- a/internal/reader/home_chain.go
+++ b/internal/reader/home_chain.go
@@ -54,6 +54,10 @@ type homeChainPoller struct {
 	mutex           *sync.RWMutex
 	state           state
 	failedPolls     uint
+	// TODO: currently unused but will be passed into GetLatestValue
+	// once the chainlink-common breaking change comes in
+	// (https://github.com/smartcontractkit/chainlink-common/pull/603).
+	ccipConfigBoundContract types.BoundContract
 	// How frequently the poller fetches the chain configs
 	pollingDuration time.Duration
 }
@@ -64,15 +68,17 @@ func NewHomeChainConfigPoller(
 	homeChainReader types.ContractReader,
 	lggr logger.Logger,
 	pollingInterval time.Duration,
+	ccipConfigBoundContract types.BoundContract,
 ) HomeChain {
 	return &homeChainPoller{
-		stopCh:          make(chan struct{}),
-		homeChainReader: homeChainReader,
-		state:           state{},
-		mutex:           &sync.RWMutex{},
-		failedPolls:     0,
-		lggr:            lggr,
-		pollingDuration: pollingInterval,
+		stopCh:                  make(chan struct{}),
+		homeChainReader:         homeChainReader,
+		state:                   state{},
+		mutex:                   &sync.RWMutex{},
+		failedPolls:             0,
+		lggr:                    lggr,
+		pollingDuration:         pollingInterval,
+		ccipConfigBoundContract: ccipConfigBoundContract,
 	}
 }
 

--- a/internal/reader/home_chain_test.go
+++ b/internal/reader/home_chain_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/smartcontractkit/libocr/commontypes"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	"github.com/stretchr/testify/mock"
@@ -53,6 +54,10 @@ func TestHomeChainConfigPoller_HealthReport(t *testing.T) {
 		homeChainReader,
 		logger.Test(t),
 		tickTime,
+		types.BoundContract{
+			Address: "0xCCIPConfigFakeAddress",
+			Name:    consts.ContractNameCCIPConfig,
+		},
 	)
 	require.NoError(t, configPoller.Start(context.Background()))
 	// Initially it's healthy
@@ -151,6 +156,10 @@ func Test_PollingWorking(t *testing.T) {
 		homeChainReader,
 		logger.Test(t),
 		tickTime,
+		types.BoundContract{
+			Address: "0xCCIPConfigFakeAddress",
+			Name:    consts.ContractNameCCIPConfig,
+		},
 	)
 
 	require.NoError(t, configPoller.Start(context.Background()))
@@ -206,6 +215,10 @@ func Test_HomeChainPoller_GetOCRConfig(t *testing.T) {
 		homeChainReader,
 		logger.Test(t),
 		10*time.Millisecond,
+		types.BoundContract{
+			Address: "0xCCIPConfigFakeAddress",
+			Name:    consts.ContractNameCCIPConfig,
+		},
 	)
 
 	configs, err := configPoller.GetOCRConfigs(context.Background(), donID, pluginType)

--- a/pkg/reader/home_chain.go
+++ b/pkg/reader/home_chain.go
@@ -23,6 +23,7 @@ func NewHomeChainReader(
 	homeChainReader types.ContractReader,
 	lggr logger.Logger,
 	pollingInterval time.Duration,
+	ccipConfigBoundContract types.BoundContract,
 ) HomeChain {
-	return reader_internal.NewHomeChainConfigPoller(homeChainReader, lggr, pollingInterval)
+	return reader_internal.NewHomeChainConfigPoller(homeChainReader, lggr, pollingInterval, ccipConfigBoundContract)
 }


### PR DESCRIPTION
Add a bound contract ctor parameter to the home chain reader constructor to facilitate passing it into the contract reader GetLatestValue calls.

Related PR: https://github.com/smartcontractkit/chainlink-common/pull/603

CCIP PR with integration test fix: https://github.com/smartcontractkit/ccip/pull/1291