### PR TITLE
commit/tokenprice: Errorw => Debugw

### DIFF
--- a/commit/merkleroot/outcome.go
+++ b/commit/merkleroot/outcome.go
@@ -129,7 +129,7 @@ func buildReport(
 
 	sigs := make([]cciptypes.RMNECDSASignature, 0)
 	if q.RMNSignatures == nil {
-		lggr.Error("RMNSignatures are nil")
+		lggr.Warn("RMNSignatures are nil")
 	} else {
 		parsedSigs, err := rmn.NewECDSASigsFromPB(q.RMNSignatures.Signatures)
 		if err != nil {

--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -252,9 +252,8 @@ func (p *Plugin) Outcome(
 		decodedQ.TokenPriceQuery,
 		tokensObservations,
 	)
-
 	if err != nil {
-		p.lggr.Errorw("failed to get token prices outcome", "err", err)
+		p.lggr.Warnw("failed to get token prices outcome", "err", err)
 	}
 
 	chainFeeOutcome, err := p.chainFeeProcessor.Outcome(
@@ -263,7 +262,7 @@ func (p *Plugin) Outcome(
 		feeObservations,
 	)
 	if err != nil {
-		p.lggr.Errorw("failed to get gas prices outcome", "err", err)
+		p.lggr.Warnw("failed to get gas prices outcome", "err", err)
 	}
 
 	return Outcome{

--- a/commit/tokenprice/observation.go
+++ b/commit/tokenprice/observation.go
@@ -24,7 +24,7 @@ func (p *processor) ObserveFChain() map[cciptypes.ChainSelector]int {
 
 func (p *processor) ObserveFeedTokenPrices(ctx context.Context) []cciptypes.TokenPrice {
 	if p.tokenPriceReader == nil {
-		p.lggr.Errorw("no token price reader available")
+		p.lggr.Debugw("no token price reader available")
 		return []cciptypes.TokenPrice{}
 	}
 
@@ -65,7 +65,7 @@ func (p *processor) ObserveFeedTokenPrices(ctx context.Context) []cciptypes.Toke
 
 func (p *processor) ObserveFeeQuoterTokenUpdates(ctx context.Context) map[types.Account]shared.TimestampedBig {
 	if p.tokenPriceReader == nil {
-		p.lggr.Errorw("no token price reader available")
+		p.lggr.Debugw("no token price reader available")
 		return map[types.Account]shared.TimestampedBig{}
 	}
 


### PR DESCRIPTION
The current log level of Errorw is spamming the logs and printing stack traces. Since this isn't really an error at the moment, make it Debugw.