### PR TITLE
.github/workflows: specify core ref in PR desc

### DIFF
--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -26,13 +26,23 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Display Go version
         run: go version
+      - name: Get the chainlink commit sha from PR description, if applicable
+        id: get_chainlink_sha
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            COMMIT_SHA=$(echo "${{ github.event.pull_request.body }}" | grep -oP 'chainlink ref: \K[0-9a-f]{40}')
+            echo "::set-output name=sha::$COMMIT_SHA"
+          else
+            # Use develop branch by default if not specified or not running in PR.
+            echo "::set-output name=sha::develop"
+          fi
       - name: Clone Chainlink repo
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           repository: smartcontractkit/chainlink
-          ref: develop
+          ref: ${{ steps.get_chainlink_sha.outputs.sha }}
           path: chainlink
-      - name: Get the correct commit SHA via GitHub API
+      - name: Get the correct chainlink-ccip commit SHA via GitHub API
         id: get_sha
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then

--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -41,7 +41,7 @@ jobs:
         id: get_chainlink_sha
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            comment="${{ steps.fetch_pr_data.outputs.result }}"
+            comment=$(echo "${{ steps.fetch_pr_data.outputs.result }}" | jq -r .)
             echo $comment
             core_ref="$(echo "$comment" | grep -oP 'core ref: \K\S+' || true)"
             echo "::set-output name=ref::$core_ref"

--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
+            const { github, context } = require('@actions/github');
             const pr = await github.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -30,17 +30,19 @@ jobs:
         id: get_chainlink_sha
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            COMMIT_SHA=$(echo "${{ github.event.pull_request.body }}" | grep -oP 'chainlink ref: \K[0-9a-f]{40}')
-            echo "::set-output name=sha::$COMMIT_SHA"
+            comment="${{ github.event.pull_request.body }}"
+            echo $comment
+            core_ref="$(echo "$comment" | grep -oP 'core ref: \K\S+' || true)"
+            echo "::set-output name=ref::$core_ref"
           else
             # Use develop branch by default if not specified or not running in PR.
-            echo "::set-output name=sha::develop"
+            echo "::set-output name=ref::develop"
           fi
       - name: Clone Chainlink repo
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
           repository: smartcontractkit/chainlink
-          ref: ${{ steps.get_chainlink_sha.outputs.sha }}
+          ref: ${{ steps.get_chainlink_sha.outputs.ref }}
           path: chainlink
       - name: Get the correct chainlink-ccip commit SHA via GitHub API
         id: get_sha

--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -26,16 +26,26 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Display Go version
         run: go version
+      - name: Fetch latest pull request data
+        id: fetch_pr_data
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const pr = await github.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            return pr.data.body;
       - name: Get the chainlink commit sha from PR description, if applicable
         id: get_chainlink_sha
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            comment="${{ github.event.pull_request.body }}"
+            comment="${{ steps.fetch_pr_data.outputs.result }}"
             echo $comment
             core_ref="$(echo "$comment" | grep -oP 'core ref: \K\S+' || true)"
             echo "::set-output name=ref::$core_ref"
           else
-            # Use develop branch by default if not specified or not running in PR.
             echo "::set-output name=ref::develop"
           fi
       - name: Clone Chainlink repo

--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -41,7 +41,7 @@ jobs:
         id: get_chainlink_sha
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            comment=$(echo "${{ steps.fetch_pr_data.outputs.result }}" | jq -r .)
+            comment=$(echo "${{ steps.fetch_pr_data.outputs.result }}" | tr -d '"')
             echo $comment
             core_ref="$(echo "$comment" | grep -oP 'core ref: \K\S+' || true)"
             echo "::set-output name=ref::$core_ref"

--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -31,8 +31,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const { github, context } = require('@actions/github');
-            const pr = await github.pulls.get({
+            const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.issue.number

--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Run ccip ocr3 add chain integration test
         run: |
           cd $GITHUB_WORKSPACE/chainlink/deployment
-          go test -v -run '^TestAddChainInbound$' -timeout 6m ./ccip/
+          go test -v -run '^TestAddChainInbound$' -timeout 6m ./ccip/changeset
           EXITCODE=${PIPESTATUS[0]}
           if [ $EXITCODE -ne 0 ]; then
             echo "Integration test failed"

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ make generate
 
 ## Development Cycle
 
-In order to keep the `ccip-develop` branch in working condition, we need to make sure the integration test
-[written in the CCIP repo](https://github.com/smartcontractkit/ccip/blob/03ae3bbed0e6020be5fa9be26d03af21f152d7dc/core/capabilities/ccip/ccip_integration_tests/ocr3_node_test.go#L37)
+In order to keep the `main` branch in working condition, we need to make sure the integration tests
+[written in the CCIP repo](https://github.com/smartcontractkit/chainlink/blob/340a6bfdf54745dd1c6d9f322d9c9515c97060bb/deployment/ccip/changeset/initial_deploy_test.go#L19)
 will pass.
 
 As such, part of CI will run this integration test combined with your latest pushed change.
@@ -52,14 +52,12 @@ As such, part of CI will run this integration test combined with your latest pus
 Follow the steps below to ensure that we don't run into any unexpected breakages.
 
 1. Create a PR on chainlink-ccip with the changes you want to make.
-2. CI will run the integration test in the CCIP repo after applying your changes.
+2. CI will run the integration test in the chainlink repo after applying your changes.
 3. If the integration test fails, make sure to fix it first before merging your changes into
-the `ccip-develop` branch of chainlink-ccip. You can do this by:
+the `main` branch of chainlink-ccip. You can do this by:
     - Creating a branch in the CCIP repo and running `go get github.com/smartcontractkit/chainlink-ccip@<your-branch-commit-sha>`.
     - Fixing the build/tests.
-4. Once your ccip PR is approved, merge it.
-5. Go back to your chainlink-ccip PR and re-run the integration test workflow.
-6. Once the integration test passes, merge your chainlink-ccip PR into `ccip-develop`, however do not delete the branch on the remote.
-7. Create a new PR in ccip that points to the newly merged commit in the `ccip-develop` tree and merge that.
-
-[ocr3]: https://github.com/smartcontractkit/libocr/blob/master/offchainreporting2plus/ocr3types/plugin.go#L108
+    - You can specify a particular commit hash on the chainlink repo by adding "core ref: commit sha" to your PR description. See [this](https://github.com/smartcontractkit/chainlink-ccip/pull/307) as an example. If you update the description, manually rerun the workflow.
+4. Once your chainlink-ccip PR is approved, merge it.
+5. Go back to your chainlink PR and bump the chainlink-ccip version to the latest main.
+6. Once the integration test passes, merge your chainlink PR into `develop`.


### PR DESCRIPTION
core ref: 3b6aacef0c21beca9387b192ce016b5ab6168e46

JIRA: https://smartcontract-it.atlassian.net/browse/CCIP-4181

This PR implements something that has been done in the relayer repos, which is that the author of a PR can specify the commit SHA to use for the Chainlink repo when running the integration tests.

Updated the README.md to reflect the new flow.

Also updated the path of the TestAddChainInbound test, previously that step was not running anything.

After running this flow for a few weeks and seeing it work we can then make the integration tests check required for all PRs to merge.