### PR TITLE
Fix flaky RMN test

### DIFF
--- a/commit/merkleroot/rmn/controller.go
+++ b/commit/merkleroot/rmn/controller.go
@@ -633,6 +633,8 @@ func (c *controller) listenForRmnReportSignatures(
 						ReportSignatureRequest: reportSigReq,
 					},
 				}
+
+				c.lggr.Infow("sending report signature request", "node", node.ID, "requestID", req.RequestId)
 				if err := c.marshalAndSend(req, node.ID); err != nil {
 					c.lggr.Errorw("failed to send report signature request", "node_id", node.ID, "err", err)
 					continue

--- a/commit/merkleroot/rmn/controller_test.go
+++ b/commit/merkleroot/rmn/controller_test.go
@@ -304,6 +304,7 @@ func (ts *testSetup) waitForReportSignatureRequestsToBeSent(
 			continue
 		}
 
+		cntValid := 0
 		// check that the requests the node received are correct
 		for _, reqs := range recvReqs {
 			for _, req := range reqs {
@@ -311,7 +312,12 @@ func (ts *testSetup) waitForReportSignatureRequestsToBeSent(
 					continue
 				}
 				assert.True(t, len(req.GetReportSignatureRequest().AttributedSignedObservations) >= minObservers)
+				cntValid++
 			}
+		}
+
+		if cntValid < expectedResponses {
+			continue
 		}
 
 		for nodeID, reqs := range recvReqs {


### PR DESCRIPTION
Verified that the issue was in the test logic and not the RMN logic itself.

Test never failed locally after running with `-count=1000`.
So issue is on lower-tier hardware, like the gh workflow one.

Checked the failed test logs, test logic was waiting for invalid request ids.
Adjusted test code in `waitForReportSignatureRequestsToBeSent` to not wait for `RMN responses` but wait for `RMN signature report responses`. Because in the lower tier hardware it might receive `Observation Responses` from previous step which took long to get processed.