### PR TITLE
Move exec Outcome into a separate file.

### DIFF
--- a/execute/outcome.go
+++ b/execute/outcome.go
@@ -1,0 +1,187 @@
+package execute
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	mapset "github.com/deckarep/golang-set/v2"
+
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
+	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
+	"github.com/smartcontractkit/chainlink-ccip/execute/report"
+	"github.com/smartcontractkit/chainlink-ccip/internal/libs/slicelib"
+	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
+	dt "github.com/smartcontractkit/chainlink-ccip/internal/plugincommon/discovery/discoverytypes"
+)
+
+// Outcome collects the reports from the two phases and constructs the final outcome. Part of the outcome is a fully
+// formed report that will be encoded for final transmission in the reporting phase.
+func (p *Plugin) Outcome(
+	outctx ocr3types.OutcomeContext, query types.Query, aos []types.AttributedObservation,
+) (ocr3types.Outcome, error) {
+	p.lggr.Debugw("Execute plugin performing outcome",
+		"outctx", outctx,
+		"query", query,
+		"attributedObservations", aos)
+	previousOutcome, err := exectypes.DecodeOutcome(outctx.PreviousOutcome)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode previous outcome: %w", err)
+	}
+
+	decodedAos, err := decodeAttributedObservations(aos)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode observations: %w", err)
+	}
+
+	// discovery processor disabled by setting it to nil.
+	if p.discovery != nil {
+		mapper := func(
+			ao plugincommon.AttributedObservation[exectypes.Observation],
+		) plugincommon.AttributedObservation[dt.Observation] {
+			return plugincommon.AttributedObservation[dt.Observation]{
+				OracleID:    ao.OracleID,
+				Observation: ao.Observation.Contracts,
+			}
+		}
+		discoveryAos := slicelib.Map(decodedAos, mapper)
+		_, err = p.discovery.Outcome(dt.Outcome{}, dt.Query{}, discoveryAos)
+		if err != nil {
+			return nil, fmt.Errorf("unable to process outcome of discovery processor: %w", err)
+		}
+		p.contractsInitialized = true
+	}
+
+	fChain, err := p.homeChain.GetFChain()
+	if err != nil {
+		return ocr3types.Outcome{}, fmt.Errorf("unable to get FChain: %w", err)
+	}
+
+	observation, err := getConsensusObservation(p.lggr, decodedAos, p.destChain, p.reportingCfg.F, fChain)
+	if err != nil {
+		return ocr3types.Outcome{}, fmt.Errorf("unable to get consensus observation: %w", err)
+	}
+
+	var outcome exectypes.Outcome
+	state := previousOutcome.State.Next()
+	switch state {
+	case exectypes.GetCommitReports:
+		outcome = p.getCommitReportsOutcome(observation)
+	case exectypes.GetMessages:
+		outcome = p.getMessagesOutcome(observation, previousOutcome)
+	case exectypes.Filter:
+		outcome, err = p.getFilterOutcome(observation, previousOutcome)
+	default:
+		panic("unknown state")
+	}
+
+	if err != nil {
+		p.lggr.Warnw(
+			fmt.Sprintf("[oracle %d] exec outcome error", p.reportingCfg.OracleID),
+			"err", err)
+		return nil, fmt.Errorf("unable to get outcome: %w", err)
+	}
+
+	if outcome.IsEmpty() {
+		p.lggr.Warnw(
+			fmt.Sprintf("[oracle %d] exec outcome: empty outcome", p.reportingCfg.OracleID),
+			"execPluginState", state)
+		if p.contractsInitialized {
+			return exectypes.Outcome{State: exectypes.Initialized}.Encode()
+		}
+		return nil, nil
+	}
+
+	p.lggr.Infow("generated outcome", "execPluginState", state, "outcome", outcome)
+
+	return outcome.Encode()
+}
+
+func (p *Plugin) getCommitReportsOutcome(observation exectypes.Observation) exectypes.Outcome {
+	// flatten commit reports and sort by timestamp.
+	var commitReports []exectypes.CommitData
+	for _, report := range observation.CommitReports {
+		commitReports = append(commitReports, report...)
+	}
+	sort.Slice(commitReports, func(i, j int) bool {
+		return commitReports[i].Timestamp.Before(commitReports[j].Timestamp)
+	})
+
+	// Must use 'NewOutcome' rather than direct struct initialization to ensure the outcome is sorted.
+	// TODO: sort in the encoder.
+	return exectypes.NewOutcome(exectypes.GetCommitReports, commitReports, cciptypes.ExecutePluginReport{})
+}
+
+func (p *Plugin) getMessagesOutcome(
+	observation exectypes.Observation,
+	previousOutcome exectypes.Outcome,
+) exectypes.Outcome {
+	commitReports := previousOutcome.PendingCommitReports
+	costlyMessagesSet := mapset.NewSet[cciptypes.Bytes32]()
+	for _, msgID := range observation.CostlyMessages {
+		costlyMessagesSet.Add(msgID)
+	}
+
+	// add messages to their commitReports.
+	for i, report := range commitReports {
+		report.Messages = nil
+		report.CostlyMessages = nil
+		for j := report.SequenceNumberRange.Start(); j <= report.SequenceNumberRange.End(); j++ {
+			if msg, ok := observation.Messages[report.SourceChain][j]; ok {
+				report.Messages = append(report.Messages, msg)
+				if costlyMessagesSet.Contains(msg.Header.MessageID) {
+					report.CostlyMessages = append(report.CostlyMessages, msg.Header.MessageID)
+				}
+			}
+
+			if tokenData, ok := observation.TokenData[report.SourceChain][j]; ok {
+				report.MessageTokenData = append(report.MessageTokenData, tokenData)
+			}
+		}
+		commitReports[i].Messages = report.Messages
+		commitReports[i].MessageTokenData = report.MessageTokenData
+		commitReports[i].CostlyMessages = report.CostlyMessages
+	}
+
+	// Must use 'NewOutcome' rather than direct struct initialization to ensure the outcome is sorted.
+	// TODO: sort in the encoder.
+	return exectypes.NewOutcome(exectypes.GetMessages, commitReports, cciptypes.ExecutePluginReport{})
+}
+
+func (p *Plugin) getFilterOutcome(
+	observation exectypes.Observation,
+	previousOutcome exectypes.Outcome,
+) (exectypes.Outcome, error) {
+	commitReports := previousOutcome.PendingCommitReports
+
+	// TODO: this function should be pure, a context should not be needed.
+	builder := report.NewBuilder(
+		context.Background(),
+		p.lggr,
+		p.msgHasher,
+		p.reportCodec,
+		p.estimateProvider,
+		observation.Nonces,
+		p.destChain,
+		uint64(maxReportSizeBytes),
+		p.offchainCfg.BatchGasLimit,
+	)
+	outcomeReports, commitReports, err := selectReport(
+		p.lggr,
+		commitReports,
+		builder)
+	if err != nil {
+		return exectypes.Outcome{}, fmt.Errorf("unable to extract proofs: %w", err)
+	}
+
+	execReport := cciptypes.ExecutePluginReport{
+		ChainReports: outcomeReports,
+	}
+
+	// Must use 'NewOutcome' rather than direct struct initialization to ensure the outcome is sorted.
+	// TODO: sort in the encoder.
+	return exectypes.NewOutcome(exectypes.Filter, commitReports, execReport), nil
+}

--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -3,7 +3,6 @@ package execute
 import (
 	"context"
 	"fmt"
-	"sort"
 	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
@@ -20,9 +19,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/execute/internal/gas"
 	"github.com/smartcontractkit/chainlink-ccip/execute/report"
 	"github.com/smartcontractkit/chainlink-ccip/execute/tokendata"
-	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon/discovery"
-	dt "github.com/smartcontractkit/chainlink-ccip/internal/plugincommon/discovery/discoverytypes"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
 	"github.com/smartcontractkit/chainlink-ccip/internal/reader"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
@@ -232,146 +229,6 @@ func selectReport(
 		"numReports", len(execReports),
 		"numPendingReports", len(stillPendingReports))
 	return execReports, stillPendingReports, err
-}
-
-// Outcome collects the reports from the two phases and constructs the final outcome. Part of the outcome is a fully
-// formed report that will be encoded for final transmission in the reporting phase.
-// nolint:gocyclo // todo
-func (p *Plugin) Outcome(
-	outctx ocr3types.OutcomeContext, query types.Query, aos []types.AttributedObservation,
-) (ocr3types.Outcome, error) {
-	p.lggr.Debugw("Execute plugin performing outcome",
-		"outctx", outctx,
-		"query", query,
-		"attributedObservations", aos)
-	var previousOutcome exectypes.Outcome
-	if outctx.PreviousOutcome != nil {
-		var err error
-		previousOutcome, err = exectypes.DecodeOutcome(outctx.PreviousOutcome)
-		if err != nil {
-			return nil, fmt.Errorf("unable to decode previous outcome: %w", err)
-		}
-	}
-
-	decodedAos, err := decodeAttributedObservations(aos)
-	if err != nil {
-		return nil, fmt.Errorf("unable to decode observations: %w", err)
-	}
-
-	// discovery processor disabled by setting it to nil.
-	if p.discovery != nil {
-		discoveryAos := make([]plugincommon.AttributedObservation[dt.Observation], len(decodedAos))
-		for i := range decodedAos {
-			discoveryAos[i] = plugincommon.AttributedObservation[dt.Observation]{
-				OracleID:    decodedAos[i].OracleID,
-				Observation: decodedAos[i].Observation.Contracts,
-			}
-		}
-		_, err = p.discovery.Outcome(dt.Outcome{}, dt.Query{}, discoveryAos)
-		if err != nil {
-			return nil, fmt.Errorf("unable to process outcome of discovery processor: %w", err)
-		}
-		p.contractsInitialized = true
-	}
-
-	fChain, err := p.homeChain.GetFChain()
-	if err != nil {
-		return ocr3types.Outcome{}, fmt.Errorf("unable to get FChain: %w", err)
-	}
-
-	observation, err := getConsensusObservation(p.lggr, decodedAos, p.destChain, p.reportingCfg.F, fChain)
-	if err != nil {
-		return ocr3types.Outcome{}, fmt.Errorf("unable to get consensus observation: %w", err)
-	}
-
-	var outcome exectypes.Outcome
-	state := previousOutcome.State.Next()
-	switch state {
-	case exectypes.GetCommitReports:
-		// flatten commit reports and sort by timestamp.
-		var commitReports []exectypes.CommitData
-		for _, report := range observation.CommitReports {
-			commitReports = append(commitReports, report...)
-		}
-		sort.Slice(commitReports, func(i, j int) bool {
-			return commitReports[i].Timestamp.Before(commitReports[j].Timestamp)
-		})
-
-		outcome = exectypes.NewOutcome(state, commitReports, cciptypes.ExecutePluginReport{})
-	case exectypes.GetMessages:
-		commitReports := previousOutcome.PendingCommitReports
-		costlyMessagesSet := mapset.NewSet[cciptypes.Bytes32]()
-		for _, msgID := range observation.CostlyMessages {
-			costlyMessagesSet.Add(msgID)
-		}
-
-		// add messages to their commitReports.
-		for i, report := range commitReports {
-			report.Messages = nil
-			report.CostlyMessages = nil
-			for j := report.SequenceNumberRange.Start(); j <= report.SequenceNumberRange.End(); j++ {
-				if msg, ok := observation.Messages[report.SourceChain][j]; ok {
-					report.Messages = append(report.Messages, msg)
-					if costlyMessagesSet.Contains(msg.Header.MessageID) {
-						report.CostlyMessages = append(report.CostlyMessages, msg.Header.MessageID)
-					}
-				}
-
-				if tokenData, ok := observation.TokenData[report.SourceChain][j]; ok {
-					report.MessageTokenData = append(report.MessageTokenData, tokenData)
-				}
-			}
-			commitReports[i].Messages = report.Messages
-			commitReports[i].MessageTokenData = report.MessageTokenData
-			commitReports[i].CostlyMessages = report.CostlyMessages
-		}
-
-		outcome = exectypes.NewOutcome(state, commitReports, cciptypes.ExecutePluginReport{})
-	case exectypes.Filter:
-		commitReports := previousOutcome.PendingCommitReports
-
-		// TODO: this function should be pure, a context should not be needed.
-		builder := report.NewBuilder(
-			context.Background(),
-			p.lggr,
-			p.msgHasher,
-			p.reportCodec,
-			p.estimateProvider,
-			observation.Nonces,
-			p.destChain,
-			uint64(maxReportSizeBytes),
-			p.offchainCfg.BatchGasLimit,
-		)
-		outcomeReports, commitReports, err := selectReport(
-			p.lggr,
-			commitReports,
-			builder)
-		if err != nil {
-			return ocr3types.Outcome{}, fmt.Errorf("unable to extract proofs: %w", err)
-		}
-
-		execReport := cciptypes.ExecutePluginReport{
-			ChainReports: outcomeReports,
-		}
-
-		outcome = exectypes.NewOutcome(state, commitReports, execReport)
-	default:
-		panic("unknown state")
-	}
-
-	if outcome.IsEmpty() {
-		p.lggr.Warnw(
-			fmt.Sprintf("[oracle %d] exec outcome: empty outcome", p.reportingCfg.OracleID),
-			"execPluginState", state)
-		if p.contractsInitialized {
-			return exectypes.Outcome{State: exectypes.Initialized}.Encode()
-		}
-		return nil, nil
-	}
-
-	p.lggr.Infow("generated outcome", "execPluginState", state, "outcome", outcome)
-
-	return outcome.Encode()
 }
 
 func (p *Plugin) Reports(seqNr uint64, outcome ocr3types.Outcome) ([]ocr3types.ReportWithInfo[[]byte], error) {


### PR DESCRIPTION
Attempt to make the function easier to read by splitting out state specific observation code into helper functions.

This addresses the disabled lint rule // nolint:gocyclo // todo, but is otherwise a no-op change.
