### PR TITLE
CCIP-4448 Types and interfaces for the Commit metrics

### DIFF
--- a/commit/committypes/types.go
+++ b/commit/committypes/types.go
@@ -1,4 +1,4 @@
-package commit
+package committypes
 
 import (
 	"encoding/json"
@@ -68,7 +68,7 @@ func (o Outcome) Encode() ([]byte, error) {
 	return encodedOutcome, nil
 }
 
-func decodeOutcome(b []byte) (Outcome, error) {
+func DecodeOutcome(b []byte) (Outcome, error) {
 	if len(b) == 0 {
 		return Outcome{}, nil
 	}

--- a/commit/factory.go
+++ b/commit/factory.go
@@ -20,6 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types/core"
 
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn"
+	"github.com/smartcontractkit/chainlink-ccip/commit/metrics"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
 	"github.com/smartcontractkit/chainlink-ccip/internal/reader"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
@@ -231,6 +232,8 @@ func (p *PluginFactory) NewReportingPlugin(ctx context.Context, config ocr3types
 		offchainConfig.PriceFeedChainSelector,
 	)
 
+	metricsReporter := &metrics.Noop{}
+
 	return NewPlugin(
 			p.donID,
 			oracleIDToP2PID,
@@ -246,6 +249,7 @@ func (p *PluginFactory) NewReportingPlugin(ctx context.Context, config ocr3types
 			p.rmnCrypto,
 			p.rmnPeerClient,
 			config,
+			metricsReporter,
 		), ocr3types.ReportingPluginInfo{
 			Name: "CCIPRoleCommit",
 			Limits: ocr3types.ReportingPluginLimits{

--- a/commit/factory_test.go
+++ b/commit/factory_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 
 	"github.com/smartcontractkit/chainlink-ccip/commit/chainfee"
+	"github.com/smartcontractkit/chainlink-ccip/commit/committypes"
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot"
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn"
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn/rmnpb"
@@ -53,7 +54,7 @@ func Test_maxQueryLength(t *testing.T) {
 		}
 	}
 
-	q := Query{
+	q := committypes.Query{
 		MerkleRootQuery: merkleroot.Query{
 			RetryRMNSignatures: true,
 			RMNSignatures: &rmn.ReportSignatures{
@@ -122,7 +123,7 @@ func Test_maxObservationLength(t *testing.T) {
 		}
 	}
 
-	maxObs := Observation{
+	maxObs := committypes.Observation{
 		MerkleRootObs: merkleRootObs,
 		TokenPriceObs: tokenprice.Observation{
 			FeedTokenPrices: make([]ccipocr3.TokenPrice, estimatedMaxNumberOfPricedTokens),
@@ -162,7 +163,7 @@ func Test_maxObservationLength(t *testing.T) {
 }
 
 func Test_maxOutcomeLength(t *testing.T) {
-	maxOutc := Outcome{
+	maxOutc := committypes.Outcome{
 		MerkleRootOutcome: merkleroot.Outcome{
 			OutcomeType:                     merkleroot.OutcomeType(math.MaxInt),
 			RangesSelectedForReport:         make([]plugintypes.ChainRange, estimatedMaxNumberOfSourceChains),

--- a/commit/metrics/reporter.go
+++ b/commit/metrics/reporter.go
@@ -1,0 +1,41 @@
+package metrics
+
+import (
+	"github.com/smartcontractkit/chainlink-ccip/commit/chainfee"
+	"github.com/smartcontractkit/chainlink-ccip/commit/committypes"
+	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot"
+)
+
+type Reporter interface {
+	TrackObservation(obs committypes.Observation, state string)
+	TrackOutcome(outcome committypes.Outcome, state string)
+
+	TrackChainFeeObservation(obs chainfee.Observation, state string)
+	TrackChainFeeOutcome(outcome chainfee.Outcome, state string)
+
+	TrackMerkleObservation(obs merkleroot.Observation, state string)
+	TrackMerkleOutcome(outcome merkleroot.Outcome, state string)
+
+	TrackTokenPricesObservation(obs merkleroot.Observation, state string)
+	TrackTokenPricesOutcome(outcome merkleroot.Outcome, state string)
+}
+
+var _ Reporter = &Noop{}
+
+type Noop struct{}
+
+func (n *Noop) TrackObservation(obs committypes.Observation, state string) {}
+
+func (n *Noop) TrackOutcome(outcome committypes.Outcome, state string) {}
+
+func (n *Noop) TrackChainFeeObservation(obs chainfee.Observation, state string) {}
+
+func (n *Noop) TrackChainFeeOutcome(outcome chainfee.Outcome, state string) {}
+
+func (n *Noop) TrackMerkleObservation(obs merkleroot.Observation, state string) {}
+
+func (n *Noop) TrackMerkleOutcome(outcome merkleroot.Outcome, state string) {}
+
+func (n *Noop) TrackTokenPricesObservation(obs merkleroot.Observation, state string) {}
+
+func (n *Noop) TrackTokenPricesOutcome(outcome merkleroot.Outcome, state string) {}

--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -17,8 +17,10 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 
 	"github.com/smartcontractkit/chainlink-ccip/commit/chainfee"
+	"github.com/smartcontractkit/chainlink-ccip/commit/committypes"
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot"
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn"
+	"github.com/smartcontractkit/chainlink-ccip/commit/metrics"
 	"github.com/smartcontractkit/chainlink-ccip/commit/tokenprice"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon/discovery"
@@ -72,6 +74,7 @@ func NewPlugin(
 	rmnCrypto cciptypes.RMNCrypto,
 	rmnPeerClient rmn.PeerClient,
 	reportingCfg ocr3types.ReportingPluginConfig,
+	reporter metrics.Reporter,
 ) *Plugin {
 	lggr.Infow("creating new plugin instance", "p2pID", oracleIDToP2pID[reportingCfg.OracleID])
 
@@ -168,9 +171,9 @@ func NewPlugin(
 
 func (p *Plugin) Query(ctx context.Context, outCtx ocr3types.OutcomeContext) (types.Query, error) {
 	var err error
-	var q Query
+	var q committypes.Query
 
-	prevOutcome, err := decodeOutcome(outCtx.PreviousOutcome)
+	prevOutcome, err := committypes.DecodeOutcome(outCtx.PreviousOutcome)
 	if err != nil {
 		return nil, fmt.Errorf("decode previous outcome: %w", err)
 	}
@@ -220,7 +223,7 @@ func (p *Plugin) Observation(
 
 	// If the contracts are not initialized then only submit contracts discovery related observation.
 	if !p.contractsInitialized.Load() && p.discoveryProcessor != nil {
-		obs := Observation{DiscoveryObs: discoveryObs}
+		obs := committypes.Observation{DiscoveryObs: discoveryObs}
 		encoded, err := obs.Encode()
 		if err != nil {
 			return nil, fmt.Errorf("encode discovery observation: %w, observation: %+v", err, obs)
@@ -232,12 +235,12 @@ func (p *Plugin) Observation(
 		return encoded, nil
 	}
 
-	prevOutcome, err := decodeOutcome(outCtx.PreviousOutcome)
+	prevOutcome, err := committypes.DecodeOutcome(outCtx.PreviousOutcome)
 	if err != nil {
 		return nil, fmt.Errorf("decode previous outcome: %w", err)
 	}
 
-	decodedQ, err := DecodeCommitPluginQuery(q)
+	decodedQ, err := committypes.DecodeCommitPluginQuery(q)
 	if err != nil {
 		return nil, fmt.Errorf("decode query: %w", err)
 	}
@@ -260,7 +263,7 @@ func (p *Plugin) Observation(
 			"err", err, "prevOutcome", prevOutcome.ChainFeeOutcome, "decodedQ", decodedQ.ChainFeeQuery)
 	}
 
-	obs := Observation{
+	obs := committypes.Observation{
 		MerkleRootObs: merkleRootObs,
 		TokenPriceObs: tokenPriceObs,
 		DiscoveryObs:  discoveryObs,
@@ -291,12 +294,12 @@ func (p *Plugin) Outcome(
 ) (ocr3types.Outcome, error) {
 	p.lggr.Debugw("performing outcome", "outctx", outCtx, "query", q, "attributedObservations", aos)
 
-	prevOutcome, err := decodeOutcome(outCtx.PreviousOutcome)
+	prevOutcome, err := committypes.DecodeOutcome(outCtx.PreviousOutcome)
 	if err != nil {
 		return nil, fmt.Errorf("decode previous outcome: %w", err)
 	}
 
-	decodedQ, err := DecodeCommitPluginQuery(q)
+	decodedQ, err := committypes.DecodeCommitPluginQuery(q)
 	if err != nil {
 		return nil, fmt.Errorf("decode query: %w", err)
 	}
@@ -307,7 +310,7 @@ func (p *Plugin) Outcome(
 	discoveryObservations := make([]plugincommon.AttributedObservation[dt.Observation], 0, len(aos))
 
 	for _, ao := range aos {
-		obs, err := DecodeCommitPluginObservation(ao.Observation)
+		obs, err := committypes.DecodeCommitPluginObservation(ao.Observation)
 		if err != nil {
 			p.lggr.Warnw("failed to decode observation, observation skipped", "err", err)
 			continue
@@ -370,7 +373,7 @@ func (p *Plugin) Outcome(
 		p.lggr.Warnw("failed to get gas prices outcome", "err", err)
 	}
 
-	return Outcome{
+	return committypes.Outcome{
 		MerkleRootOutcome: merkleRootOutcome,
 		TokenPriceOutcome: tokenPriceOutcome,
 		ChainFeeOutcome:   chainFeeOutcome,

--- a/commit/plugin_e2e_test.go
+++ b/commit/plugin_e2e_test.go
@@ -11,6 +11,8 @@ import (
 
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
+	"github.com/smartcontractkit/chainlink-ccip/commit/committypes"
+	"github.com/smartcontractkit/chainlink-ccip/commit/metrics"
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/mathslib"
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/testhelpers/rand"
 
@@ -96,7 +98,7 @@ func TestPlugin_E2E_AllNodesAgree_MerkleRoots(t *testing.T) {
 	params := defaultNodeParams(t)
 	nodes := make([]ocr3types.ReportingPlugin[[]byte], len(oracleIDs))
 
-	outcomeIntervalsSelected := Outcome{
+	outcomeIntervalsSelected := committypes.Outcome{
 		MerkleRootOutcome: merkleroot.Outcome{
 			OutcomeType: merkleroot.ReportIntervalsSelected,
 			RangesSelectedForReport: []plugintypes.ChainRange{
@@ -111,7 +113,7 @@ func TestPlugin_E2E_AllNodesAgree_MerkleRoots(t *testing.T) {
 		},
 	}
 
-	outcomeReportGenerated := Outcome{
+	outcomeReportGenerated := committypes.Outcome{
 		MerkleRootOutcome: merkleroot.Outcome{
 			OutcomeType: merkleroot.ReportGenerated,
 			RootsToReport: []ccipocr3.MerkleRootChain{
@@ -136,8 +138,8 @@ func TestPlugin_E2E_AllNodesAgree_MerkleRoots(t *testing.T) {
 
 	testCases := []struct {
 		name                  string
-		prevOutcome           Outcome
-		expOutcome            Outcome
+		prevOutcome           committypes.Outcome
+		expOutcome            committypes.Outcome
 		expTransmittedReports []ccipocr3.CommitPluginReport
 
 		offRampNextSeqNumDefaultOverrideKeys   []ccipocr3.ChainSelector
@@ -147,13 +149,13 @@ func TestPlugin_E2E_AllNodesAgree_MerkleRoots(t *testing.T) {
 	}{
 		{
 			name:        "empty previous outcome, should select ranges for report",
-			prevOutcome: Outcome{},
+			prevOutcome: committypes.Outcome{},
 			expOutcome:  outcomeIntervalsSelected,
 		},
 		{
 			name:            "discovery enabled, should discover contracts",
-			prevOutcome:     Outcome{},
-			expOutcome:      Outcome{},
+			prevOutcome:     committypes.Outcome{},
+			expOutcome:      committypes.Outcome{},
 			enableDiscovery: true,
 		},
 		{
@@ -178,7 +180,7 @@ func TestPlugin_E2E_AllNodesAgree_MerkleRoots(t *testing.T) {
 		{
 			name:        "report generated in previous outcome, still inflight",
 			prevOutcome: outcomeReportGenerated,
-			expOutcome: Outcome{
+			expOutcome: committypes.Outcome{
 				MerkleRootOutcome: merkleroot.Outcome{
 					OutcomeType:                     merkleroot.ReportInFlight,
 					ReportTransmissionCheckAttempts: 1,
@@ -192,7 +194,7 @@ func TestPlugin_E2E_AllNodesAgree_MerkleRoots(t *testing.T) {
 		{
 			name:        "report generated in previous outcome, still inflight, reached all inflight check attempts",
 			prevOutcome: outcomeReportGeneratedOneInflightCheck,
-			expOutcome: Outcome{
+			expOutcome: committypes.Outcome{
 				MerkleRootOutcome: merkleroot.Outcome{
 					OutcomeType: merkleroot.ReportTransmissionFailed,
 				},
@@ -203,7 +205,7 @@ func TestPlugin_E2E_AllNodesAgree_MerkleRoots(t *testing.T) {
 			prevOutcome:                            outcomeReportGenerated,
 			offRampNextSeqNumDefaultOverrideKeys:   []ccipocr3.ChainSelector{sourceChain1, sourceChain2},
 			offRampNextSeqNumDefaultOverrideValues: []ccipocr3.SeqNum{11, 20},
-			expOutcome: Outcome{
+			expOutcome: committypes.Outcome{
 				MerkleRootOutcome: merkleroot.Outcome{
 					OutcomeType: merkleroot.ReportTransmitted,
 				},
@@ -243,7 +245,7 @@ func TestPlugin_E2E_AllNodesAgree_MerkleRoots(t *testing.T) {
 			res, err := runner.RunRound(params.ctx)
 			assert.NoError(t, err)
 
-			decodedOutcome, err := decodeOutcome(res.Outcome)
+			decodedOutcome, err := committypes.DecodeOutcome(res.Outcome)
 			assert.NoError(t, err)
 			assert.Equal(t, normalizeOutcome(tc.expOutcome), normalizeOutcome(decodedOutcome))
 
@@ -273,15 +275,15 @@ func TestPlugin_E2E_AllNodesAgree_TokenPrices(t *testing.T) {
 
 	testCases := []struct {
 		name                  string
-		prevOutcome           Outcome
-		expOutcome            Outcome
+		prevOutcome           committypes.Outcome
+		expOutcome            committypes.Outcome
 		mockPriceReader       func(*readerpkg_mock.MockPriceReader)
 		expTransmittedReports []ccipocr3.CommitPluginReport
 		enableDiscovery       bool
 	}{
 		{
 			name:        "empty fee_quoter token updates, should select all token prices for update",
-			prevOutcome: Outcome{},
+			prevOutcome: committypes.Outcome{},
 			mockPriceReader: func(m *readerpkg_mock.MockPriceReader) {
 				m.EXPECT().
 					// tokens need to be ordered, plugin checks all tokens from commit offchain config
@@ -296,7 +298,7 @@ func TestPlugin_E2E_AllNodesAgree_TokenPrices(t *testing.T) {
 					).
 					Maybe()
 			},
-			expOutcome: Outcome{
+			expOutcome: committypes.Outcome{
 				MerkleRootOutcome: merkleOutcome,
 				TokenPriceOutcome: tokenprice.Outcome{
 					TokenPrices: orderedTokenPrices,
@@ -321,7 +323,7 @@ func TestPlugin_E2E_AllNodesAgree_TokenPrices(t *testing.T) {
 		},
 		{
 			name:        "fresh tokens don't need new updates",
-			prevOutcome: Outcome{},
+			prevOutcome: committypes.Outcome{},
 			mockPriceReader: func(m *readerpkg_mock.MockPriceReader) {
 				m.EXPECT().
 					// tokens need to be ordered, plugin checks all tokens from commit offchain config
@@ -340,14 +342,14 @@ func TestPlugin_E2E_AllNodesAgree_TokenPrices(t *testing.T) {
 					).
 					Maybe()
 			},
-			expOutcome: Outcome{
+			expOutcome: committypes.Outcome{
 				MerkleRootOutcome: merkleOutcome,
 				TokenPriceOutcome: tokenprice.Outcome{},
 			},
 		},
 		{
 			name:        "stale tokens need new updates",
-			prevOutcome: Outcome{},
+			prevOutcome: committypes.Outcome{},
 			mockPriceReader: func(m *readerpkg_mock.MockPriceReader) {
 				m.EXPECT().
 					// tokens need to be ordered, plugin checks all tokens from commit offchain config
@@ -371,7 +373,7 @@ func TestPlugin_E2E_AllNodesAgree_TokenPrices(t *testing.T) {
 					).
 					Maybe()
 			},
-			expOutcome: Outcome{
+			expOutcome: committypes.Outcome{
 				MerkleRootOutcome: merkleOutcome,
 				TokenPriceOutcome: tokenprice.Outcome{
 					TokenPrices: []ccipocr3.TokenPrice{
@@ -416,7 +418,7 @@ func TestPlugin_E2E_AllNodesAgree_TokenPrices(t *testing.T) {
 			res, err := runner.RunRound(params.ctx)
 			assert.NoError(t, err)
 
-			decodedOutcome, err := decodeOutcome(res.Outcome)
+			decodedOutcome, err := committypes.DecodeOutcome(res.Outcome)
 			assert.NoError(t, err)
 			assert.Equal(t, normalizeOutcome(tc.expOutcome), normalizeOutcome(decodedOutcome))
 
@@ -449,16 +451,16 @@ func TestPlugin_E2E_AllNodesAgree_ChainFee(t *testing.T) {
 
 	testCases := []struct {
 		name                    string
-		prevOutcome             Outcome
-		expOutcome              Outcome
+		prevOutcome             committypes.Outcome
+		expOutcome              committypes.Outcome
 		expTransmittedReportLen int
 
 		mockCCIPReader func(*readerpkg_mock.MockCCIPReader)
 	}{
 		{
 			name:        "fee components should be updated",
-			prevOutcome: Outcome{},
-			expOutcome: Outcome{
+			prevOutcome: committypes.Outcome{},
+			expOutcome: committypes.Outcome{
 				MerkleRootOutcome: merkleOutcome,
 				ChainFeeOutcome: chainfee.Outcome{
 					GasPrices: []ccipocr3.GasPriceChain{
@@ -499,8 +501,8 @@ func TestPlugin_E2E_AllNodesAgree_ChainFee(t *testing.T) {
 		},
 		{
 			name:        "fee components should be updated when there's a subset of chains",
-			prevOutcome: Outcome{},
-			expOutcome: Outcome{
+			prevOutcome: committypes.Outcome{},
+			expOutcome: committypes.Outcome{
 				MerkleRootOutcome: merkleOutcome,
 				ChainFeeOutcome:   expectedChainFeeOutcome,
 			},
@@ -524,11 +526,11 @@ func TestPlugin_E2E_AllNodesAgree_ChainFee(t *testing.T) {
 		},
 		{
 			name: "fee components should not be updated within deviation",
-			prevOutcome: Outcome{
+			prevOutcome: committypes.Outcome{
 				MerkleRootOutcome: merkleOutcome,
 				ChainFeeOutcome:   expectedChainFeeOutcome,
 			},
-			expOutcome: Outcome{
+			expOutcome: committypes.Outcome{
 				MerkleRootOutcome: noReportMerkleOutcome(params.rmnReportCfg),
 				ChainFeeOutcome:   expectedChainFeeOutcome,
 			},
@@ -550,11 +552,11 @@ func TestPlugin_E2E_AllNodesAgree_ChainFee(t *testing.T) {
 		},
 		{
 			name: "fresh fees (timestamped) should not be updated, even outside of deviation",
-			prevOutcome: Outcome{
+			prevOutcome: committypes.Outcome{
 				MerkleRootOutcome: merkleOutcome,
 				ChainFeeOutcome:   expectedChainFeeOutcome,
 			},
-			expOutcome: Outcome{
+			expOutcome: committypes.Outcome{
 				MerkleRootOutcome: noReportMerkleOutcome(params.rmnReportCfg),
 				ChainFeeOutcome: chainfee.Outcome{
 					GasPrices: []ccipocr3.GasPriceChain{
@@ -583,11 +585,11 @@ func TestPlugin_E2E_AllNodesAgree_ChainFee(t *testing.T) {
 		},
 		{
 			name: "stale fees should be updated",
-			prevOutcome: Outcome{
+			prevOutcome: committypes.Outcome{
 				MerkleRootOutcome: merkleOutcome,
 				ChainFeeOutcome:   expectedChainFeeOutcome,
 			},
-			expOutcome: Outcome{
+			expOutcome: committypes.Outcome{
 				MerkleRootOutcome: noReportMerkleOutcome(params.rmnReportCfg),
 				ChainFeeOutcome: chainfee.Outcome{
 					GasPrices: []ccipocr3.GasPriceChain{
@@ -648,7 +650,7 @@ func TestPlugin_E2E_AllNodesAgree_ChainFee(t *testing.T) {
 			res, err := runner.RunRound(params.ctx)
 			assert.NoError(t, err)
 
-			decodedOutcome, err := decodeOutcome(res.Outcome)
+			decodedOutcome, err := committypes.DecodeOutcome(res.Outcome)
 			assert.NoError(t, err)
 			assert.Equal(t, normalizeOutcome(tc.expOutcome), normalizeOutcome(decodedOutcome))
 
@@ -658,7 +660,7 @@ func TestPlugin_E2E_AllNodesAgree_ChainFee(t *testing.T) {
 }
 
 // normalizeOutcome converts empty slices to nil or nil slices to empty where needed.
-func normalizeOutcome(o Outcome) Outcome {
+func normalizeOutcome(o committypes.Outcome) committypes.Outcome {
 	if len(o.MerkleRootOutcome.RMNRemoteCfg.ContractAddress) == 0 {
 		// Normalize to `nil` if it's an empty slice
 		o.MerkleRootOutcome.RMNRemoteCfg.ContractAddress = nil
@@ -857,6 +859,7 @@ func setupNode(params SetupNodeParams) nodeSetup {
 		nil,
 		nil,
 		params.reportingCfg,
+		&metrics.Noop{},
 	)
 
 	if !params.enableDiscovery {

--- a/commit/report.go
+++ b/commit/report.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 
+	"github.com/smartcontractkit/chainlink-ccip/commit/committypes"
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot"
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/slicelib"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
@@ -44,7 +45,7 @@ func (ri *ReportInfo) Decode(encodedReportInfo []byte) error {
 func (p *Plugin) Reports(
 	ctx context.Context, seqNr uint64, outcomeBytes ocr3types.Outcome,
 ) ([]ocr3types.ReportPlus[[]byte], error) {
-	outcome, err := decodeOutcome(outcomeBytes)
+	outcome, err := committypes.DecodeOutcome(outcomeBytes)
 	if err != nil {
 		p.lggr.Errorw("failed to decode Outcome", "outcome", string(outcomeBytes), "err", err)
 		return nil, fmt.Errorf("decode outcome: %w", err)

--- a/commit/report_test.go
+++ b/commit/report_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/smartcontractkit/libocr/commontypes"
 	libocrtypes "github.com/smartcontractkit/libocr/ragep2p/types"
 
+	"github.com/smartcontractkit/chainlink-ccip/commit/committypes"
 	"github.com/smartcontractkit/chainlink-ccip/mocks/internal_/plugincommon"
 
 	"github.com/stretchr/testify/require"
@@ -24,14 +25,14 @@ import (
 func TestPluginReports(t *testing.T) {
 	testCases := []struct {
 		name          string
-		outc          Outcome
+		outc          committypes.Outcome
 		expErr        bool
 		expReports    []ccipocr3.CommitPluginReport
 		expReportInfo ReportInfo
 	}{
 		{
 			name: "wrong outcome type gives an empty report but no error",
-			outc: Outcome{
+			outc: committypes.Outcome{
 				MerkleRootOutcome: merkleroot.Outcome{
 					OutcomeType: merkleroot.ReportIntervalsSelected,
 				},
@@ -40,7 +41,7 @@ func TestPluginReports(t *testing.T) {
 		},
 		{
 			name: "correct outcome type but empty data",
-			outc: Outcome{
+			outc: committypes.Outcome{
 				MerkleRootOutcome: merkleroot.Outcome{
 					OutcomeType: merkleroot.ReportGenerated,
 				},
@@ -49,7 +50,7 @@ func TestPluginReports(t *testing.T) {
 		},
 		{
 			name: "token prices reported without merkle root is still transmitted",
-			outc: Outcome{
+			outc: committypes.Outcome{
 				MerkleRootOutcome: merkleroot.Outcome{
 					OutcomeType: merkleroot.ReportTransmissionFailed,
 				},
@@ -82,7 +83,7 @@ func TestPluginReports(t *testing.T) {
 		},
 		{
 			name: "only chain fee reported without merkle root is still transmitted",
-			outc: Outcome{
+			outc: committypes.Outcome{
 				ChainFeeOutcome: chainfee.Outcome{
 					GasPrices: []ccipocr3.GasPriceChain{
 						{GasPrice: ccipocr3.NewBigIntFromInt64(3), ChainSel: 123},
@@ -104,7 +105,7 @@ func TestPluginReports(t *testing.T) {
 		},
 		{
 			name: "token prices reported but no merkle roots so report is not empty",
-			outc: Outcome{
+			outc: committypes.Outcome{
 				MerkleRootOutcome: merkleroot.Outcome{
 					OutcomeType: merkleroot.ReportGenerated,
 					RootsToReport: []ccipocr3.MerkleRootChain{

--- a/commit/validate_observation.go
+++ b/commit/validate_observation.go
@@ -7,6 +7,7 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
+	"github.com/smartcontractkit/chainlink-ccip/commit/committypes"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
 )
 
@@ -17,17 +18,17 @@ func (p *Plugin) ValidateObservation(
 	q types.Query,
 	ao types.AttributedObservation,
 ) error {
-	decodedQ, err := DecodeCommitPluginQuery(q)
+	decodedQ, err := committypes.DecodeCommitPluginQuery(q)
 	if err != nil {
 		return fmt.Errorf("decode query: %w", err)
 	}
 
-	obs, err := DecodeCommitPluginObservation(ao.Observation)
+	obs, err := committypes.DecodeCommitPluginObservation(ao.Observation)
 	if err != nil {
 		return fmt.Errorf("failed to decode commit plugin observation: %w", err)
 	}
 
-	prevOutcome, err := decodeOutcome(outCtx.PreviousOutcome)
+	prevOutcome, err := committypes.DecodeOutcome(outCtx.PreviousOutcome)
 	if err != nil {
 		return fmt.Errorf("decode previous outcome: %w", err)
 	}

--- a/execute/metrics/reporter.go
+++ b/execute/metrics/reporter.go
@@ -203,3 +203,6 @@ type Noop struct{}
 func (n *Noop) TrackObservation(exectypes.Observation, exectypes.PluginState) {}
 
 func (n *Noop) TrackOutcome(exectypes.Outcome, exectypes.PluginState) {}
+
+var _ Reporter = &Noop{}
+var _ Reporter = &PromReporter{}


### PR DESCRIPTION
* I needed to extract types from `commit` to `committypes` to avoid cyclic dependency (it's similar to exec now)
* Created an interface for the metrics.Reporter 