### PR TITLE
internal/reader: add GetExpectedNextSequenceNumber method

### DIFF
--- a/internal/mocks/inmem/ccipreader_inmem.go
+++ b/internal/mocks/inmem/ccipreader_inmem.go
@@ -31,7 +31,7 @@ type InMemoryCCIPReader struct {
 // GetExpectedNextSequenceNumber implements reader.CCIP.
 func (r InMemoryCCIPReader) GetExpectedNextSequenceNumber(
 	ctx context.Context,
-	chain cciptypes.ChainSelector) (cciptypes.SeqNum, error) {
+	sourceChainSelector, destChainSelector cciptypes.ChainSelector) (cciptypes.SeqNum, error) {
 	panic("unimplemented")
 }
 

--- a/internal/mocks/inmem/ccipreader_inmem.go
+++ b/internal/mocks/inmem/ccipreader_inmem.go
@@ -28,6 +28,13 @@ type InMemoryCCIPReader struct {
 	Dest cciptypes.ChainSelector
 }
 
+// GetExpectedNextSequenceNumber implements reader.CCIP.
+func (r InMemoryCCIPReader) GetExpectedNextSequenceNumber(
+	ctx context.Context,
+	chain cciptypes.ChainSelector) (cciptypes.SeqNum, error) {
+	panic("unimplemented")
+}
+
 func (r InMemoryCCIPReader) CommitReportsGTETimestamp(
 	_ context.Context, _ cciptypes.ChainSelector, ts time.Time, limit int,
 ) ([]plugintypes.CommitPluginReportWithMeta, error) {

--- a/internal/reader/ccip.go
+++ b/internal/reader/ccip.go
@@ -57,7 +57,7 @@ type CCIP interface {
 	// in the onramp.
 	GetExpectedNextSequenceNumber(
 		ctx context.Context,
-		sourceChainSelector cciptypes.ChainSelector,
+		sourceChainSelector, destChainSelector cciptypes.ChainSelector,
 	) (cciptypes.SeqNum, error)
 
 	// NextSeqNum reads the destination chain.
@@ -397,7 +397,11 @@ func (r *CCIPChainReader) MsgsBetweenSeqNums(
 // GetExpectedNextSequenceNumber implements CCIP.
 func (r *CCIPChainReader) GetExpectedNextSequenceNumber(
 	ctx context.Context,
-	sourceChainSelector cciptypes.ChainSelector) (cciptypes.SeqNum, error) {
+	sourceChainSelector, destChainSelector cciptypes.ChainSelector) (cciptypes.SeqNum, error) {
+	if destChainSelector != r.destChain {
+		return 0, fmt.Errorf("expected destination chain %d, got %d", r.destChain, destChainSelector)
+	}
+
 	if err := r.validateReaderExistence(sourceChainSelector); err != nil {
 		return 0, err
 	}
@@ -414,7 +418,7 @@ func (r *CCIPChainReader) GetExpectedNextSequenceNumber(
 		consts.MethodNameGetExpectedNextSequenceNumber,
 		primitives.Unconfirmed,
 		map[string]any{
-			"destChainSelector": r.destChain,
+			"destChainSelector": destChainSelector,
 		},
 		&expectedNextSequenceNumber,
 	)

--- a/internal/reader/ccip.go
+++ b/internal/reader/ccip.go
@@ -53,6 +53,13 @@ type CCIP interface {
 		seqNumRange cciptypes.SeqNumRange,
 	) ([]cciptypes.Message, error)
 
+	// GetExpectedNextSequenceNumber returns the next sequence number to be used
+	// in the onramp.
+	GetExpectedNextSequenceNumber(
+		ctx context.Context,
+		sourceChainSelector cciptypes.ChainSelector,
+	) (cciptypes.SeqNum, error)
+
 	// NextSeqNum reads the destination chain.
 	// Returns the next expected sequence number for each one of the provided chains.
 	// TODO: if destination was a parameter, this could be a capability reused across plugin instances.
@@ -385,6 +392,37 @@ func (r *CCIPChainReader) MsgsBetweenSeqNums(
 		"seqNumRange", seqNumRange.String())
 
 	return msgs, nil
+}
+
+// GetExpectedNextSequenceNumber implements CCIP.
+func (r *CCIPChainReader) GetExpectedNextSequenceNumber(
+	ctx context.Context,
+	sourceChainSelector cciptypes.ChainSelector) (cciptypes.SeqNum, error) {
+	if err := r.validateReaderExistence(sourceChainSelector); err != nil {
+		return 0, err
+	}
+
+	bindings := r.contractReaders[sourceChainSelector].GetBindings(consts.ContractNameOnRamp)
+	if len(bindings) != 1 {
+		return 0, fmt.Errorf("expected one binding for onRamp contract, got %d", len(bindings))
+	}
+
+	var expectedNextSequenceNumber uint64
+	err := r.contractReaders[sourceChainSelector].GetLatestValue(
+		ctx,
+		consts.ContractNameOnRamp,
+		consts.MethodNameGetExpectedNextSequenceNumber,
+		primitives.Unconfirmed,
+		map[string]any{
+			"destChainSelector": r.destChain,
+		},
+		&expectedNextSequenceNumber,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get expected next sequence number from onramp: %w", err)
+	}
+
+	return cciptypes.SeqNum(expectedNextSequenceNumber), nil
 }
 
 func (r *CCIPChainReader) NextSeqNum(

--- a/internal/reader/home_chain_test.go
+++ b/internal/reader/home_chain_test.go
@@ -149,7 +149,7 @@ func Test_PollingWorking(t *testing.T) {
 
 	var (
 		tickTime       = 2 * time.Millisecond
-		totalSleepTime = tickTime * 4
+		totalSleepTime = tickTime * 20
 	)
 
 	configPoller := NewHomeChainConfigPoller(

--- a/internal/reader/onchain_prices_reader.go
+++ b/internal/reader/onchain_prices_reader.go
@@ -8,7 +8,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
 
-	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	ocr2types "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	commontyps "github.com/smartcontractkit/chainlink-common/pkg/types"
@@ -26,14 +25,14 @@ type TokenPrices interface {
 type OnchainTokenPricesReader struct {
 	// Reader for the chain that will have the token prices on-chain
 	ContractReader commontyps.ContractReader
-	PriceSources   map[types.Account]pluginconfig.ArbitrumPriceSource
-	TokenDecimals  map[types.Account]uint8
+	PriceSources   map[ocr2types.Account]pluginconfig.ArbitrumPriceSource
+	TokenDecimals  map[ocr2types.Account]uint8
 }
 
 func NewOnchainTokenPricesReader(
 	contractReader commontyps.ContractReader,
-	priceSources map[types.Account]pluginconfig.ArbitrumPriceSource,
-	tokenDecimals map[types.Account]uint8,
+	priceSources map[ocr2types.Account]pluginconfig.ArbitrumPriceSource,
+	tokenDecimals map[ocr2types.Account]uint8,
 ) *OnchainTokenPricesReader {
 	return &OnchainTokenPricesReader{
 		ContractReader: contractReader,
@@ -96,7 +95,7 @@ func (pr *OnchainTokenPricesReader) GetTokenPricesUSD(
 	return prices, nil
 }
 
-func (pr *OnchainTokenPricesReader) getFeedDecimals(ctx context.Context, token types.Account) (uint8, error) {
+func (pr *OnchainTokenPricesReader) getFeedDecimals(ctx context.Context, token ocr2types.Account) (uint8, error) {
 	var decimals uint8
 	if err :=
 		pr.ContractReader.GetLatestValue(
@@ -116,7 +115,7 @@ func (pr *OnchainTokenPricesReader) getFeedDecimals(ctx context.Context, token t
 
 func (pr *OnchainTokenPricesReader) getRawTokenPriceE18Normalized(
 	ctx context.Context,
-	token types.Account,
+	token ocr2types.Account,
 ) (*big.Int, error) {
 	var latestRoundData LatestRoundData
 	if err :=

--- a/mocks/internal_/reader/ccip.go
+++ b/mocks/internal_/reader/ccip.go
@@ -254,6 +254,63 @@ func (_c *MockCCIP_GasPrices_Call) RunAndReturn(run func(context.Context, []ccip
 	return _c
 }
 
+// GetExpectedNextSequenceNumber provides a mock function with given fields: ctx, sourceChainSelector
+func (_m *MockCCIP) GetExpectedNextSequenceNumber(ctx context.Context, sourceChainSelector ccipocr3.ChainSelector) (ccipocr3.SeqNum, error) {
+	ret := _m.Called(ctx, sourceChainSelector)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetExpectedNextSequenceNumber")
+	}
+
+	var r0 ccipocr3.SeqNum
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, ccipocr3.ChainSelector) (ccipocr3.SeqNum, error)); ok {
+		return rf(ctx, sourceChainSelector)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, ccipocr3.ChainSelector) ccipocr3.SeqNum); ok {
+		r0 = rf(ctx, sourceChainSelector)
+	} else {
+		r0 = ret.Get(0).(ccipocr3.SeqNum)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, ccipocr3.ChainSelector) error); ok {
+		r1 = rf(ctx, sourceChainSelector)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockCCIP_GetExpectedNextSequenceNumber_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetExpectedNextSequenceNumber'
+type MockCCIP_GetExpectedNextSequenceNumber_Call struct {
+	*mock.Call
+}
+
+// GetExpectedNextSequenceNumber is a helper method to define mock.On call
+//   - ctx context.Context
+//   - sourceChainSelector ccipocr3.ChainSelector
+func (_e *MockCCIP_Expecter) GetExpectedNextSequenceNumber(ctx interface{}, sourceChainSelector interface{}) *MockCCIP_GetExpectedNextSequenceNumber_Call {
+	return &MockCCIP_GetExpectedNextSequenceNumber_Call{Call: _e.mock.On("GetExpectedNextSequenceNumber", ctx, sourceChainSelector)}
+}
+
+func (_c *MockCCIP_GetExpectedNextSequenceNumber_Call) Run(run func(ctx context.Context, sourceChainSelector ccipocr3.ChainSelector)) *MockCCIP_GetExpectedNextSequenceNumber_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(ccipocr3.ChainSelector))
+	})
+	return _c
+}
+
+func (_c *MockCCIP_GetExpectedNextSequenceNumber_Call) Return(_a0 ccipocr3.SeqNum, _a1 error) *MockCCIP_GetExpectedNextSequenceNumber_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockCCIP_GetExpectedNextSequenceNumber_Call) RunAndReturn(run func(context.Context, ccipocr3.ChainSelector) (ccipocr3.SeqNum, error)) *MockCCIP_GetExpectedNextSequenceNumber_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MsgsBetweenSeqNums provides a mock function with given fields: ctx, chain, seqNumRange
 func (_m *MockCCIP) MsgsBetweenSeqNums(ctx context.Context, chain ccipocr3.ChainSelector, seqNumRange ccipocr3.SeqNumRange) ([]ccipocr3.Message, error) {
 	ret := _m.Called(ctx, chain, seqNumRange)

--- a/mocks/internal_/reader/ccip.go
+++ b/mocks/internal_/reader/ccip.go
@@ -254,9 +254,9 @@ func (_c *MockCCIP_GasPrices_Call) RunAndReturn(run func(context.Context, []ccip
 	return _c
 }
 
-// GetExpectedNextSequenceNumber provides a mock function with given fields: ctx, sourceChainSelector
-func (_m *MockCCIP) GetExpectedNextSequenceNumber(ctx context.Context, sourceChainSelector ccipocr3.ChainSelector) (ccipocr3.SeqNum, error) {
-	ret := _m.Called(ctx, sourceChainSelector)
+// GetExpectedNextSequenceNumber provides a mock function with given fields: ctx, sourceChainSelector, destChainSelector
+func (_m *MockCCIP) GetExpectedNextSequenceNumber(ctx context.Context, sourceChainSelector ccipocr3.ChainSelector, destChainSelector ccipocr3.ChainSelector) (ccipocr3.SeqNum, error) {
+	ret := _m.Called(ctx, sourceChainSelector, destChainSelector)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetExpectedNextSequenceNumber")
@@ -264,17 +264,17 @@ func (_m *MockCCIP) GetExpectedNextSequenceNumber(ctx context.Context, sourceCha
 
 	var r0 ccipocr3.SeqNum
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, ccipocr3.ChainSelector) (ccipocr3.SeqNum, error)); ok {
-		return rf(ctx, sourceChainSelector)
+	if rf, ok := ret.Get(0).(func(context.Context, ccipocr3.ChainSelector, ccipocr3.ChainSelector) (ccipocr3.SeqNum, error)); ok {
+		return rf(ctx, sourceChainSelector, destChainSelector)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, ccipocr3.ChainSelector) ccipocr3.SeqNum); ok {
-		r0 = rf(ctx, sourceChainSelector)
+	if rf, ok := ret.Get(0).(func(context.Context, ccipocr3.ChainSelector, ccipocr3.ChainSelector) ccipocr3.SeqNum); ok {
+		r0 = rf(ctx, sourceChainSelector, destChainSelector)
 	} else {
 		r0 = ret.Get(0).(ccipocr3.SeqNum)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, ccipocr3.ChainSelector) error); ok {
-		r1 = rf(ctx, sourceChainSelector)
+	if rf, ok := ret.Get(1).(func(context.Context, ccipocr3.ChainSelector, ccipocr3.ChainSelector) error); ok {
+		r1 = rf(ctx, sourceChainSelector, destChainSelector)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -290,13 +290,14 @@ type MockCCIP_GetExpectedNextSequenceNumber_Call struct {
 // GetExpectedNextSequenceNumber is a helper method to define mock.On call
 //   - ctx context.Context
 //   - sourceChainSelector ccipocr3.ChainSelector
-func (_e *MockCCIP_Expecter) GetExpectedNextSequenceNumber(ctx interface{}, sourceChainSelector interface{}) *MockCCIP_GetExpectedNextSequenceNumber_Call {
-	return &MockCCIP_GetExpectedNextSequenceNumber_Call{Call: _e.mock.On("GetExpectedNextSequenceNumber", ctx, sourceChainSelector)}
+//   - destChainSelector ccipocr3.ChainSelector
+func (_e *MockCCIP_Expecter) GetExpectedNextSequenceNumber(ctx interface{}, sourceChainSelector interface{}, destChainSelector interface{}) *MockCCIP_GetExpectedNextSequenceNumber_Call {
+	return &MockCCIP_GetExpectedNextSequenceNumber_Call{Call: _e.mock.On("GetExpectedNextSequenceNumber", ctx, sourceChainSelector, destChainSelector)}
 }
 
-func (_c *MockCCIP_GetExpectedNextSequenceNumber_Call) Run(run func(ctx context.Context, sourceChainSelector ccipocr3.ChainSelector)) *MockCCIP_GetExpectedNextSequenceNumber_Call {
+func (_c *MockCCIP_GetExpectedNextSequenceNumber_Call) Run(run func(ctx context.Context, sourceChainSelector ccipocr3.ChainSelector, destChainSelector ccipocr3.ChainSelector)) *MockCCIP_GetExpectedNextSequenceNumber_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(ccipocr3.ChainSelector))
+		run(args[0].(context.Context), args[1].(ccipocr3.ChainSelector), args[2].(ccipocr3.ChainSelector))
 	})
 	return _c
 }
@@ -306,7 +307,7 @@ func (_c *MockCCIP_GetExpectedNextSequenceNumber_Call) Return(_a0 ccipocr3.SeqNu
 	return _c
 }
 
-func (_c *MockCCIP_GetExpectedNextSequenceNumber_Call) RunAndReturn(run func(context.Context, ccipocr3.ChainSelector) (ccipocr3.SeqNum, error)) *MockCCIP_GetExpectedNextSequenceNumber_Call {
+func (_c *MockCCIP_GetExpectedNextSequenceNumber_Call) RunAndReturn(run func(context.Context, ccipocr3.ChainSelector, ccipocr3.ChainSelector) (ccipocr3.SeqNum, error)) *MockCCIP_GetExpectedNextSequenceNumber_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
Test in core: https://github.com/smartcontractkit/ccip/pull/1373

The commit plugin currently builds merkle roots of size one because it only reads offramp sequence numbers. Add this so it can read onramp sequence numbers as well