### PR TITLE
Commit plugin - Fix non deterministic outcome

### DIFF
--- a/commit/outcome.go
+++ b/commit/outcome.go
@@ -87,6 +87,9 @@ func ReportRangesOutcome(
 		}
 	}
 
+	// deterministic outcome
+	sort.Slice(rangesToReport, func(i, j int) bool { return rangesToReport[i].ChainSel < rangesToReport[j].ChainSel })
+
 	outcome := Outcome{
 		OutcomeType:             ReportIntervalsSelected,
 		RangesSelectedForReport: rangesToReport,


### PR DESCRIPTION
Outcome was not deterministic (iterating over a map and appending to a slice).