### PR TITLE
Move costlymessages observer into its own package.

### DIFF
--- a/execute/costlymessages/costly_messages_test.go
+++ b/execute/costlymessages/costly_messages_test.go
@@ -1,4 +1,4 @@
-package exectypes
+package costlymessages
 
 import (
 	"context"
@@ -93,7 +93,7 @@ func TestCCIPCostlyMessageObserver_Observe(t *testing.T) {
 			ctx := context.Background()
 			feeCalculator := NewStaticMessageFeeUSD18Calculator(tt.messageFees)
 			execCostCalculator := NewStaticMessageExecCostUSD18Calculator(tt.messageCosts)
-			observer := &CCIPCostlyMessageObserver{
+			observer := &observer{
 				lggr:               logger.Test(t),
 				enabled:            true,
 				feeCalculator:      feeCalculator,

--- a/execute/factory.go
+++ b/execute/factory.go
@@ -15,7 +15,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 
-	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
+	"github.com/smartcontractkit/chainlink-ccip/execute/costlymessages"
 	"github.com/smartcontractkit/chainlink-ccip/execute/internal/gas"
 	"github.com/smartcontractkit/chainlink-ccip/execute/tokendata"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
@@ -135,7 +135,7 @@ func (p PluginFactory) NewReportingPlugin(
 		return nil, ocr3types.ReportingPluginInfo{}, fmt.Errorf("failed to create token data observer: %w", err)
 	}
 
-	costlyMessageObserver := exectypes.NewCostlyMessageObserverWithDefaults(
+	costlyMessageObserver := costlymessages.NewObserverWithDefaults(
 		p.lggr,
 		true,
 		ccipReader,

--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -16,12 +16,12 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
-	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
-
+	"github.com/smartcontractkit/chainlink-ccip/execute/costlymessages"
 	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
 	"github.com/smartcontractkit/chainlink-ccip/execute/internal/gas"
 	"github.com/smartcontractkit/chainlink-ccip/execute/report"
 	"github.com/smartcontractkit/chainlink-ccip/execute/tokendata"
+	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon/discovery"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
 	"github.com/smartcontractkit/chainlink-ccip/internal/reader"
@@ -56,7 +56,7 @@ type Plugin struct {
 
 	oracleIDToP2pID       map[commontypes.OracleID]libocrtypes.PeerID
 	tokenDataObserver     tokendata.TokenDataObserver
-	costlyMessageObserver exectypes.CostlyMessageObserver
+	costlyMessageObserver costlymessages.Observer
 	estimateProvider      gas.EstimateProvider
 	lggr                  logger.Logger
 
@@ -77,7 +77,7 @@ func NewPlugin(
 	tokenDataObserver tokendata.TokenDataObserver,
 	estimateProvider gas.EstimateProvider,
 	lggr logger.Logger,
-	costlyMessageObserver exectypes.CostlyMessageObserver,
+	costlyMessageObserver costlymessages.Observer,
 ) *Plugin {
 	lggr = logger.Named(lggr, "ExecutePlugin")
 	lggr = logger.With(lggr, "donID", donID, "oracleID", reportingCfg.OracleID)


### PR DESCRIPTION
Reduce dependencies for the exectypes package by moving the costly messages observer into its own package.