### PR TITLE
make test less strict.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TEST_COUNT ?= 10
 COVERAGE_FILE ?= coverage.out
 
-# Detect the system architecture test
+# Detect the system architecture
 ARCH := $(shell uname -m)
 
 # Find 'protoc' download URL based on the architecture
@@ -36,7 +36,7 @@ clean-generate: ensure_go_version
 	rm -rf ./commit/merkleroot/rmn/rmnpb/*
 	rm -rf ./mocks/
 
-test: ensure_go_version
+test:
 	go test -race -fullpath -shuffle on -count $(TEST_COUNT) -coverprofile=$(COVERAGE_FILE) \
 		`go list ./... | grep -Ev 'chainlink-ccip/internal/mocks|chainlink-ccip/mocks|chainlink-ccip/commit/merkleroot/rmn/rmnpb'`
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 TEST_COUNT ?= 10
 COVERAGE_FILE ?= coverage.out
 
-# Detect the system architecture
+# Detect the system architecture test
 ARCH := $(shell uname -m)
 
 # Find 'protoc' download URL based on the architecture


### PR DESCRIPTION
Ensuring the go version when building coverage report deltas fails when the compiler is being upgraded. Removing the check allows the coverage report to run properly. CI is now pulling go versions directly from the go.mod file, so there's no longer a way for the version to de-synchronize in CI.