### PR TITLE
Move exec Observation into a separate file.

### DIFF
--- a/execute/exectypes/outcome.go
+++ b/execute/exectypes/outcome.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"sort"
 
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
+
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 )
 
@@ -103,13 +105,13 @@ func newSortedOutcome(
 // Encode encodes the outcome by first sorting the pending commit reports and the chain reports
 // and then JSON marshalling.
 // The encoding MUST be deterministic.
-func (o Outcome) Encode() ([]byte, error) {
+func (o Outcome) Encode() (ocr3types.Outcome, error) {
 	// We sort again here in case construction is not via the constructor.
 	return json.Marshal(newSortedOutcome(o.State, o.PendingCommitReports, o.Report))
 }
 
-// DecodeOutcome decodes the outcome from JSON.
-func DecodeOutcome(b []byte) (Outcome, error) {
+// DecodeOutcome decodes the outcome from JSON. An empty string is treated as an empty outcome.
+func DecodeOutcome(b ocr3types.Outcome) (Outcome, error) {
 	if len(b) == 0 {
 		return Outcome{}, nil
 	}

--- a/execute/exectypes/outcome.go
+++ b/execute/exectypes/outcome.go
@@ -110,6 +110,9 @@ func (o Outcome) Encode() ([]byte, error) {
 
 // DecodeOutcome decodes the outcome from JSON.
 func DecodeOutcome(b []byte) (Outcome, error) {
+	if len(b) == 0 {
+		return Outcome{}, nil
+	}
 	o := Outcome{}
 	err := json.Unmarshal(b, &o)
 	return o, err

--- a/execute/observation.go
+++ b/execute/observation.go
@@ -1,0 +1,222 @@
+package execute
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"golang.org/x/exp/maps"
+
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
+	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
+	typeconv "github.com/smartcontractkit/chainlink-ccip/internal/libs/typeconv"
+	dt "github.com/smartcontractkit/chainlink-ccip/internal/plugincommon/discovery/discoverytypes"
+)
+
+// Observation collects data across two phases which happen in separate rounds.
+// These phases happen continuously so that except for the first round, every
+// subsequent round can have a new execution report.
+//
+// Phase 1: Gather commit reports from the destination chain and determine
+// which messages are required to build a valid execution report.
+//
+// Phase 2: Gather messages from the source chains and build the execution
+// report.
+//
+// Phase 3: observe nonce for each unique source/sender pair.
+func (p *Plugin) Observation(
+	ctx context.Context, outctx ocr3types.OutcomeContext, _ types.Query,
+) (types.Observation, error) {
+	var err error
+	var previousOutcome exectypes.Outcome
+
+	if outctx.PreviousOutcome != nil {
+		previousOutcome, err = exectypes.DecodeOutcome(outctx.PreviousOutcome)
+		if err != nil {
+			return types.Observation{}, fmt.Errorf("unable to decode previous outcome: %w", err)
+		}
+		p.lggr.Infow("decoded previous outcome", "previousOutcome", previousOutcome)
+	}
+
+	var discoveryObs dt.Observation
+	// discovery processor disabled by setting it to nil.
+	if p.discovery != nil {
+		discoveryObs, err = p.discovery.Observation(ctx, dt.Outcome{}, dt.Query{})
+		if err != nil {
+			p.lggr.Errorw("failed to discover contracts", "err", err)
+		}
+
+		if !p.contractsInitialized {
+			p.lggr.Infow("contracts not initialized, only making discovery observations",
+				"discoveryObs", discoveryObs)
+			return exectypes.Observation{Contracts: discoveryObs}.Encode()
+		}
+	}
+
+	observation := exectypes.Observation{
+		Contracts: discoveryObs,
+	}
+
+	state := previousOutcome.State.Next()
+	p.lggr.Debugw("Execute plugin performing observation", "state", state)
+	switch state {
+	case exectypes.GetCommitReports:
+		observation, err = p.getCommitReportsObservation(ctx, observation)
+	case exectypes.GetMessages:
+		// Phase 2: Gather messages from the source chains and build the execution report.
+		observation, err = p.getMessagesObservation(ctx, previousOutcome, observation)
+	case exectypes.Filter:
+		// Phase 3: observe nonce for each unique source/sender pair.
+		observation, err = p.getFilterObservation(ctx, previousOutcome, observation)
+	default:
+		err = fmt.Errorf("unknown state")
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return observation.Encode()
+}
+
+// getCommitReportsObservations implements phase1 of the execute plugin state machine. It fetches commit reports from
+// the destination chain and determines which messages are ready to be executed. These are added to the provided
+// observation object.
+func (p *Plugin) getCommitReportsObservation(ctx context.Context, observation exectypes.Observation) (exectypes.Observation, error) {
+	fetchFrom := time.Now().Add(-p.offchainCfg.MessageVisibilityInterval.Duration()).UTC()
+
+	// Phase 1: Gather commit reports from the destination chain and determine which messages are required to build
+	//          a valid execution report.
+	supportsDest, err := p.supportsDestChain()
+	if err != nil {
+		return exectypes.Observation{}, fmt.Errorf("unable to determine if the destination chain is supported: %w", err)
+	}
+	if supportsDest {
+		groupedCommits, err := getPendingExecutedReports(ctx, p.ccipReader, p.destChain, fetchFrom, p.lggr)
+		if err != nil {
+			return exectypes.Observation{}, err
+		}
+
+		observation.CommitReports = groupedCommits
+
+		// TODO: truncate grouped to a maximum observation size?
+		return observation, nil
+	}
+
+	// No observation for non-dest readers.
+	return observation, nil
+}
+
+func (p *Plugin) getMessagesObservation(
+	ctx context.Context,
+	previousOutcome exectypes.Outcome,
+	observation exectypes.Observation,
+) (exectypes.Observation, error) {
+	messages := make(exectypes.MessageObservations)
+	if len(previousOutcome.PendingCommitReports) == 0 {
+		p.lggr.Debug("TODO: No reports to execute. This is expected after a cold start.")
+		// No reports to execute.
+		// This is expected after a cold start.
+	} else {
+		commitReportCache := make(map[cciptypes.ChainSelector][]exectypes.CommitData)
+		for _, report := range previousOutcome.PendingCommitReports {
+			commitReportCache[report.SourceChain] = append(commitReportCache[report.SourceChain], report)
+		}
+
+		for srcChain, reports := range commitReportCache {
+			if len(reports) == 0 {
+				continue
+			}
+
+			ranges, err := computeRanges(reports)
+			if err != nil {
+				return exectypes.Observation{}, err
+			}
+
+			// Read messages for each range.
+			for _, seqRange := range ranges {
+				// TODO: check if srcChain is supported.
+				msgs, err := p.ccipReader.MsgsBetweenSeqNums(ctx, srcChain, seqRange)
+				if err != nil {
+					return exectypes.Observation{}, err
+				}
+				for _, msg := range msgs {
+					if _, ok := messages[srcChain]; !ok {
+						messages[srcChain] = make(map[cciptypes.SeqNum]cciptypes.Message)
+					}
+					messages[srcChain][msg.Header.SequenceNumber] = msg
+				}
+			}
+		}
+	}
+
+	// Regroup the commit reports back into the observation format.
+	// TODO: use same format for Observation and Outcome.
+	groupedCommits := make(exectypes.CommitObservations)
+	for _, report := range previousOutcome.PendingCommitReports {
+		if _, ok := groupedCommits[report.SourceChain]; !ok {
+			groupedCommits[report.SourceChain] = []exectypes.CommitData{}
+		}
+		groupedCommits[report.SourceChain] = append(groupedCommits[report.SourceChain], report)
+	}
+
+	tkData, err1 := p.tokenDataObserver.Observe(ctx, messages)
+	if err1 != nil {
+		return exectypes.Observation{}, fmt.Errorf("unable to process token data %w", err1)
+	}
+
+	costlyMessages, err := p.costlyMessageObserver.Observe(ctx, messages)
+	if err != nil {
+		return exectypes.Observation{}, fmt.Errorf("unable to observe costly messages %w", err)
+	}
+
+	observation.CommitReports = groupedCommits
+	observation.Messages = messages
+	observation.CostlyMessages = costlyMessages
+	observation.TokenData = tkData
+
+	return observation, nil
+}
+
+func (p *Plugin) getFilterObservation(
+	ctx context.Context,
+	previousOutcome exectypes.Outcome,
+	observation exectypes.Observation,
+) (exectypes.Observation, error) {
+	// Phase 2: Filter messages and determine which messages are too costly to execute.
+	//          This phase also determines which messages are too costly to execute.
+	//          These messages will not be executed in the current round, but may be executed in future rounds
+	//          (e.g. if gas prices decrease or if these messages' fees are boosted high enough).
+
+	nonceRequestArgs := make(map[cciptypes.ChainSelector]map[string]struct{})
+
+	// Collect unique senders.
+	for _, commitReport := range previousOutcome.PendingCommitReports {
+		if _, ok := nonceRequestArgs[commitReport.SourceChain]; !ok {
+			nonceRequestArgs[commitReport.SourceChain] = make(map[string]struct{})
+		}
+
+		for _, msg := range commitReport.Messages {
+			sender := typeconv.AddressBytesToString(msg.Sender[:], uint64(p.destChain))
+			nonceRequestArgs[commitReport.SourceChain][sender] = struct{}{}
+		}
+	}
+
+	// Read args from chain.
+	nonceObservations := make(exectypes.NonceObservations)
+	for srcChain, addrSet := range nonceRequestArgs {
+		// TODO: check if srcSelector is supported.
+		addrs := maps.Keys(addrSet)
+		nonces, err := p.ccipReader.Nonces(ctx, srcChain, p.destChain, addrs)
+		if err != nil {
+			return exectypes.Observation{}, fmt.Errorf("unable to get nonces: %w", err)
+		}
+		nonceObservations[srcChain] = nonces
+	}
+
+	observation.Nonces = nonceObservations
+
+	return observation, nil
+}

--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
-	"golang.org/x/exp/maps"
 
 	"github.com/smartcontractkit/libocr/commontypes"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
@@ -21,7 +20,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/execute/internal/gas"
 	"github.com/smartcontractkit/chainlink-ccip/execute/report"
 	"github.com/smartcontractkit/chainlink-ccip/execute/tokendata"
-	typeconv "github.com/smartcontractkit/chainlink-ccip/internal/libs/typeconv"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon/discovery"
 	dt "github.com/smartcontractkit/chainlink-ccip/internal/plugincommon/discovery/discoverytypes"
@@ -163,166 +161,6 @@ func getPendingExecutedReports(
 		"groupedCommits", groupedCommits, "count", len(groupedCommits))
 
 	return groupedCommits, nil
-}
-
-// Observation collects data across two phases which happen in separate rounds.
-// These phases happen continuously so that except for the first round, every
-// subsequent round can have a new execution report.
-//
-// Phase 1: Gather commit reports from the destination chain and determine
-// which messages are required to build a valid execution report.
-//
-// Phase 2: Gather messages from the source chains and build the execution
-// report.
-// nolint:gocyclo // todo
-func (p *Plugin) Observation(
-	ctx context.Context, outctx ocr3types.OutcomeContext, _ types.Query,
-) (types.Observation, error) {
-	var err error
-	var previousOutcome exectypes.Outcome
-
-	if outctx.PreviousOutcome != nil {
-		previousOutcome, err = exectypes.DecodeOutcome(outctx.PreviousOutcome)
-		if err != nil {
-			return types.Observation{}, fmt.Errorf("unable to decode previous outcome: %w", err)
-		}
-		p.lggr.Infow("decoded previous outcome", "previousOutcome", previousOutcome)
-	}
-
-	var discoveryObs dt.Observation
-	// discovery processor disabled by setting it to nil.
-	if p.discovery != nil {
-		discoveryObs, err = p.discovery.Observation(ctx, dt.Outcome{}, dt.Query{})
-		if err != nil {
-			p.lggr.Errorw("failed to discover contracts", "err", err)
-		}
-
-		if !p.contractsInitialized {
-			p.lggr.Infow("contracts not initialized, only making discovery observations",
-				"discoveryObs", discoveryObs)
-			return exectypes.Observation{Contracts: discoveryObs}.Encode()
-		}
-	}
-
-	state := previousOutcome.State.Next()
-	p.lggr.Debugw("Execute plugin performing observation", "state", state)
-	switch state {
-	case exectypes.GetCommitReports:
-		fetchFrom := time.Now().Add(-p.offchainCfg.MessageVisibilityInterval.Duration()).UTC()
-
-		// Phase 1: Gather commit reports from the destination chain and determine which messages are required to build
-		//          a valid execution report.
-		supportsDest, err := p.supportsDestChain()
-		if err != nil {
-			return types.Observation{}, fmt.Errorf("unable to determine if the destination chain is supported: %w", err)
-		}
-		if supportsDest {
-			groupedCommits, err := getPendingExecutedReports(ctx, p.ccipReader, p.destChain, fetchFrom, p.lggr)
-			if err != nil {
-				return types.Observation{}, err
-			}
-
-			// TODO: truncate grouped to a maximum observation size?
-			return exectypes.NewObservation(groupedCommits, nil, nil, nil, nil, discoveryObs).Encode()
-		}
-
-		// No observation for non-dest readers.
-		return types.Observation{}, nil
-	case exectypes.GetMessages:
-		// Phase 2: Gather messages from the source chains and build the execution report.
-		messages := make(exectypes.MessageObservations)
-		if len(previousOutcome.PendingCommitReports) == 0 {
-			p.lggr.Debug("TODO: No reports to execute. This is expected after a cold start.")
-			// No reports to execute.
-			// This is expected after a cold start.
-		} else {
-			commitReportCache := make(map[cciptypes.ChainSelector][]exectypes.CommitData)
-			for _, report := range previousOutcome.PendingCommitReports {
-				commitReportCache[report.SourceChain] = append(commitReportCache[report.SourceChain], report)
-			}
-
-			for srcChain, reports := range commitReportCache {
-				if len(reports) == 0 {
-					continue
-				}
-
-				ranges, err := computeRanges(reports)
-				if err != nil {
-					return types.Observation{}, err
-				}
-
-				// Read messages for each range.
-				for _, seqRange := range ranges {
-					// TODO: check if srcChain is supported.
-					msgs, err := p.ccipReader.MsgsBetweenSeqNums(ctx, srcChain, seqRange)
-					if err != nil {
-						return nil, err
-					}
-					for _, msg := range msgs {
-						if _, ok := messages[srcChain]; !ok {
-							messages[srcChain] = make(map[cciptypes.SeqNum]cciptypes.Message)
-						}
-						messages[srcChain][msg.Header.SequenceNumber] = msg
-					}
-				}
-			}
-		}
-
-		// Regroup the commit reports back into the observation format.
-		// TODO: use same format for Observation and Outcome.
-		groupedCommits := make(exectypes.CommitObservations)
-		for _, report := range previousOutcome.PendingCommitReports {
-			if _, ok := groupedCommits[report.SourceChain]; !ok {
-				groupedCommits[report.SourceChain] = []exectypes.CommitData{}
-			}
-			groupedCommits[report.SourceChain] = append(groupedCommits[report.SourceChain], report)
-		}
-
-		tkData, err1 := p.tokenDataObserver.Observe(ctx, messages)
-		if err1 != nil {
-			return types.Observation{}, fmt.Errorf("unable to process token data %w", err1)
-		}
-
-		costlyMessages, err := p.costlyMessageObserver.Observe(ctx, messages)
-		if err != nil {
-			return types.Observation{}, fmt.Errorf("unable to observe costly messages %w", err)
-		}
-
-		return exectypes.NewObservation(
-			groupedCommits, messages, costlyMessages, tkData, nil, discoveryObs).Encode()
-
-	case exectypes.Filter:
-		// Phase 3: observe nonce for each unique source/sender pair.
-		nonceRequestArgs := make(map[cciptypes.ChainSelector]map[string]struct{})
-
-		// Collect unique senders.
-		for _, commitReport := range previousOutcome.PendingCommitReports {
-			if _, ok := nonceRequestArgs[commitReport.SourceChain]; !ok {
-				nonceRequestArgs[commitReport.SourceChain] = make(map[string]struct{})
-			}
-
-			for _, msg := range commitReport.Messages {
-				sender := typeconv.AddressBytesToString(msg.Sender[:], uint64(p.destChain))
-				nonceRequestArgs[commitReport.SourceChain][sender] = struct{}{}
-			}
-		}
-
-		// Read args from chain.
-		nonceObservations := make(exectypes.NonceObservations)
-		for srcChain, addrSet := range nonceRequestArgs {
-			// TODO: check if srcSelector is supported.
-			addrs := maps.Keys(addrSet)
-			nonces, err := p.ccipReader.Nonces(ctx, srcChain, p.destChain, addrs)
-			if err != nil {
-				return types.Observation{}, fmt.Errorf("unable to get nonces: %w", err)
-			}
-			nonceObservations[srcChain] = nonces
-		}
-
-		return exectypes.NewObservation(nil, nil, nil, nil, nonceObservations, discoveryObs).Encode()
-	default:
-		return types.Observation{}, fmt.Errorf("unknown state")
-	}
 }
 
 func (p *Plugin) ValidateObservation(

--- a/execute/plugin_e2e_test.go
+++ b/execute/plugin_e2e_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
@@ -54,6 +55,7 @@ func TestPlugin(t *testing.T) {
 	// Round 3 - Filter
 	// An execute report with the following messages executed: 102, 103, 104, 105.
 	outcome = runner.MustRunRound(ctx, t)
-	sequenceNumbers := extractSequenceNumbers(outcome)
+	require.Len(t, outcome.Report.ChainReports, 1)
+	sequenceNumbers := extractSequenceNumbers(outcome.Report.ChainReports[0].Messages)
 	require.ElementsMatch(t, sequenceNumbers, []cciptypes.SeqNum{102, 103, 104, 105})
 }

--- a/execute/plugin_usdc_test.go
+++ b/execute/plugin_usdc_test.go
@@ -4,12 +4,11 @@ import (
 	"testing"
 	"time"
 
-	sel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
-
+	sel "github.com/smartcontractkit/chain-selectors"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
 	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/testhelpers/rand"
@@ -81,7 +80,8 @@ func Test_USDC_Transfer(t *testing.T) {
 	// Messages 102-104 are executed, 105 doesn't have token data ready
 	outcome = runner.MustRunRound(ctx, t)
 	require.NoError(t, err)
-	sequenceNumbers := extractSequenceNumbers(outcome)
+	require.Len(t, outcome.Report.ChainReports, 1)
+	sequenceNumbers := extractSequenceNumbers(outcome.Report.ChainReports[0].Messages)
 	require.ElementsMatch(t, sequenceNumbers, []cciptypes.SeqNum{102, 103, 104})
 	//Attestation data added to the USDC
 	require.NotEmpty(t, outcome.Report.ChainReports[0].OffchainTokenData[2])
@@ -98,7 +98,8 @@ func Test_USDC_Transfer(t *testing.T) {
 		outcome = runner.MustRunRound(ctx, t)
 	}
 
-	sequenceNumbers = extractSequenceNumbers(outcome)
+	require.Len(t, outcome.Report.ChainReports, 1)
+	sequenceNumbers = extractSequenceNumbers(outcome.Report.ChainReports[0].Messages)
 	require.ElementsMatch(t, sequenceNumbers, []cciptypes.SeqNum{102, 103, 104, 105})
 	//Attestation data added to the both USDC messages
 	require.NotEmpty(t, outcome.Report.ChainReports[0].OffchainTokenData[2])

--- a/execute/test_utils.go
+++ b/execute/test_utils.go
@@ -20,6 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
 	libocrtypes "github.com/smartcontractkit/libocr/ragep2p/types"
+
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -461,8 +462,8 @@ func setupHomeChainPoller(
 	return homeChain
 }
 
-func extractSequenceNumbers(outcome exectypes.Outcome) []cciptypes.SeqNum {
-	sequenceNumbers := slicelib.Map(outcome.Report.ChainReports[0].Messages, func(m cciptypes.Message) cciptypes.SeqNum {
+func extractSequenceNumbers(messages []cciptypes.Message) []cciptypes.SeqNum {
+	sequenceNumbers := slicelib.Map(messages, func(m cciptypes.Message) cciptypes.SeqNum {
 		return m.Header.SequenceNumber
 	})
 	return sequenceNumbers


### PR DESCRIPTION
Attempt to make the function easier to read by splitting out state specific observation code into helper functions.

This addresses the disabled lint rule `// nolint:gocyclo // todo`, but is otherwise a no-op change.