### PR TITLE
Implement ccipChainReader.LinkPriceUSD()

### DIFF
--- a/internal/mocks/inmem/ccipreader_inmem.go
+++ b/internal/mocks/inmem/ccipreader_inmem.go
@@ -151,6 +151,10 @@ func (r InMemoryCCIPReader) GetRMNRemoteConfig(
 	return rmntypes.RemoteConfig{}, nil
 }
 
+func (r InMemoryCCIPReader) LinkPriceUSD(ctx context.Context) (cciptypes.BigInt, error) {
+	return cciptypes.BigInt{}, nil
+}
+
 // Sync can be used to perform frequent syncing operations inside the reader implementation.
 // Returns a bool indicating whether something was updated.
 func (r InMemoryCCIPReader) Sync(_ context.Context, _ reader.ContractAddresses) error {

--- a/mocks/pkg/reader/ccip_reader.go
+++ b/mocks/pkg/reader/ccip_reader.go
@@ -536,6 +536,62 @@ func (_c *MockCCIPReader_GetWrappedNativeTokenPriceUSD_Call) RunAndReturn(run fu
 	return _c
 }
 
+// LinkPriceUSD provides a mock function with given fields: ctx
+func (_m *MockCCIPReader) LinkPriceUSD(ctx context.Context) (ccipocr3.BigInt, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for LinkPriceUSD")
+	}
+
+	var r0 ccipocr3.BigInt
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (ccipocr3.BigInt, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) ccipocr3.BigInt); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(ccipocr3.BigInt)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockCCIPReader_LinkPriceUSD_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'LinkPriceUSD'
+type MockCCIPReader_LinkPriceUSD_Call struct {
+	*mock.Call
+}
+
+// LinkPriceUSD is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockCCIPReader_Expecter) LinkPriceUSD(ctx interface{}) *MockCCIPReader_LinkPriceUSD_Call {
+	return &MockCCIPReader_LinkPriceUSD_Call{Call: _e.mock.On("LinkPriceUSD", ctx)}
+}
+
+func (_c *MockCCIPReader_LinkPriceUSD_Call) Run(run func(ctx context.Context)) *MockCCIPReader_LinkPriceUSD_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockCCIPReader_LinkPriceUSD_Call) Return(_a0 ccipocr3.BigInt, _a1 error) *MockCCIPReader_LinkPriceUSD_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockCCIPReader_LinkPriceUSD_Call) RunAndReturn(run func(context.Context) (ccipocr3.BigInt, error)) *MockCCIPReader_LinkPriceUSD_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // MsgsBetweenSeqNums provides a mock function with given fields: ctx, chain, seqNumRange
 func (_m *MockCCIPReader) MsgsBetweenSeqNums(ctx context.Context, chain ccipocr3.ChainSelector, seqNumRange ccipocr3.SeqNumRange) ([]ccipocr3.Message, error) {
 	ret := _m.Called(ctx, chain, seqNumRange)

--- a/pkg/reader/ccip_interface.go
+++ b/pkg/reader/ccip_interface.go
@@ -144,6 +144,12 @@ type CCIPReader interface {
 	// to be passed in here. We'll attempt to fetch the source config from the offramp for each of them.
 	DiscoverContracts(ctx context.Context, allChains []cciptypes.ChainSelector) (ContractAddresses, error)
 
+	// LinkPriceUSD gets the LINK price in 1e-18 USDs from the FeeQuoter contract on the destination chain.
+	// For example, if the price is 1 LINK = 10 USD, this function will return 10e18 (10 * 1e18). You can think of this
+	// function returning the price of LINK not in USD, but in a small denomination of USD, similar to returning
+	// the price of ETH not in ETH but in wei (1e-18 ETH).
+	LinkPriceUSD(ctx context.Context) (cciptypes.BigInt, error)
+
 	// Sync can be used to perform frequent syncing operations inside the reader implementation.
 	// Returns a bool indicating whether something was updated.
 	Sync(ctx context.Context, contracts ContractAddresses) error


### PR DESCRIPTION
Implement a function in ccipChainReader to get the price of the LINK token. We first call the dest chain FeeQuoter's `GetStaticConfig` method to get the address of the LINK token, then we call the `GetTokenPrices` method to get the price of LINK.