### PR TITLE
Update token data consensus to support e2e tests.

### DIFF
--- a/execute/plugin_functions.go
+++ b/execute/plugin_functions.go
@@ -308,11 +308,23 @@ func mergeTokenObservations(
 	observations []shared.AttributedObservation[exectypes.Observation],
 	_ map[cciptypes.ChainSelector]int,
 ) exectypes.TokenDataObservations {
-	// Return first one, dummy implementation to make tests passing
+	// Finds the observation with the most token data.
+	// This is a dummy algorithm, proper consensus should be implemented.
+
+	maxCnt := -1
+	maxV := exectypes.TokenDataObservations{}
 	for _, ao := range observations {
-		return ao.Observation.TokenData
+		cnt := 0
+		for _, tokenData := range ao.Observation.TokenData {
+			cnt += len(tokenData)
+		}
+		if cnt > maxCnt {
+			maxCnt = cnt
+			maxV = ao.Observation.TokenData
+		}
 	}
-	return nil
+
+	return maxV
 }
 
 // mergeNonceObservations merges all observations which reach the fChain threshold into a single result.

--- a/execute/plugin_functions.go
+++ b/execute/plugin_functions.go
@@ -308,7 +308,7 @@ func mergeTokenObservations(
 	observations []shared.AttributedObservation[exectypes.Observation],
 	_ map[cciptypes.ChainSelector]int,
 ) exectypes.TokenDataObservations {
-	// Finds the observation with the most token data.
+	// Finds the observation with 'the most token data'.
 	// This is a dummy algorithm, proper consensus should be implemented.
 
 	maxCnt := -1
@@ -324,6 +324,9 @@ func mergeTokenObservations(
 		}
 	}
 
+	if maxCnt == -1 {
+		return nil
+	}
 	return maxV
 }
 


### PR DESCRIPTION
Current token data consensus implementation is probably breaking e2e tests.

I believe that some Oracle Node can be a bit behind, not observing any msgs, while it's token data observations are selected by token data consensus algorithm.
