### PR TITLE
remove 1.21 from matrix

### DIFF
--- a/.github/workflows/ccip-ocr3-build-lint-test.yml
+++ b/.github/workflows/ccip-ocr3-build-lint-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        go-version: ['1.21', '1.22']
+        go-version: ['1.22']
     defaults:
       run:
         working-directory: .


### PR DESCRIPTION
### What

Remove 1.21 from the CI matrix

### Why

The Go version in the go.mod is 1.22
