### PR TITLE
Split CostlyMessageObserver into Fee and ExecCost components

### DIFF
--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -30,7 +30,8 @@ jobs:
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           repository: smartcontractkit/chainlink
-          ref: develop
+          # TODO: switch back to develop
+          ref: BCF-2887-context-propagation
           path: chainlink
       - name: Get the correct commit SHA via GitHub API
         id: get_sha

--- a/execute/exectypes/costly_messages.go
+++ b/execute/exectypes/costly_messages.go
@@ -1,0 +1,187 @@
+package exectypes
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+
+	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
+)
+
+// CostlyMessageObserver observes messages that are too costly to execute.
+type CostlyMessageObserver interface {
+	// Observe takes a set of messages and returns a slice of message IDs that are too costly to execute.
+	// Also takes in a map from message ID to the message's timestamp, needed to calculate fee boosting.
+	Observe(
+		ctx context.Context,
+		messages []cciptypes.Message,
+		messageTimestamps map[cciptypes.Bytes32]time.Time,
+	) ([]cciptypes.Bytes32, error)
+}
+
+func NewCostlyMessageObserver() CostlyMessageObserver {
+	return &CCIPCostlyMessageObserver{
+		// TODO: Implement fee and exec cost calculators
+		feeCalculator:      &ZeroMessageFeeUSD18Calculator{},
+		execCostCalculator: &ZeroMessageExecCostUSD18Calculator{},
+	}
+}
+
+type CCIPCostlyMessageObserver struct {
+	feeCalculator      MessageFeeE18USDCalculator
+	execCostCalculator MessageExecCostUSD18Calculator
+}
+
+// Observe returns a slice of message IDs that are too costly to execute.
+// It calculates the fee and execution cost of each message. The messages are considered too costly if the fee is less
+// than the execution cost.
+func (o *CCIPCostlyMessageObserver) Observe(
+	ctx context.Context,
+	messages []cciptypes.Message,
+	messageTimestamps map[cciptypes.Bytes32]time.Time,
+) ([]cciptypes.Bytes32, error) {
+	messageFees, err := o.feeCalculator.MessageFeeUSD18(ctx, messages, messageTimestamps)
+	if err != nil {
+		return nil, fmt.Errorf("unable to calculate message fees: %w", err)
+	}
+
+	execCosts, err := o.execCostCalculator.MessageExecCostUSD18(ctx, messages)
+	if err != nil {
+		return nil, fmt.Errorf("unable to calculate message execution costs: %w", err)
+	}
+
+	costlyMessages := make([]cciptypes.Bytes32, 0)
+	for _, msg := range messages {
+		fee, ok := messageFees[msg.Header.MessageID]
+		if !ok {
+			return nil, fmt.Errorf("missing fee for message %s", msg.Header.MessageID)
+		}
+		execCost, ok := execCosts[msg.Header.MessageID]
+		if !ok {
+			return nil, fmt.Errorf("missing exec cost for message %s", msg.Header.MessageID)
+		}
+		if fee.Cmp(execCost) < 0 {
+			costlyMessages = append(costlyMessages, msg.Header.MessageID)
+		}
+	}
+
+	return costlyMessages, nil
+}
+
+var _ CostlyMessageObserver = &CCIPCostlyMessageObserver{}
+
+// MessageFeeE18USDCalculator Calculates the fees (paid at source) of a set of messages in USD18s.
+type MessageFeeE18USDCalculator interface {
+	// MessageFeeUSD18 Returns a map from message ID to the message's fee in USD18s.
+	MessageFeeUSD18(
+		ctx context.Context,
+		messages []cciptypes.Message,
+		messageTimestamps map[cciptypes.Bytes32]time.Time,
+	) (map[cciptypes.Bytes32]plugintypes.USD18, error)
+}
+
+// ZeroMessageFeeUSD18Calculator returns a fee of 0 for all messages.
+type ZeroMessageFeeUSD18Calculator struct{}
+
+// MessageFeeUSD18 returns a fee of 0 for all messages.
+func (n *ZeroMessageFeeUSD18Calculator) MessageFeeUSD18(
+	_ context.Context,
+	messages []cciptypes.Message,
+	_ map[cciptypes.Bytes32]time.Time,
+) (map[cciptypes.Bytes32]plugintypes.USD18, error) {
+	messageFees := make(map[cciptypes.Bytes32]plugintypes.USD18)
+	for _, msg := range messages {
+		messageFees[msg.Header.MessageID] = plugintypes.NewUSD18(0)
+	}
+	return messageFees, nil
+}
+
+var _ MessageFeeE18USDCalculator = &ZeroMessageFeeUSD18Calculator{}
+
+// MessageExecCostUSD18Calculator Calculates the execution cost of a set of messages in USD18s.
+type MessageExecCostUSD18Calculator interface {
+	// MessageExecCostUSD18 Returns a map from message ID to the message's estimated execution cost in USD18s.
+	MessageExecCostUSD18(context.Context, []cciptypes.Message) (map[cciptypes.Bytes32]plugintypes.USD18, error)
+}
+
+// ZeroMessageExecCostUSD18Calculator returns a cost of 0 for all messages.
+type ZeroMessageExecCostUSD18Calculator struct{}
+
+// MessageExecCostUSD18 returns a cost of 0 for all messages.
+func (n *ZeroMessageExecCostUSD18Calculator) MessageExecCostUSD18(
+	_ context.Context,
+	messages []cciptypes.Message,
+) (map[cciptypes.Bytes32]plugintypes.USD18, error) {
+	messageExecCosts := make(map[cciptypes.Bytes32]plugintypes.USD18)
+	for _, msg := range messages {
+		messageExecCosts[msg.Header.MessageID] = plugintypes.NewUSD18(0)
+	}
+	return messageExecCosts, nil
+}
+
+var _ MessageExecCostUSD18Calculator = &ZeroMessageExecCostUSD18Calculator{}
+
+// StaticMessageFeeUSD18Calculator returns a static fee for all messages.
+type StaticMessageFeeUSD18Calculator struct {
+	fees map[cciptypes.Bytes32]plugintypes.USD18
+}
+
+func NewStaticMessageFeeUSD18Calculator(
+	fees map[cciptypes.Bytes32]plugintypes.USD18,
+) *StaticMessageFeeUSD18Calculator {
+	return &StaticMessageFeeUSD18Calculator{fees: fees}
+}
+
+// MessageFeeUSD18 returns a fee of 0 for all messages.
+func (n *StaticMessageFeeUSD18Calculator) MessageFeeUSD18(
+	_ context.Context,
+	messages []cciptypes.Message,
+	_ map[cciptypes.Bytes32]time.Time,
+) (map[cciptypes.Bytes32]plugintypes.USD18, error) {
+	messageFees := make(map[cciptypes.Bytes32]plugintypes.USD18)
+
+	for _, msg := range messages {
+		fee, ok := n.fees[msg.Header.MessageID]
+		if !ok {
+			return nil, fmt.Errorf("missing fee for message %s", msg.Header.MessageID)
+		}
+		messageFees[msg.Header.MessageID] = fee
+	}
+
+	return messageFees, nil
+}
+
+var _ MessageFeeE18USDCalculator = &StaticMessageFeeUSD18Calculator{}
+
+// StaticMessageExecCostUSD18Calculator returns a static cost for all messages.
+type StaticMessageExecCostUSD18Calculator struct {
+	costs map[cciptypes.Bytes32]plugintypes.USD18
+}
+
+func NewStaticMessageExecCostUSD18Calculator(
+	costs map[cciptypes.Bytes32]plugintypes.USD18,
+) *StaticMessageExecCostUSD18Calculator {
+	return &StaticMessageExecCostUSD18Calculator{costs: costs}
+}
+
+// MessageExecCostUSD18 returns a cost of 0 for all messages.
+func (n *StaticMessageExecCostUSD18Calculator) MessageExecCostUSD18(
+	_ context.Context,
+	messages []cciptypes.Message,
+) (map[cciptypes.Bytes32]plugintypes.USD18, error) {
+	messageExecCosts := make(map[cciptypes.Bytes32]plugintypes.USD18)
+
+	for _, msg := range messages {
+		cost, ok := n.costs[msg.Header.MessageID]
+		if !ok {
+			return nil, fmt.Errorf("missing exec cost for message %s", msg.Header.MessageID)
+		}
+		messageExecCosts[msg.Header.MessageID] = cost
+	}
+
+	return messageExecCosts, nil
+}
+
+var _ MessageExecCostUSD18Calculator = &StaticMessageExecCostUSD18Calculator{}

--- a/execute/exectypes/costly_messages_test.go
+++ b/execute/exectypes/costly_messages_test.go
@@ -1,0 +1,94 @@
+package exectypes
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+
+	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
+)
+
+func TestCCIPCostlyMessageObserver_Observe(t *testing.T) {
+	b1, _ := ccipocr3.NewBytes32FromString("1")
+	b2, _ := ccipocr3.NewBytes32FromString("2")
+	b3, _ := ccipocr3.NewBytes32FromString("3")
+
+	tests := []struct {
+		name         string
+		messageIDs   []ccipocr3.Bytes32
+		messageFees  map[ccipocr3.Bytes32]plugintypes.USD18
+		messageCosts map[ccipocr3.Bytes32]plugintypes.USD18
+		want         []ccipocr3.Bytes32
+		wantErr      assert.ErrorAssertionFunc
+	}{
+		{
+			name:         "empty",
+			messageIDs:   []ccipocr3.Bytes32{},
+			messageFees:  map[ccipocr3.Bytes32]plugintypes.USD18{},
+			messageCosts: map[ccipocr3.Bytes32]plugintypes.USD18{},
+			want:         []ccipocr3.Bytes32{},
+			wantErr:      assert.NoError,
+		},
+		{
+			name:         "missing fees",
+			messageIDs:   []ccipocr3.Bytes32{b1, b2, b2},
+			messageFees:  map[ccipocr3.Bytes32]plugintypes.USD18{},
+			messageCosts: map[ccipocr3.Bytes32]plugintypes.USD18{},
+			want:         []ccipocr3.Bytes32{},
+			wantErr:      assert.Error,
+		},
+		{
+			name:       "missing costs",
+			messageIDs: []ccipocr3.Bytes32{b1, b2, b2},
+			messageFees: map[ccipocr3.Bytes32]plugintypes.USD18{
+				b1: plugintypes.NewUSD18(10),
+				b2: plugintypes.NewUSD18(20),
+				b3: plugintypes.NewUSD18(30),
+			},
+			messageCosts: map[ccipocr3.Bytes32]plugintypes.USD18{},
+			want:         []ccipocr3.Bytes32{},
+			wantErr:      assert.Error,
+		},
+		{
+			name:       "happy path",
+			messageIDs: []ccipocr3.Bytes32{b1, b2, b2},
+			messageFees: map[ccipocr3.Bytes32]plugintypes.USD18{
+				b1: plugintypes.NewUSD18(10),
+				b2: plugintypes.NewUSD18(20),
+				b3: plugintypes.NewUSD18(30),
+			},
+			messageCosts: map[ccipocr3.Bytes32]plugintypes.USD18{
+				b1: plugintypes.NewUSD18(5),
+				b2: plugintypes.NewUSD18(25),
+				b3: plugintypes.NewUSD18(15),
+			},
+			want:    []ccipocr3.Bytes32{b2},
+			wantErr: assert.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			feeCalculator := NewStaticMessageFeeUSD18Calculator(tt.messageFees)
+			execCostCalculator := NewStaticMessageExecCostUSD18Calculator(tt.messageCosts)
+			observer := &CCIPCostlyMessageObserver{
+				feeCalculator:      feeCalculator,
+				execCostCalculator: execCostCalculator,
+			}
+			messages := make([]ccipocr3.Message, len(tt.messageIDs))
+			for _, id := range tt.messageIDs {
+				messages = append(messages, ccipocr3.Message{Header: ccipocr3.RampMessageHeader{MessageID: id}})
+			}
+
+			got, err := observer.Observe(ctx, messages, nil)
+			if tt.wantErr(t, err, "Observe(...)") {
+				return
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/execute/exectypes/observation.go
+++ b/execute/exectypes/observation.go
@@ -1,7 +1,6 @@
 package exectypes
 
 import (
-	"context"
 	"encoding/json"
 
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
@@ -98,17 +97,3 @@ func DecodeObservation(b []byte) (Observation, error) {
 	err := json.Unmarshal(b, &obs)
 	return obs, err
 }
-
-// CostlyMessageObserver observes messages that are too costly to execute.
-type CostlyMessageObserver interface {
-	// Observe takes a set of messages and returns a slice of message IDs that are too costly to execute.
-	Observe(context.Context, MessageObservations) ([]cciptypes.Bytes32, error)
-}
-
-type NoOpCostlyMessageObserver struct{}
-
-func (n *NoOpCostlyMessageObserver) Observe(_ context.Context, _ MessageObservations) ([]cciptypes.Bytes32, error) {
-	return nil, nil
-}
-
-var _ CostlyMessageObserver = &NoOpCostlyMessageObserver{}

--- a/execute/observation.go
+++ b/execute/observation.go
@@ -7,9 +7,10 @@ import (
 
 	"golang.org/x/exp/maps"
 
-	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
 	typeconv "github.com/smartcontractkit/chainlink-ccip/internal/libs/typeconv"
@@ -128,7 +129,9 @@ func (p *Plugin) getMessagesObservation(
 	previousOutcome exectypes.Outcome,
 	observation exectypes.Observation,
 ) (exectypes.Observation, error) {
-	messages := make(exectypes.MessageObservations)
+	messageObs := make(exectypes.MessageObservations)
+	messages := make([]cciptypes.Message, 0)
+	messageTimestamps := make(map[cciptypes.Bytes32]time.Time)
 	if len(previousOutcome.PendingCommitReports) == 0 {
 		p.lggr.Debug("TODO: No reports to execute. This is expected after a cold start.")
 		// No reports to execute.
@@ -156,28 +159,35 @@ func (p *Plugin) getMessagesObservation(
 				if err != nil {
 					return exectypes.Observation{}, err
 				}
+				messages = append(messages, msgs...)
 				for _, msg := range msgs {
-					if _, ok := messages[srcChain]; !ok {
-						messages[srcChain] = make(map[cciptypes.SeqNum]cciptypes.Message)
+					if _, ok := messageObs[srcChain]; !ok {
+						messageObs[srcChain] = make(map[cciptypes.SeqNum]cciptypes.Message)
 					}
-					messages[srcChain][msg.Header.SequenceNumber] = msg
+					messageObs[srcChain][msg.Header.SequenceNumber] = msg
 				}
 			}
 		}
+
+		var err error
+		messageTimestamps, err = getMessageTimestampMap(commitReportCache, messageObs)
+		if err != nil {
+			return exectypes.Observation{}, err
+		}
 	}
 
-	tkData, err1 := p.tokenDataObserver.Observe(ctx, messages)
+	tkData, err1 := p.tokenDataObserver.Observe(ctx, messageObs)
 	if err1 != nil {
 		return exectypes.Observation{}, fmt.Errorf("unable to process token data %w", err1)
 	}
 
-	costlyMessages, err := p.costlyMessageObserver.Observe(ctx, messages)
+	costlyMessages, err := p.costlyMessageObserver.Observe(ctx, messages, messageTimestamps)
 	if err != nil {
-		return exectypes.Observation{}, fmt.Errorf("unable to observe costly messages %w", err)
+		return exectypes.Observation{}, fmt.Errorf("unable to observe costly messageObs %w", err)
 	}
 
 	observation.CommitReports = regroup(previousOutcome.PendingCommitReports)
-	observation.Messages = messages
+	observation.Messages = messageObs
 	observation.CostlyMessages = costlyMessages
 	observation.TokenData = tkData
 

--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -74,20 +74,19 @@ func NewPlugin(
 	lggr.Infow("creating new plugin instance", "p2pID", oracleIDToP2pID[reportingCfg.OracleID])
 
 	return &Plugin{
-		donID:             donID,
-		reportingCfg:      reportingCfg,
-		offchainCfg:       offchainCfg,
-		destChain:         destChain,
-		oracleIDToP2pID:   oracleIDToP2pID,
-		ccipReader:        ccipReader,
-		reportCodec:       reportCodec,
-		msgHasher:         msgHasher,
-		homeChain:         homeChain,
-		tokenDataObserver: tokenDataObserver,
-		estimateProvider:  estimateProvider,
-		lggr:              lggr,
-		// TODO: implement
-		costlyMessageObserver: &exectypes.NoOpCostlyMessageObserver{},
+		donID:                 donID,
+		reportingCfg:          reportingCfg,
+		offchainCfg:           offchainCfg,
+		destChain:             destChain,
+		oracleIDToP2pID:       oracleIDToP2pID,
+		ccipReader:            ccipReader,
+		reportCodec:           reportCodec,
+		msgHasher:             msgHasher,
+		homeChain:             homeChain,
+		tokenDataObserver:     tokenDataObserver,
+		estimateProvider:      estimateProvider,
+		lggr:                  lggr,
+		costlyMessageObserver: exectypes.NewCostlyMessageObserver(),
 		discovery: discovery.NewContractDiscoveryProcessor(
 			lggr,
 			&ccipReader,

--- a/execute/plugin_functions.go
+++ b/execute/plugin_functions.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
 
@@ -500,4 +501,30 @@ func getConsensusObservation(
 	)
 
 	return observation, nil
+}
+
+// getMessageTimestampMap returns a map of message IDs to their timestamps.
+// cciptypes.Message does not contain a timestamp, so we need to derive the timestamp from the commit data.
+func getMessageTimestampMap(
+	commitReportCache map[cciptypes.ChainSelector][]exectypes.CommitData,
+	messages exectypes.MessageObservations,
+) (map[cciptypes.Bytes32]time.Time, error) {
+	messageTimestamps := make(map[cciptypes.Bytes32]time.Time)
+
+	for chainSel, SeqNumToMsg := range messages {
+		commitData, ok := commitReportCache[chainSel]
+		if !ok {
+			return nil, fmt.Errorf("missing commit data for chain %s", chainSel)
+		}
+
+		for seqNum, msg := range SeqNumToMsg {
+			for _, commit := range commitData {
+				if commit.SequenceNumberRange.Contains(seqNum) {
+					messageTimestamps[msg.Header.MessageID] = commit.Timestamp
+				}
+			}
+		}
+	}
+
+	return messageTimestamps, nil
 }

--- a/internal/plugintypes/common.go
+++ b/internal/plugintypes/common.go
@@ -1,6 +1,8 @@
 package plugintypes
 
 import (
+	"math/big"
+
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 )
 
@@ -22,3 +24,15 @@ type ChainRange struct {
 }
 
 type DonID = uint32
+
+// USD18 is a small unit of USD, where 1 USD18 is 1e-18 USD, meaning it is 18 decimal places smaller than 1 USD.
+//
+// 1 USD18 = 1e-18 USD   = 0.000000000000000001 USD
+// 1 USD   = 1e18  USD18 = 1,000,000,000,000,000,000 USD18
+//
+// Token prices stored in many contracts (e.g. FeeQuoter) are denominated in USD18
+type USD18 = *big.Int
+
+func NewUSD18(value int64) USD18 {
+	return big.NewInt(value)
+}


### PR DESCRIPTION
Implements CostlyMessageObserver in terms of a feeCalculator and a execCostCalculator. When checking if a message is too costly, we use these 2 components to compute the message fee and exec cost. If the cost is greater than the fee, the message is considered too costly. Also adds messageTimestamps as a param to CostlyMessageObserver.Observe() so that fee boosting can use the message timestamps.