### PR TITLE
Compute message execution cost in USD

### DIFF
--- a/execute/factory.go
+++ b/execute/factory.go
@@ -140,6 +140,7 @@ func (p PluginFactory) NewReportingPlugin(
 		false, // TODO: enable
 		ccipReader,
 		offchainConfig.RelativeBoostPerWaitHour,
+		p.estimateProvider,
 	)
 
 	return NewPlugin(

--- a/internal/mocks/inmem/ccipreader_inmem.go
+++ b/internal/mocks/inmem/ccipreader_inmem.go
@@ -2,7 +2,7 @@ package inmem
 
 import (
 	"context"
-
+	"math/big"
 	"time"
 
 	rmntypes "github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn/types"
@@ -126,6 +126,15 @@ func (r InMemoryCCIPReader) GetAvailableChainsFeeComponents(
 ) map[cciptypes.ChainSelector]types.ChainFeeComponents {
 	panic("implement me")
 }
+
+func (r InMemoryCCIPReader) GetDestChainFeeComponents(_ context.Context) (types.ChainFeeComponents, error) {
+	feeComponents := types.ChainFeeComponents{
+		ExecutionFee:        big.NewInt(0),
+		DataAvailabilityFee: big.NewInt(0),
+	}
+	return feeComponents, nil
+}
+
 func (r InMemoryCCIPReader) GetWrappedNativeTokenPriceUSD(
 	ctx context.Context,
 	selectors []cciptypes.ChainSelector,

--- a/mocks/pkg/reader/ccip_reader.go
+++ b/mocks/pkg/reader/ccip_reader.go
@@ -372,6 +372,62 @@ func (_c *MockCCIPReader_GetContractAddress_Call) RunAndReturn(run func(string, 
 	return _c
 }
 
+// GetDestChainFeeComponents provides a mock function with given fields: ctx
+func (_m *MockCCIPReader) GetDestChainFeeComponents(ctx context.Context) (types.ChainFeeComponents, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDestChainFeeComponents")
+	}
+
+	var r0 types.ChainFeeComponents
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (types.ChainFeeComponents, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) types.ChainFeeComponents); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(types.ChainFeeComponents)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockCCIPReader_GetDestChainFeeComponents_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDestChainFeeComponents'
+type MockCCIPReader_GetDestChainFeeComponents_Call struct {
+	*mock.Call
+}
+
+// GetDestChainFeeComponents is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockCCIPReader_Expecter) GetDestChainFeeComponents(ctx interface{}) *MockCCIPReader_GetDestChainFeeComponents_Call {
+	return &MockCCIPReader_GetDestChainFeeComponents_Call{Call: _e.mock.On("GetDestChainFeeComponents", ctx)}
+}
+
+func (_c *MockCCIPReader_GetDestChainFeeComponents_Call) Run(run func(ctx context.Context)) *MockCCIPReader_GetDestChainFeeComponents_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockCCIPReader_GetDestChainFeeComponents_Call) Return(_a0 types.ChainFeeComponents, _a1 error) *MockCCIPReader_GetDestChainFeeComponents_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockCCIPReader_GetDestChainFeeComponents_Call) RunAndReturn(run func(context.Context) (types.ChainFeeComponents, error)) *MockCCIPReader_GetDestChainFeeComponents_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetExpectedNextSequenceNumber provides a mock function with given fields: ctx, sourceChainSelector, destChainSelector
 func (_m *MockCCIPReader) GetExpectedNextSequenceNumber(ctx context.Context, sourceChainSelector ccipocr3.ChainSelector, destChainSelector ccipocr3.ChainSelector) (ccipocr3.SeqNum, error) {
 	ret := _m.Called(ctx, sourceChainSelector, destChainSelector)

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -471,6 +471,24 @@ func (r *ccipChainReader) GetAvailableChainsFeeComponents(ctx context.Context,
 	return feeComponents
 }
 
+func (r *ccipChainReader) GetDestChainFeeComponents(
+	ctx context.Context,
+) (types.ChainFeeComponents, error) {
+	chainWriter, ok := r.contractWriters[r.destChain]
+	if !ok {
+		r.lggr.Errorw("dest chain contract writer not found", "chain", r.destChain)
+		return types.ChainFeeComponents{}, errors.New("dest chain contract writer not found")
+	}
+
+	feeComponents, err := chainWriter.GetFeeComponents(ctx)
+	if err != nil {
+		r.lggr.Errorw("failed to get dest chain fee components", "chain", r.destChain)
+		return types.ChainFeeComponents{}, err
+	}
+
+	return *feeComponents, nil
+}
+
 func (r *ccipChainReader) GetWrappedNativeTokenPriceUSD(
 	ctx context.Context,
 	selectors []cciptypes.ChainSelector,

--- a/pkg/reader/ccip_interface.go
+++ b/pkg/reader/ccip_interface.go
@@ -126,6 +126,9 @@ type CCIPReader interface {
 		chains []cciptypes.ChainSelector,
 	) map[cciptypes.ChainSelector]types.ChainFeeComponents
 
+	// GetDestChainFeeComponents Reads the fee components for the destination chain.
+	GetDestChainFeeComponents(ctx context.Context) (types.ChainFeeComponents, error)
+
 	// GetWrappedNativeTokenPriceUSD Gets the wrapped native token price in USD for the provided chains.
 	GetWrappedNativeTokenPriceUSD(
 		ctx context.Context,


### PR DESCRIPTION
Creates `CCIPMessageExecCostUSD18Calculator` to estimate the cost of executing a message. There are two costs: the L1/exec cost, and the L2/DA costs. This PR adds logic to accurately compute the L1/exec cost, the L2/DA cost estimation will be included in a future PR. 

The L1/exec cost is computed as `messageGas` * `executionFee`, see `computeExecutionCostUSD18` for the implementation. `executionFee` is fetched from FeeQuoter here: https://github.com/smartcontractkit/ccip/blob/d888177438c2256ecbb79a61158739d5a92543c8/contracts/src/v0.8/ccip/FeeQuoter.sol#L295
The documentation says the gasPrice/Execution fee is in USD18s ([see here](https://github.com/smartcontractkit/ccip/blob/d888177438c2256ecbb79a61158739d5a92543c8/contracts/src/v0.8/ccip/FeeQuoter.sol#L168)), so `messageGas` * `executionFee` should be USD18