### PR TITLE
RMN Controller Improvements

### DIFF
--- a/commit/merkleroot/outcome.go
+++ b/commit/merkleroot/outcome.go
@@ -164,6 +164,8 @@ func buildReport(
 		for _, root := range roots {
 			if signedRoots.Contains(root) {
 				rootsToReport = append(rootsToReport, root)
+			} else {
+				lggr.Warnw("skipping merkle root not signed by RMN", "root", root)
 			}
 		}
 		roots = rootsToReport

--- a/commit/merkleroot/query.go
+++ b/commit/merkleroot/query.go
@@ -51,6 +51,8 @@ func (w *Processor) Query(ctx context.Context, prevOutcome Outcome) (Query, erro
 	ctxQuery, cancel := context.WithTimeout(ctx, w.cfg.RMNSignaturesTimeout)
 	defer cancel()
 
+	// Get signatures for the requested updates. The signatures might contain a subset of the requested updates.
+	// While building the report the plugin should exclude source chain updates without signatures.
 	sigs, err := w.rmnClient.ComputeReportSignatures(ctxQuery, dstChainInfo, reqUpdates)
 	if err != nil {
 		if errors.Is(err, rmn.ErrTimeout) {

--- a/commit/merkleroot/rmn/config.go
+++ b/commit/merkleroot/rmn/config.go
@@ -35,3 +35,5 @@ type RMNNodeInfo struct {
 	SignObservationsPublicKey *ed25519.PublicKey // offChainPublicKey
 	SignObservationPrefix     string             // e.g. "chainlink ccip 1.6 rmn observation"
 }
+
+type NodeID uint32

--- a/commit/merkleroot/rmn/controller.go
+++ b/commit/merkleroot/rmn/controller.go
@@ -639,7 +639,8 @@ func (c *controller) sendReportSignatureRequest(reportSigReq *rmnpb.ReportSignat
 	return requestIDs, signersRequested, nil
 }
 
-// reportSigWithSignerAddress is a helper struct to store the report signature and the address of the SK that signed it.
+// reportSigWithSignerAddress is a helper struct to store the report signature and
+// the address of the private key that signed it.
 type reportSigWithSignerAddress struct {
 	reportSig     *rmnpb.ReportSignature
 	signerAddress cciptypes.Bytes

--- a/commit/merkleroot/rmn/controller_test.go
+++ b/commit/merkleroot/rmn/controller_test.go
@@ -240,7 +240,7 @@ func (ts *testSetup) waitForObservationRequestsToBeSent(
 		}
 		continue
 	}
-	ts.t.Logf("nodes received the observation requests: %v", requestIDs)
+	ts.t.Logf("test/mock nodes received the observation requests: %v", requestIDs)
 	return requestIDs, requestedChains
 }
 
@@ -288,6 +288,7 @@ func (ts *testSetup) nodesRespondToTheObservationRequests(
 		b, err := proto.Marshal(resp)
 		require.NoError(ts.t, err)
 
+		ts.t.Logf("test/mock node %d responds to %d", nodeID, resp.RequestId)
 		rmnClient.resChan <- PeerResponse{
 			RMNNodeID: nodeID,
 			Body:      b,


### PR DESCRIPTION
- Improved logging.
- In the Outcome phase exclude source chains that are not signed to prevent on-chain revert.
- Add comments explaining critical components.
- Trigger additional RMN requests instantly on the first error instead of waiting for timer expiration.
- Fix bug where duplicate lane updates were added in the same RMN report prior to verifying sigs.
- Cleaner less complicated logic.
- Handle edge case where some RMN node mix valid and invalid roots for different chains in their observation.
- Stop earlier after all RMN responses are received instead of waiting for timer expiration (on signature requests).