### PR TITLE
internal/plugincommon/discovery: discover nonce mgr

### DIFF
--- a/commit/tokenprice/observation_test.go
+++ b/commit/tokenprice/observation_test.go
@@ -79,7 +79,7 @@ func Test_Observation(t *testing.T) {
 					tokenPriceReader: tokenPriceReader,
 					homeChain:        homeChain,
 					cfg:              defaultCfg,
-					bigF:             f,
+					fRoleDON:         f,
 				}
 			},
 			expObs: Observation{
@@ -105,7 +105,7 @@ func Test_Observation(t *testing.T) {
 					tokenPriceReader: tokenPriceReader,
 					homeChain:        homeChain,
 					cfg:              defaultCfg,
-					bigF:             f,
+					fRoleDON:         f,
 				}
 			},
 			expObs: Observation{},

--- a/commit/tokenprice/outcome.go
+++ b/commit/tokenprice/outcome.go
@@ -20,13 +20,13 @@ func (p *processor) getConsensusObservation(
 ) (ConsensusObservation, error) {
 	aggObs := aggregateObservations(aos)
 
-	fMin := make(map[cciptypes.ChainSelector]int)
-	for chain := range aggObs.FChain {
-		fMin[chain] = p.bigF
-	}
-
 	// consensus on the fChain map uses the role DON F value
 	// because all nodes can observe the home chain.
+	fMin := make(map[cciptypes.ChainSelector]int)
+	for chain := range aggObs.FChain {
+		// TODO: this doesn't seem right, should be passing in 2 * fRoleDON + 1?
+		fMin[chain] = p.fRoleDON
+	}
 	fChains := plugincommon.GetConsensusMap(p.lggr, "fChain", aggObs.FChain, fMin)
 
 	fDestChain, exists := fChains[p.cfg.DestChain]

--- a/commit/tokenprice/outcome_test.go
+++ b/commit/tokenprice/outcome_test.go
@@ -68,7 +68,7 @@ func TestGetConsensusObservation(t *testing.T) {
 			DestChain:      destChainSel,
 			OffchainConfig: offChainCfg,
 		},
-		bigF: 1,
+		fRoleDON: 1,
 	}
 
 	// 3 oracles, same observations, will pass destChain 2f+1 and fail feedChain 2f+1
@@ -117,7 +117,7 @@ func TestSelectTokensForUpdate(t *testing.T) {
 			DestChain:      destChainSel,
 			OffchainConfig: offChainCfg,
 		},
-		bigF: 1,
+		fRoleDON: 1,
 	}
 
 	conObs := ConsensusObservation{
@@ -146,7 +146,7 @@ func TestOutcome(t *testing.T) {
 			DestChain:      destChainSel,
 			OffchainConfig: offChainCfg,
 		},
-		bigF: 1,
+		fRoleDON: 1,
 	}
 
 	outcome, err := p.Outcome(Outcome{}, Query{}, []plugincommon.AttributedObservation[Observation]{

--- a/commit/tokenprice/processor.go
+++ b/commit/tokenprice/processor.go
@@ -25,7 +25,7 @@ type processor struct {
 	chainSupport     plugincommon.ChainSupport
 	tokenPriceReader reader.PriceReader
 	homeChain        reader.HomeChain
-	bigF             int
+	fRoleDON         int
 }
 
 // nolint: revive
@@ -45,7 +45,7 @@ func NewProcessor(
 		chainSupport:     chainSupport,
 		tokenPriceReader: tokenPriceReader,
 		homeChain:        homeChain,
-		bigF:             bigF,
+		fRoleDON:         bigF,
 	}
 }
 

--- a/internal/plugincommon/consensus.go
+++ b/internal/plugincommon/consensus.go
@@ -92,3 +92,21 @@ func BigIntComparator(a, b cciptypes.BigInt) bool {
 func TokenPriceComparator(a, b cciptypes.TokenPrice) bool {
 	return a.Price.Int.Cmp(b.Price.Int) == -1
 }
+
+// HonestMajorityThreshold takes a fault-tolerance f value
+// and returns the threshold value that is set to 2f+1.
+// Use this in cases where an honest majority is required.
+func HonestMajorityThreshold(f int) int {
+	return 2*f + 1
+}
+
+// HonestMajorityThresholdMap takes a map of chains to fault-tolerance
+// f values and returns a map of chains to threshold values that are set to 2f+1.
+// Use this in cases where an honest majority is required.
+func HonestMajorityThresholdMap(fMap map[cciptypes.ChainSelector]int) map[cciptypes.ChainSelector]int {
+	thresholdMap := make(map[cciptypes.ChainSelector]int)
+	for chain, f := range fMap {
+		thresholdMap[chain] = HonestMajorityThreshold(f)
+	}
+	return thresholdMap
+}

--- a/internal/plugincommon/consensus.go
+++ b/internal/plugincommon/consensus.go
@@ -81,14 +81,14 @@ func Median[T any](vals []T, less func(T, T) bool) T {
 	return valsCopy[len(valsCopy)/2]
 }
 
-var TimestampComparator = func(a, b time.Time) bool {
+func TimestampComparator(a, b time.Time) bool {
 	return a.Before(b)
 }
 
-var BigIntComparator = func(a, b cciptypes.BigInt) bool {
+func BigIntComparator(a, b cciptypes.BigInt) bool {
 	return a.Cmp(b.Int) == -1
 }
 
-var TokenPriceComparator = func(a, b cciptypes.TokenPrice) bool {
+func TokenPriceComparator(a, b cciptypes.TokenPrice) bool {
 	return a.Price.Int.Cmp(b.Price.Int) == -1
 }

--- a/internal/plugincommon/consensus_test.go
+++ b/internal/plugincommon/consensus_test.go
@@ -1,6 +1,7 @@
 package plugincommon
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -123,6 +124,82 @@ func TestMedianBigInt(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equalf(t, tt.want, Median(tt.vals, BigIntComparator), "Median(%v)", tt.vals)
+		})
+	}
+}
+
+func Test_HonestMajorityThreshold(t *testing.T) {
+	tests := []struct {
+		f    int
+		want int
+	}{
+		{f: 0, want: 1},
+		{f: 1, want: 3},
+		{f: 2, want: 5},
+		{f: 3, want: 7},
+		{f: 10, want: 21},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("f=%d", tt.f), func(t *testing.T) {
+			got := HonestMajorityThreshold(tt.f)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_HonestMajorityThresholdMap(t *testing.T) {
+	tests := []struct {
+		name string
+		fMap map[cciptypes.ChainSelector]int
+		want map[cciptypes.ChainSelector]int
+	}{
+		{
+			name: "base case",
+			fMap: map[cciptypes.ChainSelector]int{
+				cciptypes.ChainSelector(1): 0,
+				cciptypes.ChainSelector(2): 1,
+				cciptypes.ChainSelector(3): 2,
+			},
+			want: map[cciptypes.ChainSelector]int{
+				cciptypes.ChainSelector(1): 1,
+				cciptypes.ChainSelector(2): 3,
+				cciptypes.ChainSelector(3): 5,
+			},
+		},
+		{
+			name: "empty map",
+			fMap: map[cciptypes.ChainSelector]int{},
+			want: map[cciptypes.ChainSelector]int{},
+		},
+		{
+			name: "single entry",
+			fMap: map[cciptypes.ChainSelector]int{
+				cciptypes.ChainSelector(1): 10,
+			},
+			want: map[cciptypes.ChainSelector]int{
+				cciptypes.ChainSelector(1): 21,
+			},
+		},
+		{
+			name: "multiple entries",
+			fMap: map[cciptypes.ChainSelector]int{
+				cciptypes.ChainSelector(1): 3,
+				cciptypes.ChainSelector(2): 5,
+				cciptypes.ChainSelector(3): 7,
+			},
+			want: map[cciptypes.ChainSelector]int{
+				cciptypes.ChainSelector(1): 7,
+				cciptypes.ChainSelector(2): 11,
+				cciptypes.ChainSelector(3): 15,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HonestMajorityThresholdMap(tt.fMap)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/plugincommon/discovery/discoverytypes/types.go
+++ b/internal/plugincommon/discovery/discoverytypes/types.go
@@ -13,8 +13,9 @@ type Query []byte
 
 // Observation of contract addresses.
 type Observation struct {
-	FChain map[ccipocr3.ChainSelector]int
-	OnRamp map[ccipocr3.ChainSelector][]byte
+	FChain           map[ccipocr3.ChainSelector]int
+	OnRamp           map[ccipocr3.ChainSelector][]byte
+	DestNonceManager []byte
 
 	// TODO: some sort of request flag to avoid including this every time.
 	// Request bool


### PR DESCRIPTION
Seeing the following error in the integration test in the base branch (as of time of writing):

```
CCIPCCIPExecOCR3.evm.90000003.0x9679ef6115f76a1543173a94809107b365f55e1c	protocol/common.go:40	call to ReportingPlugin.Observation errored	{"version": "unset@unset", "error": "unable to get nonces: failed to get nonce for address 0x4b354002591c60618a7bce10e421460b10dd9a7d: ExtendedGetLatestValue: getOneBinding: no binding found for NonceManager contract: no bindings found", "proto": "outgen", "e": 6, "l": 2, "configDigest": "000a3548c444f0295b9ddfa5bebf118a2ac1ae5259d3c2b85431bbb39ef2e159", "oid": 3, "round": 1, "seqNr": 15}
```

Discover the nonce manager as part of the discovery processor.