### PR TITLE
pkg/reader: enforce non-copyability of ccip reader

### DIFF
--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -114,7 +114,7 @@ func NewPlugin(
 
 	discoveryProcessor := discovery.NewContractDiscoveryProcessor(
 		lggr,
-		&ccipReader,
+		ccipReader,
 		homeChain,
 		cfg.DestChain,
 		reportingCfg.F,

--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -90,7 +90,7 @@ func NewPlugin(
 		lggr:              lggr,
 		discovery: discovery.NewContractDiscoveryProcessor(
 			lggr,
-			&ccipReader,
+			ccipReader,
 			homeChain,
 			cfg.DestChain,
 			reportingCfg.F,

--- a/internal/plugincommon/discovery/processor.go
+++ b/internal/plugincommon/discovery/processor.go
@@ -20,7 +20,7 @@ var _ plugincommon.PluginProcessor[dt.Query, dt.Observation, dt.Outcome] = &Cont
 // ContractDiscoveryProcessor is a plugin processor for discovering contracts.
 type ContractDiscoveryProcessor struct {
 	lggr      logger.Logger
-	reader    *reader.CCIPReader
+	reader    reader.CCIPReader
 	homechain reader.HomeChain
 	dest      cciptypes.ChainSelector
 	fRoleDON  int
@@ -28,7 +28,7 @@ type ContractDiscoveryProcessor struct {
 
 func NewContractDiscoveryProcessor(
 	lggr logger.Logger,
-	reader *reader.CCIPReader,
+	reader reader.CCIPReader,
 	homechain reader.HomeChain,
 	dest cciptypes.ChainSelector,
 	fRoleDON int,
@@ -52,7 +52,7 @@ func (cdp *ContractDiscoveryProcessor) Query(_ context.Context, _ dt.Outcome) (d
 func (cdp *ContractDiscoveryProcessor) Observation(
 	ctx context.Context, _ dt.Outcome, _ dt.Query,
 ) (dt.Observation, error) {
-	contracts, err := (*cdp.reader).DiscoverContracts(ctx, cdp.dest)
+	contracts, err := cdp.reader.DiscoverContracts(ctx, cdp.dest)
 	if err != nil {
 		if errors.Is(err, reader.ErrContractReaderNotFound) {
 			// Not a dest reader, no observations will be made.
@@ -112,7 +112,7 @@ func (cdp *ContractDiscoveryProcessor) Outcome(
 	// call Sync to bind contracts.
 	contracts := make(map[string]map[cciptypes.ChainSelector][]byte)
 	contracts[consts.ContractNameOnRamp] = plugincommon.GetConsensusMap(cdp.lggr, "onramp", onrampAddrs, fChain)
-	if err := (*cdp.reader).Sync(context.Background(), contracts); err != nil {
+	if err := cdp.reader.Sync(context.Background(), contracts); err != nil {
 		return dt.Outcome{}, fmt.Errorf("unable to sync contracts: %w", err)
 	}
 

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -30,6 +30,9 @@ import (
 // TODO: unit test the implementation when the actual contract reader and writer interfaces are finalized and mocks
 // can be generated.
 type ccipChainReader struct {
+	// to prevent copying this struct.
+	_ sync.Mutex
+
 	lggr            logger.Logger
 	contractReaders map[cciptypes.ChainSelector]contractreader.Extended
 	contractWriters map[cciptypes.ChainSelector]types.ChainWriter


### PR DESCRIPTION
The CCIP reader is a shared object used by all processors from within the plugin.

In order to enforce it always being passed by pointer ensure that it is non-copyable by embedding a mutex.

Note that trying to copy the object will not cause compilation failures but linting failures.