### PR TITLE
.github/workflows: add integration test matrix

### DIFF
--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -116,6 +116,6 @@ jobs:
         env:
           CL_DATABASE_URL: ${{ env.DB_URL }}
       - name: Run ${{ matrix.type.name }}
-        run: ${{ matrix.type.cmd }}
+        run: cd $GITHUB_WORKSPACE/chainlink/ && ${{ matrix.type.cmd }}
         env:
           CL_DATABASE_URL: ${{ env.DB_URL }}

--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -122,7 +122,6 @@ jobs:
 
   integration-test-ccip-ocr3:
     if: always()
-    name: Integration Tests Checker
     runs-on: ubuntu-latest
     needs: [integration-test-matrix]
     steps:

--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -7,16 +7,6 @@ on:
       - 'main'
 
 jobs:
-  integration-test-ccip-ocr3:
-    if: always()
-    name: Integration Tests Checker
-    runs-on: ubuntu-latest
-    needs: [integration-test-matrix]
-    steps:
-      - name: Fail the job if ccip tests in PR not successful
-        if: always() && needs.integration-test-matrix.result == 'failure'
-        run: exit 1
-  
   integration-test-matrix:
     env:
       # We explicitly have this env var not be "CL_DATABASE_URL" to avoid having it be used by core related tests
@@ -129,3 +119,13 @@ jobs:
         run: cd $GITHUB_WORKSPACE/chainlink/ && ${{ matrix.type.cmd }}
         env:
           CL_DATABASE_URL: ${{ env.DB_URL }}
+
+  integration-test-ccip-ocr3:
+    if: always()
+    name: Integration Tests Checker
+    runs-on: ubuntu-latest
+    needs: [integration-test-matrix]
+    steps:
+      - name: Fail the job if ccip tests in PR not successful
+        if: always() && needs.integration-test-matrix.result == 'failure'
+        run: exit 1

--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -8,6 +8,16 @@ on:
 
 jobs:
   integration-test-ccip-ocr3:
+    if: always()
+    name: Integration Tests Checker
+    runs-on: ubuntu-latest
+    needs: [integration-test-matrix]
+    steps:
+      - name: Fail the job if ccip tests in PR not successful
+        if: always() && needs.integration-test-matrix.result == 'failure'
+        run: exit 1
+  
+  integration-test-matrix:
     env:
       # We explicitly have this env var not be "CL_DATABASE_URL" to avoid having it be used by core related tests
       # when they should not be using it, while still allowing us to DRY up the setup

--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -12,7 +12,23 @@ jobs:
       # We explicitly have this env var not be "CL_DATABASE_URL" to avoid having it be used by core related tests
       # when they should not be using it, while still allowing us to DRY up the setup
       DB_URL: postgresql://postgres:postgres@localhost:5432/chainlink_test?sslmode=disable
-
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        type:
+          - cmd: cd integration-tests/smoke/ccip && go test ccip_fees_test.go -timeout 12m -test.parallel=2 -count=1 -json
+            name: "Fees Test"
+          - cmd: cd integration-tests/smoke/ccip && go test ccip_messaging_test.go -timeout 12m -test.parallel=2 -count=1 -json
+            name: "Messaging Test"
+          - cmd: cd integration-tests/smoke/ccip && go test ccip_fee_boosting_test.go -timeout 12m -test.parallel=2 -count=1 -json
+            name: "Fee Boosting Test"
+          - cmd: cd integration-tests/smoke/ccip && go test ccip_batching_test.go -timeout 12m -test.parallel=2 -count=1 -json
+            name: "Batching Test"
+          - cmd: cd integration-tests/contracts && go test ccipreader_test.go -timeout 5m -test.parallel=1 -count=1 -json
+            name: "CCIPReader Test"
+    
+    name: Integration Tests (${{ matrix.type.name }})
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the chainlink-ccip repo
@@ -99,29 +115,7 @@ jobs:
           ./ccip.test local db preparetest
         env:
           CL_DATABASE_URL: ${{ env.DB_URL }}
-      - name: Run ccip ocr3 initial deploy integration test
-        run: |
-          cd $GITHUB_WORKSPACE/chainlink/deployment
-          go test -v -run '^TestAddLanesWithTestRouter$' -timeout 6m ./ccip/changeset
-          EXITCODE=${PIPESTATUS[0]}
-          if [ $EXITCODE -ne 0 ]; then
-            echo "Integration test failed"
-          else
-            echo "Integration test passed!"
-          fi
-          exit $EXITCODE
-        env:
-          CL_DATABASE_URL: ${{ env.DB_URL }}
-      - name: Run ccip ocr3 add chain integration test
-        run: |
-          cd $GITHUB_WORKSPACE/chainlink/deployment
-          go test -v -run '^TestAddChainInbound$' -timeout 6m ./ccip/changeset
-          EXITCODE=${PIPESTATUS[0]}
-          if [ $EXITCODE -ne 0 ]; then
-            echo "Integration test failed"
-          else
-            echo "Integration test passed!"
-          fi
-          exit $EXITCODE
+      - name: Run ${{ matrix.type.name }}
+        run: ${{ matrix.type.cmd }}
         env:
           CL_DATABASE_URL: ${{ env.DB_URL }}


### PR DESCRIPTION
Run the in-memory tests from chainlink as part of a matrix. Right now, this matrix is manually defined, similar to the .github/integration-in-memory-tests.yml file in the chainlink repo. 