### PR TITLE
init wlog package

### DIFF
--- a/internal/libs/wlog/wrappedlogger.go
+++ b/internal/libs/wlog/wrappedlogger.go
@@ -1,0 +1,54 @@
+package wlog
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+type WrappedLogger struct {
+	baseLogger logger.Logger
+	data       map[string]any
+}
+
+func NewWrappedLogger(baseLogger logger.Logger) *WrappedLogger {
+	return &WrappedLogger{
+		baseLogger: baseLogger,
+		data:       make(map[string]any),
+	}
+}
+
+func (w *WrappedLogger) WithField(key string, value any) {
+	w.data[key] = value
+}
+
+func (w *WrappedLogger) dataToString(prefix, suffix string) string {
+	extraData := make([]string, 0, len(w.data))
+	for k, v := range w.data {
+		extraData = append(extraData, fmt.Sprintf("%s=%v", k, v))
+	}
+
+	extraDataStr := ""
+	if len(extraData) > 0 {
+		extraDataStr = prefix + strings.Join(extraData, " ") + suffix
+	}
+
+	return extraDataStr
+}
+
+func (w *WrappedLogger) Debug(args ...interface{}) {
+	w.baseLogger.Debug(w.basic(args...)...)
+}
+
+func (w *WrappedLogger) Debugf(format string, values ...interface{}) {
+	w.baseLogger.Debugf(format+w.dataToString(" ", ""), values...)
+}
+
+func (w *WrappedLogger) Debugw(msg string, keysAndValues ...interface{}) {
+	w.baseLogger.Debugw(msg+w.dataToString(" ", ""), keysAndValues...)
+}
+
+func (w *WrappedLogger) basic(args ...interface{}) []interface{} {
+	return append(args, []interface{}{w.dataToString(" ", "")}...)
+}

--- a/internal/libs/wlog/wrappedlogger_test.go
+++ b/internal/libs/wlog/wrappedlogger_test.go
@@ -1,0 +1,32 @@
+package wlog
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+func TestIt(t *testing.T) {
+	baseLogger := logger.Test(t)
+	w := NewWrappedLogger(baseLogger)
+
+	w.WithField("foo", "bar")
+	w.WithField("baz", 123)
+	w.WithField("str", map[string]any{"a": 1, "b": big.NewInt(123)})
+
+	t.Logf("------------------")
+
+	baseLogger.Debug("some message", "some other message")
+	w.Debug("some message", "some other message")
+
+	t.Logf("------------------")
+
+	baseLogger.Debugf("hello %d %s", 123, "world")
+	w.Debugf("hello %d %s", 123, "world")
+
+	t.Logf("------------------")
+
+	baseLogger.Debugw("hello friend", "foo", 123, "bar", "baz")
+	w.Debugw("hello friend", "foo", 123, "bar", "baz")
+}


### PR DESCRIPTION
Usage:

```
w := NewWrappedLogger(baseLogger)
w.WithField("foo", "bar")

w.Info("something") // something foo=bar	
```

WrappedLogger is compliant with cl-common Logger and can be provided to functions like that, meaning there won't be any breaking changes.


Comparing output with set fields against existing logger:

```
    wrappedlogger_test.go:18: ------------------
    logger.go:146: 17:15:42.822006000	DEBUG	some messagesome other message
    logger.go:146: 17:15:42.822274000	DEBUG	some messagesome other message str=map[a:1 b:123] foo=bar baz=123
    wrappedlogger_test.go:23: ------------------
    logger.go:146: 17:15:42.822284000	DEBUG	hello 123 world
    logger.go:146: 17:15:42.822291000	DEBUG	hello 123 world foo=bar baz=123 str=map[a:1 b:123]
    wrappedlogger_test.go:28: ------------------
    logger.go:146: 17:15:42.822299000	DEBUG	hello friend	{"foo": 123, "bar": "baz"}
    logger.go:146: 17:15:42.822338000	DEBUG	hello friend foo=bar baz=123 str=map[a:1 b:123]	{"foo": 123, "bar": "baz"}
```

Looking for some early feedback.
Fields will be ordered, ignore them being unordered in the output above.