### PR TITLE
Exec v2 scaffolding to determine costly messages

### DIFF
--- a/execute/exectypes/commit_data.go
+++ b/execute/exectypes/commit_data.go
@@ -25,6 +25,11 @@ type CommitData struct {
 	// ExecutedMessages are the messages in this report that have already been executed.
 	ExecutedMessages []cciptypes.SeqNum `json:"executedMessages"`
 
+	// CostlyMessages are the message IDs of messages that cost more to execute than was paid to execute them (i.e.
+	// source fee < execution cost). These messages will not be executed in the current round, but may be executed in
+	// future rounds (e.g. if gas prices decrease or if these messages' fees are boosted high enough).
+	CostlyMessages []cciptypes.Bytes32 `json:"costlyMessages"`
+
 	// TokenData for each message.
 	MessageTokenData []MessageTokenData `json:"messageTokenData"`
 }

--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -9,12 +9,13 @@ import (
 	mapset "github.com/deckarep/golang-set/v2"
 	"golang.org/x/exp/maps"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/libocr/commontypes"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	libocrtypes "github.com/smartcontractkit/libocr/ragep2p/types"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
 	"github.com/smartcontractkit/chainlink-ccip/execute/internal/gas"
@@ -47,10 +48,11 @@ type Plugin struct {
 	homeChain   reader.HomeChain
 	discovery   *discovery.ContractDiscoveryProcessor
 
-	oracleIDToP2pID   map[commontypes.OracleID]libocrtypes.PeerID
-	tokenDataObserver tokendata.TokenDataObserver
-	estimateProvider  gas.EstimateProvider
-	lggr              logger.Logger
+	oracleIDToP2pID       map[commontypes.OracleID]libocrtypes.PeerID
+	tokenDataObserver     tokendata.TokenDataObserver
+	costlyMessageObserver exectypes.CostlyMessageObserver
+	estimateProvider      gas.EstimateProvider
+	lggr                  logger.Logger
 
 	// state
 	contractsInitialized bool
@@ -85,6 +87,8 @@ func NewPlugin(
 		tokenDataObserver: tokenDataObserver,
 		estimateProvider:  estimateProvider,
 		lggr:              lggr,
+		// TODO: implement
+		costlyMessageObserver: &exectypes.NoOpCostlyMessageObserver{},
 		discovery: discovery.NewContractDiscoveryProcessor(
 			lggr,
 			&ccipReader,
@@ -216,7 +220,7 @@ func (p *Plugin) Observation(
 			}
 
 			// TODO: truncate grouped to a maximum observation size?
-			return exectypes.NewObservation(groupedCommits, nil, nil, nil, discoveryObs).Encode()
+			return exectypes.NewObservation(groupedCommits, nil, nil, nil, nil, discoveryObs).Encode()
 		}
 
 		// No observation for non-dest readers.
@@ -276,7 +280,13 @@ func (p *Plugin) Observation(
 			return types.Observation{}, fmt.Errorf("unable to process token data %w", err1)
 		}
 
-		return exectypes.NewObservation(groupedCommits, messages, tkData, nil, discoveryObs).Encode()
+		costlyMessages, err := p.costlyMessageObserver.Observe(ctx, messages)
+		if err != nil {
+			return types.Observation{}, fmt.Errorf("unable to observe costly messages %w", err)
+		}
+
+		return exectypes.NewObservation(
+			groupedCommits, messages, costlyMessages, tkData, nil, discoveryObs).Encode()
 
 	case exectypes.Filter:
 		// Phase 3: observe nonce for each unique source/sender pair.
@@ -306,7 +316,7 @@ func (p *Plugin) Observation(
 			nonceObservations[srcChain] = nonces
 		}
 
-		return exectypes.NewObservation(nil, nil, nil, nonceObservations, discoveryObs).Encode()
+		return exectypes.NewObservation(nil, nil, nil, nil, nonceObservations, discoveryObs).Encode()
 	default:
 		return types.Observation{}, fmt.Errorf("unknown state")
 	}
@@ -450,13 +460,21 @@ func (p *Plugin) Outcome(
 		outcome = exectypes.NewOutcome(state, commitReports, cciptypes.ExecutePluginReport{})
 	case exectypes.GetMessages:
 		commitReports := previousOutcome.PendingCommitReports
+		costlyMessagesSet := mapset.NewSet[cciptypes.Bytes32]()
+		for _, msgID := range observation.CostlyMessages {
+			costlyMessagesSet.Add(msgID)
+		}
 
 		// add messages to their commitReports.
 		for i, report := range commitReports {
 			report.Messages = nil
+			report.CostlyMessages = nil
 			for j := report.SequenceNumberRange.Start(); j <= report.SequenceNumberRange.End(); j++ {
 				if msg, ok := observation.Messages[report.SourceChain][j]; ok {
 					report.Messages = append(report.Messages, msg)
+					if costlyMessagesSet.Contains(msg.Header.MessageID) {
+						report.CostlyMessages = append(report.CostlyMessages, msg.Header.MessageID)
+					}
 				}
 
 				if tokenData, ok := observation.TokenData[report.SourceChain][j]; ok {
@@ -465,6 +483,7 @@ func (p *Plugin) Outcome(
 			}
 			commitReports[i].Messages = report.Messages
 			commitReports[i].MessageTokenData = report.MessageTokenData
+			commitReports[i].CostlyMessages = report.CostlyMessages
 		}
 
 		outcome = exectypes.NewOutcome(state, commitReports, cciptypes.ExecutePluginReport{})

--- a/execute/plugin_functions_test.go
+++ b/execute/plugin_functions_test.go
@@ -5,12 +5,14 @@ import (
 	"testing"
 
 	mapset "github.com/deckarep/golang-set/v2"
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+	"github.com/stretchr/testify/require"
+
 	"github.com/smartcontractkit/libocr/commontypes"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
@@ -1161,6 +1163,80 @@ func Test_mergeTokenDataObservation(t *testing.T) {
 					assert.Equal(t, exp.data, obs[chainSelector][seqNum].ToByteSlice())
 				}
 			}
+		})
+	}
+}
+
+func Test_mergeCostlyMessages(t *testing.T) {
+	tests := []struct {
+		name       string
+		aos        []plugincommon.AttributedObservation[exectypes.Observation]
+		fChainDest int
+		want       []cciptypes.Bytes32
+	}{
+		{
+			name:       "no observations",
+			aos:        []plugincommon.AttributedObservation[exectypes.Observation]{},
+			fChainDest: 1,
+			want:       nil,
+		},
+		{
+			name: "observations below threshold",
+			aos: []plugincommon.AttributedObservation[exectypes.Observation]{
+				{
+					Observation: exectypes.Observation{
+						CostlyMessages: []cciptypes.Bytes32{
+							{0x01},
+						},
+					},
+				},
+				{
+					Observation: exectypes.Observation{
+						CostlyMessages: []cciptypes.Bytes32{
+							{0x01},
+						},
+					},
+				},
+			},
+			fChainDest: 3,
+			want:       nil,
+		},
+		{
+			name: "observations above threshold",
+			aos: []plugincommon.AttributedObservation[exectypes.Observation]{
+				{
+					Observation: exectypes.Observation{
+						CostlyMessages: []cciptypes.Bytes32{
+							{0x01},
+						},
+					},
+				},
+				{
+					Observation: exectypes.Observation{
+						CostlyMessages: []cciptypes.Bytes32{
+							{0x01},
+						},
+					},
+				},
+				{
+					Observation: exectypes.Observation{
+						CostlyMessages: []cciptypes.Bytes32{
+							{0x01},
+						},
+					},
+				},
+			},
+			fChainDest: 2,
+			want: []cciptypes.Bytes32{
+				{0x01},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeCostlyMessages(tt.aos, tt.fChainDest)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/execute/plugin_test.go
+++ b/execute/plugin_test.go
@@ -230,7 +230,7 @@ func TestPlugin_ValidateObservation_IneligibleObserver(t *testing.T) {
 				},
 			},
 		},
-	}, nil, nil, dt.Observation{})
+	}, nil, nil, nil, dt.Observation{})
 	encoded, err := observation.Encode()
 	require.NoError(t, err)
 	err = p.ValidateObservation(ocr3types.OutcomeContext{}, types.Query{}, types.AttributedObservation{
@@ -262,7 +262,9 @@ func TestPlugin_ValidateObservation_ValidateObservedSeqNum_Error(t *testing.T) {
 			{MerkleRoot: root},
 		},
 	}
-	observation := exectypes.NewObservation(commitReports, nil, nil, nil, dt.Observation{})
+	observation := exectypes.NewObservation(
+		commitReports, nil, nil, nil, nil, dt.Observation{},
+	)
 	encoded, err := observation.Encode()
 	require.NoError(t, err)
 	err = p.ValidateObservation(ocr3types.OutcomeContext{}, types.Query{}, types.AttributedObservation{
@@ -355,7 +357,9 @@ func TestPlugin_Outcome_CommitReportsMergeError(t *testing.T) {
 	commitReports := map[cciptypes.ChainSelector][]exectypes.CommitData{
 		1: {},
 	}
-	observation, err := exectypes.NewObservation(commitReports, nil, nil, nil, dt.Observation{}).Encode()
+	observation, err := exectypes.NewObservation(
+		commitReports, nil, nil, nil, nil, dt.Observation{},
+	).Encode()
 	require.NoError(t, err)
 	_, err = p.Outcome(ocr3types.OutcomeContext{}, nil, []types.AttributedObservation{
 		{
@@ -388,7 +392,9 @@ func TestPlugin_Outcome_MessagesMergeError(t *testing.T) {
 			},
 		},
 	}
-	observation, err := exectypes.NewObservation(nil, messages, nil, nil, dt.Observation{}).Encode()
+	observation, err := exectypes.NewObservation(
+		nil, messages, nil, nil, nil, dt.Observation{},
+	).Encode()
 	require.NoError(t, err)
 	_, err = p.Outcome(ocr3types.OutcomeContext{}, nil, []types.AttributedObservation{
 		{


### PR DESCRIPTION
Adds scaffolding to the V2 Exec Plugin to enable observing which messages are too costly to execute.