### PR TITLE
Fixing logger in parallel tests 

### DIFF
--- a/execute/tokendata/usdc/attestation_test.go
+++ b/execute/tokendata/usdc/attestation_test.go
@@ -19,6 +19,12 @@ import (
 )
 
 func Test_AttestationClient(t *testing.T) {
+	lggr := logger.Test(t)
+
+	t.Cleanup(func() {
+		_ = lggr.Sync()
+	})
+
 	type example struct {
 		hash   []byte
 		keccak string
@@ -157,7 +163,7 @@ func Test_AttestationClient(t *testing.T) {
 			server := httptest.NewServer(createHandler(t, tc.success, tc.pending))
 			defer server.Close()
 
-			client, err := NewSequentialAttestationClient(logger.Test(t), pluginconfig.USDCCCTPObserverConfig{
+			client, err := NewSequentialAttestationClient(lggr, pluginconfig.USDCCCTPObserverConfig{
 				AttestationAPI:         server.URL,
 				AttestationAPIInterval: commonconfig.MustNewDuration(1 * time.Millisecond),
 				AttestationAPITimeout:  commonconfig.MustNewDuration(1 * time.Minute),

--- a/execute/tokendata/usdc/http_test.go
+++ b/execute/tokendata/usdc/http_test.go
@@ -323,6 +323,12 @@ func Test_HTTPClient_CoolDownWithRetryHeader(t *testing.T) {
 }
 
 func Test_HTTPClient_RateLimiting_Parallel(t *testing.T) {
+	lggr := logger.Test(t)
+
+	t.Cleanup(func() {
+		_ = lggr.Sync()
+	})
+
 	testCases := []struct {
 		name         string
 		requests     uint64
@@ -373,7 +379,7 @@ func Test_HTTPClient_RateLimiting_Parallel(t *testing.T) {
 			attestationURI, err := url.ParseRequestURI(ts.URL)
 			require.NoError(t, err)
 
-			client, err := newHTTPClient(logger.Test(t), attestationURI.String(), tc.rateConfig, longTimeout)
+			client, err := newHTTPClient(lggr, attestationURI.String(), tc.rateConfig, longTimeout)
 			require.NoError(t, err)
 
 			ctx := context.Background()


### PR DESCRIPTION
Sync the logger state after timeouting underlying Go routines in the tests

If the killed routine is woken up after the test is finished, it will try to log which cause zap logger to panic