### PR TITLE
Add ErrTooManyBindings and ErrNoBindings.

### DIFF
--- a/pkg/contractreader/extended.go
+++ b/pkg/contractreader/extended.go
@@ -14,6 +14,9 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/internal/reader/contractreader"
 )
 
+const ErrTooManyBindings = "contract binding not found"
+const ErrNoBindings = "no bindings found"
+
 // Extended version of a ContractReader.
 type Extended interface {
 	Bind(ctx context.Context, bindings []types.BoundContract) error
@@ -61,6 +64,20 @@ func NewExtendedContractReader(baseContractReader contractreader.ContractReaderF
 	}
 }
 
+func (e *extendedContractReader) getOneBinding(contractName string) (ExtendedBoundContract, error) {
+	extendedBindings := e.GetBindings(contractName)
+	switch numBindings := len(extendedBindings); numBindings {
+	case 1:
+		return extendedBindings[0], nil
+	case 0:
+		return ExtendedBoundContract{}, fmt.Errorf(
+			"getOneBinding: no binding found for %s contract: %w", contractName, ErrNoBindings)
+	default:
+		return ExtendedBoundContract{}, fmt.Errorf(
+			"getOneBinding: expected one binding got %d: %w", numBindings, ErrTooManyBindings)
+	}
+}
+
 func (e *extendedContractReader) ExtendedQueryKey(
 	ctx context.Context,
 	contractName string,
@@ -68,16 +85,14 @@ func (e *extendedContractReader) ExtendedQueryKey(
 	limitAndSort query.LimitAndSort,
 	sequenceDataType any,
 ) ([]types.Sequence, error) {
-	extendedBindings := e.GetBindings(contractName)
-	if len(extendedBindings) != 1 {
-		return nil, fmt.Errorf(
-			"ExtendedQueryKey: expected one binding for %s contract, got %d", contractName, len(extendedBindings))
+	binding, err := e.getOneBinding(contractName)
+	if err != nil {
+		return nil, fmt.Errorf("ExtendedQueryKey: %w", err)
 	}
-	contractBinding := extendedBindings[0].Binding
 
 	return e.QueryKey(
 		ctx,
-		contractBinding,
+		binding.Binding,
 		filter,
 		limitAndSort,
 		sequenceDataType,
@@ -90,13 +105,11 @@ func (e *extendedContractReader) ExtendedGetLatestValue(
 	confidenceLevel primitives.ConfidenceLevel,
 	params, returnVal any,
 ) error {
-	extendedBindings := e.GetBindings(contractName)
-	if len(extendedBindings) != 1 {
-		return fmt.Errorf(
-			"ExtendedGetLatestValue: expected one binding for the %s contract, got %d", contractName, len(extendedBindings))
+	binding, err := e.getOneBinding(contractName)
+	if err != nil {
+		return fmt.Errorf("ExtendedGetLatestValue: %w", err)
 	}
-	contractBinding := extendedBindings[0].Binding
-	readIdentifier := contractBinding.ReadIdentifier(methodName)
+	readIdentifier := binding.Binding.ReadIdentifier(methodName)
 
 	return e.GetLatestValue(
 		ctx,

--- a/pkg/contractreader/extended.go
+++ b/pkg/contractreader/extended.go
@@ -2,6 +2,7 @@ package contractreader
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -14,8 +15,10 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/internal/reader/contractreader"
 )
 
-const ErrTooManyBindings = "contract binding not found"
-const ErrNoBindings = "no bindings found"
+var (
+	ErrTooManyBindings = errors.New("contract binding not found")
+	ErrNoBindings      = errors.New("no bindings found")
+)
 
 // Extended version of a ContractReader.
 type Extended interface {

--- a/pkg/contractreader/extended_test.go
+++ b/pkg/contractreader/extended_test.go
@@ -3,6 +3,7 @@ package contractreader
 import (
 	"context"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -45,4 +46,63 @@ func TestExtendedContractReader(t *testing.T) {
 	assert.Len(t, bindings, 2)
 	assert.Equal(t, "0x123", bindings[0].Binding.Address)
 	assert.Equal(t, "0x124", bindings[1].Binding.Address)
+}
+
+func TestGetOneBinding(t *testing.T) {
+	tests := []struct {
+		name          string
+		bindings      []types.BoundContract
+		expectedError error
+	}{
+		{
+			name:          "no bindings",
+			bindings:      []types.BoundContract{},
+			expectedError: ErrNoBindings,
+		},
+		{
+			name: "one binding",
+			bindings: []types.BoundContract{
+				{Name: "testContract", Address: "0x123"},
+			},
+			expectedError: nil,
+		},
+		{
+			name: "multiple bindings",
+			bindings: []types.BoundContract{
+				{Name: "testContract", Address: "0x123"},
+				{Name: "testContract", Address: "0x124"},
+			},
+			expectedError: ErrTooManyBindings,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cr := chainreadermocks.NewMockContractReaderFacade(t)
+			contractName := "testContract"
+
+			var extendedBindings []ExtendedBoundContract
+			for _, binding := range tt.bindings {
+				extendedBindings = append(extendedBindings, ExtendedBoundContract{
+					Binding: binding,
+				})
+			}
+			extendedReader := &extendedContractReader{
+				ContractReaderFacade: cr,
+				contractBindingsByName: map[string][]ExtendedBoundContract{
+					contractName: extendedBindings,
+				},
+				mu: &sync.RWMutex{},
+			}
+
+			_, err := extendedReader.getOneBinding(contractName)
+			if tt.expectedError != nil {
+				assert.ErrorIs(t, err, tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Add additional error types so that CCIPReader callers can categorize error behaviors.

Specifically, these would allow plugins to gracefully handle pre-initialization conditions when called before all contracts have been bound.