### PR TITLE
Move a function that made the code misleading

### DIFF
--- a/commit/merkleroot/transmission_checks.go
+++ b/commit/merkleroot/transmission_checks.go
@@ -1,0 +1,59 @@
+package merkleroot
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	mapset "github.com/deckarep/golang-set/v2"
+
+	"github.com/smartcontractkit/chainlink-ccip/pkg/reader"
+	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+)
+
+// ValidateMerkleRootsState validates the proposed merkle roots against the current on-chain state.
+// This function is not-pure as it reads from the chain by making one network/reader call.
+func ValidateMerkleRootsState(
+	ctx context.Context,
+	proposedMerkleRoots []cciptypes.MerkleRootChain,
+	reader reader.CCIPReader,
+) error {
+	if len(proposedMerkleRoots) == 0 {
+		return nil
+	}
+
+	chainSet := mapset.NewSet[cciptypes.ChainSelector]()
+	newNextOnRampSeqNums := make(map[cciptypes.ChainSelector]cciptypes.SeqNum)
+
+	for _, r := range proposedMerkleRoots {
+		if chainSet.Contains(r.ChainSel) {
+			return fmt.Errorf("duplicate chain %d", r.ChainSel)
+		}
+		chainSet.Add(r.ChainSel)
+		newNextOnRampSeqNums[r.ChainSel] = r.SeqNumsRange.Start()
+	}
+
+	chainSlice := chainSet.ToSlice()
+	sort.Slice(chainSlice, func(i, j int) bool { return chainSlice[i] < chainSlice[j] })
+
+	offRampExpNextSeqNums, err := reader.NextSeqNum(ctx, chainSlice)
+	if err != nil {
+		return fmt.Errorf("get next sequence numbers: %w", err)
+	}
+
+	for chain, newNextOnRampSeqNum := range newNextOnRampSeqNums {
+		offRampExpNextSeqNum, ok := offRampExpNextSeqNums[chain]
+		if !ok {
+			// Due to some chain being disabled while the sequence numbers were already observed.
+			// Report should not be considered valid in that case.
+			return fmt.Errorf("offRamp expected next sequence number for chain %d was not found", chain)
+		}
+
+		if newNextOnRampSeqNum != offRampExpNextSeqNum {
+			return fmt.Errorf("unexpected seq nums offRampNext=%d newOnRampNext=%d",
+				offRampExpNextSeqNum, newNextOnRampSeqNum)
+		}
+	}
+
+	return nil
+}

--- a/commit/merkleroot/transmission_checks_test.go
+++ b/commit/merkleroot/transmission_checks_test.go
@@ -1,0 +1,95 @@
+package merkleroot
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
+	readermock "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/reader"
+	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+)
+
+func Test_validateMerkleRootsState(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		onRampNextSeqNum     []plugintypes.SeqNumChain
+		offRampExpNextSeqNum map[cciptypes.ChainSelector]cciptypes.SeqNum
+		readerErr            error
+		expErr               bool
+	}{
+		{
+			name: "happy path",
+			onRampNextSeqNum: []plugintypes.SeqNumChain{
+				plugintypes.NewSeqNumChain(10, 100),
+				plugintypes.NewSeqNumChain(20, 200),
+			},
+			offRampExpNextSeqNum: map[cciptypes.ChainSelector]cciptypes.SeqNum{10: 100, 20: 200},
+			expErr:               false,
+		},
+		{
+			name: "one root is stale",
+			onRampNextSeqNum: []plugintypes.SeqNumChain{
+				plugintypes.NewSeqNumChain(10, 100),
+				plugintypes.NewSeqNumChain(20, 200),
+			},
+			// <- 200 is already on chain
+			offRampExpNextSeqNum: map[cciptypes.ChainSelector]cciptypes.SeqNum{10: 100, 20: 201},
+			expErr:               true,
+		},
+		{
+			name: "one root has gap",
+			onRampNextSeqNum: []plugintypes.SeqNumChain{
+				plugintypes.NewSeqNumChain(10, 101), // <- onchain 99 but we submit 101 instead of 100
+				plugintypes.NewSeqNumChain(20, 200),
+			},
+			offRampExpNextSeqNum: map[cciptypes.ChainSelector]cciptypes.SeqNum{10: 100, 20: 200},
+			expErr:               true,
+		},
+		{
+			name: "reader returned wrong number of seq nums, should be ok",
+			onRampNextSeqNum: []plugintypes.SeqNumChain{
+				plugintypes.NewSeqNumChain(10, 100),
+				plugintypes.NewSeqNumChain(20, 200),
+			},
+			offRampExpNextSeqNum: map[cciptypes.ChainSelector]cciptypes.SeqNum{10: 100, 20: 200, 30: 300},
+			expErr:               false,
+		},
+		{
+			name: "reader error",
+			onRampNextSeqNum: []plugintypes.SeqNumChain{
+				plugintypes.NewSeqNumChain(10, 100),
+				plugintypes.NewSeqNumChain(20, 200),
+			},
+			offRampExpNextSeqNum: map[cciptypes.ChainSelector]cciptypes.SeqNum{10: 100, 20: 200},
+			readerErr:            fmt.Errorf("reader error"),
+			expErr:               true,
+		},
+	}
+
+	ctx := tests.Context(t)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			reader := readermock.NewMockCCIPReader(t)
+			rep := cciptypes.CommitPluginReport{}
+			chains := make([]cciptypes.ChainSelector, 0, len(tc.onRampNextSeqNum))
+			for _, snc := range tc.onRampNextSeqNum {
+				rep.MerkleRoots = append(rep.MerkleRoots, cciptypes.MerkleRootChain{
+					ChainSel:     snc.ChainSel,
+					SeqNumsRange: cciptypes.NewSeqNumRange(snc.SeqNum, snc.SeqNum+10),
+				})
+				chains = append(chains, snc.ChainSel)
+			}
+			reader.EXPECT().NextSeqNum(ctx, chains).Return(tc.offRampExpNextSeqNum, tc.readerErr)
+
+			err := ValidateMerkleRootsState(ctx, rep.MerkleRoots, reader)
+			if tc.expErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/commit/merkleroot/validate_observation.go
+++ b/commit/merkleroot/validate_observation.go
@@ -1,9 +1,7 @@
 package merkleroot
 
 import (
-	"context"
 	"fmt"
-	"sort"
 
 	mapset "github.com/deckarep/golang-set/v2"
 
@@ -12,7 +10,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn/types"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
-	"github.com/smartcontractkit/chainlink-ccip/pkg/reader"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
 
@@ -174,53 +171,6 @@ func validateRMNRemoteConfig(
 			return fmt.Errorf("duplicate NodeIndex %d", signer.NodeIndex)
 		}
 		seenNodeIndexes.Add(signer.NodeIndex)
-	}
-
-	return nil
-}
-
-// ValidateMerkleRootsState validates the proposed merkle roots against the current on-chain state.
-// This function is not-pure as it reads from the chain by making one network/reader call.
-func ValidateMerkleRootsState(
-	ctx context.Context,
-	proposedMerkleRoots []cciptypes.MerkleRootChain,
-	reader reader.CCIPReader,
-) error {
-	if len(proposedMerkleRoots) == 0 {
-		return nil
-	}
-
-	chainSet := mapset.NewSet[cciptypes.ChainSelector]()
-	newNextOnRampSeqNums := make(map[cciptypes.ChainSelector]cciptypes.SeqNum)
-
-	for _, r := range proposedMerkleRoots {
-		if chainSet.Contains(r.ChainSel) {
-			return fmt.Errorf("duplicate chain %d", r.ChainSel)
-		}
-		chainSet.Add(r.ChainSel)
-		newNextOnRampSeqNums[r.ChainSel] = r.SeqNumsRange.Start()
-	}
-
-	chainSlice := chainSet.ToSlice()
-	sort.Slice(chainSlice, func(i, j int) bool { return chainSlice[i] < chainSlice[j] })
-
-	offRampExpNextSeqNums, err := reader.NextSeqNum(ctx, chainSlice)
-	if err != nil {
-		return fmt.Errorf("get next sequence numbers: %w", err)
-	}
-
-	for chain, newNextOnRampSeqNum := range newNextOnRampSeqNums {
-		offRampExpNextSeqNum, ok := offRampExpNextSeqNums[chain]
-		if !ok {
-			// Due to some chain being disabled while the sequence numbers were already observed.
-			// Report should not be considered valid in that case.
-			return fmt.Errorf("offRamp expected next sequence number for chain %d was not found", chain)
-		}
-
-		if newNextOnRampSeqNum != offRampExpNextSeqNum {
-			return fmt.Errorf("unexpected seq nums offRampNext=%d newOnRampNext=%d",
-				offRampExpNextSeqNum, newNextOnRampSeqNum)
-		}
 	}
 
 	return nil

--- a/commit/merkleroot/validate_observation_test.go
+++ b/commit/merkleroot/validate_observation_test.go
@@ -1,18 +1,15 @@
 package merkleroot
 
 import (
-	"fmt"
 	"testing"
 
 	mapset "github.com/deckarep/golang-set/v2"
-	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/smartcontractkit/libocr/commontypes"
 
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn/types"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
-	readermock "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/reader"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
 
@@ -333,88 +330,6 @@ func Test_validateRMNRemoteConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validateRMNRemoteConfig(tt.observer, tt.supportsDestChain, tt.rmnRemoteConfig)
 			if tt.expectedError {
-				assert.Error(t, err)
-				return
-			}
-			assert.NoError(t, err)
-		})
-	}
-}
-
-func Test_validateMerkleRootsState(t *testing.T) {
-	testCases := []struct {
-		name                 string
-		onRampNextSeqNum     []plugintypes.SeqNumChain
-		offRampExpNextSeqNum map[cciptypes.ChainSelector]cciptypes.SeqNum
-		readerErr            error
-		expErr               bool
-	}{
-		{
-			name: "happy path",
-			onRampNextSeqNum: []plugintypes.SeqNumChain{
-				plugintypes.NewSeqNumChain(10, 100),
-				plugintypes.NewSeqNumChain(20, 200),
-			},
-			offRampExpNextSeqNum: map[cciptypes.ChainSelector]cciptypes.SeqNum{10: 100, 20: 200},
-			expErr:               false,
-		},
-		{
-			name: "one root is stale",
-			onRampNextSeqNum: []plugintypes.SeqNumChain{
-				plugintypes.NewSeqNumChain(10, 100),
-				plugintypes.NewSeqNumChain(20, 200),
-			},
-			// <- 200 is already on chain
-			offRampExpNextSeqNum: map[cciptypes.ChainSelector]cciptypes.SeqNum{10: 100, 20: 201},
-			expErr:               true,
-		},
-		{
-			name: "one root has gap",
-			onRampNextSeqNum: []plugintypes.SeqNumChain{
-				plugintypes.NewSeqNumChain(10, 101), // <- onchain 99 but we submit 101 instead of 100
-				plugintypes.NewSeqNumChain(20, 200),
-			},
-			offRampExpNextSeqNum: map[cciptypes.ChainSelector]cciptypes.SeqNum{10: 100, 20: 200},
-			expErr:               true,
-		},
-		{
-			name: "reader returned wrong number of seq nums, should be ok",
-			onRampNextSeqNum: []plugintypes.SeqNumChain{
-				plugintypes.NewSeqNumChain(10, 100),
-				plugintypes.NewSeqNumChain(20, 200),
-			},
-			offRampExpNextSeqNum: map[cciptypes.ChainSelector]cciptypes.SeqNum{10: 100, 20: 200, 30: 300},
-			expErr:               false,
-		},
-		{
-			name: "reader error",
-			onRampNextSeqNum: []plugintypes.SeqNumChain{
-				plugintypes.NewSeqNumChain(10, 100),
-				plugintypes.NewSeqNumChain(20, 200),
-			},
-			offRampExpNextSeqNum: map[cciptypes.ChainSelector]cciptypes.SeqNum{10: 100, 20: 200},
-			readerErr:            fmt.Errorf("reader error"),
-			expErr:               true,
-		},
-	}
-
-	ctx := tests.Context(t)
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			reader := readermock.NewMockCCIPReader(t)
-			rep := cciptypes.CommitPluginReport{}
-			chains := make([]cciptypes.ChainSelector, 0, len(tc.onRampNextSeqNum))
-			for _, snc := range tc.onRampNextSeqNum {
-				rep.MerkleRoots = append(rep.MerkleRoots, cciptypes.MerkleRootChain{
-					ChainSel:     snc.ChainSel,
-					SeqNumsRange: cciptypes.NewSeqNumRange(snc.SeqNum, snc.SeqNum+10),
-				})
-				chains = append(chains, snc.ChainSel)
-			}
-			reader.EXPECT().NextSeqNum(ctx, chains).Return(tc.offRampExpNextSeqNum, tc.readerErr)
-
-			err := ValidateMerkleRootsState(ctx, rep.MerkleRoots, reader)
-			if tc.expErr {
 				assert.Error(t, err)
 				return
 			}


### PR DESCRIPTION
Before it was easy to falsely assume this code was related to observations.

`core ref: ec3e1406bb937e39a2f538d49b35da589016767b`