### PR TITLE
Discover Router and FeeQuoters

### DIFF
--- a/internal/mocks/inmem/ccipreader_inmem.go
+++ b/internal/mocks/inmem/ccipreader_inmem.go
@@ -138,7 +138,7 @@ func (r InMemoryCCIPReader) GetChainFeePriceUpdate(
 }
 
 func (r InMemoryCCIPReader) DiscoverContracts(
-	ctx context.Context, destChain cciptypes.ChainSelector,
+	ctx context.Context, allChains []cciptypes.ChainSelector,
 ) (reader.ContractAddresses, error) {
 	return nil, nil
 }

--- a/internal/plugincommon/discovery/discoverytypes/types.go
+++ b/internal/plugincommon/discovery/discoverytypes/types.go
@@ -1,6 +1,8 @@
 package discoverytypes
 
-import "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+import (
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+)
 
 // Outcome isn't needed for this processor.
 type Outcome struct {
@@ -13,10 +15,13 @@ type Query []byte
 
 // Observation of contract addresses.
 type Observation struct {
-	FChain           map[ccipocr3.ChainSelector]int
-	OnRamp           map[ccipocr3.ChainSelector][]byte
-	DestNonceManager []byte
-	RMNRemote        []byte
+	//SourceChains     []ccipocr3.ChainSelector
+	FChain map[cciptypes.ChainSelector]int
+	// See reader.ContractAddresses for more info on this data structure.
+	Addresses map[string]map[cciptypes.ChainSelector][]byte
+
+	// TODO: fix circular dependency /w token reader
+	//Addresses  reader.ContractAddresses
 
 	// TODO: some sort of request flag to avoid including this every time.
 	// Request bool

--- a/internal/plugincommon/discovery/processor.go
+++ b/internal/plugincommon/discovery/processor.go
@@ -200,7 +200,7 @@ func (cdp *ContractDiscoveryProcessor) Outcome(
 	donThresh := consensus.MakeConstantThreshold[cciptypes.ChainSelector](consensus.TwoFPlus1(cdp.fRoleDON))
 	fChain := consensus.GetConsensusMap(cdp.lggr, "fChain", fChainObs, donThresh)
 	fChainThresh := consensus.MakeMultiThreshold(fChain, consensus.TwoFPlus1)
-	destThresh := consensus.MakeConstantThreshold[cciptypes.ChainSelector](consensus.TwoFPlus1(cdp.fRoleDON))
+	destThresh := consensus.MakeConstantThreshold[cciptypes.ChainSelector](consensus.TwoFPlus1(fChain[cdp.dest]))
 
 	agg := aggregateObservations(cdp.lggr, cdp.dest, aos)
 

--- a/internal/plugincommon/discovery/processor.go
+++ b/internal/plugincommon/discovery/processor.go
@@ -232,6 +232,9 @@ func (cdp *ContractDiscoveryProcessor) Outcome(
 		"nonceManagerAddrs", agg.nonceManagerAddrs,
 		"fChainThresh", fChainThresh,
 	)
+	if len(nonceManagerConsensus) == 0 {
+		cdp.lggr.Warnw("No consensus on nonce manager, nonceManagerConsensus map is empty")
+	}
 	contracts[consts.ContractNameNonceManager] = nonceManagerConsensus
 
 	// RMNRemote address consensus
@@ -246,6 +249,9 @@ func (cdp *ContractDiscoveryProcessor) Outcome(
 		"rmnRemoteAddrs", agg.rmnRemoteAddrs,
 		"fChainThresh", fChainThresh,
 	)
+	if len(rmnRemoteConsensus) == 0 {
+		cdp.lggr.Warnw("No consensus on RMNRemote, rmnRemoteConsensus map is empty")
+	}
 	contracts[consts.ContractNameRMNRemote] = rmnRemoteConsensus
 
 	// Router address consensus
@@ -260,6 +266,9 @@ func (cdp *ContractDiscoveryProcessor) Outcome(
 		"RouterAddrs", agg.routerAddrs,
 		"fChainThresh", fChainThresh,
 	)
+	if len(routerConsensus) == 0 {
+		cdp.lggr.Warnw("No consensus on router, routerConsensus map is empty")
+	}
 	contracts[consts.ContractNameRouter] = routerConsensus
 
 	feeQuoterConsensus := consensus.GetConsensusMap(

--- a/internal/plugincommon/discovery/processor_test.go
+++ b/internal/plugincommon/discovery/processor_test.go
@@ -44,8 +44,8 @@ func TestContractDiscoveryProcessor_Observation_SupportsDest_HappyPath(t *testin
 		source: []byte("onRamp"),
 	}
 	expectedFeeQuoter := map[cciptypes.ChainSelector][]byte{
-		source: []byte("onRamp"),
-		dest:   []byte("dest"),
+		source: []byte("from_source_onramp"),
+		dest:   []byte("from_dest_offramp"),
 	}
 	expectedRMNRemote := []byte("rmnRemote")
 	expectedRouter := []byte("router")
@@ -430,7 +430,7 @@ func TestContractDiscoveryProcessor_Outcome_NotEnoughObservations(t *testing.T) 
 		{Observation: destObs},
 		{Observation: destObs},
 		{Observation: destObs},
-		{Observation: destObs},
+		{Observation: destObs}, // dest requires 2*f+1, for f=2 we need 5 observations
 		{Observation: fChainObs},
 		{Observation: fChainObs},
 		{Observation: fChainObs},

--- a/mocks/pkg/reader/ccip_reader.go
+++ b/mocks/pkg/reader/ccip_reader.go
@@ -140,9 +140,9 @@ func (_c *MockCCIPReader_CommitReportsGTETimestamp_Call) RunAndReturn(run func(c
 	return _c
 }
 
-// DiscoverContracts provides a mock function with given fields: ctx, destChain
-func (_m *MockCCIPReader) DiscoverContracts(ctx context.Context, destChain ccipocr3.ChainSelector) (reader.ContractAddresses, error) {
-	ret := _m.Called(ctx, destChain)
+// DiscoverContracts provides a mock function with given fields: ctx, allChains
+func (_m *MockCCIPReader) DiscoverContracts(ctx context.Context, allChains []ccipocr3.ChainSelector) (reader.ContractAddresses, error) {
+	ret := _m.Called(ctx, allChains)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DiscoverContracts")
@@ -150,19 +150,19 @@ func (_m *MockCCIPReader) DiscoverContracts(ctx context.Context, destChain ccipo
 
 	var r0 reader.ContractAddresses
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, ccipocr3.ChainSelector) (reader.ContractAddresses, error)); ok {
-		return rf(ctx, destChain)
+	if rf, ok := ret.Get(0).(func(context.Context, []ccipocr3.ChainSelector) (reader.ContractAddresses, error)); ok {
+		return rf(ctx, allChains)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, ccipocr3.ChainSelector) reader.ContractAddresses); ok {
-		r0 = rf(ctx, destChain)
+	if rf, ok := ret.Get(0).(func(context.Context, []ccipocr3.ChainSelector) reader.ContractAddresses); ok {
+		r0 = rf(ctx, allChains)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(reader.ContractAddresses)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, ccipocr3.ChainSelector) error); ok {
-		r1 = rf(ctx, destChain)
+	if rf, ok := ret.Get(1).(func(context.Context, []ccipocr3.ChainSelector) error); ok {
+		r1 = rf(ctx, allChains)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -177,14 +177,14 @@ type MockCCIPReader_DiscoverContracts_Call struct {
 
 // DiscoverContracts is a helper method to define mock.On call
 //   - ctx context.Context
-//   - destChain ccipocr3.ChainSelector
-func (_e *MockCCIPReader_Expecter) DiscoverContracts(ctx interface{}, destChain interface{}) *MockCCIPReader_DiscoverContracts_Call {
-	return &MockCCIPReader_DiscoverContracts_Call{Call: _e.mock.On("DiscoverContracts", ctx, destChain)}
+//   - allChains []ccipocr3.ChainSelector
+func (_e *MockCCIPReader_Expecter) DiscoverContracts(ctx interface{}, allChains interface{}) *MockCCIPReader_DiscoverContracts_Call {
+	return &MockCCIPReader_DiscoverContracts_Call{Call: _e.mock.On("DiscoverContracts", ctx, allChains)}
 }
 
-func (_c *MockCCIPReader_DiscoverContracts_Call) Run(run func(ctx context.Context, destChain ccipocr3.ChainSelector)) *MockCCIPReader_DiscoverContracts_Call {
+func (_c *MockCCIPReader_DiscoverContracts_Call) Run(run func(ctx context.Context, allChains []ccipocr3.ChainSelector)) *MockCCIPReader_DiscoverContracts_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(ccipocr3.ChainSelector))
+		run(args[0].(context.Context), args[1].([]ccipocr3.ChainSelector))
 	})
 	return _c
 }
@@ -194,7 +194,7 @@ func (_c *MockCCIPReader_DiscoverContracts_Call) Return(_a0 reader.ContractAddre
 	return _c
 }
 
-func (_c *MockCCIPReader_DiscoverContracts_Call) RunAndReturn(run func(context.Context, ccipocr3.ChainSelector) (reader.ContractAddresses, error)) *MockCCIPReader_DiscoverContracts_Call {
+func (_c *MockCCIPReader_DiscoverContracts_Call) RunAndReturn(run func(context.Context, []ccipocr3.ChainSelector) (reader.ContractAddresses, error)) *MockCCIPReader_DiscoverContracts_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -27,7 +27,7 @@ const (
 	MethodNameGetSourceChainConfig         = "GetSourceChainConfig"
 	MethodNameOffRampGetDynamicConfig      = "OffRampGetDynamicConfig"
 	MethodNameOffRampGetStaticConfig       = "OffRampGetStaticConfig"
-	MethodNameOffRampGetDestChainConfig    = "GetDestChainConfig"
+	MethodNameOffRampGetDestChainConfig    = "OffRampGetDestChainConfig"
 	MethodNameGetLatestPriceSequenceNumber = "GetLatestPriceSequenceNumber"
 	MethodNameIsBlessed                    = "IsBlessed"
 	MethodNameGetMerkleRoot                = "GetMerkleRoot"

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -7,13 +7,13 @@ const (
 	ContractNameOffRamp                = "OffRamp"
 	ContractNameOnRamp                 = "OnRamp"
 	ContractNameFeeQuoter              = "FeeQuoter"
-	ContractNameRouter                 = "Router"
 	ContractNameCapabilitiesRegistry   = "CapabilitiesRegistry"
 	ContractNameCCIPConfig             = "CCIPConfig"
 	ContractNamePriceAggregator        = "AggregatorV3Interface"
 	ContractNameNonceManager           = "NonceManager"
 	ContractNameRMNHome                = "RMNHome"
 	ContractNameRMNRemote              = "RMNRemote"
+	ContractNameRouter                 = "Router"
 	ContractNameCCTPMessageTransmitter = "MessageTransmitter"
 )
 
@@ -23,18 +23,19 @@ const (
 	// Router methods
 	MethodNameRouterGetWrappedNative = "GetWrappedNative"
 
-	// Offramp methods
+	// OffRamp methods
 	MethodNameGetSourceChainConfig         = "GetSourceChainConfig"
-	MethodNameOfframpGetDynamicConfig      = "OfframpGetDynamicConfig"
-	MethodNameOfframpGetStaticConfig       = "OfframpGetStaticConfig"
+	MethodNameOffRampGetDynamicConfig      = "OffRampGetDynamicConfig"
+	MethodNameOffRampGetStaticConfig       = "OffRampGetStaticConfig"
+	MethodNameOffRampGetDestChainConfig    = "GetDestChainConfig"
 	MethodNameGetLatestPriceSequenceNumber = "GetLatestPriceSequenceNumber"
 	MethodNameIsBlessed                    = "IsBlessed"
 	MethodNameGetMerkleRoot                = "GetMerkleRoot"
 	MethodNameGetExecutionState            = "GetExecutionState"
 
-	// Onramp methods
-	MethodNameOnrampGetDynamicConfig        = "OnrampGetDynamicConfig"
-	MethodNameOnrampGetStaticConfig         = "OnrampGetStaticConfig"
+	// OnRamp methods
+	MethodNameOnRampGetDynamicConfig        = "OnRampGetDynamicConfig"
+	MethodNameOnRampGetStaticConfig         = "OnRampGetStaticConfig"
 	MethodNameGetExpectedNextSequenceNumber = "GetExpectedNextSequenceNumber"
 
 	// FeeQuoter view/pure methods
@@ -56,6 +57,12 @@ const (
 	// NonceManager methods
 	MethodNameGetInboundNonce  = "GetInboundNonce"
 	MethodNameGetOutboundNonce = "GetOutboundNonce"
+
+	// Deprecated: TODO: remove after chainlink is updated.
+	MethodNameOfframpGetDynamicConfig = "OfframpGetDynamicConfig"
+	MethodNameOfframpGetStaticConfig  = "OfframpGetStaticConfig"
+	MethodNameOnrampGetDynamicConfig  = "OnrampGetDynamicConfig"
+	MethodNameOnrampGetStaticConfig   = "OnrampGetStaticConfig"
 
 	/*
 		// On EVM:

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -60,9 +60,12 @@ const (
 
 	// Deprecated: TODO: remove after chainlink is updated.
 	MethodNameOfframpGetDynamicConfig = "OfframpGetDynamicConfig"
-	MethodNameOfframpGetStaticConfig  = "OfframpGetStaticConfig"
-	MethodNameOnrampGetDynamicConfig  = "OnrampGetDynamicConfig"
-	MethodNameOnrampGetStaticConfig   = "OnrampGetStaticConfig"
+	// Deprecated: TODO: remove after chainlink is updated.
+	MethodNameOfframpGetStaticConfig = "OfframpGetStaticConfig"
+	// Deprecated: TODO: remove after chainlink is updated.
+	MethodNameOnrampGetDynamicConfig = "OnrampGetDynamicConfig"
+	// Deprecated: TODO: remove after chainlink is updated.
+	MethodNameOnrampGetStaticConfig = "OnrampGetStaticConfig"
 
 	/*
 		// On EVM:

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -64,7 +64,7 @@ func newCCIPChainReaderInternal(
 		},
 	}
 	if err := reader.Sync(context.Background(), contracts); err != nil {
-		lggr.Infow("failed to sync contracts", "err", err)
+		lggr.Errorw("failed to sync contracts", "err", err)
 	}
 
 	return reader
@@ -372,7 +372,7 @@ func (r *ccipChainReader) GetExpectedNextSequenceNumber(
 func (r *ccipChainReader) NextSeqNum(
 	ctx context.Context, chains []cciptypes.ChainSelector,
 ) ([]cciptypes.SeqNum, error) {
-	cfgs, err := r.getSourceChainsConfig(ctx, chains)
+	cfgs, err := r.getOffRampSourceChainsConfig(ctx, chains)
 	if err != nil {
 		return nil, fmt.Errorf("get source chains config: %w", err)
 	}
@@ -482,7 +482,7 @@ func (r *ccipChainReader) GetWrappedNativeTokenPriceUSD(
 			&nativeTokenAddress)
 
 		if err != nil {
-			r.lggr.Errorw("failed to get native token address", "chain", chain, "err", err)
+			r.lggr.Warnw("failed to get native token address", "chain", chain, "err", err)
 			continue
 		}
 
@@ -537,7 +537,7 @@ func (r *ccipChainReader) GetChainFeePriceUpdate(ctx context.Context, selectors 
 			&update,
 		)
 		if err != nil {
-			r.lggr.Errorw("failed to get chain fee price update", "chain", chain, "err", err)
+			r.lggr.Warnw("failed to get chain fee price update", "chain", chain, "err", err)
 			continue
 		}
 		feeUpdates[chain] = update
@@ -550,45 +550,119 @@ func (r *ccipChainReader) GetChainFeePriceUpdate(ctx context.Context, selectors 
 	return feeUpdates
 }
 
-func (r *ccipChainReader) DiscoverContracts(
+func (r *ccipChainReader) discoverDestinationContracts(
 	ctx context.Context,
-	destChain cciptypes.ChainSelector,
+	allChains []cciptypes.ChainSelector,
 ) (ContractAddresses, error) {
-	if err := validateExtendedReaderExistence(r.contractReaders, destChain); err != nil {
-		return nil, err
+	// Exit without an error if we cannot read the destination.
+	if err := validateExtendedReaderExistence(r.contractReaders, r.destChain); err != nil {
+		return nil, fmt.Errorf("validate extended reader existence: %w", err)
 	}
 
-	chains := maps.Keys(r.contractReaders)
+	// build up resp as we go.
+	var resp ContractAddresses
 
-	// OnRamps are in the offramp SourceChainConfig.
-	sourceConfigs, err := r.getSourceChainsConfig(ctx, chains)
+	// OnRamps are in the offRamp SourceChainConfig.
+	sourceConfigs, err := r.getOffRampSourceChainsConfig(ctx, allChains)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get SourceChainsConfig: %w", err)
 	}
-
-	// NonceManager and RMNRemote are in the offramp static config
-	staticConfig, err := r.getOfframpStaticConfig(ctx, r.destChain)
-	if err != nil {
-		return nil, fmt.Errorf("unable to lookup nonce manager: %w", err)
-	}
-
-	// TODO: Lookup FeeQuoter (from onRamp DynamicConfig)
-	// TODO: Lookup Router (from onRamp DestChainConfig)
-
-	// Build response object.
-	onramps := make(map[cciptypes.ChainSelector][]byte, len(chains))
 	for chain, cfg := range sourceConfigs {
-		onramps[chain] = cfg.OnRamp
+		resp = resp.Append(consts.ContractNameOnRamp, chain, cfg.OnRamp)
 	}
-	resp := map[string]map[cciptypes.ChainSelector][]byte{
-		consts.ContractNameOnRamp: onramps,
-		consts.ContractNameNonceManager: {
-			destChain: staticConfig.NonceManager,
-		},
-		consts.ContractNameRMNRemote: {
-			destChain: staticConfig.Rmn,
-		},
+
+	// NonceManager and RMNRemote are in the offramp static config.
+	var staticConfig offRampStaticChainConfig
+	err = r.getDestinationData(
+		ctx,
+		r.destChain,
+		consts.ContractNameOffRamp,
+		consts.MethodNameOffRampGetStaticConfig,
+		&staticConfig,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to lookup nonce manager (offramp static config): %w", err)
 	}
+	resp = resp.Append(consts.ContractNameNonceManager, r.destChain, staticConfig.NonceManager)
+	resp = resp.Append(consts.ContractNameRMNRemote, r.destChain, staticConfig.Rmn)
+
+	// FeeQuoter from the offRamp dynamic config.
+	var dynamicConfig offRampDynamicChainConfig
+	err = r.getDestinationData(
+		ctx,
+		r.destChain,
+		consts.ContractNameOffRamp,
+		consts.MethodNameOffRampGetDynamicConfig,
+		&dynamicConfig,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to lookup fee quoter (offramp dynamic config): %w", err)
+	}
+	resp = resp.Append(consts.ContractNameFeeQuoter, r.destChain, dynamicConfig.FeeQuoter)
+
+	// TODO: re-enable router discovery once the chainreader has been configured with
+	/*
+		// Router is in the offRamp chain config.
+		var chainConfig offRampDestChainConfig
+		err = r.getDestinationData(
+			ctx,
+			r.destChain,
+			consts.ContractNameOffRamp,
+			consts.MethodNameOffRampGetDestChainConfig,
+			&chainConfig,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("unable to lookup router (offramp dest chain config): %w", err)
+		}
+		resp = resp.Append(consts.ContractNameRouter, r.destChain, chainConfig.Router)
+	*/
+
+	return resp, nil
+}
+
+func (r *ccipChainReader) DiscoverContracts(
+	ctx context.Context,
+	allChains []cciptypes.ChainSelector,
+) (ContractAddresses, error) {
+	// TODO: Remove nil handling once the discovery processor is able to discover source chain addresses.
+	// At that point it will pass in the destChain on the first round, and in subsequent rounds it will pass in
+	// the full list of observed sources.
+	if allChains == nil {
+		allChains = maps.Keys(r.contractReaders)
+	}
+	resp, err := r.discoverDestinationContracts(ctx, allChains)
+	// Ignore the error if the destination chain is not available. We still want to continue
+	// discovering contracts from any source chains that may be available.
+	if err != nil {
+		if !errors.Is(err, ErrContractReaderNotFound) {
+			return nil, fmt.Errorf("discover destination contracts: %w", err)
+		}
+		// Make sure
+		resp = nil
+	}
+
+	// The following calls are on dynamically configured chains which may not
+	// be available when this function is called. Eventually they will be
+	// configured through consensus when the Sync function is called, but until
+	// that happens the ErrNoBindings case must be handled gracefully.
+
+	myChains := maps.Keys(r.contractReaders)
+
+	// Read onRamps for FeeQuoter in DynamicConfig.
+	dynamicConfigs, err := r.getOnRampDynamicConfigs(ctx, myChains)
+	if err != nil {
+		r.lggr.Infow("unable to lookup source fee quoters, this is expected during initialization", "err", err)
+
+		// ErrNoBindings is an allowable error.
+		if !errors.Is(err, contractreader.ErrNoBindings) {
+			return nil, fmt.Errorf("unable to lookup source fee quoters (onRamp dynamic config): %w", err)
+		}
+	} else {
+		for chain, cfg := range dynamicConfigs {
+			resp = resp.Append(consts.ContractNameFeeQuoter, chain, cfg.FeeQuoter)
+		}
+	}
+
 	return resp, nil
 }
 
@@ -642,8 +716,19 @@ func (r *ccipChainReader) GetContractAddress(contractName string, chain cciptype
 	return addressBytes, nil
 }
 
-// getSourceChainsConfig returns the offRamp contract's source chain configurations for each supported source chain.
-func (r *ccipChainReader) getSourceChainsConfig(
+// sourceChainConfig is used to parse the response from the offRamp contract's getSourceChainConfig method.
+// See: https://github.com/smartcontractkit/ccip/blob/a3f61f7458e4499c2c62eb38581c60b4942b1160/contracts/src/v0.8/ccip/offRamp/OffRamp.sol#L94
+//
+//nolint:lll // It's a URL.
+type sourceChainConfig struct {
+	IsEnabled bool
+	OnRamp    []byte
+	MinSeqNr  uint64
+}
+
+// getOffRampSourceChainsConfig returns the offRamp contract's source chain configurations for each supported source
+// chain.
+func (r *ccipChainReader) getOffRampSourceChainsConfig(
 	ctx context.Context, chains []cciptypes.ChainSelector) (map[cciptypes.ChainSelector]sourceChainConfig, error) {
 	if err := validateExtendedReaderExistence(r.contractReaders, r.destChain); err != nil {
 		return nil, err
@@ -705,49 +790,112 @@ func (r *ccipChainReader) getSourceChainsConfig(
 	return res, nil
 }
 
-// sourceChainConfig is used to parse the response from the offRamp contract's getSourceChainConfig method.
-// See: https://github.com/smartcontractkit/ccip/blob/a3f61f7458e4499c2c62eb38581c60b4942b1160/contracts/src/v0.8/ccip/offRamp/OffRamp.sol#L94
-//
-//nolint:lll // It's a URL.
-type sourceChainConfig struct {
-	IsEnabled bool
-	OnRamp    []byte
-	MinSeqNr  uint64
-}
-
-// getOfframpStaticConfig returns the destination offRamp contract's static configuration.
-func (r *ccipChainReader) getOfframpStaticConfig(
-	ctx context.Context,
-	chain cciptypes.ChainSelector,
-) (offrampStaticChainConfig, error) {
-	if err := validateExtendedReaderExistence(r.contractReaders, chain); err != nil {
-		return offrampStaticChainConfig{}, err
-	}
-
-	resp := offrampStaticChainConfig{}
-	err := r.contractReaders[chain].ExtendedGetLatestValue(
-		ctx,
-		consts.ContractNameOffRamp,
-		consts.MethodNameOfframpGetStaticConfig,
-		primitives.Unconfirmed,
-		map[string]any{},
-		&resp,
-	)
-	if err != nil {
-		return offrampStaticChainConfig{}, fmt.Errorf("failed to get source chain config: %w", err)
-	}
-	return resp, nil
-}
-
-// offrampStaticChainConfig is used to parse the response from the offRamp contract's getStaticConfig method.
+// offRampStaticChainConfig is used to parse the response from the offRamp contract's getStaticConfig method.
 // See: https://github.com/smartcontractkit/ccip/blob/a3f61f7458e4499c2c62eb38581c60b4942b1160/contracts/src/v0.8/ccip/offRamp/OffRamp.sol#L86
 //
 //nolint:lll // It's a URL.
-type offrampStaticChainConfig struct {
+type offRampStaticChainConfig struct {
 	ChainSelector      cciptypes.ChainSelector `json:"chainSelector"`
 	Rmn                []byte                  `json:"rmn"`
 	TokenAdminRegistry []byte                  `json:"tokenAdminRegistry"`
 	NonceManager       []byte                  `json:"nonceManager"`
+}
+
+// offRampDynamicChainConfig maps to DynamicChainConfig in OffRamp.sol
+type offRampDynamicChainConfig struct {
+	FeeQuoter                               []byte `json:"feeQuoter"`
+	PermissionLessExecutionThresholdSeconds uint32 `json:"permissionLessExecutionThresholdSeconds"`
+	MaxTokenTransferGas                     uint32 `json:"maxTokenTransferGas"`
+	MaxPoolReleaseOrMintGas                 uint32 `json:"maxPoolReleaseOrMintGas"`
+	MessageValidator                        []byte `json:"messageValidator"`
+}
+
+//nolint:unused // it will be used soon // TODO: Remove nolint
+type offRampDestChainConfig struct {
+	SequenceNumber   uint64 `json:"sequenceNumber"`
+	AllowListEnabled bool   `json:"allowListEnabled"`
+	Router           []byte `json:"router"`
+}
+
+// getData returns data for a single reader.
+func (r *ccipChainReader) getDestinationData(
+	ctx context.Context,
+	destChain cciptypes.ChainSelector,
+	contract string,
+	method string,
+	returnVal any,
+) error {
+	if err := validateExtendedReaderExistence(r.contractReaders, destChain); err != nil {
+		return err
+	}
+
+	if destChain != r.destChain {
+		return fmt.Errorf("expected destination chain %d, got %d", r.destChain, destChain)
+	}
+
+	return r.contractReaders[destChain].ExtendedGetLatestValue(
+		ctx,
+		contract,
+		method,
+		primitives.Unconfirmed,
+		map[string]any{},
+		returnVal,
+	)
+}
+
+// See DynamicChainConfig in OnRamp.sol
+type onRampDynamicChainConfig struct {
+	FeeQuoter        []byte `json:"feeQuoter"`
+	MessageValidator []byte `json:"messageValidator"`
+	FeeAggregator    []byte `json:"feeAggregator"`
+	AllowListAdmin   []byte `json:"allowListAdmin"`
+}
+
+func (r *ccipChainReader) getOnRampDynamicConfigs(
+	ctx context.Context,
+	srcChains []cciptypes.ChainSelector,
+) (map[cciptypes.ChainSelector]onRampDynamicChainConfig, error) {
+	if err := validateExtendedReaderExistence(r.contractReaders, srcChains...); err != nil {
+		return nil, err
+	}
+
+	result := make(map[cciptypes.ChainSelector]onRampDynamicChainConfig)
+
+	mu := new(sync.Mutex)
+	eg := new(errgroup.Group)
+	for _, chainSel := range srcChains {
+		// no onramp for the destination chain
+		if chainSel == r.destChain {
+			continue
+		}
+
+		chainSel := chainSel
+		eg.Go(func() error {
+			// read onramp dynamic config
+			resp := onRampDynamicChainConfig{}
+			err := r.contractReaders[chainSel].ExtendedGetLatestValue(
+				ctx,
+				consts.ContractNameOnRamp,
+				consts.MethodNameOnRampGetDynamicConfig,
+				primitives.Unconfirmed,
+				map[string]any{},
+				&resp,
+			)
+			if err != nil {
+				return fmt.Errorf("failed to get onramp dynamic config: %w", err)
+			}
+			mu.Lock()
+			result[chainSel] = resp
+			mu.Unlock()
+
+			return nil
+		})
+	}
+
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 // Interface compliance check

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -577,7 +577,7 @@ func (r *ccipChainReader) discoverDestinationContracts(
 		ctx,
 		r.destChain,
 		consts.ContractNameOffRamp,
-		consts.MethodNameOffRampGetStaticConfig,
+		consts.MethodNameOfframpGetStaticConfig, //nolint:staticcheck // TODO: use the new name.
 		&staticConfig,
 	)
 	if err != nil {
@@ -592,7 +592,7 @@ func (r *ccipChainReader) discoverDestinationContracts(
 		ctx,
 		r.destChain,
 		consts.ContractNameOffRamp,
-		consts.MethodNameOffRampGetDynamicConfig,
+		consts.MethodNameOfframpGetDynamicConfig, //nolint:staticcheck // TODO: use the new name.
 		&dynamicConfig,
 	)
 	if err != nil {
@@ -876,7 +876,7 @@ func (r *ccipChainReader) getOnRampDynamicConfigs(
 			err := r.contractReaders[chainSel].ExtendedGetLatestValue(
 				ctx,
 				consts.ContractNameOnRamp,
-				consts.MethodNameOnRampGetDynamicConfig,
+				consts.MethodNameOnrampGetDynamicConfig, //nolint:staticcheck // TODO: use the new name.
 				primitives.Unconfirmed,
 				map[string]any{},
 				&resp,

--- a/pkg/reader/ccip_interface.go
+++ b/pkg/reader/ccip_interface.go
@@ -134,6 +134,8 @@ type CCIPReader interface {
 
 	// DiscoverContracts reads the destination chain for contract addresses. They are returned per
 	// contract and source chain selector.
+	// allChains is needed because there is currently no way to discover all source contracts. So we allow them
+	// to be passed in here. We'll attempt to fetch the source config from the offramp for each of them.
 	DiscoverContracts(ctx context.Context, allChains []cciptypes.ChainSelector) (ContractAddresses, error)
 
 	// Sync can be used to perform frequent syncing operations inside the reader implementation.

--- a/pkg/reader/ccip_interface.go
+++ b/pkg/reader/ccip_interface.go
@@ -24,6 +24,18 @@ var (
 // Currently only one contract per chain per name is supported.
 type ContractAddresses map[string]map[cciptypes.ChainSelector][]byte
 
+func (ca ContractAddresses) Append(contract string, chain cciptypes.ChainSelector, address []byte) ContractAddresses {
+	resp := ca
+	if resp == nil {
+		resp = make(ContractAddresses)
+	}
+	if resp[contract] == nil {
+		resp[contract] = make(map[cciptypes.ChainSelector][]byte)
+	}
+	resp[contract][chain] = address
+	return resp
+}
+
 func NewCCIPChainReader(
 	lggr logger.Logger,
 	contractReaders map[cciptypes.ChainSelector]contractreader.ContractReaderFacade,
@@ -122,7 +134,7 @@ type CCIPReader interface {
 
 	// DiscoverContracts reads the destination chain for contract addresses. They are returned per
 	// contract and source chain selector.
-	DiscoverContracts(ctx context.Context, destChain cciptypes.ChainSelector) (ContractAddresses, error)
+	DiscoverContracts(ctx context.Context, allChains []cciptypes.ChainSelector) (ContractAddresses, error)
 
 	// Sync can be used to perform frequent syncing operations inside the reader implementation.
 	// Returns a bool indicating whether something was updated.

--- a/pkg/reader/ccip_interface_test.go
+++ b/pkg/reader/ccip_interface_test.go
@@ -1,0 +1,87 @@
+package reader
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+)
+
+func TestContractAddresses_Append(t *testing.T) {
+	type args struct {
+		contract string
+		chain    ccipocr3.ChainSelector
+		address  []byte
+	}
+	tests := []struct {
+		name string
+		ca   ContractAddresses
+		args args
+		want ContractAddresses
+	}{
+		{
+			name: "append on nil",
+			ca:   nil,
+			args: args{
+				contract: "foo",
+				chain:    ccipocr3.ChainSelector(1),
+				address:  []byte("bar"),
+			},
+			want: ContractAddresses{
+				"foo": {
+					ccipocr3.ChainSelector(1): []byte("bar"),
+				},
+			},
+		},
+		{
+			name: "append on existing",
+			ca: ContractAddresses{
+				"foo": {
+					ccipocr3.ChainSelector(1): []byte("bar"),
+				},
+			},
+			args: args{
+				contract: "foo",
+				chain:    ccipocr3.ChainSelector(2),
+				address:  []byte("baz"),
+			},
+			want: ContractAddresses{
+				"foo": {
+
+					ccipocr3.ChainSelector(1): []byte("bar"),
+					ccipocr3.ChainSelector(2): []byte("baz"),
+				},
+			},
+		},
+		{
+			name: "append on new contract",
+			ca: ContractAddresses{
+				"foo": {
+					ccipocr3.ChainSelector(1): []byte("bar"),
+				},
+			},
+			args: args{
+				contract: "newContract",
+				chain:    ccipocr3.ChainSelector(1),
+				address:  []byte("newAddress"),
+			},
+			want: ContractAddresses{
+				"foo": {
+					ccipocr3.ChainSelector(1): []byte("bar"),
+				},
+				"newContract": {
+					ccipocr3.ChainSelector(1): []byte("newAddress"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t,
+				tt.want,
+				tt.ca.Append(tt.args.contract, tt.args.chain, tt.args.address),
+				"Append(%v, %v, %v)", tt.args.contract, tt.args.chain, tt.args.address)
+		})
+	}
+}

--- a/pkg/reader/ccip_test.go
+++ b/pkg/reader/ccip_test.go
@@ -381,7 +381,7 @@ func addDestinationContractAssertions(
 	extended.EXPECT().ExtendedGetLatestValue(
 		mock.Anything,
 		consts.ContractNameOffRamp,
-		consts.MethodNameOffRampGetStaticConfig,
+		consts.MethodNameOfframpGetStaticConfig, //nolint:staticcheck // TODO: use the new name.
 		primitives.Unconfirmed,
 		map[string]any{},
 		mock.Anything,
@@ -394,7 +394,7 @@ func addDestinationContractAssertions(
 	extended.EXPECT().ExtendedGetLatestValue(
 		mock.Anything,
 		consts.ContractNameOffRamp,
-		consts.MethodNameOffRampGetDynamicConfig,
+		consts.MethodNameOfframpGetDynamicConfig, //nolint:staticcheck // TODO: use the new name.
 		primitives.Unconfirmed,
 		map[string]any{},
 		mock.Anything,
@@ -456,7 +456,7 @@ func TestCCIPChainReader_DiscoverContracts_HappyPath_Round1(t *testing.T) {
 		mockReaders[selector].EXPECT().ExtendedGetLatestValue(
 			mock.Anything,
 			consts.ContractNameOnRamp,
-			consts.MethodNameOnRampGetDynamicConfig,
+			consts.MethodNameOnrampGetDynamicConfig, //nolint:staticcheck // TODO: use the new name.
 			primitives.Unconfirmed,
 			map[string]any{},
 			mock.Anything,
@@ -541,7 +541,7 @@ func TestCCIPChainReader_DiscoverContracts_HappyPath_Round2(t *testing.T) {
 		mockReaders[selector].EXPECT().ExtendedGetLatestValue(
 			mock.Anything,
 			consts.ContractNameOnRamp,
-			consts.MethodNameOnRampGetDynamicConfig,
+			consts.MethodNameOnrampGetDynamicConfig, //nolint:staticcheck // TODO: use the new name.
 			primitives.Unconfirmed,
 			map[string]any{},
 			mock.Anything,
@@ -611,7 +611,7 @@ func TestCCIPChainReader_DiscoverContracts_HappyPath_OnlySupportDest(t *testing.
 	destExtended.EXPECT().ExtendedGetLatestValue(
 		mock.Anything,
 		consts.ContractNameOffRamp,
-		consts.MethodNameOffRampGetStaticConfig,
+		consts.MethodNameOfframpGetStaticConfig, //nolint:staticcheck // TODO: use the new name.
 		primitives.Unconfirmed,
 		map[string]any{},
 		mock.Anything,
@@ -624,7 +624,7 @@ func TestCCIPChainReader_DiscoverContracts_HappyPath_OnlySupportDest(t *testing.
 	destExtended.EXPECT().ExtendedGetLatestValue(
 		mock.Anything,
 		consts.ContractNameOffRamp,
-		consts.MethodNameOffRampGetDynamicConfig,
+		consts.MethodNameOfframpGetDynamicConfig, //nolint:staticcheck // TODO: use the new name.
 		primitives.Unconfirmed,
 		map[string]any{},
 		mock.Anything,
@@ -757,7 +757,7 @@ func TestCCIPChainReader_DiscoverContracts_GetOfframpStaticConfig_Errors(t *test
 	destExtended.EXPECT().ExtendedGetLatestValue(
 		mock.Anything,
 		consts.ContractNameOffRamp,
-		consts.MethodNameOffRampGetStaticConfig,
+		consts.MethodNameOfframpGetStaticConfig, //nolint:staticcheck // TODO: use the new name.
 		primitives.Unconfirmed,
 		map[string]any{},
 		mock.Anything,

--- a/pkg/reader/ccip_test.go
+++ b/pkg/reader/ccip_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
@@ -76,7 +77,7 @@ func TestCCIPChainReader_getSourceChainsConfig(t *testing.T) {
 			Address: typeconv.AddressBytesToString(offrampAddress, 111_111)}}))
 
 	ctx := context.Background()
-	cfgs, err := ccipReader.getSourceChainsConfig(ctx, []cciptypes.ChainSelector{chainA, chainB})
+	cfgs, err := ccipReader.getOffRampSourceChainsConfig(ctx, []cciptypes.ChainSelector{chainA, chainB})
 	assert.NoError(t, err)
 	assert.Len(t, cfgs, 2)
 	assert.Equal(t, []byte("onramp-1"), cfgs[chainA].OnRamp)
@@ -372,122 +373,279 @@ func TestCCIPChainReader_Sync_BindError(t *testing.T) {
 	require.ErrorIs(t, err, expectedErr)
 }
 
-func TestCCIPChainReader_DiscoverContracts_HappyPath(t *testing.T) {
-	ctx := tests.Context(t)
-	destChain := cciptypes.ChainSelector(1)
-	sourceChain1 := cciptypes.ChainSelector(2)
-	sourceChain2 := cciptypes.ChainSelector(3)
-	s1Onramp := []byte{0x1}
-	s2Onramp := []byte{0x2}
-	destNonceMgr := []byte{0x3}
-	rmnRemote := []byte{0x4}
-	expectedContractAddresses := ContractAddresses{
-		consts.ContractNameOnRamp: {
-			sourceChain1: s1Onramp,
-			sourceChain2: s2Onramp,
-		},
-		consts.ContractNameNonceManager: {
-			destChain: destNonceMgr,
-		},
-		consts.ContractNameRMNRemote: {
-			destChain: rmnRemote,
-		},
-	}
-	destExtended := reader_mocks.NewMockExtended(t)
-
-	// mock the call for sourceChain1
-	destExtended.EXPECT().ExtendedGetLatestValue(
-		mock.Anything,
-		consts.ContractNameOffRamp,
-		consts.MethodNameGetSourceChainConfig,
-		primitives.Unconfirmed,
-		map[string]any{"sourceChainSelector": sourceChain1},
-		mock.Anything,
-	).Return(nil).Run(withReturnValueOverridden(func(returnVal interface{}) {
-		v := returnVal.(*sourceChainConfig)
-		v.OnRamp = s1Onramp
-		v.IsEnabled = true
-	}))
-	// mock the call for sourceChain2
-	destExtended.EXPECT().ExtendedGetLatestValue(
-		mock.Anything,
-		consts.ContractNameOffRamp,
-		consts.MethodNameGetSourceChainConfig,
-		primitives.Unconfirmed,
-		map[string]any{"sourceChainSelector": sourceChain2},
-		mock.Anything,
-	).Return(nil).Run(withReturnValueOverridden(func(returnVal interface{}) {
-		v := returnVal.(*sourceChainConfig)
-		v.OnRamp = s2Onramp
-		v.IsEnabled = true
-	}))
+func addDestinationContractAssertions(
+	extended *reader_mocks.MockExtended,
+	destNonceMgr, destRMNRemote, destFeeQuoter, _ []byte,
+) {
 	// mock the call to get the nonce manager
-	destExtended.EXPECT().ExtendedGetLatestValue(
+	extended.EXPECT().ExtendedGetLatestValue(
 		mock.Anything,
 		consts.ContractNameOffRamp,
-		consts.MethodNameOfframpGetStaticConfig,
+		consts.MethodNameOffRampGetStaticConfig,
 		primitives.Unconfirmed,
 		map[string]any{},
 		mock.Anything,
 	).Return(nil).Run(withReturnValueOverridden(func(returnVal interface{}) {
-		v := returnVal.(*offrampStaticChainConfig)
+		v := returnVal.(*offRampStaticChainConfig)
 		v.NonceManager = destNonceMgr
-		v.Rmn = rmnRemote
+		v.Rmn = destRMNRemote
 	}))
+	// mock the call to get the fee quoter
+	extended.EXPECT().ExtendedGetLatestValue(
+		mock.Anything,
+		consts.ContractNameOffRamp,
+		consts.MethodNameOffRampGetDynamicConfig,
+		primitives.Unconfirmed,
+		map[string]any{},
+		mock.Anything,
+	).Return(nil).Run(withReturnValueOverridden(func(returnVal interface{}) {
+		v := returnVal.(*offRampDynamicChainConfig)
+		v.FeeQuoter = destFeeQuoter
+	}))
+	// mock the call to get the router
+	/*
+		extended.EXPECT().ExtendedGetLatestValue(
+			mock.Anything,
+			consts.ContractNameOffRamp,
+			consts.MethodNameGetDestChainConfig,
+			primitives.Unconfirmed,
+			map[string]any{},
+			mock.Anything,
+		).Return(nil).Run(withReturnValueOverridden(func(returnVal interface{}) {
+			v := returnVal.(*offRampDestChainConfig)
+			v.Router = destRouter
+		}))
+	*/
+}
+
+// The round1 version returns NoBindingFound errors for onramp contracts to simulate
+// the two-phase approach to discovering those contracts.
+func TestCCIPChainReader_DiscoverContracts_HappyPath_Round1(t *testing.T) {
+	ctx := tests.Context(t)
+	destChain := cciptypes.ChainSelector(1)
+	sourceChain := [2]cciptypes.ChainSelector{2, 3}
+	onramps := [2][]byte{{0x1}, {0x2}}
+	destNonceMgr := []byte{0x3}
+	destRMNRemote := []byte{0x4}
+	destFeeQuoter := []byte{0x5}
+	destRouter := []byte{0x6}
+	//srcFeeQuoters := [2][]byte{{0x7}, {0x8}}
+
+	// Build expected addresses.
+	var expectedContractAddresses ContractAddresses
+	// Source FeeQuoter's are missing.
+	for i := range onramps {
+		expectedContractAddresses = expectedContractAddresses.Append(
+			consts.ContractNameOnRamp, sourceChain[i], onramps[i])
+	}
+	//expectedContractAddresses = expectedContractAddresses.Append(consts.ContractNameRouter, destChain, destRouter)
+	expectedContractAddresses = expectedContractAddresses.Append(consts.ContractNameFeeQuoter, destChain, destFeeQuoter)
+	expectedContractAddresses = expectedContractAddresses.Append(consts.ContractNameRMNRemote, destChain, destRMNRemote)
+	expectedContractAddresses = expectedContractAddresses.Append(consts.ContractNameNonceManager, destChain, destNonceMgr)
+
+	mockReaders := make(map[cciptypes.ChainSelector]*reader_mocks.MockExtended)
+
+	mockReaders[destChain] = reader_mocks.NewMockExtended(t)
+	addDestinationContractAssertions(mockReaders[destChain], destNonceMgr, destRMNRemote, destFeeQuoter, destRouter)
+
+	// mock calls to get fee quoter from onramps and source chain config from offramp.
+	for i, selector := range sourceChain {
+		mockReaders[selector] = reader_mocks.NewMockExtended(t)
+
+		// ErrNoBindings is ignored.
+		mockReaders[selector].EXPECT().ExtendedGetLatestValue(
+			mock.Anything,
+			consts.ContractNameOnRamp,
+			consts.MethodNameOnRampGetDynamicConfig,
+			primitives.Unconfirmed,
+			map[string]any{},
+			mock.Anything,
+		).Return(contractreader.ErrNoBindings)
+
+		mockReaders[destChain].EXPECT().ExtendedGetLatestValue(
+			mock.Anything,
+			consts.ContractNameOffRamp,
+			consts.MethodNameGetSourceChainConfig,
+			primitives.Unconfirmed,
+			map[string]any{"sourceChainSelector": selector},
+			mock.Anything,
+		).Return(nil).Run(withReturnValueOverridden(func(returnVal interface{}) {
+			v := returnVal.(*sourceChainConfig)
+			v.OnRamp = onramps[i]
+			v.IsEnabled = true
+		}))
+	}
+
+	castToExtended := make(map[cciptypes.ChainSelector]contractreader.Extended)
+	for sel, v := range mockReaders {
+		castToExtended[sel] = v
+	}
+
+	lggr, hook := logger.TestObserved(t, zapcore.InfoLevel)
+	// create the reader
+	ccipChainReader := &ccipChainReader{
+		destChain:       destChain,
+		contractReaders: castToExtended,
+		lggr:            lggr,
+	}
+
+	// TODO: allChains should be initialized to "append(onramps, destChain)" when that feature is implemented.
+	contractAddresses, err := ccipChainReader.DiscoverContracts(ctx, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedContractAddresses, contractAddresses)
+	require.Equal(t, 1, hook.Len())
+	assert.Contains(
+		t,
+		"unable to lookup source fee quoters, this is expected during initialization",
+		hook.All()[0].Message,
+	)
+}
+
+// The round2 version includes calls to the onRamp contracts.
+func TestCCIPChainReader_DiscoverContracts_HappyPath_Round2(t *testing.T) {
+	ctx := tests.Context(t)
+	destChain := cciptypes.ChainSelector(1)
+	sourceChain := [2]cciptypes.ChainSelector{2, 3}
+	onramps := [2][]byte{{0x1}, {0x2}}
+	destNonceMgr := []byte{0x3}
+	destRMNRemote := []byte{0x4}
+	destFeeQuoter := []byte{0x5}
+	destRouter := []byte{0x6}
+	srcFeeQuoters := [2][]byte{{0x7}, {0x8}}
+
+	// Build expected addresses.
+	var expectedContractAddresses ContractAddresses
+	for i := range onramps {
+		expectedContractAddresses = expectedContractAddresses.Append(
+			consts.ContractNameOnRamp, sourceChain[i], onramps[i])
+	}
+	for i := range srcFeeQuoters {
+		expectedContractAddresses = expectedContractAddresses.Append(
+			consts.ContractNameFeeQuoter, sourceChain[i], srcFeeQuoters[i])
+	}
+	//expectedContractAddresses = expectedContractAddresses.Append(consts.ContractNameRouter, destChain, destRouter)
+	expectedContractAddresses = expectedContractAddresses.Append(consts.ContractNameFeeQuoter, destChain, destFeeQuoter)
+	expectedContractAddresses = expectedContractAddresses.Append(consts.ContractNameRMNRemote, destChain, destRMNRemote)
+	expectedContractAddresses = expectedContractAddresses.Append(consts.ContractNameNonceManager, destChain, destNonceMgr)
+
+	mockReaders := make(map[cciptypes.ChainSelector]*reader_mocks.MockExtended)
+
+	mockReaders[destChain] = reader_mocks.NewMockExtended(t)
+	addDestinationContractAssertions(mockReaders[destChain], destNonceMgr, destRMNRemote, destFeeQuoter, destRouter)
+
+	// mock calls to get fee quoter from onramps and source chain config from offramp.
+	for i, selector := range sourceChain {
+		mockReaders[selector] = reader_mocks.NewMockExtended(t)
+
+		mockReaders[selector].EXPECT().ExtendedGetLatestValue(
+			mock.Anything,
+			consts.ContractNameOnRamp,
+			consts.MethodNameOnRampGetDynamicConfig,
+			primitives.Unconfirmed,
+			map[string]any{},
+			mock.Anything,
+		).Return(nil).Run(withReturnValueOverridden(func(returnVal interface{}) {
+			v := returnVal.(*onRampDynamicChainConfig)
+			v.FeeQuoter = srcFeeQuoters[i]
+		}))
+
+		// mock the call for sourceChain2
+		mockReaders[destChain].EXPECT().ExtendedGetLatestValue(
+			mock.Anything,
+			consts.ContractNameOffRamp,
+			consts.MethodNameGetSourceChainConfig,
+			primitives.Unconfirmed,
+			map[string]any{"sourceChainSelector": selector},
+			mock.Anything,
+		).Return(nil).Run(withReturnValueOverridden(func(returnVal interface{}) {
+			v := returnVal.(*sourceChainConfig)
+			v.OnRamp = onramps[i]
+			v.IsEnabled = true
+		}))
+	}
+
+	castToExtended := make(map[cciptypes.ChainSelector]contractreader.Extended)
+	for sel, v := range mockReaders {
+		castToExtended[sel] = v
+	}
 
 	// create the reader
 	ccipChainReader := &ccipChainReader{
-		destChain: destChain,
-		contractReaders: map[cciptypes.ChainSelector]contractreader.Extended{
-			destChain: destExtended,
-			// these won't be used in this test, but are needed because
-			// we determine the source chain selectors to query from the chains
-			// that we have readers for.
-			sourceChain1: reader_mocks.NewMockExtended(t),
-			sourceChain2: reader_mocks.NewMockExtended(t),
-		},
-		lggr: logger.Test(t),
+		destChain:       destChain,
+		contractReaders: castToExtended,
+		lggr:            logger.Test(t),
 	}
 
-	contractAddresses, err := ccipChainReader.DiscoverContracts(ctx, destChain)
+	// TODO: allChains should be initialized to "append(onramps, destChain)" when that feature is implemented.
+	contractAddresses, err := ccipChainReader.DiscoverContracts(ctx, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, expectedContractAddresses, contractAddresses)
 }
 
+// TODO: Remove this test when allChains is implemented.
+// This test checks that onramps are not discovered if there are only dest readers available.
 func TestCCIPChainReader_DiscoverContracts_HappyPath_OnlySupportDest(t *testing.T) {
 	ctx := tests.Context(t)
 	destChain := cciptypes.ChainSelector(1)
 	destNonceMgr := []byte{0x3}
 	destRMNRemote := []byte{0x4}
-	expectedContractAddresses := ContractAddresses{
-		// since the source chains are not supported, we should not have any onramp addresses
-		// after discovery.
-		consts.ContractNameOnRamp: {},
-		// the nonce manager doesn't require source chain support though,
-		// so we should discover that always if we support the dest.
-		consts.ContractNameNonceManager: {
-			destChain: destNonceMgr,
-		},
-		consts.ContractNameRMNRemote: {
-			destChain: destRMNRemote,
-		},
-	}
+	destFeeQuoter := []byte{0x5}
+	//destRouter := []byte{0x6}
+
+	var expectedContractAddresses ContractAddresses
+	// All dest chain contracts should be discovered, they do not require source chain support.
+	//expectedContractAddresses = expectedContractAddresses.Append(consts.ContractNameRouter, destChain, destRouter)
+	expectedContractAddresses = expectedContractAddresses.Append(consts.ContractNameFeeQuoter, destChain, destFeeQuoter)
+	expectedContractAddresses = expectedContractAddresses.Append(consts.ContractNameRMNRemote, destChain, destRMNRemote)
+	expectedContractAddresses = expectedContractAddresses.Append(consts.ContractNameNonceManager, destChain, destNonceMgr)
+
+	// since the source chains are not supported, we should not have any onramp addresses
+	// after discovery.
+	require.Len(t, expectedContractAddresses[consts.ContractNameOnRamp], 0)
+
 	destExtended := reader_mocks.NewMockExtended(t)
 
 	// mock the call to get the nonce manager
 	destExtended.EXPECT().ExtendedGetLatestValue(
 		mock.Anything,
 		consts.ContractNameOffRamp,
-		consts.MethodNameOfframpGetStaticConfig,
+		consts.MethodNameOffRampGetStaticConfig,
 		primitives.Unconfirmed,
 		map[string]any{},
 		mock.Anything,
 	).Return(nil).Run(withReturnValueOverridden(func(returnVal interface{}) {
-		v := returnVal.(*offrampStaticChainConfig)
+		v := returnVal.(*offRampStaticChainConfig)
 		v.NonceManager = destNonceMgr
 		v.Rmn = destRMNRemote
 	}))
+	// mock the call to get the fee quoter
+	destExtended.EXPECT().ExtendedGetLatestValue(
+		mock.Anything,
+		consts.ContractNameOffRamp,
+		consts.MethodNameOffRampGetDynamicConfig,
+		primitives.Unconfirmed,
+		map[string]any{},
+		mock.Anything,
+	).Return(nil).Run(withReturnValueOverridden(func(returnVal interface{}) {
+		v := returnVal.(*offRampDynamicChainConfig)
+		v.FeeQuoter = destFeeQuoter
+	}))
+	// mock the call to get the router
+	/*
+		destExtended.EXPECT().ExtendedGetLatestValue(
+			mock.Anything,
+			consts.ContractNameOffRamp,
+			consts.MethodNameGetDestChainConfig,
+			primitives.Unconfirmed,
+			map[string]any{},
+			mock.Anything,
+		).Return(nil).Run(withReturnValueOverridden(func(returnVal interface{}) {
+			v := returnVal.(*offRampDestChainConfig)
+			v.Router = destRouter
+		}))
+	*/
 
 	// create the reader
 	ccipChainReader := &ccipChainReader{
@@ -498,7 +656,8 @@ func TestCCIPChainReader_DiscoverContracts_HappyPath_OnlySupportDest(t *testing.
 		lggr: logger.Test(t),
 	}
 
-	contractAddresses, err := ccipChainReader.DiscoverContracts(ctx, destChain)
+	// TODO: allChains should be initialized to "append(onramps, destChain)" when that feature is implemented.
+	contractAddresses, err := ccipChainReader.DiscoverContracts(ctx, nil)
 	require.NoError(t, err)
 	require.Equal(t, expectedContractAddresses, contractAddresses)
 }
@@ -552,7 +711,8 @@ func TestCCIPChainReader_DiscoverContracts_GetSourceChainConfig_Errors(t *testin
 		lggr: logger.Test(t),
 	}
 
-	_, err := ccipChainReader.DiscoverContracts(ctx, destChain)
+	// TODO: allChains should be initialized to "append(onramps, destChain)" when that feature is implemented.
+	_, err := ccipChainReader.DiscoverContracts(ctx, nil)
 	require.Error(t, err)
 	require.ErrorIs(t, err, getLatestValueErr)
 }
@@ -597,7 +757,7 @@ func TestCCIPChainReader_DiscoverContracts_GetOfframpStaticConfig_Errors(t *test
 	destExtended.EXPECT().ExtendedGetLatestValue(
 		mock.Anything,
 		consts.ContractNameOffRamp,
-		consts.MethodNameOfframpGetStaticConfig,
+		consts.MethodNameOffRampGetStaticConfig,
 		primitives.Unconfirmed,
 		map[string]any{},
 		mock.Anything,
@@ -617,7 +777,8 @@ func TestCCIPChainReader_DiscoverContracts_GetOfframpStaticConfig_Errors(t *test
 		lggr: logger.Test(t),
 	}
 
-	_, err := ccipChainReader.DiscoverContracts(ctx, destChain)
+	// TODO: allChains should be initialized to "append(onramps, destChain)" when that feature is implemented.
+	_, err := ccipChainReader.DiscoverContracts(ctx, nil)
 	require.Error(t, err)
 	require.ErrorIs(t, err, getLatestValueErr)
 }


### PR DESCRIPTION
Extend the DiscoverContract function:
* Accepts a slice of chains. In the future this should be the total list of all supported chains.
* Best-effort discovery of addresses known to the onramps. These will not be discovered until the second round.
* Lookup additional offramp contracts: FeeQuoter, Router.