### PR TITLE
Refactor: Moving logic out of `state.rs` [NONEVM-1114]

### DIFF
--- a/chains/solana/contracts/programs/ccip-router/src/context.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/context.rs
@@ -15,11 +15,9 @@ pub const ANCHOR_DISCRIMINATOR: usize = 8;
 
 // track state versions
 pub const MAX_CONFIG_V: u8 = 1;
-pub const MAX_CHAINSTATE_V: u8 = 1;
-pub const MAX_NONCE_V: u8 = 1;
-pub const MAX_COMMITREPORT_V: u8 = 1;
-pub const MAX_TOKEN_REGISTRY_V: u8 = 1;
-pub const MAX_TOKEN_AND_CHAIN_CONFIG_V: u8 = 1;
+const MAX_CHAINSTATE_V: u8 = 1;
+const MAX_NONCE_V: u8 = 1;
+const MAX_COMMITREPORT_V: u8 = 1;
 
 // valid_version validates that the passed in version is not 0 (uninitialized)
 // and it is within the expected maximum supported version bounds

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/offramp.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/offramp.rs
@@ -361,7 +361,7 @@ fn internal_execute<'info>(
         solana_chain_selector,
     )?;
 
-    let original_state = commit_report_state::get(commit_report, message_header.sequence_number);
+    let original_state = execution_state::get(commit_report, message_header.sequence_number);
 
     if original_state == MessageExecutionState::Success {
         emit!(SkippedAlreadyExecutedMessage {
@@ -509,7 +509,7 @@ fn internal_execute<'info>(
     }
 
     let new_state = MessageExecutionState::Success;
-    commit_report_state::set(
+    execution_state::set(
         commit_report,
         message_header.sequence_number,
         new_state.to_owned(),
@@ -713,7 +713,7 @@ fn hash(msg: &Any2SolanaRampMessage, on_ramp_address: &[u8]) -> [u8; 32] {
     result.to_bytes()
 }
 
-mod commit_report_state {
+mod execution_state {
     use crate::{CommitReport, MessageExecutionState};
 
     pub fn set(

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/onramp.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/onramp.rs
@@ -11,10 +11,9 @@ use super::pools::{
 };
 
 use crate::{
-    AnyExtraArgs, BillingTokenConfig, CCIPMessageSent, CcipRouterError, CcipSend, Config,
-    ExtraArgsInput, GetFee, Nonce, PerChainPerTokenConfig, RampMessageHeader, Solana2AnyMessage,
-    Solana2AnyRampMessage, Solana2AnyTokenTransfer, SolanaTokenAmount, EXTERNAL_TOKEN_POOL_SEED,
-    TOKEN_POOL_BILLING_SEED,
+    AnyExtraArgs, CCIPMessageSent, CcipRouterError, CcipSend, Config, ExtraArgsInput, GetFee,
+    Nonce, RampMessageHeader, Solana2AnyMessage, Solana2AnyRampMessage, Solana2AnyTokenTransfer,
+    SolanaTokenAmount, EXTERNAL_TOKEN_POOL_SEED,
 };
 
 pub fn get_fee<'info>(
@@ -37,14 +36,14 @@ pub fn get_fee<'info>(
         .iter()
         .zip(message.token_amounts.iter())
         .map(|(a, SolanaTokenAmount { token, .. })| {
-            BillingTokenConfig::validated_try_from(a, *token)
+            validated_try_to::billing_token_config(a, *token)
         })
         .collect::<Result<Vec<_>>>()?;
     let per_chain_per_token_config_accounts = per_chain_per_token_config_accounts
         .iter()
         .zip(message.token_amounts.iter())
         .map(|(a, SolanaTokenAmount { token, .. })| {
-            validated_try_to_per_chain_per_token_config(a, *token, dest_chain_selector)
+            validated_try_to::per_chain_per_token_config(a, *token, dest_chain_selector)
         })
         .collect::<Result<Vec<_>>>()?;
 
@@ -96,13 +95,13 @@ pub fn ccip_send<'info>(
 
     let token_billing_config_accounts = accounts_per_sent_token
         .iter()
-        .map(|accs| BillingTokenConfig::validated_try_from(accs.fee_token_config, accs.mint.key()))
+        .map(|accs| validated_try_to::billing_token_config(accs.fee_token_config, accs.mint.key()))
         .collect::<Result<Vec<_>>>()?;
 
     let per_chain_per_token_config_accounts = accounts_per_sent_token
         .iter()
         .map(|accs| {
-            validated_try_to_per_chain_per_token_config(
+            validated_try_to::per_chain_per_token_config(
                 accs.token_billing_config,
                 accs.mint.key(),
                 dest_chain_selector,
@@ -342,25 +341,57 @@ fn hash(msg: &Solana2AnyRampMessage) -> [u8; 32] {
     result.to_bytes()
 }
 
-fn validated_try_to_per_chain_per_token_config<'info>(
-    account: &'info AccountInfo<'info>,
-    token: Pubkey,
-    dest_chain_selector: u64,
-) -> Result<PerChainPerTokenConfig> {
-    let (expected, _) = Pubkey::find_program_address(
-        &[
-            TOKEN_POOL_BILLING_SEED,
-            dest_chain_selector.to_le_bytes().as_ref(),
-            token.key().as_ref(),
-        ],
-        &crate::ID,
-    );
-    require_keys_eq!(account.key(), expected, CcipRouterError::InvalidInputs);
-    let account = Account::<PerChainPerTokenConfig>::try_from(account)?;
-    require_eq!(
-        account.version,
-        1, // the v1 version of the onramp will always be tied to version 1 of the state
-        CcipRouterError::InvalidInputs
-    );
-    Ok(account.into_inner())
+/// Methods in this module are used to deserialize AccountInfo into the state structs
+mod validated_try_to {
+    use anchor_lang::prelude::*;
+
+    use crate::{
+        BillingTokenConfig, BillingTokenConfigWrapper, CcipRouterError, PerChainPerTokenConfig,
+        FEE_BILLING_TOKEN_CONFIG, TOKEN_POOL_BILLING_SEED,
+    };
+
+    pub fn per_chain_per_token_config<'info>(
+        account: &'info AccountInfo<'info>,
+        token: Pubkey,
+        dest_chain_selector: u64,
+    ) -> Result<PerChainPerTokenConfig> {
+        let (expected, _) = Pubkey::find_program_address(
+            &[
+                TOKEN_POOL_BILLING_SEED,
+                dest_chain_selector.to_le_bytes().as_ref(),
+                token.key().as_ref(),
+            ],
+            &crate::ID,
+        );
+        require_keys_eq!(account.key(), expected, CcipRouterError::InvalidInputs);
+        let account = Account::<PerChainPerTokenConfig>::try_from(account)?;
+        require_eq!(
+            account.version,
+            1, // the v1 version of the onramp will always be tied to version 1 of the state
+            CcipRouterError::InvalidInputs
+        );
+        Ok(account.into_inner())
+    }
+
+    // Returns Ok(None) when parsing the ZERO address, which is a valid input from users
+    // specifying a token that has no Billing config.
+    pub fn billing_token_config<'info>(
+        account: &'info AccountInfo<'info>,
+        token: Pubkey,
+    ) -> Result<Option<BillingTokenConfig>> {
+        if account.key() == Pubkey::default() {
+            return Ok(None);
+        }
+
+        let (expected, _) =
+            Pubkey::find_program_address(&[FEE_BILLING_TOKEN_CONFIG, token.as_ref()], &crate::ID);
+        require_keys_eq!(account.key(), expected, CcipRouterError::InvalidInputs);
+        let account = Account::<BillingTokenConfigWrapper>::try_from(account)?;
+        require_eq!(
+            account.version,
+            1, // the v1 version of the onramp will always be tied to version 1 of the state
+            CcipRouterError::InvalidInputs
+        );
+        Ok(Some(account.into_inner().config))
+    }
 }

--- a/chains/solana/contracts/programs/ccip-router/src/state.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/state.rs
@@ -149,28 +149,6 @@ pub struct CommitReport {
     pub execution_states: u128,
 }
 
-#[derive(Clone, AnchorSerialize, AnchorDeserialize, Debug, PartialEq)]
-pub enum MessageExecutionState {
-    Untouched = 0,
-    InProgress = 1, // Not used in Solana, but used in EVM
-    Success = 2,
-    Failure = 3,
-}
-
-impl TryFrom<u128> for MessageExecutionState {
-    type Error = &'static str;
-
-    fn try_from(value: u128) -> std::result::Result<MessageExecutionState, &'static str> {
-        match value {
-            0 => Ok(MessageExecutionState::Untouched),
-            1 => Ok(MessageExecutionState::InProgress),
-            2 => Ok(MessageExecutionState::Success),
-            3 => Ok(MessageExecutionState::Failure),
-            _ => Err("Invalid ExecutionState"),
-        }
-    }
-}
-
 #[account]
 #[derive(InitSpace, Debug)]
 pub struct PerChainPerTokenConfig {
@@ -248,6 +226,28 @@ impl TimestampedPackedU224 {
 pub struct UnpackedDoubleU224 {
     pub high: u128,
     pub low: u128,
+}
+
+#[derive(Clone, AnchorSerialize, AnchorDeserialize, Debug, PartialEq)]
+pub enum MessageExecutionState {
+    Untouched = 0,
+    InProgress = 1, // Not used in Solana, but used in EVM
+    Success = 2,
+    Failure = 3,
+}
+
+impl TryFrom<u128> for MessageExecutionState {
+    type Error = &'static str;
+
+    fn try_from(value: u128) -> std::result::Result<MessageExecutionState, &'static str> {
+        match value {
+            0 => Ok(MessageExecutionState::Untouched),
+            1 => Ok(MessageExecutionState::InProgress),
+            2 => Ok(MessageExecutionState::Success),
+            3 => Ok(MessageExecutionState::Failure),
+            _ => Err("Invalid ExecutionState"),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/chains/solana/contracts/programs/ccip-router/src/state.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/state.rs
@@ -1,10 +1,7 @@
 use anchor_lang::prelude::*;
 use ethnum::U256;
 
-use crate::{
-    valid_version, CcipRouterError, FEE_BILLING_TOKEN_CONFIG, MAX_TOKEN_AND_CHAIN_CONFIG_V,
-    TOKEN_POOL_BILLING_SEED,
-};
+use crate::{valid_version, CcipRouterError, FEE_BILLING_TOKEN_CONFIG};
 
 // zero_copy is used to prevent hitting stack/heap memory limits
 #[account(zero_copy)]
@@ -184,30 +181,6 @@ pub struct PerChainPerTokenConfig {
     pub mint: Pubkey,        // token on solana
 
     pub billing: TokenBilling, // EVM: configurable in router only by ccip admins
-}
-
-impl PerChainPerTokenConfig {
-    pub fn validated_try_from<'info>(
-        account: &'info AccountInfo<'info>,
-        token: Pubkey,
-        dest_chain_selector: u64,
-    ) -> Result<Self> {
-        let (expected, _) = Pubkey::find_program_address(
-            &[
-                TOKEN_POOL_BILLING_SEED,
-                dest_chain_selector.to_le_bytes().as_ref(),
-                token.key().as_ref(),
-            ],
-            &crate::ID,
-        );
-        require_keys_eq!(account.key(), expected, CcipRouterError::InvalidInputs);
-        let account = Account::<PerChainPerTokenConfig>::try_from(account)?;
-        require!(
-            valid_version(account.version, MAX_TOKEN_AND_CHAIN_CONFIG_V),
-            CcipRouterError::InvalidInputs
-        );
-        Ok(account.into_inner())
-    }
 }
 
 #[derive(InitSpace, Debug, Clone, AnchorSerialize, AnchorDeserialize)]

--- a/chains/solana/contracts/programs/ccip-router/src/token_context.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/token_context.rs
@@ -6,6 +6,10 @@ use crate::CcipRouterError;
 
 use anchor_spl::token_interface::Mint;
 
+// track state versions
+const MAX_TOKEN_REGISTRY_V: u8 = 1;
+const MAX_TOKEN_AND_CHAIN_CONFIG_V: u8 = 1;
+
 #[account]
 #[derive(InitSpace)]
 pub struct TokenAdminRegistry {
@@ -24,7 +28,7 @@ pub struct RegisterTokenAdminRegistryViaGetCCIPAdmin<'info> {
     #[account(
         seeds = [CONFIG_SEED],
         bump,
-        constraint = valid_version(config.load()?.version, MAX_TOKEN_REGISTRY_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs,
     )]
     pub config: AccountLoader<'info, Config>,
     #[account(


### PR DESCRIPTION
_Continues the refactor from #414, #418 & #432_

Moves most logic out of `state.rs` into the onramp or offramp. 

Note for reviewers: I've tried to make every commit be a unit of the refactor on its own, so you might want to review this PR commit by commit.

---
# TODO:
- [ ] Move `PackedPrice` and `UnpackedDoubleU224` to the fee_quoter after #427 is merged. Can be done in a separate PR if needed, no need to delay this one for that.