### PR TITLE
Remove temporary call to DiscoverContracts.

### DIFF
--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -504,15 +504,6 @@ func (r *ccipChainReader) DiscoverContracts(
 
 // Sync goes through the input contracts and binds them to the contract reader.
 func (r *ccipChainReader) Sync(ctx context.Context, contracts ContractAddresses) error {
-	if len(contracts) == 0 {
-		// TODO: stop calling DiscoverContracts here once the contracts are passed in via observations.
-		var err error
-		contracts, err = r.DiscoverContracts(ctx, r.destChain)
-		if err != nil {
-			return fmt.Errorf("sync: %w", err)
-		}
-	}
-
 	var errs []error
 	for contractName, chainSelToAddress := range contracts {
 		for chainSel, address := range chainSelToAddress {


### PR DESCRIPTION
Removing temporary code which is no longer needed. The Discovery Processor handles this, and it is now fully integrated with plugins.