### PR TITLE
Dedaub audit finding H3.2, return subset of merkle root sequence numbers if ccip reader fails

### DIFF
--- a/commit/merkleroot/observation.go
+++ b/commit/merkleroot/observation.go
@@ -391,6 +391,9 @@ func (o observerImpl) ObserveOffRampNextSeqNums(ctx context.Context) []plugintyp
 		result = append(result, plugintypes.SeqNumChain{ChainSel: c, SeqNum: s})
 	}
 
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].ChainSel < result[j].ChainSel
+	})
 	return result
 }
 

--- a/commit/merkleroot/observation.go
+++ b/commit/merkleroot/observation.go
@@ -390,7 +390,7 @@ func (o observerImpl) ObserveOffRampNextSeqNums(ctx context.Context) []plugintyp
 	for c, s := range offRampNextSeqNums {
 		result = append(result, plugintypes.SeqNumChain{ChainSel: c, SeqNum: s})
 	}
-	
+
 	return result
 }
 

--- a/commit/merkleroot/observation.go
+++ b/commit/merkleroot/observation.go
@@ -380,17 +380,9 @@ func (o observerImpl) ObserveOffRampNextSeqNums(ctx context.Context) []plugintyp
 		return nil
 	}
 
-	o.lggr.Debugw("Output of ccipreader is ", "offrampnextseqnums", offRampNextSeqNums)
-	if len(offRampNextSeqNums) != len(sourceChains) {
-		o.lggr.Warnw("unexpected number of sequence numbers returned",
-			"expected", len(sourceChains),
-			"actual", len(offRampNextSeqNums),
-		)
-	}
-
 	for _, c := range sourceChains {
 		if _, ok := offRampNextSeqNums[c]; !ok {
-			o.lggr.Errorf("error finding source chain %d in sequence numbers", c)
+			o.lggr.Errorf("error finding source chain %d in sequence numbers, skipping", c)
 		}
 	}
 
@@ -398,8 +390,7 @@ func (o observerImpl) ObserveOffRampNextSeqNums(ctx context.Context) []plugintyp
 	for c, s := range offRampNextSeqNums {
 		result = append(result, plugintypes.SeqNumChain{ChainSel: c, SeqNum: s})
 	}
-
-	o.lggr.Debugw("observed final result is", "result", result)
+	
 	return result
 }
 

--- a/commit/merkleroot/observation_test.go
+++ b/commit/merkleroot/observation_test.go
@@ -241,7 +241,8 @@ func Test_ObserveOffRampNextSeqNums(t *testing.T) {
 				chainSupport.EXPECT().KnownSourceChainsSlice().Return(knownSourceChains, nil)
 				ccipReader := reader_mock.NewMockCCIPReader(t)
 				// return a smaller slice, should return subset
-				ccipReader.EXPECT().NextSeqNum(mock.Anything, knownSourceChains).Return(map[cciptypes.ChainSelector]cciptypes.SeqNum{4: 345}, nil)
+				ccipReader.EXPECT().NextSeqNum(mock.Anything, knownSourceChains).
+					Return(map[cciptypes.ChainSelector]cciptypes.SeqNum{4: 345}, nil)
 				ccipReader.EXPECT().GetRmnCurseInfo(mock.Anything, mock.Anything, mock.Anything).
 					Return(&reader.CurseInfo{}, nil)
 				return chainSupport, ccipReader

--- a/commit/merkleroot/validate_observation.go
+++ b/commit/merkleroot/validate_observation.go
@@ -209,13 +209,7 @@ func ValidateMerkleRootsState(
 		return fmt.Errorf("get next sequence numbers: %w", err)
 	}
 
-	if len(offRampExpNextSeqNums) != len(chainSlice) {
-		return fmt.Errorf("critical reader error: seq nums length mismatch")
-	}
-
-	for i, offRampExpNextSeqNum := range offRampExpNextSeqNums {
-		chain := chainSlice[i]
-
+	for chain, offRampExpNextSeqNum := range offRampExpNextSeqNums {
 		newNextOnRampSeqNum, ok := newNextOnRampSeqNums[chain]
 		if !ok {
 			return fmt.Errorf("critical unexpected error: newOnRampSeqNum not found")

--- a/commit/merkleroot/validate_observation_test.go
+++ b/commit/merkleroot/validate_observation_test.go
@@ -345,7 +345,7 @@ func Test_validateMerkleRootsState(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		onRampNextSeqNum     []plugintypes.SeqNumChain
-		offRampExpNextSeqNum []cciptypes.SeqNum
+		offRampExpNextSeqNum map[cciptypes.ChainSelector]cciptypes.SeqNum
 		readerErr            error
 		expErr               bool
 	}{
@@ -355,7 +355,7 @@ func Test_validateMerkleRootsState(t *testing.T) {
 				plugintypes.NewSeqNumChain(10, 100),
 				plugintypes.NewSeqNumChain(20, 200),
 			},
-			offRampExpNextSeqNum: []cciptypes.SeqNum{100, 200},
+			offRampExpNextSeqNum: map[cciptypes.ChainSelector]cciptypes.SeqNum{10: 100, 20: 200},
 			expErr:               false,
 		},
 		{
@@ -364,7 +364,7 @@ func Test_validateMerkleRootsState(t *testing.T) {
 				plugintypes.NewSeqNumChain(10, 100),
 				plugintypes.NewSeqNumChain(20, 200),
 			},
-			offRampExpNextSeqNum: []cciptypes.SeqNum{100, 201}, // <- 200 is already on chain
+			offRampExpNextSeqNum: map[cciptypes.ChainSelector]cciptypes.SeqNum{10: 100, 20: 201}, // <- 200 is already on chain
 			expErr:               true,
 		},
 		{
@@ -373,7 +373,7 @@ func Test_validateMerkleRootsState(t *testing.T) {
 				plugintypes.NewSeqNumChain(10, 101), // <- onchain 99 but we submit 101 instead of 100
 				plugintypes.NewSeqNumChain(20, 200),
 			},
-			offRampExpNextSeqNum: []cciptypes.SeqNum{100, 200},
+			offRampExpNextSeqNum: map[cciptypes.ChainSelector]cciptypes.SeqNum{10: 100, 20: 200},
 			expErr:               true,
 		},
 		{
@@ -382,7 +382,7 @@ func Test_validateMerkleRootsState(t *testing.T) {
 				plugintypes.NewSeqNumChain(10, 100),
 				plugintypes.NewSeqNumChain(20, 200),
 			},
-			offRampExpNextSeqNum: []cciptypes.SeqNum{100, 200, 300},
+			offRampExpNextSeqNum: map[cciptypes.ChainSelector]cciptypes.SeqNum{10: 100, 20: 200, 30: 300},
 			expErr:               true,
 		},
 		{
@@ -391,7 +391,7 @@ func Test_validateMerkleRootsState(t *testing.T) {
 				plugintypes.NewSeqNumChain(10, 100),
 				plugintypes.NewSeqNumChain(20, 200),
 			},
-			offRampExpNextSeqNum: []cciptypes.SeqNum{100, 200},
+			offRampExpNextSeqNum: map[cciptypes.ChainSelector]cciptypes.SeqNum{10: 100, 20: 200},
 			readerErr:            fmt.Errorf("reader error"),
 			expErr:               true,
 		},

--- a/commit/plugin_e2e_test.go
+++ b/commit/plugin_e2e_test.go
@@ -201,10 +201,13 @@ func TestPlugin_E2E_AllNodesAgree_MerkleRoots(t *testing.T) {
 			},
 		},
 		{
-			name:                                   "report generated in previous outcome, transmitted with success",
-			prevOutcome:                            outcomeReportGenerated,
-			offRampNextSeqNumDefaultOverrideKeys:   []ccipocr3.ChainSelector{sourceChain1, sourceChain2},
-			offRampNextSeqNumDefaultOverrideValues: map[ccipocr3.ChainSelector]ccipocr3.SeqNum{sourceChain1: 11, sourceChain2: 20},
+			name:                                 "report generated in previous outcome, transmitted with success",
+			prevOutcome:                          outcomeReportGenerated,
+			offRampNextSeqNumDefaultOverrideKeys: []ccipocr3.ChainSelector{sourceChain1, sourceChain2},
+			offRampNextSeqNumDefaultOverrideValues: map[ccipocr3.ChainSelector]ccipocr3.SeqNum{
+				sourceChain1: 11,
+				sourceChain2: 20,
+			},
 			expOutcome: committypes.Outcome{
 				MerkleRootOutcome: merkleroot.Outcome{
 					OutcomeType: merkleroot.ReportTransmitted,

--- a/internal/mocks/inmem/ccipreader_inmem.go
+++ b/internal/mocks/inmem/ccipreader_inmem.go
@@ -110,7 +110,7 @@ func (r InMemoryCCIPReader) MsgsBetweenSeqNums(
 
 func (r InMemoryCCIPReader) NextSeqNum(
 	ctx context.Context, chains []cciptypes.ChainSelector,
-) (seqNum []cciptypes.SeqNum, err error) {
+) (seqNum map[cciptypes.ChainSelector]cciptypes.SeqNum, err error) {
 	panic("implement me")
 }
 

--- a/mocks/pkg/reader/ccip_reader.go
+++ b/mocks/pkg/reader/ccip_reader.go
@@ -940,23 +940,23 @@ func (_c *MockCCIPReader_MsgsBetweenSeqNums_Call) RunAndReturn(run func(context.
 }
 
 // NextSeqNum provides a mock function with given fields: ctx, chains
-func (_m *MockCCIPReader) NextSeqNum(ctx context.Context, chains []ccipocr3.ChainSelector) ([]ccipocr3.SeqNum, error) {
+func (_m *MockCCIPReader) NextSeqNum(ctx context.Context, chains []ccipocr3.ChainSelector) (map[ccipocr3.ChainSelector]ccipocr3.SeqNum, error) {
 	ret := _m.Called(ctx, chains)
 
 	if len(ret) == 0 {
 		panic("no return value specified for NextSeqNum")
 	}
 
-	var r0 []ccipocr3.SeqNum
+	var r0 map[ccipocr3.ChainSelector]ccipocr3.SeqNum
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, []ccipocr3.ChainSelector) ([]ccipocr3.SeqNum, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []ccipocr3.ChainSelector) (map[ccipocr3.ChainSelector]ccipocr3.SeqNum, error)); ok {
 		return rf(ctx, chains)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, []ccipocr3.ChainSelector) []ccipocr3.SeqNum); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []ccipocr3.ChainSelector) map[ccipocr3.ChainSelector]ccipocr3.SeqNum); ok {
 		r0 = rf(ctx, chains)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]ccipocr3.SeqNum)
+			r0 = ret.Get(0).(map[ccipocr3.ChainSelector]ccipocr3.SeqNum)
 		}
 	}
 
@@ -988,12 +988,12 @@ func (_c *MockCCIPReader_NextSeqNum_Call) Run(run func(ctx context.Context, chai
 	return _c
 }
 
-func (_c *MockCCIPReader_NextSeqNum_Call) Return(seqNum []ccipocr3.SeqNum, err error) *MockCCIPReader_NextSeqNum_Call {
+func (_c *MockCCIPReader_NextSeqNum_Call) Return(seqNum map[ccipocr3.ChainSelector]ccipocr3.SeqNum, err error) *MockCCIPReader_NextSeqNum_Call {
 	_c.Call.Return(seqNum, err)
 	return _c
 }
 
-func (_c *MockCCIPReader_NextSeqNum_Call) RunAndReturn(run func(context.Context, []ccipocr3.ChainSelector) ([]ccipocr3.SeqNum, error)) *MockCCIPReader_NextSeqNum_Call {
+func (_c *MockCCIPReader_NextSeqNum_Call) RunAndReturn(run func(context.Context, []ccipocr3.ChainSelector) (map[ccipocr3.ChainSelector]ccipocr3.SeqNum, error)) *MockCCIPReader_NextSeqNum_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -399,13 +399,13 @@ func (r *ccipChainReader) GetExpectedNextSequenceNumber(
 
 func (r *ccipChainReader) NextSeqNum(
 	ctx context.Context, chains []cciptypes.ChainSelector,
-) ([]cciptypes.SeqNum, error) {
+) (map[cciptypes.ChainSelector]cciptypes.SeqNum, error) {
 	cfgs, err := r.getOffRampSourceChainsConfig(ctx, chains)
 	if err != nil {
 		return nil, fmt.Errorf("get source chains config: %w", err)
 	}
 
-	res := make([]cciptypes.SeqNum, 0, len(chains))
+	res := map[cciptypes.ChainSelector]cciptypes.SeqNum{}
 	for _, chain := range chains {
 		cfg, exists := cfgs[chain]
 		if !exists {
@@ -414,7 +414,7 @@ func (r *ccipChainReader) NextSeqNum(
 		if cfg.MinSeqNr == 0 {
 			return nil, fmt.Errorf("minSeqNr not found for chain %d", chain)
 		}
-		res = append(res, cciptypes.SeqNum(cfg.MinSeqNr))
+		res[chain] = cciptypes.SeqNum(cfg.MinSeqNr)
 	}
 
 	return res, err

--- a/pkg/reader/ccip_interface.go
+++ b/pkg/reader/ccip_interface.go
@@ -108,7 +108,7 @@ type CCIPReader interface {
 	// NextSeqNum reads the destination chain.
 	// Returns the next expected sequence number for each one of the provided chains.
 	// TODO: if destination was a parameter, this could be a capability reused across plugin instances.
-	NextSeqNum(ctx context.Context, chains []cciptypes.ChainSelector) (seqNum []cciptypes.SeqNum, err error)
+	NextSeqNum(ctx context.Context, chains []cciptypes.ChainSelector) (seqNum map[cciptypes.ChainSelector]cciptypes.SeqNum, err error)
 
 	// GetContractAddress returns the contract address that is registered for the provided contract name and chain.
 	GetContractAddress(contractName string, chain cciptypes.ChainSelector) ([]byte, error)

--- a/pkg/reader/ccip_interface.go
+++ b/pkg/reader/ccip_interface.go
@@ -108,7 +108,10 @@ type CCIPReader interface {
 	// NextSeqNum reads the destination chain.
 	// Returns the next expected sequence number for each one of the provided chains.
 	// TODO: if destination was a parameter, this could be a capability reused across plugin instances.
-	NextSeqNum(ctx context.Context, chains []cciptypes.ChainSelector) (seqNum map[cciptypes.ChainSelector]cciptypes.SeqNum, err error)
+	NextSeqNum(
+		ctx context.Context,
+		chains []cciptypes.ChainSelector,
+	) (seqNum map[cciptypes.ChainSelector]cciptypes.SeqNum, err error)
 
 	// GetContractAddress returns the contract address that is registered for the provided contract name and chain.
 	GetContractAddress(contractName string, chain cciptypes.ChainSelector) ([]byte, error)


### PR DESCRIPTION
Audit findings: 


https://smartcontract-it.atlassian.net/browse/CCIP-4760