### PR TITLE
Allow only price aggregator contract to have multiple bindings [CCIP-4781]

### DIFF
--- a/pkg/contractreader/extended.go
+++ b/pkg/contractreader/extended.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 	"sync"
 	"time"
+
+	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"

--- a/pkg/contractreader/extended.go
+++ b/pkg/contractreader/extended.go
@@ -107,14 +107,13 @@ func NewExtendedContractReader(baseContractReader ContractReaderFacade) Extended
 	if ecr, ok := baseContractReader.(Extended); ok {
 		return ecr
 	}
-	// so far this is the only contract that allows multiple bindings
-	// if more contracts are added, this should be moved to a config
-	multiBindAllowed := map[string]bool{consts.ContractNamePriceAggregator: true}
 	return &extendedContractReader{
 		reader:                 baseContractReader,
 		contractBindingsByName: make(map[string][]ExtendedBoundContract),
-		multiBindAllowed:       multiBindAllowed,
-		mu:                     &sync.RWMutex{},
+		// so far this is the only contract that allows multiple bindings
+		// if more contracts are added, this should be moved to a config
+		multiBindAllowed: map[string]bool{consts.ContractNamePriceAggregator: true},
+		mu:               &sync.RWMutex{},
 	}
 }
 

--- a/pkg/contractreader/extended_test.go
+++ b/pkg/contractreader/extended_test.go
@@ -30,6 +30,8 @@ func TestExtendedContractReader(t *testing.T) {
 
 	cr.On("Bind", context.Background(),
 		[]types.BoundContract{{Name: contractName, Address: "0x123"}}).Return(nil)
+	cr.On("Unbind", context.Background(),
+		[]types.BoundContract{{Name: contractName, Address: "0x123"}}).Return(nil)
 	cr.On("Bind", context.Background(),
 		[]types.BoundContract{{Name: contractName, Address: "0x124"}}).Return(nil)
 	cr.On("Bind", context.Background(),

--- a/pkg/contractreader/extended_test.go
+++ b/pkg/contractreader/extended_test.go
@@ -3,6 +3,7 @@ package contractreader_test
 import (
 	"context"
 	"fmt"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,6 +21,40 @@ import (
 
 func TestExtendedContractReader(t *testing.T) {
 	const contractName = "testContract"
+	cr := chainreadermocks.NewMockContractReaderFacade(t)
+	extCr := contractreader.NewExtendedContractReader(cr)
+
+	bindings := extCr.GetBindings(contractName)
+	assert.Len(t, bindings, 0)
+
+	cr.On("Bind", context.Background(),
+		[]types.BoundContract{{Name: contractName, Address: "0x123"}}).Return(nil)
+	cr.On("Bind", context.Background(),
+		[]types.BoundContract{{Name: contractName, Address: "0x124"}}).Return(nil)
+	cr.On("Bind", context.Background(),
+		[]types.BoundContract{{Name: contractName, Address: "0x125"}}).Return(fmt.Errorf("some err"))
+
+	err := extCr.Bind(context.Background(), []types.BoundContract{{Name: contractName, Address: "0x123"}})
+	assert.NoError(t, err)
+
+	// ignored since 0x123 already exists
+	err = extCr.Bind(context.Background(), []types.BoundContract{{Name: contractName, Address: "0x123"}})
+	assert.NoError(t, err)
+
+	err = extCr.Bind(context.Background(), []types.BoundContract{{Name: contractName, Address: "0x124"}})
+	assert.NoError(t, err)
+
+	// Bind fails
+	err = extCr.Bind(context.Background(), []types.BoundContract{{Name: contractName, Address: "0x125"}})
+	assert.Error(t, err)
+
+	bindings = extCr.GetBindings(contractName)
+	assert.Len(t, bindings, 1)
+	assert.Equal(t, "0x124", bindings[0].Binding.Address)
+}
+
+func TestExtendedContractReader_AllowMultiBindingForAggregator(t *testing.T) {
+	const contractName = consts.ContractNamePriceAggregator
 	cr := chainreadermocks.NewMockContractReaderFacade(t)
 	extCr := contractreader.NewExtendedContractReader(cr)
 

--- a/pkg/contractreader/extended_test.go
+++ b/pkg/contractreader/extended_test.go
@@ -3,8 +3,9 @@ package contractreader_test
 import (
 	"context"
 	"fmt"
-	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 	"testing"
+
+	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"


### PR DESCRIPTION
Allow only price aggregator contract to have multiple bindings, othe contracts should only have one instance at any single time.

core ref: 843e228fba3c5264d34fb5bc2bd972f1576057d8

Core PR: https://github.com/smartcontractkit/chainlink/pull/15854