### PR TITLE
Add DiscoverContracts to CCIPReader.

### DIFF
--- a/internal/mocks/inmem/ccipreader_inmem.go
+++ b/internal/mocks/inmem/ccipreader_inmem.go
@@ -122,14 +122,20 @@ func (r InMemoryCCIPReader) GasPrices(
 	panic("implement me")
 }
 
+func (r InMemoryCCIPReader) DiscoverContracts(
+	ctx context.Context, destChain cciptypes.ChainSelector,
+) (reader.ContractAddresses, error) {
+	return nil, nil
+}
+
 func (r InMemoryCCIPReader) Close(ctx context.Context) error {
 	return nil
 }
 
 // Sync can be used to perform frequent syncing operations inside the reader implementation.
 // Returns a bool indicating whether something was updated.
-func (r InMemoryCCIPReader) Sync(ctx context.Context) (bool, error) {
-	return false, nil
+func (r InMemoryCCIPReader) Sync(_ context.Context, _ reader.ContractAddresses) error {
+	return nil
 }
 
 // Interface compatibility check.

--- a/internal/plugincommon/ccipreader.go
+++ b/internal/plugincommon/ccipreader.go
@@ -104,9 +104,10 @@ func backgroundReaderSync(
 				lggr.Debug("backgroundReaderSync context done")
 				return
 			case <-ticker:
-				if err := syncReader(ctx, lggr, reader, syncTimeout); err != nil {
+				if err := syncReader(ctx, reader, syncTimeout); err != nil {
 					lggr.Errorw("runBackgroundReaderSync failed", "err", err)
 				}
+				lggr.Infow("runBackgroundReaderSync success")
 			}
 		}
 	}()
@@ -114,7 +115,6 @@ func backgroundReaderSync(
 
 func syncReader(
 	ctx context.Context,
-	_ logger.Logger,
 	reader reader.CCIPReader,
 	syncTimeout time.Duration,
 ) error {

--- a/internal/plugincommon/ccipreader.go
+++ b/internal/plugincommon/ccipreader.go
@@ -114,22 +114,16 @@ func backgroundReaderSync(
 
 func syncReader(
 	ctx context.Context,
-	lggr logger.Logger,
+	_ logger.Logger,
 	reader reader.CCIPReader,
 	syncTimeout time.Duration,
 ) error {
 	timeoutCtx, cf := context.WithTimeout(ctx, syncTimeout)
 	defer cf()
 
-	updated, err := reader.Sync(timeoutCtx)
+	err := reader.Sync(timeoutCtx, nil)
 	if err != nil {
-		return err
-	}
-
-	if !updated {
-		lggr.Debug("no updates found after trying to sync")
-	} else {
-		lggr.Info("ccip reader sync success")
+		return fmt.Errorf("syncReader: %w", err)
 	}
 
 	return nil

--- a/mocks/pkg/reader/ccip_reader.go
+++ b/mocks/pkg/reader/ccip_reader.go
@@ -11,6 +11,8 @@ import (
 
 	plugintypes "github.com/smartcontractkit/chainlink-ccip/plugintypes"
 
+	reader "github.com/smartcontractkit/chainlink-ccip/pkg/reader"
+
 	time "time"
 )
 
@@ -130,6 +132,65 @@ func (_c *MockCCIPReader_CommitReportsGTETimestamp_Call) Return(_a0 []plugintype
 }
 
 func (_c *MockCCIPReader_CommitReportsGTETimestamp_Call) RunAndReturn(run func(context.Context, ccipocr3.ChainSelector, time.Time, int) ([]plugintypes.CommitPluginReportWithMeta, error)) *MockCCIPReader_CommitReportsGTETimestamp_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// DiscoverContracts provides a mock function with given fields: ctx, destChain
+func (_m *MockCCIPReader) DiscoverContracts(ctx context.Context, destChain ccipocr3.ChainSelector) (reader.ContractAddresses, error) {
+	ret := _m.Called(ctx, destChain)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DiscoverContracts")
+	}
+
+	var r0 reader.ContractAddresses
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, ccipocr3.ChainSelector) (reader.ContractAddresses, error)); ok {
+		return rf(ctx, destChain)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, ccipocr3.ChainSelector) reader.ContractAddresses); ok {
+		r0 = rf(ctx, destChain)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(reader.ContractAddresses)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, ccipocr3.ChainSelector) error); ok {
+		r1 = rf(ctx, destChain)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockCCIPReader_DiscoverContracts_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DiscoverContracts'
+type MockCCIPReader_DiscoverContracts_Call struct {
+	*mock.Call
+}
+
+// DiscoverContracts is a helper method to define mock.On call
+//   - ctx context.Context
+//   - destChain ccipocr3.ChainSelector
+func (_e *MockCCIPReader_Expecter) DiscoverContracts(ctx interface{}, destChain interface{}) *MockCCIPReader_DiscoverContracts_Call {
+	return &MockCCIPReader_DiscoverContracts_Call{Call: _e.mock.On("DiscoverContracts", ctx, destChain)}
+}
+
+func (_c *MockCCIPReader_DiscoverContracts_Call) Run(run func(ctx context.Context, destChain ccipocr3.ChainSelector)) *MockCCIPReader_DiscoverContracts_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(ccipocr3.ChainSelector))
+	})
+	return _c
+}
+
+func (_c *MockCCIPReader_DiscoverContracts_Call) Return(_a0 reader.ContractAddresses, _a1 error) *MockCCIPReader_DiscoverContracts_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockCCIPReader_DiscoverContracts_Call) RunAndReturn(run func(context.Context, ccipocr3.ChainSelector) (reader.ContractAddresses, error)) *MockCCIPReader_DiscoverContracts_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -551,32 +612,22 @@ func (_c *MockCCIPReader_Nonces_Call) RunAndReturn(run func(context.Context, cci
 	return _c
 }
 
-// Sync provides a mock function with given fields: ctx
-func (_m *MockCCIPReader) Sync(ctx context.Context) (bool, error) {
-	ret := _m.Called(ctx)
+// Sync provides a mock function with given fields: ctx, contracts
+func (_m *MockCCIPReader) Sync(ctx context.Context, contracts reader.ContractAddresses) error {
+	ret := _m.Called(ctx, contracts)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Sync")
 	}
 
-	var r0 bool
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context) (bool, error)); ok {
-		return rf(ctx)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context) bool); ok {
-		r0 = rf(ctx)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, reader.ContractAddresses) error); ok {
+		r0 = rf(ctx, contracts)
 	} else {
-		r0 = ret.Get(0).(bool)
+		r0 = ret.Error(0)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // MockCCIPReader_Sync_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Sync'
@@ -586,23 +637,24 @@ type MockCCIPReader_Sync_Call struct {
 
 // Sync is a helper method to define mock.On call
 //   - ctx context.Context
-func (_e *MockCCIPReader_Expecter) Sync(ctx interface{}) *MockCCIPReader_Sync_Call {
-	return &MockCCIPReader_Sync_Call{Call: _e.mock.On("Sync", ctx)}
+//   - contracts reader.ContractAddresses
+func (_e *MockCCIPReader_Expecter) Sync(ctx interface{}, contracts interface{}) *MockCCIPReader_Sync_Call {
+	return &MockCCIPReader_Sync_Call{Call: _e.mock.On("Sync", ctx, contracts)}
 }
 
-func (_c *MockCCIPReader_Sync_Call) Run(run func(ctx context.Context)) *MockCCIPReader_Sync_Call {
+func (_c *MockCCIPReader_Sync_Call) Run(run func(ctx context.Context, contracts reader.ContractAddresses)) *MockCCIPReader_Sync_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
+		run(args[0].(context.Context), args[1].(reader.ContractAddresses))
 	})
 	return _c
 }
 
-func (_c *MockCCIPReader_Sync_Call) Return(_a0 bool, _a1 error) *MockCCIPReader_Sync_Call {
-	_c.Call.Return(_a0, _a1)
+func (_c *MockCCIPReader_Sync_Call) Return(_a0 error) *MockCCIPReader_Sync_Call {
+	_c.Call.Return(_a0)
 	return _c
 }
 
-func (_c *MockCCIPReader_Sync_Call) RunAndReturn(run func(context.Context) (bool, error)) *MockCCIPReader_Sync_Call {
+func (_c *MockCCIPReader_Sync_Call) RunAndReturn(run func(context.Context, reader.ContractAddresses) error) *MockCCIPReader_Sync_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -530,22 +530,6 @@ func (r *ccipChainReader) DiscoverContracts(
 	return resp, nil
 }
 
-// bindReaderContracts calls bindReaderContract for a list of chain selectors.
-//
-//nolint:unused // it will be used soon.
-func (r *ccipChainReader) bindReaderContracts(
-	ctx context.Context,
-	chainSels []cciptypes.ChainSelector,
-	contractName string,
-	addresses ContractAddresses,
-) error {
-	var errs []error
-	for _, chainSel := range chainSels {
-		errs = append(errs, r.bindReaderContract(ctx, chainSel, contractName, addresses))
-	}
-	return errors.Join(errs...)
-}
-
 // bindReaderContract is a generic helper for binding contracts to readers, the addresses input is the same object
 // returned by DiscoverContracts.
 //
@@ -647,8 +631,6 @@ func (r *ccipChainReader) newSync(ctx context.Context, contracts ContractAddress
 			return fmt.Errorf("sync error (nonce manager): %w", err)
 		}
 	*/
-
-	return nil
 }
 
 func (r *ccipChainReader) Close(ctx context.Context) error {

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -2,12 +2,14 @@ package reader
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"strconv"
 	"sync"
 	"time"
 
+	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 
 	types2 "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
@@ -47,13 +49,26 @@ func newCCIPChainReaderInternal(
 		crs[chainSelector] = contractreader.NewExtendedContractReader(cr)
 	}
 
-	return &ccipChainReader{
+	reader := &ccipChainReader{
 		lggr:            lggr,
 		contractReaders: crs,
 		contractWriters: contractWriters,
 		destChain:       destChain,
 		offrampAddress:  typeconv.AddressBytesToString(offrampAddress, uint64(destChain)),
 	}
+
+	/*
+		contracts := ContractAddresses{
+			consts.ContractNameOffRamp: {
+				destChain: offrampAddress,
+			},
+		}
+		if err := reader.Sync(context.Background(), contracts); err != nil {
+			lggr.Infow("failed to sync contracts", "err", err)
+		}
+	*/
+
+	return reader
 }
 
 // WithExtendedContractReader sets the extended contract reader for the provided chain.
@@ -477,124 +492,154 @@ func (r *ccipChainReader) GasPrices(ctx context.Context, chains []cciptypes.Chai
 	return gasPrices, nil
 }
 
-func (r *ccipChainReader) bindOfframp(ctx context.Context) error {
-	if err := r.validateReaderExistence(r.destChain); err != nil {
-		return err
-	}
-
-	// Bind the offRamp contract address to the reader.
-	// If the same address exists -> no-op
-	// If the address is changed -> updates the address, overwrites the existing one
-	// If the contract not binded -> binds to the new address
-	if err := r.contractReaders[r.destChain].Bind(ctx, []types.BoundContract{
-		{
-			Address: r.offrampAddress,
-			Name:    consts.ContractNameOffRamp,
-		},
-	}); err != nil {
-		return fmt.Errorf("bind offRamp: %w", err)
-	}
-
-	return nil
-}
-
-// bindOnRamps reads the onchain configuration to discover source ramp addresses.
-func (r *ccipChainReader) bindOnramps(
+func (r *ccipChainReader) DiscoverContracts(
 	ctx context.Context,
-) error {
-	chains := make([]cciptypes.ChainSelector, 0, len(r.contractReaders))
-	for chain := range r.contractReaders {
-		chains = append(chains, chain)
+	destChain cciptypes.ChainSelector,
+) (ContractAddresses, error) {
+	if err := r.validateReaderExistence(destChain); err != nil {
+		return nil, err
 	}
+
+	chains := maps.Keys(r.contractReaders)
+
+	// OnRamps are in the offramp SourceChainConfig.
 	sourceConfigs, err := r.getSourceChainsConfig(ctx, chains)
 	if err != nil {
-		return fmt.Errorf("get onramps: %w", err)
+		return nil, fmt.Errorf("unable to get SourceChainsConfig: %w", err)
 	}
 
-	r.lggr.Infow("got source chain configs", "onramps", func() []string {
-		var r []string
-		for chainSelector, scc := range sourceConfigs {
-			r = append(r, typeconv.AddressBytesToString(scc.OnRamp, uint64(chainSelector)))
-		}
-		return r
-	}())
+	// NonceManager is in the offramp static config.
+	staticConfig, err := r.getOfframpStaticConfig(ctx, r.destChain)
+	if err != nil {
+		return nil, fmt.Errorf("unable to lookup nonce manager: %w", err)
+	}
 
+	// TODO: Loookup fee quoter?
+
+	// Build response object.
+	onramps := make(map[cciptypes.ChainSelector][]byte, len(chains))
 	for chain, cfg := range sourceConfigs {
-		if len(cfg.OnRamp) == 0 {
-			return fmt.Errorf("onRamp address not found for chain %d", chain)
-		}
-
-		// We only want to produce reports for enabled source chains.
-		if !cfg.IsEnabled {
-			continue
-		}
-
-		// Bind the onRamp contract address to the reader.
-		// If the same address exists -> no-op
-		// If the address is changed -> updates the address, overwrites the existing one
-		// If the contract not binded -> binds to the new address
-		if err := r.contractReaders[chain].Bind(ctx, []types.BoundContract{
-			{
-				Address: typeconv.AddressBytesToString(cfg.OnRamp, uint64(chain)),
-				Name:    consts.ContractNameOnRamp,
-			},
-		}); err != nil {
-			return fmt.Errorf("bind onRamp: %w", err)
-		}
+		onramps[chain] = cfg.OnRamp
 	}
-
-	return nil
+	resp := map[string]map[cciptypes.ChainSelector][]byte{
+		consts.ContractNameOnRamp: onramps,
+		consts.ContractNameNonceManager: {
+			destChain: staticConfig.NonceManager,
+		},
+	}
+	return resp, nil
 }
 
-func (r *ccipChainReader) bindNonceManager(ctx context.Context) error {
-	destReader, ok := r.contractReaders[r.destChain]
-	if !ok {
-		r.lggr.Debugw("skipping nonce manager, dest chain not configured for this deployment",
-			"destChain", r.destChain)
+// bindReaderContracts calls bindReaderContract for a list of chain selectors.
+//
+//nolint:unused // it will be used soon.
+func (r *ccipChainReader) bindReaderContracts(
+	ctx context.Context,
+	chainSels []cciptypes.ChainSelector,
+	contractName string,
+	addresses ContractAddresses,
+) error {
+	var errs []error
+	for _, chainSel := range chainSels {
+		errs = append(errs, r.bindReaderContract(ctx, chainSel, contractName, addresses))
+	}
+	return errors.Join(errs...)
+}
+
+// bindReaderContract is a generic helper for binding contracts to readers, the addresses input is the same object
+// returned by DiscoverContracts.
+//
+// No error is returned if contractName is not found in the contracts. This allows calling the function before all
+// contracts are discovered.
+//
+//nolint:unused // it will be used soon.
+func (r *ccipChainReader) bindReaderContract(
+	ctx context.Context,
+	chainSel cciptypes.ChainSelector,
+	contractName string,
+	contracts ContractAddresses,
+) error {
+	if err := r.validateReaderExistence(chainSel); err != nil {
+		return fmt.Errorf("validate reader existence: %w", err)
+	}
+
+	// No contracts provided for the requested contract is a no-op.
+	if _, ok := contracts[contractName]; !ok {
 		return nil
 	}
 
-	staticConfig, err := r.getOfframpStaticConfig(ctx)
-	if err != nil {
-		return fmt.Errorf("get offramp static config: %w", err)
+	if _, ok := contracts[contractName][chainSel]; !ok {
+		return fmt.Errorf("missing address for chain %d", chainSel)
 	}
 
-	if staticConfig.ChainSelector != r.destChain {
-		return fmt.Errorf("invalid configuration detected, somehow reading from non-dest offramp")
-	}
+	address := contracts[contractName][chainSel]
+	encAddress := typeconv.AddressBytesToString(address, uint64(chainSel))
 
-	// Bind the nonceManager contract address to the reader.
+	// Bind the contract address to the reader.
 	// If the same address exists -> no-op
 	// If the address is changed -> updates the address, overwrites the existing one
-	// If the contract not binded -> binds to the new address
-	if err := destReader.Bind(ctx, []types.BoundContract{
+	// If the contract not bound -> binds to the new address
+	if err := r.contractReaders[chainSel].Bind(ctx, []types.BoundContract{
 		{
-			Address: typeconv.AddressBytesToString(staticConfig.NonceManager, uint64(r.destChain)),
-			Name:    consts.ContractNameNonceManager,
+			Address: encAddress,
+			Name:    contractName,
 		},
 	}); err != nil {
-		return fmt.Errorf("bind nonce manager: %w", err)
+		return fmt.Errorf("unable to bind %s for chain %d: %w", contractName, chainSel, err)
 	}
 
 	return nil
 }
 
-func (r *ccipChainReader) Sync(ctx context.Context) (bool, error) {
-	// Note: offramp must be bound first, otherwise onramp bindings
-	// will fail.
-	if err := r.bindOfframp(ctx); err != nil {
-		return false, err
+// newSync binds ContractAddresses to the contract readers.
+//
+//nolint:unused // it will be used soon.
+func (r *ccipChainReader) newSync(ctx context.Context, contracts ContractAddresses) error {
+	var err error
+
+	// OffRamp
+	/*
+		offrampBytes, err := typeconv.AddressStringToBytes(r.offrampAddress, uint64(r.destChain))
+		if err != nil {
+			return err
+		}
+		contracts[consts.ContractNameOffRamp] = map[cciptypes.ChainSelector][]byte{
+			r.destChain: offrampBytes,
+		}
+	*/
+	err = r.bindReaderContract(
+		ctx,
+		r.destChain,
+		consts.ContractNameOffRamp,
+		contracts,
+	)
+	if err != nil {
+		return fmt.Errorf("sync error (offramp): %w", err)
 	}
 
-	if err := r.bindOnramps(ctx); err != nil {
-		return false, err
+	// OnRamps
+	err = r.bindReaderContracts(
+		ctx,
+		maps.Keys(r.contractReaders),
+		consts.ContractNameOnRamp,
+		contracts,
+	)
+	if err != nil {
+		return fmt.Errorf("sync error (onramp): %w", err)
 	}
 
-	if err := r.bindNonceManager(ctx); err != nil {
-		return false, err
+	// Nonce manager
+	err = r.bindReaderContract(
+		ctx,
+		r.destChain,
+		consts.ContractNameNonceManager,
+		contracts,
+	)
+	if err != nil {
+		return fmt.Errorf("sync error (nonce manager): %w", err)
 	}
 
-	return true, nil
+	return nil
 }
 
 func (r *ccipChainReader) Close(ctx context.Context) error {
@@ -695,12 +740,15 @@ func (r *ccipChainReader) validateWriterExistence(chains ...cciptypes.ChainSelec
 }
 
 // getSourceChainsConfig returns the destination offRamp contract's static chain configuration.
-func (r *ccipChainReader) getOfframpStaticConfig(ctx context.Context) (offrampStaticChainConfig, error) {
-	if err := r.validateReaderExistence(r.destChain); err != nil {
+func (r *ccipChainReader) getOfframpStaticConfig(
+	ctx context.Context,
+	chain cciptypes.ChainSelector,
+) (offrampStaticChainConfig, error) {
+	if err := r.validateReaderExistence(chain); err != nil {
 		return offrampStaticChainConfig{}, err
 	}
 
-	extendedBindings := r.contractReaders[r.destChain].GetBindings(consts.ContractNameOffRamp)
+	extendedBindings := r.contractReaders[chain].GetBindings(consts.ContractNameOffRamp)
 	if len(extendedBindings) != 1 {
 		return offrampStaticChainConfig{},
 			fmt.Errorf("expected one binding for Offramp contract, got %d", len(extendedBindings))
@@ -708,7 +756,7 @@ func (r *ccipChainReader) getOfframpStaticConfig(ctx context.Context) (offrampSt
 	contractBinding := extendedBindings[0].Binding
 
 	resp := offrampStaticChainConfig{}
-	err := r.contractReaders[r.destChain].GetLatestValue(
+	err := r.contractReaders[chain].GetLatestValue(
 		ctx,
 		contractBinding.ReadIdentifier(consts.MethodNameOfframpGetStaticConfig),
 		primitives.Unconfirmed,

--- a/pkg/reader/ccip_interface.go
+++ b/pkg/reader/ccip_interface.go
@@ -18,6 +18,10 @@ var (
 	ErrContractWriterNotFound = errors.New("contract writer not found")
 )
 
+// ContractAddresses is a map of contract names across all chain selectors and their address.
+// Currently only one contract per chain per name is supported.
+type ContractAddresses map[string]map[cciptypes.ChainSelector][]byte
+
 func NewCCIPChainReader(
 	lggr logger.Logger,
 	contractReaders map[cciptypes.ChainSelector]types.ContractReader,
@@ -102,9 +106,13 @@ type CCIPReader interface {
 	// GasPrices reads the provided chains gas prices.
 	GasPrices(ctx context.Context, chains []cciptypes.ChainSelector) ([]cciptypes.BigInt, error)
 
+	// DiscoverContracts reads the destination chain for contract addresses. They are returned per
+	// contract and source chain selector.
+	DiscoverContracts(ctx context.Context, destChain cciptypes.ChainSelector) (ContractAddresses, error)
+
 	// Sync can be used to perform frequent syncing operations inside the reader implementation.
 	// Returns a bool indicating whether something was updated.
-	Sync(ctx context.Context) (bool, error)
+	Sync(ctx context.Context, contracts ContractAddresses) error
 
 	// Close closes any open resources.
 	Close(ctx context.Context) error

--- a/pkg/reader/ccip_old_sync.go
+++ b/pkg/reader/ccip_old_sync.go
@@ -1,0 +1,128 @@
+package reader
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+
+	typeconv "github.com/smartcontractkit/chainlink-ccip/internal/libs/typeconv"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
+)
+
+func (r *ccipChainReader) bindOfframp(ctx context.Context) error {
+	if err := r.validateReaderExistence(r.destChain); err != nil {
+		return err
+	}
+
+	// Bind the offRamp contract address to the reader.
+	// If the same address exists -> no-op
+	// If the address is changed -> updates the address, overwrites the existing one
+	// If the contract not binded -> binds to the new address
+	if err := r.contractReaders[r.destChain].Bind(ctx, []types.BoundContract{
+		{
+			Address: r.offrampAddress,
+			Name:    consts.ContractNameOffRamp,
+		},
+	}); err != nil {
+		return fmt.Errorf("bind offRamp: %w", err)
+	}
+
+	return nil
+}
+
+// bindOnRamps reads the onchain configuration to discover source ramp addresses.
+func (r *ccipChainReader) bindOnramps(
+	ctx context.Context,
+) error {
+	chains := make([]cciptypes.ChainSelector, 0, len(r.contractReaders))
+	for chain := range r.contractReaders {
+		chains = append(chains, chain)
+	}
+	sourceConfigs, err := r.getSourceChainsConfig(ctx, chains)
+	if err != nil {
+		return fmt.Errorf("get onramps: %w", err)
+	}
+
+	r.lggr.Infow("got source chain configs", "onramps", func() []string {
+		var r []string
+		for chainSelector, scc := range sourceConfigs {
+			r = append(r, typeconv.AddressBytesToString(scc.OnRamp, uint64(chainSelector)))
+		}
+		return r
+	}())
+
+	for chain, cfg := range sourceConfigs {
+		if len(cfg.OnRamp) == 0 {
+			return fmt.Errorf("onRamp address not found for chain %d", chain)
+		}
+
+		// We only want to produce reports for enabled source chains.
+		if !cfg.IsEnabled {
+			continue
+		}
+
+		// Bind the onRamp contract address to the reader.
+		// If the same address exists -> no-op
+		// If the address is changed -> updates the address, overwrites the existing one
+		// If the contract not binded -> binds to the new address
+		if err := r.contractReaders[chain].Bind(ctx, []types.BoundContract{
+			{
+				Address: typeconv.AddressBytesToString(cfg.OnRamp, uint64(chain)),
+				Name:    consts.ContractNameOnRamp,
+			},
+		}); err != nil {
+			return fmt.Errorf("bind onRamp: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (r *ccipChainReader) bindNonceManager(ctx context.Context) error {
+	destReader, ok := r.contractReaders[r.destChain]
+	if !ok {
+		r.lggr.Debugw("skipping nonce manager, dest chain not configured for this deployment",
+			"destChain", r.destChain)
+		return nil
+	}
+
+	staticConfig, err := r.getOfframpStaticConfig(ctx, r.destChain)
+	if err != nil {
+		return fmt.Errorf("get offramp static config: %w", err)
+	}
+
+	if staticConfig.ChainSelector != r.destChain {
+		return fmt.Errorf("invalid configuration detected, somehow reading from non-dest offramp")
+	}
+
+	// Bind the nonceManager contract address to the reader.
+	// If the same address exists -> no-op
+	// If the address is changed -> updates the address, overwrites the existing one
+	// If the contract not binded -> binds to the new address
+	if err := destReader.Bind(ctx, []types.BoundContract{
+		{
+			Address: typeconv.AddressBytesToString(staticConfig.NonceManager, uint64(r.destChain)),
+			Name:    consts.ContractNameNonceManager,
+		},
+	}); err != nil {
+		return fmt.Errorf("bind nonce manager: %w", err)
+	}
+
+	return nil
+}
+
+func (r *ccipChainReader) Sync(ctx context.Context, _ ContractAddresses) error {
+	// Note: offramp must be bound first, otherwise onramp bindings
+	// will fail.
+	if err := r.bindOfframp(ctx); err != nil {
+		return err
+	}
+
+	if err := r.bindOnramps(ctx); err != nil {
+		return err
+	}
+
+	return r.bindNonceManager(ctx)
+}


### PR DESCRIPTION
Update CCIPReader interface:
* New `DiscoverContracts` function and `ContractAddresses` type.
* Update `Sync` to accept a `ContractAddresses` object.
* Rough implementation of `newSync` which will replace `Sync` in a future PR.
* Bind/discover functions refactored into `newSync` and new `bindContractReader(s)` functions.
* Deprecated `Sync` function and helpers moved to `ccip_old_sync.go`