### PR TITLE
enable nolintlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,18 +9,19 @@ linters:
     - errorlint
     - exhaustive
     - exportloopref
-    - gofmt
-    - gocyclo
     - goconst
+    - gocyclo
+    - gofmt
     - goimports
-    - gosimple
     - gosec
+    - gosimple
     - govet
     - ineffassign
     - lll
     - misspell
     - nakedret
     - noctx
+    - nolintlint
     - revive
     - rowserrcheck
     - sqlclosecheck

--- a/commit/chainfee/outcome.go
+++ b/commit/chainfee/outcome.go
@@ -43,10 +43,12 @@ func (p *processor) Outcome(
 	// We need to report a packed GasPrice
 	// The packed GasPrice is a 224-bit integer with the following format:
 	// (dataAvFeePriceUSD) << 112 | (executionFeePriceUSD)
-	// nolint:lll
+	//
 	// https://github.com/smartcontractkit/chainlink/blob/60e8b1181dd74b66903cf5b9a8427557b85357ec/contracts/src/v0.8/ccip/FeeQuoter.sol#L498
 	// In next loop we calculate the price in USD for the data availability and execution fees.
 	// And getGasPricesToUpdate will select and calculate the **packed** gas price to update based.
+	//
+	//nolint:lll
 	for chain, feeComp := range consensusObs.FeeComponents {
 		// The price, in USD with 18 decimals, per 1e18 of the smallest token denomination.
 		// 1 USDC = 1.00 USD per full token, each full token is 1e6 units -> 1 * 1e18 * 1e18 / 1e6 = 1e30

--- a/commit/chainfee/types.go
+++ b/commit/chainfee/types.go
@@ -81,8 +81,10 @@ func FromPackedFee(packedFee *big.Int) ComponentsUSDPrices {
 
 // ToPackedFee PackedFee is a Bitwise operation:
 // (dataAvFeeUSD << 112) | executionFeeUSD
-// nolint:lll
+//
 // https://github.com/smartcontractkit/chainlink/blob/60e8b1181dd74b66903cf5b9a8427557b85357ec/contracts/src/v0.8/ccip/FeeQuoter.sol#L498
+//
+//nolint:lll
 func (c ComponentsUSDPrices) ToPackedFee() *big.Int {
 	daShifted := new(big.Int).Lsh(c.DataAvFeePriceUSD, 112)
 	return new(big.Int).Or(daShifted, c.ExecutionFeePriceUSD)

--- a/commit/chainfee/validate_observation.go
+++ b/commit/chainfee/validate_observation.go
@@ -11,7 +11,6 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-// nolint:revive,govet
 func (p *processor) ValidateObservation(
 	prevOutcome Outcome,
 	query Query,

--- a/commit/merkleroot/rmn/controller.go
+++ b/commit/merkleroot/rmn/controller.go
@@ -338,7 +338,8 @@ func (c *controller) sendObservationRequests(
 // listenForRmnObservationResponses listens for the RMN observation responses.
 // It waits for the responses until all the requests are finished or until the context is done.
 // It is responsible for sending additional observation requests if the initial requests timeout.
-// nolint:gocyclo // todo
+//
+//nolint:gocyclo // todo
 func (c *controller) listenForRmnObservationResponses(
 	ctx context.Context,
 	destChain *rmnpb.LaneDest,
@@ -466,7 +467,7 @@ func gotSufficientObservationResponses(
 	return true
 }
 
-// nolint:gocyclo // todo
+//nolint:gocyclo // todo
 func (c *controller) validateSignedObservationResponse(
 	parsedResp *rmnpb.Response,
 	rmnNodeID rmntypes.NodeID,
@@ -778,7 +779,7 @@ type reportSigWithSignerAddress struct {
 	signerAddress cciptypes.Bytes
 }
 
-// nolint:gocyclo // todo
+//nolint:gocyclo // todo
 func (c *controller) listenForRmnReportSignatures(
 	ctx context.Context,
 	requestIDs mapset.Set[uint64],

--- a/commit/tokenprice/processor.go
+++ b/commit/tokenprice/processor.go
@@ -29,7 +29,6 @@ type processor struct {
 	fRoleDON         int
 }
 
-// nolint: revive
 func NewProcessor(
 	oracleID commontypes.OracleID,
 	lggr logger.Logger,
@@ -39,7 +38,7 @@ func NewProcessor(
 	tokenPriceReader reader.PriceReader,
 	homeChain reader.HomeChain,
 	fRoleDON int,
-) *processor {
+) plugincommon.PluginProcessor[Query, Observation, Outcome] {
 	return &processor{
 		oracleID:         oracleID,
 		lggr:             lggr,

--- a/execute/plugin_functions.go
+++ b/execute/plugin_functions.go
@@ -133,7 +133,8 @@ func groupByChainSelector(
 
 // filterOutExecutedMessages returns a new reports slice with fully executed messages removed.
 // Unordered inputs are supported.
-// nolint:gocyclo // todo
+//
+//nolint:gocyclo // todo
 func filterOutExecutedMessages(
 	reports []exectypes.CommitData, executedMessages []cciptypes.SeqNumRange,
 ) ([]exectypes.CommitData, error) {
@@ -311,7 +312,6 @@ func mergeTokenObservations(
 	fChain map[cciptypes.ChainSelector]int,
 ) (exectypes.TokenDataObservations, error) {
 	// Single message can transfer multiple tokens, so we need to find consensus on the token level.
-	//nolint:lll
 	validators := make(map[cciptypes.ChainSelector]map[reader.MessageTokenID]consensus.MinObservation[exectypes.TokenData])
 	results := make(exectypes.TokenDataObservations)
 

--- a/execute/plugin_test.go
+++ b/execute/plugin_test.go
@@ -302,7 +302,7 @@ func TestPlugin_Observation_EligibilityCheckFailure(t *testing.T) {
 
 	_, err := p.Observation(context.Background(), ocr3types.OutcomeContext{}, nil)
 	require.Error(t, err)
-	// nolint:lll // error message
+	//nolint:lll // error message
 	assert.Contains(t, err.Error(), "unable to determine if the destination chain is supported: error getting supported chains: oracle ID 0 not found in oracleIDToP2pID")
 }
 
@@ -498,7 +498,7 @@ func TestPlugin_ShouldTransmitAcceptReport_ElegibilityCheckFailure(t *testing.T)
 
 	_, err := p.ShouldTransmitAcceptedReport(context.Background(), 1, ocr3types.ReportWithInfo[[]byte]{})
 	require.Error(t, err)
-	// nolint:lll // error message
+	//nolint:lll // error message
 	assert.Contains(t, err.Error(), "unable to determine if the destination chain is supported: error getting supported chains: oracle ID 0 not found in oracleIDToP2pID")
 }
 

--- a/execute/report/report.go
+++ b/execute/report/report.go
@@ -148,8 +148,7 @@ const (
 
 func (b *execReportBuilder) checkMessage(
 	_ context.Context, idx int, execReport exectypes.CommitData,
-	// TODO: get rid of the nolint when the error is used
-) (exectypes.CommitData, messageStatus, error) { // nolint this will use the error eventually
+) (exectypes.CommitData, messageStatus, error) {
 	result := execReport
 
 	if idx >= len(execReport.Messages) {
@@ -320,7 +319,8 @@ func (b *execReportBuilder) verifyReport(
 
 // buildSingleChainReport generates the largest report which fits into maxSizeBytes.
 // See buildSingleChainReport for more details about how a report is built.
-// nolint:gocyclo // todo
+//
+//nolint:gocyclo // todo
 func (b *execReportBuilder) buildSingleChainReport(
 	ctx context.Context,
 	report exectypes.CommitData,

--- a/execute/report/report_test.go
+++ b/execute/report/report_test.go
@@ -34,7 +34,6 @@ func randomAddress() string {
 
 // mustMakeBytes parses a given string into a byte array, any error causes a panic. Pass in an empty string for a
 // random byte array.
-// nolint:unparam // surly this will be useful at some point...
 func mustMakeBytes(byteStr string) cciptypes.Bytes32 {
 	if byteStr == "" {
 		var randomBytes cciptypes.Bytes32

--- a/internal/libs/testhelpers/ocr3runner.go
+++ b/internal/libs/testhelpers/ocr3runner.go
@@ -53,7 +53,8 @@ func NewOCR3Runner[RI any](
 
 // RunRound will run some basic steps of an OCR3 flow.
 // This is not a full OCR3 round but only the bare minimum.
-// nolint:gocyclo // This is a test helper.
+//
+//nolint:gocyclo // This is a test helper.
 func (r *OCR3Runner[RI]) RunRound(ctx context.Context) (result RoundResult[RI], err error) {
 	r.round++
 	seqNr := uint64(r.round)

--- a/internal/mocks/null_logger.go
+++ b/internal/mocks/null_logger.go
@@ -5,7 +5,6 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-// nolint
 var NullLogger logger.Logger = &nullLogger{}
 
 type nullLogger struct{}

--- a/internal/reader/onchain_prices_reader_test.go
+++ b/internal/reader/onchain_prices_reader_test.go
@@ -151,7 +151,6 @@ func TestPriceService_calculateUsdPer1e18TokenAmount(t *testing.T) {
 	}
 }
 
-// nolint unparam
 func createMockReader(
 	t *testing.T,
 	mockPrices map[ocr2types.Account]*big.Int,

--- a/internal/reader/rmn_home.go
+++ b/internal/reader/rmn_home.go
@@ -333,7 +333,7 @@ func IsNodeObserver(sourceChain SourceChain, nodeIndex int, totalNodes int) (boo
 
 // VersionedConfigWithDigest mirrors RMNHome.sol's VersionedConfigWithDigest struct
 type VersionedConfigWithDigest struct {
-	// nolint:lll // don't split up the long url
+	//nolint:lll // don't split up the long url
 	// https://github.com/smartcontractkit/ccip/blob/e6e26ad31eef625faf68806a2b4f0549bc89b15c/contracts/src/v0.8/ccip/RMNRemote.sol#L34
 	ConfigDigest    cciptypes.Bytes32 `json:"configDigest"`
 	VersionedConfig VersionedConfig   `json:"versionedConfig"`

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -472,8 +472,9 @@ func (r *ccipChainReader) GetWrappedNativeTokenPriceUSD(
 	selectors []cciptypes.ChainSelector,
 ) map[cciptypes.ChainSelector]cciptypes.BigInt {
 	// 1. Call chain's router to get native token address https://github.com/smartcontractkit/chainlink/blob/60e8b1181dd74b66903cf5b9a8427557b85357ec/contracts/src/v0.8/ccip/Router.sol#L189:L191
-	// nolint:lll
 	// 2. Call chain's FeeQuoter to get native tokens price  https://github.com/smartcontractkit/chainlink/blob/60e8b1181dd74b66903cf5b9a8427557b85357ec/contracts/src/v0.8/ccip/FeeQuoter.sol#L229-L229
+	//
+	//nolint:lll
 	prices := make(map[cciptypes.ChainSelector]cciptypes.BigInt)
 	for _, chain := range selectors {
 		reader, ok := r.contractReaders[chain]
@@ -529,8 +530,9 @@ func (r *ccipChainReader) GetWrappedNativeTokenPriceUSD(
 
 // GetChainFeePriceUpdate Read from Destination chain FeeQuoter latest fee updates for the provided chains.
 // It unpacks the packed fee into the ChainFeeUSDPrices struct.
-// nolint:lll
 // https://github.com/smartcontractkit/chainlink/blob/60e8b1181dd74b66903cf5b9a8427557b85357ec/contracts/src/v0.8/ccip/FeeQuoter.sol#L263-L263
+//
+//nolint:lll
 func (r *ccipChainReader) GetChainFeePriceUpdate(ctx context.Context, selectors []cciptypes.ChainSelector) map[cciptypes.ChainSelector]plugintypes.TimestampedBig {
 	feeUpdates := make(map[cciptypes.ChainSelector]plugintypes.TimestampedBig, len(selectors))
 	for _, chain := range selectors {
@@ -1121,8 +1123,6 @@ func (r *ccipChainReader) getOnRampDestChainConfig(
 
 // signer is used to parse the response from the RMNRemote contract's getVersionedConfig method.
 // See: https://github.com/smartcontractkit/ccip/blob/ccip-develop/contracts/src/v0.8/ccip/rmn/RMNRemote.sol#L42-L45
-//
-//nolint:lll // It's a URL.
 type signer struct {
 	OnchainPublicKey []byte `json:"onchainPublicKey"`
 	NodeIndex        uint64 `json:"nodeIndex"`
@@ -1130,8 +1130,6 @@ type signer struct {
 
 // config is used to parse the response from the RMNRemote contract's getVersionedConfig method.
 // See: https://github.com/smartcontractkit/ccip/blob/ccip-develop/contracts/src/v0.8/ccip/rmn/RMNRemote.sol#L49-L53
-//
-//nolint:lll // It's a URL.
 type config struct {
 	RMNHomeContractConfigDigest []byte   `json:"rmnHomeContractConfigDigest"`
 	Signers                     []signer `json:"signers"`
@@ -1140,8 +1138,6 @@ type config struct {
 
 // versionnedConfig is used to parse the response from the RMNRemote contract's getVersionedConfig method.
 // See: https://github.com/smartcontractkit/ccip/blob/ccip-develop/contracts/src/v0.8/ccip/rmn/RMNRemote.sol#L167-L169
-//
-//nolint:lll // It's a URL.
 type versionedConfig struct {
 	Version uint32 `json:"version"`
 	Config  config `json:"config"`

--- a/pkg/reader/usdc_reader.go
+++ b/pkg/reader/usdc_reader.go
@@ -216,7 +216,7 @@ func (u usdcMessageReader) recreateMessageTransmitterEvents(
 			return nil, fmt.Errorf("destination domain not found for chain %d", destChainSelector)
 		}
 
-		// nolint:lll
+		//nolint:lll
 		// USDC message payload:
 		// uint32 _msgVersion,
 		// uint32 _msgSourceDomain,

--- a/pluginconfig/token.go
+++ b/pluginconfig/token.go
@@ -120,7 +120,7 @@ func (p *USDCCCTPObserverConfig) setDefaults() {
 	}
 }
 
-// nolint:lll // CCTP link
+//nolint:lll // CCTP link
 type USDCCCTPTokenConfig struct {
 	// SourcePoolAddress is the address of the USDC token pool on the source chain that support USDC token transfers
 	SourcePoolAddress string `json:"sourceTokenAddress"`


### PR DESCRIPTION
Small PR to enable the `nolintlint` linter and fix warnings. Removed a couple that were not needed.