### PR TITLE
Fix integration test chainlink repo branch

### DIFF
--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -30,8 +30,7 @@ jobs:
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           repository: smartcontractkit/chainlink
-          # TODO: switch back to develop
-          ref: BCF-2887-context-propagation
+          ref: develop
           path: chainlink
       - name: Get the correct commit SHA via GitHub API
         id: get_sha


### PR DESCRIPTION
The test branch was not restored after migration to latest libocr.
Restoring it now.