### PR TITLE
internal/reader: remove interval struct

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ test: ensure_go_version
 lint: ensure_go_version
 	golangci-lint run -c .golangci.yml
 
+checks: test lint
+
 ensure_go_version:
 	@go version | grep -q 'go1.22' || (echo "Please use go1.22" && exit 1)
 

--- a/internal/reader/ccip.go
+++ b/internal/reader/ccip.go
@@ -339,7 +339,7 @@ func (r *CCIPChainReader) MsgsBetweenSeqNums(
 		ctx,
 		consts.ContractNameOnRamp,
 		query.KeyFilter{
-			Key: consts.EventNameCCIPSendRequested,
+			Key: consts.EventNameCCIPMessageSent,
 			Expressions: []query.Expression{
 				query.Confidence(primitives.Finalized),
 			},

--- a/internal/reader/ccip.go
+++ b/internal/reader/ccip.go
@@ -138,14 +138,10 @@ func (r *CCIPChainReader) CommitReportsGTETimestamp(
 	// The following types are used to decode the events
 	// but should be replaced by chain-reader modifiers and use the base cciptypes.CommitReport type.
 
-	type Interval struct {
-		Min uint64
-		Max uint64
-	}
-
 	type MerkleRoot struct {
 		SourceChainSelector uint64
-		Interval            Interval
+		MinSeqNr            uint64
+		MaxSeqNr            uint64
 		MerkleRoot          cciptypes.Bytes32
 	}
 
@@ -219,8 +215,8 @@ func (r *CCIPChainReader) CommitReportsGTETimestamp(
 			merkleRoots = append(merkleRoots, cciptypes.MerkleRootChain{
 				ChainSel: cciptypes.ChainSelector(mr.SourceChainSelector),
 				SeqNumsRange: cciptypes.NewSeqNumRange(
-					cciptypes.SeqNum(mr.Interval.Min),
-					cciptypes.SeqNum(mr.Interval.Max),
+					cciptypes.SeqNum(mr.MinSeqNr),
+					cciptypes.SeqNum(mr.MaxSeqNr),
 				),
 				MerkleRoot: mr.MerkleRoot,
 			})

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -76,7 +76,7 @@ const (
 
 // Event Names
 const (
-	EventNameCCIPSendRequested     = "CCIPSendRequested"
+	EventNameCCIPMessageSent       = "CCIPMessageSent"
 	EventNameExecutionStateChanged = "ExecutionStateChanged"
 	EventNameCommitReportAccepted  = "CommitReportAccepted"
 )


### PR DESCRIPTION
Due to some recent refactoring the Interval struct is no longer present in the MerkleRoot struct.

Core PR draft: https://github.com/smartcontractkit/chainlink/pull/14345