### PR TITLE
Add SignObservationPrefix in the OffchainConfig

### DIFF
--- a/commit/merkleroot/rmn/config.go
+++ b/commit/merkleroot/rmn/config.go
@@ -34,8 +34,6 @@ type RMNNodeInfo struct {
 	IsSigner                  bool
 	SignReportsAddress        cciptypes.Bytes
 	SignObservationsPublicKey *ed25519.PublicKey // offChainPublicKey
-	// TODO: clarify this field
-	SignObservationPrefix string // e.g. "chainlink ccip 1.6 rmn observation"
 }
 
 type NodeID uint32

--- a/commit/merkleroot/rmn/controller_test.go
+++ b/commit/merkleroot/rmn/controller_test.go
@@ -14,12 +14,13 @@ import (
 
 	mapset "github.com/deckarep/golang-set/v2"
 	chainsel "github.com/smartcontractkit/chain-selectors"
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn/rmnpb"
 )
@@ -51,6 +52,7 @@ func TestClient_ComputeReportSignatures(t *testing.T) {
 		ctx := tests.Context(t)
 		resChan := make(chan PeerResponse, 200)
 		peerClient := newMockPeerClient(resChan)
+		// signObservationPrefix := "chainlink ccip 1.6 rmn observation"
 
 		const numNodes = 4
 		rmnNodes := make([]RMNNodeInfo, numNodes)
@@ -65,7 +67,6 @@ func TestClient_ComputeReportSignatures(t *testing.T) {
 				IsSigner:                  true,
 				SignReportsAddress:        cciptypes.Bytes{uint8(i + 1), 0, 0, 0},
 				SignObservationsPublicKey: &publicKey,
-				SignObservationPrefix:     "chainlink ccip 1.6 rmn observation",
 			}
 		}
 

--- a/commit/merkleroot/rmn/controller_test.go
+++ b/commit/merkleroot/rmn/controller_test.go
@@ -52,7 +52,6 @@ func TestClient_ComputeReportSignatures(t *testing.T) {
 		ctx := tests.Context(t)
 		resChan := make(chan PeerResponse, 200)
 		peerClient := newMockPeerClient(resChan)
-		// signObservationPrefix := "chainlink ccip 1.6 rmn observation"
 
 		const numNodes = 4
 		rmnNodes := make([]RMNNodeInfo, numNodes)

--- a/commit/merkleroot/rmn/crypto.go
+++ b/commit/merkleroot/rmn/crypto.go
@@ -33,6 +33,7 @@ func (ED25519VerifierImpl) Verify(publicKey ed25519.PublicKey, message, sig []by
 //	e.g. ed25519.sign(sha256("chainlink ccip 1.6 rmn observation"|sha256(observation)))
 func verifyObservationSignature(
 	rmnNode RMNNodeInfo,
+	signedObservationPrefix string,
 	signedObs *rmnpb.SignedObservation,
 	verifier ED25519Verifier,
 ) error {
@@ -42,7 +43,7 @@ func verifyObservationSignature(
 	}
 
 	observationBytesSha256 := sha256.Sum256(observationBytes)
-	msg := append([]byte(rmnNode.SignObservationPrefix), observationBytesSha256[:]...)
+	msg := append([]byte(signedObservationPrefix), observationBytesSha256[:]...)
 	msgSha256 := sha256.Sum256(msg)
 
 	isValid := verifier.Verify(*rmnNode.SignObservationsPublicKey, msgSha256[:], signedObs.Signature)

--- a/commit/merkleroot/rmn/crypto_test.go
+++ b/commit/merkleroot/rmn/crypto_test.go
@@ -105,20 +105,20 @@ func Test_verifyObservationSignature(t *testing.T) {
 
 			rmnNode := RMNNodeInfo{
 				SignObservationsPublicKey: &offchainPK,
-				SignObservationPrefix:     "chainlink ccip 1.6 rmn observation",
 			}
+			signObservationPrefix1 := "chainlink ccip 1.6 rmn observation"
 
-			err = verifyObservationSignature(rmnNode, tc.signedObs, NewED25519Verifier())
+			err = verifyObservationSignature(rmnNode, signObservationPrefix1, tc.signedObs, NewED25519Verifier())
 			assert.NoError(t, err)
 
 			rmnNode2 := rmnNode
-			rmnNode2.SignObservationPrefix = "chainlink ccip 1.6 rmn observation2----------"
-			err = verifyObservationSignature(rmnNode2, tc.signedObs, NewED25519Verifier())
+			signObservationPrefix2 := "chainlink ccip 1.6 rmn observation2----------"
+			err = verifyObservationSignature(rmnNode2, signObservationPrefix2, tc.signedObs, NewED25519Verifier())
 			assert.Error(t, err)
 
 			// After we update one byte in the signature, the signature verification should fail
 			tc.signedObs.Signature[0] = tc.signedObs.Signature[0] + 1
-			err = verifyObservationSignature(rmnNode, tc.signedObs, NewED25519Verifier())
+			err = verifyObservationSignature(rmnNode, signObservationPrefix1, tc.signedObs, NewED25519Verifier())
 			assert.Error(t, err)
 		})
 	}

--- a/pluginconfig/commit.go
+++ b/pluginconfig/commit.go
@@ -25,6 +25,7 @@ const (
 	defaultMaxReportTransmissionCheckAttempts = 5
 	defaultRMNEnabled                         = false
 	defaultRemoteGasPriceBatchWriteFrequency  = 1 * time.Minute
+	defaultSignObservationPrefix              = "chainlink ccip 1.6 rmn observation"
 )
 
 type FeeInfo struct {
@@ -113,6 +114,9 @@ type CommitOffchainConfig struct {
 	// If for example in the next round we have 1000 pending messages and a max tree size of 256, only 256 seq nums
 	// will be in the report. If a value is not set we fallback to EvmDefaultMaxMerkleTreeSize.
 	MaxMerkleTreeSize uint64 `json:"maxTreeSize"`
+
+	// SignObservationPrefix is the prefix used by the RMN node to sign observations.
+	SignObservationPrefix string `json:"signObservationPrefix"`
 }
 
 func (c *CommitOffchainConfig) applyDefaults() {
@@ -134,6 +138,10 @@ func (c *CommitOffchainConfig) applyDefaults() {
 
 	if c.RemoteGasPriceBatchWriteFrequency.Duration() == 0 {
 		c.RemoteGasPriceBatchWriteFrequency = *commonconfig.MustNewDuration(defaultRemoteGasPriceBatchWriteFrequency)
+	}
+
+	if c.SignObservationPrefix == "" {
+		c.SignObservationPrefix = defaultSignObservationPrefix
 	}
 }
 
@@ -172,6 +180,10 @@ func (c *CommitOffchainConfig) Validate() error {
 
 	if c.MaxMerkleTreeSize == 0 {
 		return fmt.Errorf("maxMerkleTreeSize not set")
+	}
+
+	if c.SignObservationPrefix == "" {
+		return fmt.Errorf("signObservationPrefix not set")
 	}
 
 	return nil

--- a/pluginconfig/commit_test.go
+++ b/pluginconfig/commit_test.go
@@ -123,6 +123,7 @@ func TestCommitOffchainConfig_Validate(t *testing.T) {
 		NewMsgScanBatchSize                uint32
 		MaxReportTransmissionCheckAttempts uint32
 		MaxMerkleTreeSize                  uint32
+		SignObservationPrefix              string
 	}
 	remoteTokenAddress := rand.RandomAddress()
 	aggregatorAddress := string(rand.RandomAddress())
@@ -147,6 +148,7 @@ func TestCommitOffchainConfig_Validate(t *testing.T) {
 				NewMsgScanBatchSize:                256,
 				MaxReportTransmissionCheckAttempts: 10,
 				MaxMerkleTreeSize:                  1000,
+				SignObservationPrefix:              defaultSignObservationPrefix,
 			},
 			false,
 		},
@@ -159,6 +161,7 @@ func TestCommitOffchainConfig_Validate(t *testing.T) {
 				NewMsgScanBatchSize:                256,
 				MaxReportTransmissionCheckAttempts: 10,
 				MaxMerkleTreeSize:                  1000,
+				SignObservationPrefix:              defaultSignObservationPrefix,
 			},
 			false,
 		},
@@ -177,6 +180,7 @@ func TestCommitOffchainConfig_Validate(t *testing.T) {
 				NewMsgScanBatchSize:                256,
 				MaxReportTransmissionCheckAttempts: 10,
 				MaxMerkleTreeSize:                  1000,
+				SignObservationPrefix:              defaultSignObservationPrefix,
 			},
 			true,
 		},
@@ -195,6 +199,7 @@ func TestCommitOffchainConfig_Validate(t *testing.T) {
 				NewMsgScanBatchSize:                256,
 				MaxReportTransmissionCheckAttempts: 10,
 				MaxMerkleTreeSize:                  1000,
+				SignObservationPrefix:              defaultSignObservationPrefix,
 			},
 			true,
 		},
@@ -204,6 +209,26 @@ func TestCommitOffchainConfig_Validate(t *testing.T) {
 				RemoteGasPriceBatchWriteFrequency:  *commonconfig.MustNewDuration(1),
 				TokenPriceBatchWriteFrequency:      *commonconfig.MustNewDuration(1),
 				TokenInfo:                          map[types.Account]TokenInfo{},
+				MaxReportTransmissionCheckAttempts: 10,
+				MaxMerkleTreeSize:                  1000,
+				SignObservationPrefix:              defaultSignObservationPrefix,
+			},
+			true,
+		},
+		{
+			"invalid, missing SignObservationPrefix",
+			fields{
+				RemoteGasPriceBatchWriteFrequency: *commonconfig.MustNewDuration(1),
+				TokenPriceBatchWriteFrequency:     *commonconfig.MustNewDuration(1),
+				TokenInfo: map[types.Account]TokenInfo{
+					remoteTokenAddress: {
+						AggregatorAddress: aggregatorAddress,
+						DeviationPPB:      cciptypes.BigInt{Int: big.NewInt(1)},
+						Decimals:          18,
+					},
+				},
+				TokenPriceChainSelector:            10,
+				NewMsgScanBatchSize:                256,
 				MaxReportTransmissionCheckAttempts: 10,
 				MaxMerkleTreeSize:                  1000,
 			},
@@ -220,6 +245,7 @@ func TestCommitOffchainConfig_Validate(t *testing.T) {
 				NewMsgScanBatchSize:                int(tt.fields.NewMsgScanBatchSize),
 				MaxReportTransmissionCheckAttempts: uint(tt.fields.MaxReportTransmissionCheckAttempts),
 				MaxMerkleTreeSize:                  uint64(tt.fields.MaxMerkleTreeSize),
+				SignObservationPrefix:              tt.fields.SignObservationPrefix,
 			}
 			err := c.Validate()
 			if tt.wantErr {
@@ -305,6 +331,7 @@ func TestCommitOffchainConfig_ApplyDefaults(t *testing.T) {
 				MaxReportTransmissionCheckAttempts: defaultMaxReportTransmissionCheckAttempts,
 				MaxMerkleTreeSize:                  defaultEvmDefaultMaxMerkleTreeSize,
 				RemoteGasPriceBatchWriteFrequency:  *commonconfig.MustNewDuration(defaultRemoteGasPriceBatchWriteFrequency),
+				SignObservationPrefix:              defaultSignObservationPrefix,
 			},
 		},
 		{
@@ -319,6 +346,7 @@ func TestCommitOffchainConfig_ApplyDefaults(t *testing.T) {
 				MaxReportTransmissionCheckAttempts: defaultMaxReportTransmissionCheckAttempts,
 				MaxMerkleTreeSize:                  defaultEvmDefaultMaxMerkleTreeSize,
 				RemoteGasPriceBatchWriteFrequency:  *commonconfig.MustNewDuration(defaultRemoteGasPriceBatchWriteFrequency),
+				SignObservationPrefix:              defaultSignObservationPrefix,
 			},
 		},
 		{
@@ -337,6 +365,7 @@ func TestCommitOffchainConfig_ApplyDefaults(t *testing.T) {
 				MaxReportTransmissionCheckAttempts: 10,
 				MaxMerkleTreeSize:                  1000,
 				RemoteGasPriceBatchWriteFrequency:  *commonconfig.MustNewDuration(defaultRemoteGasPriceBatchWriteFrequency),
+				SignObservationPrefix:              defaultSignObservationPrefix,
 			},
 		},
 		{
@@ -353,6 +382,7 @@ func TestCommitOffchainConfig_ApplyDefaults(t *testing.T) {
 				MaxReportTransmissionCheckAttempts: defaultMaxReportTransmissionCheckAttempts,
 				MaxMerkleTreeSize:                  500,
 				RemoteGasPriceBatchWriteFrequency:  *commonconfig.MustNewDuration(defaultRemoteGasPriceBatchWriteFrequency),
+				SignObservationPrefix:              defaultSignObservationPrefix,
 			},
 		},
 	}
@@ -392,6 +422,7 @@ func TestCommitOffchainConfig_ApplyDefaultsAndValidate(t *testing.T) {
 				MaxReportTransmissionCheckAttempts: 10,
 				MaxMerkleTreeSize:                  1000,
 				RMNEnabled:                         true,
+				SignObservationPrefix:              defaultSignObservationPrefix,
 			},
 		},
 	}
@@ -412,6 +443,7 @@ func TestCommitOffchainConfig_ApplyDefaultsAndValidate(t *testing.T) {
 				assert.NotZero(t, config.NewMsgScanBatchSize)
 				assert.NotZero(t, config.MaxReportTransmissionCheckAttempts)
 				assert.NotZero(t, config.MaxMerkleTreeSize)
+				assert.NotZero(t, config.SignObservationPrefix)
 
 				// Check specific defaults
 				if !tt.input.RMNEnabled {


### PR DESCRIPTION
SignObservationPrefix Is not part of the onchain RMN config. Hence adding it in the CommitOffchainConfig.