### PR TITLE
CCIP-3555 Using token data encoder from chainlink-common

### DIFF
--- a/execute/factory.go
+++ b/execute/factory.go
@@ -51,17 +51,16 @@ func (p PluginFactoryConstructor) NewValidationService(ctx context.Context) (cor
 
 // PluginFactory implements common ReportingPluginFactory and is used for (re-)initializing commit plugin instances.
 type PluginFactory struct {
-	lggr              logger.Logger
-	donID             plugintypes.DonID
-	ocrConfig         reader.OCR3ConfigWithMeta
-	execCodec         cciptypes.ExecutePluginCodec
-	msgHasher         cciptypes.MessageHasher
-	homeChainReader   reader.HomeChain
-	estimateProvider  gas.EstimateProvider
-	tokenDataObserver tokendata.TokenDataObserver
-	tokenDataEncoder  cciptypes.TokenDataEncoder
-	contractReaders   map[cciptypes.ChainSelector]types.ContractReader
-	chainWriters      map[cciptypes.ChainSelector]types.ChainWriter
+	lggr             logger.Logger
+	donID            plugintypes.DonID
+	ocrConfig        reader.OCR3ConfigWithMeta
+	execCodec        cciptypes.ExecutePluginCodec
+	msgHasher        cciptypes.MessageHasher
+	homeChainReader  reader.HomeChain
+	estimateProvider gas.EstimateProvider
+	tokenDataEncoder cciptypes.TokenDataEncoder
+	contractReaders  map[cciptypes.ChainSelector]types.ContractReader
+	chainWriters     map[cciptypes.ChainSelector]types.ChainWriter
 }
 
 func NewPluginFactory(
@@ -71,24 +70,22 @@ func NewPluginFactory(
 	execCodec cciptypes.ExecutePluginCodec,
 	msgHasher cciptypes.MessageHasher,
 	homeChainReader reader.HomeChain,
-	tokenDataObserver tokendata.TokenDataObserver,
 	tokenDataEncoder cciptypes.TokenDataEncoder,
 	estimateProvider gas.EstimateProvider,
 	contractReaders map[cciptypes.ChainSelector]types.ContractReader,
 	chainWriters map[cciptypes.ChainSelector]types.ChainWriter,
 ) *PluginFactory {
 	return &PluginFactory{
-		lggr:              lggr,
-		donID:             donID,
-		ocrConfig:         ocrConfig,
-		execCodec:         execCodec,
-		msgHasher:         msgHasher,
-		homeChainReader:   homeChainReader,
-		estimateProvider:  estimateProvider,
-		contractReaders:   contractReaders,
-		chainWriters:      chainWriters,
-		tokenDataObserver: tokenDataObserver,
-		tokenDataEncoder:  tokenDataEncoder,
+		lggr:             lggr,
+		donID:            donID,
+		ocrConfig:        ocrConfig,
+		execCodec:        execCodec,
+		msgHasher:        msgHasher,
+		homeChainReader:  homeChainReader,
+		estimateProvider: estimateProvider,
+		contractReaders:  contractReaders,
+		chainWriters:     chainWriters,
+		tokenDataEncoder: tokenDataEncoder,
 	}
 }
 

--- a/execute/factory.go
+++ b/execute/factory.go
@@ -59,6 +59,7 @@ type PluginFactory struct {
 	homeChainReader   reader.HomeChain
 	estimateProvider  gas.EstimateProvider
 	tokenDataObserver tokendata.TokenDataObserver
+	tokenDataEncoder  cciptypes.TokenDataEncoder
 	contractReaders   map[cciptypes.ChainSelector]types.ContractReader
 	chainWriters      map[cciptypes.ChainSelector]types.ChainWriter
 }
@@ -71,6 +72,7 @@ func NewPluginFactory(
 	msgHasher cciptypes.MessageHasher,
 	homeChainReader reader.HomeChain,
 	tokenDataObserver tokendata.TokenDataObserver,
+	tokenDataEncoder cciptypes.TokenDataEncoder,
 	estimateProvider gas.EstimateProvider,
 	contractReaders map[cciptypes.ChainSelector]types.ContractReader,
 	chainWriters map[cciptypes.ChainSelector]types.ChainWriter,
@@ -86,6 +88,7 @@ func NewPluginFactory(
 		contractReaders:   contractReaders,
 		chainWriters:      chainWriters,
 		tokenDataObserver: tokenDataObserver,
+		tokenDataEncoder:  tokenDataEncoder,
 	}
 }
 
@@ -124,6 +127,7 @@ func (p PluginFactory) NewReportingPlugin(
 		p.lggr,
 		p.ocrConfig.Config.ChainSelector,
 		offchainConfig.TokenDataObservers,
+		p.tokenDataEncoder,
 		readers,
 	)
 	if err != nil {

--- a/execute/plugin_usdc_test.go
+++ b/execute/plugin_usdc_test.go
@@ -372,6 +372,7 @@ func setupSimpleTest(
 		lggr,
 		cfg.DestChain,
 		cfg.OffchainConfig.TokenDataObservers,
+		testhelpers.TokenDataEncoderInstance,
 		map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
 			srcSelector: r,
 			dstSelector: r,

--- a/execute/tokendata/observer.go
+++ b/execute/tokendata/observer.go
@@ -51,6 +51,7 @@ func NewConfigBasedCompositeObservers(
 	lggr logger.Logger,
 	destChainSelector cciptypes.ChainSelector,
 	config []pluginconfig.TokenDataObserverConfig,
+	encoder cciptypes.TokenDataEncoder,
 	readers map[cciptypes.ChainSelector]contractreader.ContractReaderFacade,
 ) (TokenDataObserver, error) {
 	observers := make([]TokenDataObserver, len(config))
@@ -59,7 +60,7 @@ func NewConfigBasedCompositeObservers(
 		// e.g. observers[i] := config.CreateTokenDataObserver()
 		switch {
 		case c.USDCCCTPObserverConfig != nil:
-			observer, err := createUSDCTokenObserver(lggr, destChainSelector, *c.USDCCCTPObserverConfig, readers)
+			observer, err := createUSDCTokenObserver(lggr, destChainSelector, *c.USDCCCTPObserverConfig, encoder, readers)
 			if err != nil {
 				return nil, fmt.Errorf("create USDC/CCTP token observer: %w", err)
 			}
@@ -75,6 +76,7 @@ func createUSDCTokenObserver(
 	lggr logger.Logger,
 	destChainSelector cciptypes.ChainSelector,
 	cctpConfig pluginconfig.USDCCCTPObserverConfig,
+	encoder cciptypes.TokenDataEncoder,
 	readers map[cciptypes.ChainSelector]contractreader.ContractReaderFacade,
 ) (TokenDataObserver, error) {
 	usdcReader, err := reader.NewUSDCMessageReader(
@@ -94,6 +96,7 @@ func createUSDCTokenObserver(
 		lggr,
 		destChainSelector,
 		cctpConfig.Tokens,
+		encoder.EncodeUSDC,
 		usdcReader,
 		client,
 	), nil

--- a/execute/tokendata/observer_test.go
+++ b/execute/tokendata/observer_test.go
@@ -21,6 +21,7 @@ func Test_CompositeTokenDataObserver_EmptyObservers(t *testing.T) {
 		100,
 		[]pluginconfig.TokenDataObserverConfig{},
 		nil,
+		nil,
 	)
 	require.NoError(t, err)
 

--- a/execute/tokendata/usdc/attestation.go
+++ b/execute/tokendata/usdc/attestation.go
@@ -40,6 +40,8 @@ func ErrorAttestationStatus(err error) AttestationStatus {
 	return AttestationStatus{Error: err}
 }
 
+type AttestationEncoder func(context.Context, cciptypes.Bytes, cciptypes.Bytes) (cciptypes.Bytes, error)
+
 // AttestationClient is an interface for fetching attestation data from the Circle API.
 // It returns a data grouped by chainSelector, sequenceNumber and tokenIndex
 //

--- a/execute/tokendata/usdc/usdc_int_test.go
+++ b/execute/tokendata/usdc/usdc_int_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
 	"github.com/smartcontractkit/chainlink-ccip/execute/tokendata/usdc"
 	"github.com/smartcontractkit/chainlink-ccip/internal"
+	"github.com/smartcontractkit/chainlink-ccip/internal/libs/testhelpers"
 	readermock "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/contractreader"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
@@ -220,6 +221,7 @@ func Test_USDC_CCTP_Flow(t *testing.T) {
 		logger.Test(t),
 		baseChain,
 		config,
+		testhelpers.USDCEncoder,
 		usdcReader,
 		attestation,
 	)

--- a/execute/tokendata/usdc/usdc_test.go
+++ b/execute/tokendata/usdc/usdc_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
 	"github.com/smartcontractkit/chainlink-ccip/execute/tokendata/usdc"
 	"github.com/smartcontractkit/chainlink-ccip/internal"
+	"github.com/smartcontractkit/chainlink-ccip/internal/libs/testhelpers"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/reader"
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
 )
@@ -217,7 +218,14 @@ func TestTokenDataObserver_Observe_USDCAndRegularTokens(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			observer := usdc.NewTokenDataObserver(logger.Test(t), 1, config, test.usdcReader, test.attestationClient)
+			observer := usdc.NewTokenDataObserver(
+				logger.Test(t),
+				1,
+				config,
+				testhelpers.USDCEncoder,
+				test.usdcReader,
+				test.attestationClient,
+			)
 
 			tkData, err := observer.Observe(context.Background(), test.messageObservations)
 			require.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.5
 require (
 	github.com/deckarep/golang-set/v2 v2.6.0
 	github.com/smartcontractkit/chain-selectors v1.0.23
-	github.com/smartcontractkit/chainlink-common v0.2.3-0.20240927162447-20630b333f57
+	github.com/smartcontractkit/chainlink-common v0.2.3-0.20240930132738-84b94d022da3
 	github.com/smartcontractkit/libocr v0.0.0-20240717100443-f6226e09bee7
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/zap v1.27.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.5
 require (
 	github.com/deckarep/golang-set/v2 v2.6.0
 	github.com/smartcontractkit/chain-selectors v1.0.23
-	github.com/smartcontractkit/chainlink-common v0.2.3-0.20240930132738-84b94d022da3
+	github.com/smartcontractkit/chainlink-common v0.2.3-0.20240930142117-ef04dd443670
 	github.com/smartcontractkit/libocr v0.0.0-20240717100443-f6226e09bee7
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/smartcontractkit/chain-selectors v1.0.23 h1:D2Eaex4Cw/O7Lg3tX6WklOqnjjIQAEBnutCtksPzVDY=
 github.com/smartcontractkit/chain-selectors v1.0.23/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
-github.com/smartcontractkit/chainlink-common v0.2.3-0.20240930132738-84b94d022da3 h1:Vd7ViAQVgefcvyHGdpMhF3GX7oXafumoxW5cSaOLM3k=
-github.com/smartcontractkit/chainlink-common v0.2.3-0.20240930132738-84b94d022da3/go.mod h1:F6WUS6N4mP5ScwpwyTyAJc9/vjR+GXbMCRUOVekQi1g=
+github.com/smartcontractkit/chainlink-common v0.2.3-0.20240930142117-ef04dd443670 h1:z+XnayyX7pyvVv9OuMQ7oik7RkguQeWHhxcOoVM4oKI=
+github.com/smartcontractkit/chainlink-common v0.2.3-0.20240930142117-ef04dd443670/go.mod h1:F6WUS6N4mP5ScwpwyTyAJc9/vjR+GXbMCRUOVekQi1g=
 github.com/smartcontractkit/libocr v0.0.0-20240717100443-f6226e09bee7 h1:e38V5FYE7DA1JfKXeD5Buo/7lczALuVXlJ8YNTAUxcw=
 github.com/smartcontractkit/libocr v0.0.0-20240717100443-f6226e09bee7/go.mod h1:fb1ZDVXACvu4frX3APHZaEBp0xi1DIm34DcA0CwTsZM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/smartcontractkit/chain-selectors v1.0.23 h1:D2Eaex4Cw/O7Lg3tX6WklOqnjjIQAEBnutCtksPzVDY=
 github.com/smartcontractkit/chain-selectors v1.0.23/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
-github.com/smartcontractkit/chainlink-common v0.2.3-0.20240927162447-20630b333f57 h1:pRiTiFOkPEyvgG0hchcCSZzwUbwYydnZBu0QbVaRnVk=
-github.com/smartcontractkit/chainlink-common v0.2.3-0.20240927162447-20630b333f57/go.mod h1:F6WUS6N4mP5ScwpwyTyAJc9/vjR+GXbMCRUOVekQi1g=
+github.com/smartcontractkit/chainlink-common v0.2.3-0.20240930132738-84b94d022da3 h1:Vd7ViAQVgefcvyHGdpMhF3GX7oXafumoxW5cSaOLM3k=
+github.com/smartcontractkit/chainlink-common v0.2.3-0.20240930132738-84b94d022da3/go.mod h1:F6WUS6N4mP5ScwpwyTyAJc9/vjR+GXbMCRUOVekQi1g=
 github.com/smartcontractkit/libocr v0.0.0-20240717100443-f6226e09bee7 h1:e38V5FYE7DA1JfKXeD5Buo/7lczALuVXlJ8YNTAUxcw=
 github.com/smartcontractkit/libocr v0.0.0-20240717100443-f6226e09bee7/go.mod h1:fb1ZDVXACvu4frX3APHZaEBp0xi1DIm34DcA0CwTsZM=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/internal/libs/testhelpers/usdc.go
+++ b/internal/libs/testhelpers/usdc.go
@@ -1,0 +1,24 @@
+package testhelpers
+
+import (
+	"context"
+
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+)
+
+var (
+	TokenDataEncoderInstance cciptypes.TokenDataEncoder = TokenDataEncoder{}
+	USDCEncoder                                         = TokenDataEncoderInstance.EncodeUSDC
+)
+
+// TokenDataEncoder is a fake encoder that just returns the attestation as is, it's used only for tests to verify
+// if proper attestation is returned. Production implementation is going to be chain-specific
+type TokenDataEncoder struct{}
+
+func (t TokenDataEncoder) EncodeUSDC(
+	_ context.Context,
+	_ cciptypes.Bytes,
+	attestation cciptypes.Bytes,
+) (cciptypes.Bytes, error) {
+	return attestation, nil
+}


### PR DESCRIPTION
USDC attestation needs to be converted to the common shared `[]byte` format before creating a report. This operation is chain specific, so we need to create an encoding interface in chainlink-common and then implement that in the Chainlink (evm specific logic)

Chainlink-Common https://github.com/smartcontractkit/chainlink-common/pull/813
Chainlink https://github.com/smartcontractkit/chainlink/pull/14603