### PR TITLE
solana: ccip router ownership events

### DIFF
--- a/chains/solana/contracts/programs/ccip-router/src/event.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/event.rs
@@ -136,3 +136,15 @@ pub struct AdministratorRegistered {
     pub token_mint: Pubkey,
     pub administrator: Pubkey,
 }
+
+#[event]
+pub struct OwnershipTransferRequested {
+    pub from: Pubkey,
+    pub to: Pubkey,
+}
+
+#[event]
+pub struct OwnershipTransferred {
+    pub from: Pubkey,
+    pub to: Pubkey,
+}

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/admin.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/admin.rs
@@ -5,11 +5,11 @@ use crate::{
     AcceptOwnership, AddBillingTokenConfig, AddChainSelector, BillingTokenConfig, CcipRouterError,
     DestChainAdded, DestChainConfig, DestChainConfigUpdated, DestChainState, FeeTokenAdded,
     FeeTokenDisabled, FeeTokenEnabled, FeeTokenRemoved, Ocr3ConfigInfo, OcrPluginType,
-    RemoveBillingTokenConfig, SetOcrConfig, SetTokenBillingConfig, SourceChainAdded,
-    SourceChainConfig, SourceChainConfigUpdated, SourceChainState, TimestampedPackedU224,
-    TokenBilling, TransferOwnership, UpdateBillingTokenConfig, UpdateConfigCCIPRouter,
-    UpdateDestChainSelectorConfig, UpdateSourceChainSelectorConfig, WithdrawBilledFunds,
-    FEE_BILLING_SIGNER_SEEDS,
+    OwnershipTransferRequested, OwnershipTransferred, RemoveBillingTokenConfig, SetOcrConfig,
+    SetTokenBillingConfig, SourceChainAdded, SourceChainConfig, SourceChainConfigUpdated,
+    SourceChainState, TimestampedPackedU224, TokenBilling, TransferOwnership,
+    UpdateBillingTokenConfig, UpdateConfigCCIPRouter, UpdateDestChainSelectorConfig,
+    UpdateSourceChainSelectorConfig, WithdrawBilledFunds, FEE_BILLING_SIGNER_SEEDS,
 };
 
 use super::fee_quoter::do_billing_transfer;
@@ -20,12 +20,20 @@ pub fn transfer_ownership(ctx: Context<TransferOwnership>, proposed_owner: Pubke
         proposed_owner != config.owner,
         CcipRouterError::InvalidInputs
     );
+    emit!(OwnershipTransferRequested {
+        from: config.owner,
+        to: proposed_owner,
+    });
     config.proposed_owner = proposed_owner;
     Ok(())
 }
 
 pub fn accept_ownership(ctx: Context<AcceptOwnership>) -> Result<()> {
     let mut config = ctx.accounts.config.load_mut()?;
+    emit!(OwnershipTransferred {
+        from: config.owner,
+        to: config.proposed_owner,
+    });
     config.owner = std::mem::take(&mut config.proposed_owner);
     config.proposed_owner = Pubkey::new_from_array([0; 32]);
     Ok(())

--- a/chains/solana/contracts/target/idl/ccip_router.json
+++ b/chains/solana/contracts/target/idl/ccip_router.json
@@ -3254,6 +3254,36 @@
       ]
     },
     {
+      "name": "OwnershipTransferRequested",
+      "fields": [
+        {
+          "name": "from",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "to",
+          "type": "publicKey",
+          "index": false
+        }
+      ]
+    },
+    {
+      "name": "OwnershipTransferred",
+      "fields": [
+        {
+          "name": "from",
+          "type": "publicKey",
+          "index": false
+        },
+        {
+          "name": "to",
+          "type": "publicKey",
+          "index": false
+        }
+      ]
+    },
+    {
       "name": "ConfigSet",
       "fields": [
         {

--- a/chains/solana/contracts/tests/ccip/ccip_router_test.go
+++ b/chains/solana/contracts/tests/ccip/ccip_router_test.go
@@ -822,6 +822,11 @@ func TestCCIPRouter(t *testing.T) {
 			result = testutils.SendAndConfirm(ctx, t, solanaGoClient, []solana.Instruction{instruction}, admin, config.DefaultCommitment)
 			require.NotNil(t, result)
 
+			transferEvent := ccip.OwnershipTransferRequested{}
+			require.NoError(t, common.ParseEvent(result.Meta.LogMessages, "OwnershipTransferRequested", &transferEvent, config.PrintEvents))
+			require.Equal(t, admin.PublicKey(), transferEvent.From)
+			require.Equal(t, anotherAdmin.PublicKey(), transferEvent.To)
+
 			// Fail to accept ownership when not proposed_owner
 			instruction, err = ccip_router.NewAcceptOwnershipInstruction(
 				config.RouterConfigPDA,
@@ -840,6 +845,10 @@ func TestCCIPRouter(t *testing.T) {
 			require.NoError(t, err)
 			result = testutils.SendAndConfirm(ctx, t, solanaGoClient, []solana.Instruction{instruction}, anotherAdmin, config.DefaultCommitment)
 			require.NotNil(t, result)
+			acceptEvent := ccip.OwnershipTransferred{}
+			require.NoError(t, common.ParseEvent(result.Meta.LogMessages, "OwnershipTransferred", &acceptEvent, config.PrintEvents))
+			require.Equal(t, admin.PublicKey(), transferEvent.From)
+			require.Equal(t, anotherAdmin.PublicKey(), transferEvent.To)
 
 			// Current owner cannot propose self
 			instruction, err = ccip_router.NewTransferOwnershipInstruction(

--- a/chains/solana/utils/ccip/ccip_events.go
+++ b/chains/solana/utils/ccip/ccip_events.go
@@ -65,3 +65,15 @@ type UsdPerUnitGasUpdated struct {
 	Value         [28]byte
 	Timestamp     int64
 }
+
+type OwnershipTransferRequested struct {
+	Discriminator [8]byte
+	From          solana.PublicKey
+	To            solana.PublicKey
+}
+
+type OwnershipTransferred struct {
+	Discriminator [8]byte
+	From          solana.PublicKey
+	To            solana.PublicKey
+}


### PR DESCRIPTION
This PR is a part of EVM compatible event emission task scope[NONEVM-1029]

- Added `OwnershipTransferRequested` and `OwnershipTransferred` events in `ccip-router/v1/admin`
- Added event validation logic in test