### PR TITLE
Fix: OnRamp discovery

### DIFF
--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -30,8 +30,7 @@ jobs:
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           repository: smartcontractkit/chainlink
-          #ref: develop
-          ref: fix-fee-quoter
+          ref: develop
           path: chainlink
       - name: Get the correct commit SHA via GitHub API
         id: get_sha

--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           repository: smartcontractkit/chainlink
           #ref: develop
-          ref: develop
+          ref: fix-fee-quoter
           path: chainlink
       - name: Get the correct commit SHA via GitHub API
         id: get_sha

--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -30,7 +30,8 @@ jobs:
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           repository: smartcontractkit/chainlink
-          ref: develop
+#          ref: develop
+          ref: fix-fee-quoter
           path: chainlink
       - name: Get the correct commit SHA via GitHub API
         id: get_sha

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -727,6 +727,10 @@ func (r *ccipChainReader) DiscoverContracts(
 			return nil, fmt.Errorf("unable to lookup source fee quoters (onRamp dynamic config): %w", err)
 		} else {
 			for chain, cfg := range dynamicConfigs {
+				r.lggr.Infow("appending source fee quoter contract address",
+					"chain", chain,
+					"address", cfg.FeeQuoter,
+				)
 				resp = resp.Append(consts.ContractNameFeeQuoter, chain, cfg.FeeQuoter)
 			}
 		}
@@ -742,6 +746,10 @@ func (r *ccipChainReader) DiscoverContracts(
 			return nil, fmt.Errorf("unable to lookup source routers (onRamp dest chain config): %w", err)
 		} else {
 			for chain, cfg := range destChainConfig {
+				r.lggr.Infow("appending Router contract address",
+					"chain", chain,
+					"address", cfg.Router,
+				)
 				resp = resp.Append(consts.ContractNameRouter, chain, cfg.Router)
 			}
 		}

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -626,7 +626,7 @@ func (r *ccipChainReader) GetRMNRemoteConfig(
 }
 
 func (r *ccipChainReader) isValidAddress(address []byte, contractName string, chain cciptypes.ChainSelector) bool {
-	if address == nil || len(address) == 0 {
+	if len(address) == 0 {
 		r.lggr.Errorw("address for contract is empty",
 			"contract", contractName,
 			"chain", chain,
@@ -733,7 +733,9 @@ func (r *ccipChainReader) DiscoverContracts(ctx context.Context) (ContractAddres
 			return nil, fmt.Errorf("unable to lookup source fee quoters (onRamp dynamic config): %w", err)
 		} else {
 			for chain, cfg := range dynamicConfigs {
-				resp = resp.Append(consts.ContractNameFeeQuoter, chain, cfg.DynamicConfig.FeeQuoter)
+				if r.isValidAddress(cfg.DynamicConfig.FeeQuoter, consts.ContractNameFeeQuoter, chain) {
+					resp = resp.Append(consts.ContractNameFeeQuoter, chain, cfg.DynamicConfig.FeeQuoter)
+				}
 			}
 		}
 	}

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -729,7 +729,7 @@ func (r *ccipChainReader) DiscoverContracts(
 			for chain, cfg := range dynamicConfigs {
 				r.lggr.Infow("appending source fee quoter contract address",
 					"chain", chain,
-					"address", cfg.FeeQuoter,
+					"feequoter-address", typeconv.AddressBytesToString(cfg.FeeQuoter, uint64(chain)),
 				)
 				resp = resp.Append(consts.ContractNameFeeQuoter, chain, cfg.FeeQuoter)
 			}
@@ -748,7 +748,7 @@ func (r *ccipChainReader) DiscoverContracts(
 			for chain, cfg := range destChainConfig {
 				r.lggr.Infow("appending Router contract address",
 					"chain", chain,
-					"address", cfg.Router,
+					"router-address", typeconv.AddressBytesToString(cfg.Router, uint64(chain)),
 				)
 				resp = resp.Append(consts.ContractNameRouter, chain, cfg.Router)
 			}

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -1109,8 +1109,9 @@ type onRampDynamicConfig struct {
 }
 
 // We're wrapping the onRampDynamicConfig this way to map to on-chain return type which is a named struct
-// nolint:lll
 // https://github.com/smartcontractkit/chainlink/blob/12af1de88238e0e918177d6b5622070417f48adf/contracts/src/v0.8/ccip/onRamp/OnRamp.sol#L328
+//
+//nolint:lll
 type getOnRampDynamicConfigResponse struct {
 	DynamicConfig onRampDynamicConfig `json:"dynamicConfig"`
 }

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -636,7 +636,7 @@ func (r *ccipChainReader) isValidAddress(address []byte, contractName string, ch
 	return true
 }
 
-func (r *ccipChainReader) discoverDestinationContracts(
+func (r *ccipChainReader) discoverOffRampContracts(
 	ctx context.Context,
 	chain cciptypes.ChainSelector,
 ) (ContractAddresses, error) {

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -625,17 +625,6 @@ func (r *ccipChainReader) GetRMNRemoteConfig(
 	}, nil
 }
 
-func (r *ccipChainReader) isValidAddress(address []byte, contractName string, chain cciptypes.ChainSelector) bool {
-	if len(address) == 0 {
-		r.lggr.Errorw("address for contract is empty",
-			"contract", contractName,
-			"chain", chain,
-		)
-		return false
-	}
-	return true
-}
-
 // discoverOffRampContracts uses the offRamp for a given chain to discover the addresses of other contracts.
 func (r *ccipChainReader) discoverOffRampContracts(
 	ctx context.Context,
@@ -734,9 +723,7 @@ func (r *ccipChainReader) DiscoverContracts(ctx context.Context) (ContractAddres
 			return nil, fmt.Errorf("unable to lookup source fee quoters (onRamp dynamic config): %w", err)
 		} else {
 			for chain, cfg := range dynamicConfigs {
-				if r.isValidAddress(cfg.DynamicConfig.FeeQuoter, consts.ContractNameFeeQuoter, chain) {
-					resp = resp.Append(consts.ContractNameFeeQuoter, chain, cfg.DynamicConfig.FeeQuoter)
-				}
+				resp = resp.Append(consts.ContractNameFeeQuoter, chain, cfg.DynamicConfig.FeeQuoter)
 			}
 		}
 	}

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -627,7 +627,7 @@ func (r *ccipChainReader) GetRMNRemoteConfig(
 
 func (r *ccipChainReader) isValidAddress(address []byte, contractName string, chain cciptypes.ChainSelector) bool {
 	if len(address) == 0 {
-		r.lggr.Warnw("address for contract is empty",
+		r.lggr.Errorw("address for contract is empty",
 			"contract", contractName,
 			"chain", chain,
 		)

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -1149,15 +1149,14 @@ func (r *ccipChainReader) GetOnRampDestChainConfig(
 		chainSel := chainSel
 		eg.Go(func() error {
 			// read onramp dynamic config
-			//resp := onRampDestChainConfig{}
-			resp := make(map[string]any)
+			resp := onRampDestChainConfig{}
 			err := r.contractReaders[chainSel].ExtendedGetLatestValue(
 				ctx,
 				consts.ContractNameOnRamp,
 				consts.MethodNameOnRampGetDestChainConfig,
 				primitives.Unconfirmed,
 				map[string]any{
-					"destChainSelector": chainSel,
+					"destChainSelector": r.destChain,
 				},
 				&resp,
 			)
@@ -1165,7 +1164,7 @@ func (r *ccipChainReader) GetOnRampDestChainConfig(
 				return fmt.Errorf("failed to get onramp dynamic config: %w", err)
 			}
 			mu.Lock()
-			//result[chainSel] = resp
+			result[chainSel] = resp
 			mu.Unlock()
 
 			return nil

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -636,6 +636,7 @@ func (r *ccipChainReader) isValidAddress(address []byte, contractName string, ch
 	return true
 }
 
+// discoverOffRampContracts uses the offRamp for a given chain to discover the addresses of other contracts.
 func (r *ccipChainReader) discoverOffRampContracts(
 	ctx context.Context,
 	chain cciptypes.ChainSelector,
@@ -1186,11 +1187,9 @@ func (r *ccipChainReader) getOnRampDestChainConfig(
 			continue
 		}
 
-		//TODO: loop over all other source chains except self and make sure
-		// that to get at least one valid router
+		// For chain X, all DestChainConfigs will have same OnRamp address which is the chainX OnRamp
 		chainSel := chainSel
 		eg.Go(func() error {
-			// read onramp dynamic config
 			resp := onRampDestChainConfig{}
 			err := r.contractReaders[chainSel].ExtendedGetLatestValue(
 				ctx,
@@ -1198,7 +1197,10 @@ func (r *ccipChainReader) getOnRampDestChainConfig(
 				consts.MethodNameOnRampGetDestChainConfig,
 				primitives.Unconfirmed,
 				map[string]any{
-					"destChainSelector": r.destChain, // Any other chain other than self should work fine in happy case.
+					// Any other chain other than self should work as a chain don't have self as a destination
+					// Here we use destChain as the chainSel is looping over all source chains, so all of them should have
+					// a config for the destChain
+					"destChainSelector": r.destChain,
 				},
 				&resp,
 			)

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -761,7 +761,7 @@ func (r *ccipChainReader) DiscoverContracts(
 
 	// Read onRamps for Router in DestChainConfig.
 	{
-		destChainConfig, err := r.getOnRampDestChainConfig(ctx, myChains)
+		destChainConfig, err := r.GetOnRampDestChainConfig(ctx, myChains)
 		if errors.Is(err, contractreader.ErrNoBindings) {
 			// ErrNoBindings is an allowable error.
 			r.lggr.Infow("unable to lookup source routers, this is expected during initialization", "err", err)
@@ -1128,7 +1128,7 @@ type onRampDestChainConfig struct {
 	Router           []byte `json:"router"`
 }
 
-func (r *ccipChainReader) getOnRampDestChainConfig(
+func (r *ccipChainReader) GetOnRampDestChainConfig(
 	ctx context.Context,
 	srcChains []cciptypes.ChainSelector,
 ) (map[cciptypes.ChainSelector]onRampDestChainConfig, error) {
@@ -1149,8 +1149,8 @@ func (r *ccipChainReader) getOnRampDestChainConfig(
 		chainSel := chainSel
 		eg.Go(func() error {
 			// read onramp dynamic config
-			resp := onRampDestChainConfig{}
-			//resp := make(map[string]any)
+			//resp := onRampDestChainConfig{}
+			resp := make(map[string]any)
 			err := r.contractReaders[chainSel].ExtendedGetLatestValue(
 				ctx,
 				consts.ContractNameOnRamp,
@@ -1165,7 +1165,7 @@ func (r *ccipChainReader) getOnRampDestChainConfig(
 				return fmt.Errorf("failed to get onramp dynamic config: %w", err)
 			}
 			mu.Lock()
-			result[chainSel] = resp
+			//result[chainSel] = resp
 			mu.Unlock()
 
 			return nil

--- a/pkg/reader/ccip_test.go
+++ b/pkg/reader/ccip_test.go
@@ -484,7 +484,7 @@ func TestCCIPChainReader_DiscoverContracts_HappyPath_Round1(t *testing.T) {
 			consts.MethodNameOnRampGetDestChainConfig,
 			primitives.Unconfirmed,
 			map[string]any{
-				"destChainSelector": selector,
+				"destChainSelector": destChain,
 			},
 			mock.Anything,
 		).Return(contractreader.ErrNoBindings)
@@ -610,7 +610,7 @@ func TestCCIPChainReader_DiscoverContracts_HappyPath_Round2(t *testing.T) {
 			consts.MethodNameOnRampGetDestChainConfig,
 			primitives.Unconfirmed,
 			map[string]any{
-				"destChainSelector": selector,
+				"destChainSelector": destChain,
 			},
 			mock.Anything,
 		).Return(nil).Run(withReturnValueOverridden(func(returnVal interface{}) {

--- a/pkg/reader/ccip_test.go
+++ b/pkg/reader/ccip_test.go
@@ -566,8 +566,8 @@ func TestCCIPChainReader_DiscoverContracts_HappyPath_Round2(t *testing.T) {
 			map[string]any{},
 			mock.Anything,
 		).Return(nil).Run(withReturnValueOverridden(func(returnVal interface{}) {
-			v := returnVal.(*onRampDynamicChainConfig)
-			v.FeeQuoter = srcFeeQuoters[i]
+			v := returnVal.(*getOnRampDynamicConfigResponse)
+			v.DynamicConfig.FeeQuoter = srcFeeQuoters[i]
 		}))
 
 		mockReaders[selector].EXPECT().ExtendedGetLatestValue(

--- a/pkg/reader/helpers.go
+++ b/pkg/reader/helpers.go
@@ -73,7 +73,7 @@ func bindReaderContract(
 		Name:    contractName,
 	}
 
-	lggr.Infow("Binding contract",
+	lggr.Debugw("Binding contract",
 		"chainSel", chainSel,
 		"contractName", contractName,
 		"address", encAddress,

--- a/pkg/reader/helpers.go
+++ b/pkg/reader/helpers.go
@@ -73,7 +73,7 @@ func bindReaderContract(
 		Name:    contractName,
 	}
 
-	lggr.Debugw("Binding contract",
+	lggr.Infow("Binding contract",
 		"chainSel", chainSel,
 		"contractName", contractName,
 		"address", encAddress,


### PR DESCRIPTION
* Use another chainSelector other than self to get the destChainConfig
* Fix `onRampDynamicConfig` type to match on-chain

Note: It was silently failing to get the `onRampDynamicConfig` so we were seeing only the symptoms when we were not able to read NativeToken as the flow is:
1. Get Router address
2. Get OnRamp Address
3. Get wrapped token address from Router (step 1)
4. Get FeeQuoter address from OnRamp (step 2)
5. Get native token using fee quoter and the wrapped token address.
