### PR TITLE
Remove completed discovery TODOs.

### DIFF
--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -1138,7 +1138,6 @@ func (r *ccipChainReader) getAllOffRampSourceChainsConfig(
 	configs := make(map[cciptypes.ChainSelector]sourceChainConfig)
 
 	var resp selectorsAndConfigs
-	//var resp map[string]any
 	err := r.contractReaders[chain].ExtendedGetLatestValue(
 		ctx,
 		consts.ContractNameOffRamp,
@@ -1194,13 +1193,6 @@ type offRampDynamicChainConfig struct {
 	PermissionLessExecutionThresholdSeconds uint32 `json:"permissionLessExecutionThresholdSeconds"`
 	IsRMNVerificationDisabled               bool   `json:"isRMNVerificationDisabled"`
 	MessageInterceptor                      []byte `json:"messageInterceptor"`
-}
-
-//nolint:unused // it will be used soon // TODO: Remove nolint
-type offRampDestChainConfig struct {
-	SequenceNumber   uint64 `json:"sequenceNumber"`
-	AllowListEnabled bool   `json:"allowListEnabled"`
-	Router           []byte `json:"router"`
 }
 
 // getData returns data for a single reader.

--- a/pkg/reader/ccip_test.go
+++ b/pkg/reader/ccip_test.go
@@ -506,7 +506,6 @@ func TestCCIPChainReader_DiscoverContracts_HappyPath_Round1(t *testing.T) {
 		lggr:            lggr,
 	}
 
-	// TODO: allChains should be initialized to "append(onramps, destChain)" when that feature is implemented.
 	contractAddresses, err := ccipChainReader.DiscoverContracts(ctx)
 	require.NoError(t, err)
 
@@ -634,99 +633,9 @@ func TestCCIPChainReader_DiscoverContracts_HappyPath_Round2(t *testing.T) {
 		lggr:            logger.Test(t),
 	}
 
-	// TODO: allChains should be initialized to "append(onramps, destChain)" when that feature is implemented.
 	contractAddresses, err := ccipChainReader.DiscoverContracts(ctx)
 	require.NoError(t, err)
 
-	require.Equal(t, expectedContractAddresses, contractAddresses)
-}
-
-// TODO: Remove this test when allChains is implemented.
-// This test checks that onramps are not discovered if there are only dest readers available.
-func TestCCIPChainReader_DiscoverContracts_HappyPath_OnlySupportDest(t *testing.T) {
-	ctx := tests.Context(t)
-	destChain := cciptypes.ChainSelector(1)
-	sourceChain := [2]cciptypes.ChainSelector{2, 3}
-	onramps := [2][]byte{{0x1}, {0x2}}
-	destNonceMgr := []byte{0x3}
-	destRMNRemote := []byte{0x4}
-	destFeeQuoter := []byte{0x5}
-	destRouter := []byte{0x6}
-
-	var expectedContractAddresses ContractAddresses
-	for i := range onramps {
-		expectedContractAddresses = expectedContractAddresses.Append(
-			consts.ContractNameOnRamp, sourceChain[i], onramps[i])
-	}
-	// All dest chain contracts should be discovered, they do not require source chain support.
-	expectedContractAddresses = expectedContractAddresses.Append(consts.ContractNameRouter, destChain, destRouter)
-	expectedContractAddresses = expectedContractAddresses.Append(consts.ContractNameFeeQuoter, destChain, destFeeQuoter)
-	expectedContractAddresses = expectedContractAddresses.Append(consts.ContractNameRMNRemote, destChain, destRMNRemote)
-	expectedContractAddresses = expectedContractAddresses.Append(consts.ContractNameNonceManager, destChain, destNonceMgr)
-
-	destExtended := reader_mocks.NewMockExtended(t)
-
-	// mock the call to get the nonce manager
-	destExtended.EXPECT().ExtendedGetLatestValue(
-		mock.Anything,
-		consts.ContractNameOffRamp,
-		consts.MethodNameOffRampGetStaticConfig,
-		primitives.Unconfirmed,
-		map[string]any{},
-		mock.Anything,
-	).Return(nil).Run(withReturnValueOverridden(func(returnVal interface{}) {
-		v := returnVal.(*offRampStaticChainConfig)
-		v.NonceManager = destNonceMgr
-		v.RmnRemote = destRMNRemote
-	}))
-	// mock the call to get the fee quoter
-	destExtended.EXPECT().ExtendedGetLatestValue(
-		mock.Anything,
-		consts.ContractNameOffRamp,
-		consts.MethodNameOffRampGetDynamicConfig,
-		primitives.Unconfirmed,
-		map[string]any{},
-		mock.Anything,
-	).Return(nil).Run(withReturnValueOverridden(func(returnVal interface{}) {
-		v := returnVal.(*offRampDynamicChainConfig)
-		v.FeeQuoter = destFeeQuoter
-	}))
-	destExtended.EXPECT().ExtendedGetLatestValue(
-		mock.Anything,
-		consts.ContractNameOffRamp,
-		consts.MethodNameOffRampGetAllSourceChainConfigs,
-		primitives.Unconfirmed,
-		map[string]any{},
-		mock.Anything,
-	).Return(nil).Run(withReturnValueOverridden(func(returnVal interface{}) {
-		v := returnVal.(*selectorsAndConfigs)
-		v.Selectors = []uint64{uint64(sourceChain[0]), uint64(sourceChain[1])}
-		v.SourceChainConfigs = []sourceChainConfig{
-			{
-				OnRamp:    onramps[0],
-				Router:    destRouter,
-				IsEnabled: true,
-			},
-			{
-				OnRamp:    onramps[1],
-				Router:    destRouter,
-				IsEnabled: true,
-			},
-		}
-	}))
-
-	// create the reader
-	ccipChainReader := &ccipChainReader{
-		destChain: destChain,
-		contractReaders: map[cciptypes.ChainSelector]contractreader.Extended{
-			destChain: destExtended,
-		},
-		lggr: logger.Test(t),
-	}
-
-	// TODO: allChains should be initialized to "append(onramps, destChain)" when that feature is implemented.
-	contractAddresses, err := ccipChainReader.DiscoverContracts(ctx)
-	require.NoError(t, err)
 	require.Equal(t, expectedContractAddresses, contractAddresses)
 }
 
@@ -764,7 +673,6 @@ func TestCCIPChainReader_DiscoverContracts_GetAllSourceChainConfig_Errors(t *tes
 		lggr: logger.Test(t),
 	}
 
-	// TODO: allChains should be initialized to "append(onramps, destChain)" when that feature is implemented.
 	_, err := ccipChainReader.DiscoverContracts(ctx)
 	require.Error(t, err)
 	require.ErrorIs(t, err, getLatestValueErr)
@@ -811,7 +719,6 @@ func TestCCIPChainReader_DiscoverContracts_GetOfframpStaticConfig_Errors(t *test
 		lggr: logger.Test(t),
 	}
 
-	// TODO: allChains should be initialized to "append(onramps, destChain)" when that feature is implemented.
 	_, err := ccipChainReader.DiscoverContracts(ctx)
 	require.Error(t, err)
 	require.ErrorIs(t, err, getLatestValueErr)


### PR DESCRIPTION
These TODOs refer to "allChains" which was replaced by the "OffRampGetAllSourceChainConfigs" on-chain function.