### PR TITLE
Exec v2 scaffolding to observes prices/costs

### DIFF
--- a/execute/plugin_test.go
+++ b/execute/plugin_test.go
@@ -230,7 +230,7 @@ func TestPlugin_ValidateObservation_IneligibleObserver(t *testing.T) {
 				},
 			},
 		},
-	}, nil, nil, dt.Observation{})
+	}, exectypes.PriceObservations{}, nil, nil, dt.Observation{})
 	encoded, err := observation.Encode()
 	require.NoError(t, err)
 	err = p.ValidateObservation(ocr3types.OutcomeContext{}, types.Query{}, types.AttributedObservation{
@@ -262,7 +262,9 @@ func TestPlugin_ValidateObservation_ValidateObservedSeqNum_Error(t *testing.T) {
 			{MerkleRoot: root},
 		},
 	}
-	observation := exectypes.NewObservation(commitReports, nil, nil, nil, dt.Observation{})
+	observation := exectypes.NewObservation(
+		commitReports, nil, exectypes.PriceObservations{}, nil, nil, dt.Observation{},
+	)
 	encoded, err := observation.Encode()
 	require.NoError(t, err)
 	err = p.ValidateObservation(ocr3types.OutcomeContext{}, types.Query{}, types.AttributedObservation{
@@ -355,7 +357,9 @@ func TestPlugin_Outcome_CommitReportsMergeError(t *testing.T) {
 	commitReports := map[cciptypes.ChainSelector][]exectypes.CommitData{
 		1: {},
 	}
-	observation, err := exectypes.NewObservation(commitReports, nil, nil, nil, dt.Observation{}).Encode()
+	observation, err := exectypes.NewObservation(
+		commitReports, nil, exectypes.PriceObservations{}, nil, nil, dt.Observation{},
+	).Encode()
 	require.NoError(t, err)
 	_, err = p.Outcome(ocr3types.OutcomeContext{}, nil, []types.AttributedObservation{
 		{
@@ -388,7 +392,9 @@ func TestPlugin_Outcome_MessagesMergeError(t *testing.T) {
 			},
 		},
 	}
-	observation, err := exectypes.NewObservation(nil, messages, nil, nil, dt.Observation{}).Encode()
+	observation, err := exectypes.NewObservation(
+		nil, messages, exectypes.PriceObservations{}, nil, nil, dt.Observation{},
+	).Encode()
 	require.NoError(t, err)
 	_, err = p.Outcome(ocr3types.OutcomeContext{}, nil, []types.AttributedObservation{
 		{

--- a/execute/report/builder.go
+++ b/execute/report/builder.go
@@ -26,9 +26,11 @@ func NewBuilder(
 	encoder cciptypes.ExecutePluginCodec,
 	estimateProvider gas.EstimateProvider,
 	nonces map[cciptypes.ChainSelector]map[string]uint64,
+	prices exectypes.PriceObservations,
 	destChainSelector cciptypes.ChainSelector,
 	maxReportSizeBytes uint64,
 	maxGas uint64,
+	messageExecutionEconomicsEnabled bool,
 ) ExecReportBuilder {
 	return &execReportBuilder{
 		ctx:  ctx,
@@ -39,10 +41,12 @@ func NewBuilder(
 		estimateProvider: estimateProvider,
 		sendersNonce:     nonces,
 		expectedNonce:    make(map[cciptypes.ChainSelector]map[string]uint64),
+		prices:           prices,
 
-		destChainSelector:  destChainSelector,
-		maxReportSizeBytes: maxReportSizeBytes,
-		maxGas:             maxGas,
+		destChainSelector:                destChainSelector,
+		maxReportSizeBytes:               maxReportSizeBytes,
+		maxGas:                           maxGas,
+		messageExecutionEconomicsEnabled: messageExecutionEconomicsEnabled,
 	}
 }
 
@@ -68,11 +72,13 @@ type execReportBuilder struct {
 	hasher           cciptypes.MessageHasher
 	estimateProvider gas.EstimateProvider
 	sendersNonce     map[cciptypes.ChainSelector]map[string]uint64
+	prices           exectypes.PriceObservations
 
 	// Config
-	destChainSelector  cciptypes.ChainSelector
-	maxReportSizeBytes uint64
-	maxGas             uint64
+	destChainSelector                cciptypes.ChainSelector
+	maxReportSizeBytes               uint64
+	maxGas                           uint64
+	messageExecutionEconomicsEnabled bool
 
 	// State
 	accumulated validationMetadata

--- a/execute/report/report_test.go
+++ b/execute/report/report_test.go
@@ -754,9 +754,11 @@ func Test_Builder_Build(t *testing.T) {
 				codec,
 				evm.EstimateProvider{},
 				tt.args.nonces,
+				exectypes.PriceObservations{},
 				1,
 				tt.args.maxReportSize,
 				tt.args.maxGasLimit,
+				false,
 			)
 
 			var updatedMessages []exectypes.CommitData


### PR DESCRIPTION
Adds scaffolding to the V2 Exec Plugin to enable observing prices and costs (but does not yet observe these values). Once prices and costs are observed, message fees and costs can be computed, and messages with higher costs than paid fees can be filtered.

The core data type is PriceObservations:

```// PriceObservations contains prices and costs that can be used to compute message fees and execution costs in USD
type PriceObservations struct {
	// The price of Juels (the smallest denomination of LINK) in USD. Each CCIP message has a fee denominated in Juels.
	JuelPriceUSD cciptypes.BigInt `json:"juelPriceUSD"`

	// The price of gas in the destination chain, denoted in the native token of the destination chain
	GasPrice cciptypes.BigInt `json:"gasPrice"`

	// The price of the native token of the destination chain in USD
	DestNativeTokenPriceUSD cciptypes.BigInt `json:"destNativeTokenPriceUSD"`

	// Maps message IDs to the estimated gas cost of executing these messages
	MessageExecutionGasCosts map[string]cciptypes.BigInt `json:"messageExecutionCosts"`
}
```

The message fee in USD will be: `message.jeuls * JuelPriceUSD * feeBoostFactor`
The message execution cost will be `GasPrice * MessageExecutionGasCosts * DestNativeTokenPriceUSD`