### PR TITLE
Allow single quote in PR description.

### DIFF
--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -44,7 +44,10 @@ jobs:
         run: |
           default="develop"
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            comment='${{ steps.fetch_pr_data.outputs.result }}'
+          comment=$(cat <<'GREAT_PR_DESCRIPTION_HERE'
+          ${{ steps.fetch_pr_data.outputs.result }}
+          GREAT_PR_DESCRIPTION_HERE
+          )
             echo $comment
             core_ref=$(echo "$comment" | grep -oE 'core ref: [a-f0-9]{40}' | cut -d' ' -f3 || true)
             if [ -n "$core_ref" ]; then

--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -48,7 +48,7 @@ jobs:
           ${{ steps.fetch_pr_data.outputs.result }}
           GREAT_PR_DESCRIPTION_HERE
           )
-            echo $comment
+            echo "$comment"
             core_ref=$(echo "$comment" | grep -oE 'core ref: [a-f0-9]{40}' | cut -d' ' -f3 || true)
             if [ -n "$core_ref" ]; then
               echo "Overriding chainlink repository commit hash with: $core_ref"


### PR DESCRIPTION
Let's see if it works.

The previous code allowed sneaky shell injection to occur. It also caused issues if there was a single quote in the description. Switch to a comment block so that this comment isn't interpreted.

core ref: 732cc15aa87d998835bc093e6a2d92877edeaf0a