### PR TITLE
.golangci.yml: remove exportloopref, add copyloopvar

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,12 +3,12 @@ run:
 linters:
   verbose: true
   enable:
+    - copyloopvar
     - depguard
     - dupl
     - errcheck
     - errorlint
     - exhaustive
-    - exportloopref
     - goconst
     - gocyclo
     - gofmt

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ test:
 lint: ensure_go_version ensure_golangcilint_1_62_2
 	golangci-lint run -c .golangci.yml
 
+lint-fix: ensure_go_version ensure_golangcilint_1_62_2
+	golangci-lint run -c .golangci.yml --fix
+
 checks: test lint
 
 install-protoc:

--- a/commit/merkleroot/observation.go
+++ b/commit/merkleroot/observation.go
@@ -394,7 +394,6 @@ func (o observerImpl) ObserveLatestOnRampSeqNums(
 	eg := &errgroup.Group{}
 
 	for i, sourceChain := range sourceChains {
-		i, sourceChain := i, sourceChain
 		eg.Go(func() error {
 			nextOnRampSeqNum, err := o.ccipReader.GetExpectedNextSequenceNumber(ctx, sourceChain, destChain)
 			if err != nil {
@@ -436,7 +435,6 @@ func (o observerImpl) ObserveMerkleRoots(
 	rootsMu := &sync.Mutex{}
 	wg := sync.WaitGroup{}
 	for _, chainRange := range ranges {
-		chainRange := chainRange
 		if supportedChains.Contains(chainRange.ChainSel) {
 			wg.Add(1)
 			go func() {
@@ -516,8 +514,6 @@ func (o observerImpl) computeMerkleRoot(ctx context.Context, msgs []cciptypes.Me
 
 	eg := &errgroup.Group{}
 	for i, msg := range msgs {
-		i := i
-		msg := msg
 		eg.Go(func() error {
 			// Assert there are no sequence number gaps in msgs
 			if i > 0 {

--- a/execute/exectypes/outcome_test.go
+++ b/execute/exectypes/outcome_test.go
@@ -45,7 +45,6 @@ func TestPluginState_Next(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if tt.isPanic {

--- a/execute/plugin_functions_test.go
+++ b/execute/plugin_functions_test.go
@@ -252,7 +252,6 @@ func Test_computeRanges(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := computeRanges(tt.args.reports)
@@ -307,7 +306,6 @@ func Test_groupByChainSelector(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equalf(t, tt.want, groupByChainSelector(tt.args.reports), "groupByChainSelector(%v)", tt.args.reports)

--- a/execute/plugin_test.go
+++ b/execute/plugin_test.go
@@ -138,7 +138,6 @@ func Test_getPendingExecutedReports(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -613,7 +612,6 @@ func TestPlugin_ShouldAcceptAttestedReport_ShouldAccept(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			codec, chainSupport, ccipReader := tc.getDeps()
 			lggr, obs := logger.TestObserved(t, zapcore.DebugLevel)

--- a/execute/report/report_test.go
+++ b/execute/report/report_test.go
@@ -97,7 +97,6 @@ func TestMustMakeBytes(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if tt.willPanic {
@@ -403,7 +402,6 @@ func Test_buildSingleChainReport_Errors(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -740,7 +738,6 @@ func Test_Builder_Build(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
@@ -933,7 +930,6 @@ func Test_execReportBuilder_verifyReport(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		lggr, logs := logger.TestObserved(t, zapcore.DebugLevel)
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
@@ -1167,7 +1163,6 @@ func Test_execReportBuilder_checkMessage(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			lggr, logs := logger.TestObserved(t, zapcore.DebugLevel)

--- a/execute/tokendata/usdc/http_test.go
+++ b/execute/tokendata/usdc/http_test.go
@@ -378,7 +378,6 @@ func Test_HTTPClient_RateLimiting_Parallel(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				_, err := w.Write(validAttestationResponse)

--- a/internal/libs/slicelib/bits_test.go
+++ b/internal/libs/slicelib/bits_test.go
@@ -46,7 +46,6 @@ func TestBoolsToBitFlags(t *testing.T) {
 		},
 	}
 	for i, tc := range tt {
-		tc := tc
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			t.Parallel()
 			a := BoolsToBitFlags(tc.flags)

--- a/internal/mocks/inmem/ccipreader_inmem_test.go
+++ b/internal/mocks/inmem/ccipreader_inmem_test.go
@@ -85,7 +85,6 @@ func TestInMemoryCCIPReader_CommitReportsGTETimestamp(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			r := InMemoryCCIPReader{
@@ -211,7 +210,6 @@ func TestInMemoryCCIPReader_ExecutedMessageRanges(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			r := InMemoryCCIPReader{
@@ -313,7 +311,6 @@ func TestInMemoryCCIPReader_MsgsBetweenSeqNums(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			r := InMemoryCCIPReader{

--- a/internal/plugincommon/consensus/min_observation_test.go
+++ b/internal/plugincommon/consensus/min_observation_test.go
@@ -87,7 +87,6 @@ func Test_CommitReportValidator_ExecutePluginCommitData(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/plugincommon/discovery/processor_test.go
+++ b/internal/plugincommon/discovery/processor_test.go
@@ -693,7 +693,6 @@ func TestContractDiscoveryProcessor_ValidateObservation_OracleNotAllowedToObserv
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			lggr := logger.Test(t)
 			fRoleDON := 1

--- a/pkg/contractreader/extended_unit_test.go
+++ b/pkg/contractreader/extended_unit_test.go
@@ -38,7 +38,6 @@ func TestGetOneBinding(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			contractName := "testContract"

--- a/pkg/peergroup/factory_test.go
+++ b/pkg/peergroup/factory_test.go
@@ -65,7 +65,6 @@ func Test_writePrefix(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -177,7 +176,6 @@ func TestCreator_Create(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -434,7 +434,6 @@ func (r *ccipChainReader) Nonces(
 	eg := new(errgroup.Group)
 
 	for _, address := range addresses {
-		address := address
 		eg.Go(func() error {
 			sender, err := typeconv.AddressStringToBytes(address, uint64(destChainSelector))
 			if err != nil {
@@ -1055,7 +1054,6 @@ func (r *ccipChainReader) getOffRampSourceChainsConfig(
 		}
 
 		// TODO: look into using BatchGetLatestValue instead to simplify concurrency?
-		chainSel := chainSel
 		eg.Go(func() error {
 			resp := sourceChainConfig{}
 			err := r.contractReaders[r.destChain].ExtendedGetLatestValue(
@@ -1240,7 +1238,6 @@ func (r *ccipChainReader) getOnRampDynamicConfigs(
 			continue
 		}
 
-		chainSel := chainSel
 		eg.Go(func() error {
 			// read onramp dynamic config
 			resp := getOnRampDynamicConfigResponse{}
@@ -1300,7 +1297,6 @@ func (r *ccipChainReader) getOnRampDestChainConfig(
 		// For chain X, all DestChainConfigs will have one of 2 values for the Router address
 		// 1. Chain X Test Router in case we're testing a new lane
 		// 2. Chain X Router
-		chainSel := chainSel
 		eg.Go(func() error {
 			resp := onRampDestChainConfig{}
 			err := r.contractReaders[chainSel].ExtendedGetLatestValue(

--- a/pkg/reader/price_reader.go
+++ b/pkg/reader/price_reader.go
@@ -152,8 +152,6 @@ func (pr *priceReader) GetFeedPricesUSD(
 	}
 	eg := new(errgroup.Group)
 	for idx, token := range tokens {
-		idx := idx
-		token := token
 		eg.Go(func() error {
 			boundContract := commontypes.BoundContract{
 				Address: string(pr.tokenInfo[token].AggregatorAddress),

--- a/pkg/reader/rmn_home_test.go
+++ b/pkg/reader/rmn_home_test.go
@@ -74,7 +74,6 @@ func TestRMNHomePoller_HealthReport(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			homeChainReader := readermock.NewMockContractReaderFacade(t)


### PR DESCRIPTION
From golangci:

```
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
```