### PR TITLE
[Solana][NONEVM-677] processMessageArgs flow

### DIFF
--- a/chains/solana/contracts/programs/ccip-router/src/context.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/context.rs
@@ -525,6 +525,12 @@ pub struct CcipSend<'info> {
     )]
     pub fee_token_config: Account<'info, BillingTokenConfigWrapper>, // pass pre-2022 wSOL config if using native SOL
 
+    #[account(
+        seeds = [FEE_BILLING_TOKEN_CONFIG, config.load()?.link_token_mint.key().as_ref()],
+        bump,
+    )]
+    pub link_token_config: Account<'info, BillingTokenConfigWrapper>,
+
     /// CHECK this is the associated token account for the user paying the fee.
     /// If paying with native SOL, this must be the zero address.
     #[account(

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/fee_quoter.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/fee_quoter.rs
@@ -5,6 +5,7 @@ use anchor_spl::{token::spl_token::native_mint, token_interface};
 use ethnum::U256;
 use solana_program::{program::invoke_signed, system_instruction};
 
+use crate::v1::price_math::get_validated_token_price;
 use crate::{
     BillingTokenConfig, CcipRouterError, DestChain, PerChainPerTokenConfig, Solana2AnyMessage,
     SolanaTokenAmount, TimestampedPackedU224, FEE_BILLING_SIGNER_SEEDS,
@@ -294,21 +295,6 @@ fn get_validated_gas_price(dest_chain: &DestChain) -> Result<PackedPrice> {
     require!(
         threshold == 0 || threshold > elapsed_time,
         CcipRouterError::StaleGasPrice
-    );
-
-    Ok(price)
-}
-
-fn get_validated_token_price(token_config: &BillingTokenConfig) -> Result<Usd18Decimals> {
-    let timestamp = token_config.usd_per_token.timestamp;
-    let price: Usd18Decimals = (&token_config.usd_per_token).into();
-
-    // NOTE: There's no validation done with respect to token price staleness since data feeds are not
-    // supported in solana. Only the existence of `any` timestamp is checked, to ensure the price
-    // was set at least once.
-    require!(
-        price.0 != 0 && timestamp != 0,
-        CcipRouterError::InvalidTokenPrice
     );
 
     Ok(price)

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/fee_quoter.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/fee_quoter.rs
@@ -649,7 +649,7 @@ pub mod tests {
             })
             .collect();
 
-        let tokens: Vec<_> = tokens.into_iter().map(|t| Some(t)).collect();
+        let tokens: Vec<_> = tokens.into_iter().map(Some).collect();
         let per_chains: Vec<_> = per_chains.into_iter().collect();
         set_syscall_stubs(Box::new(TestStubs));
 

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/fee_quoter.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/fee_quoter.rs
@@ -357,7 +357,7 @@ pub fn do_billing_transfer<'info>(
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use solana_program::{
         entrypoint::SUCCESS,
         program_stubs::{set_syscall_stubs, SyscallStubs},
@@ -673,7 +673,7 @@ mod tests {
         );
     }
 
-    fn sample_additional_token() -> (BillingTokenConfig, PerChainPerTokenConfig) {
+    pub fn sample_additional_token() -> (BillingTokenConfig, PerChainPerTokenConfig) {
         let mint = Pubkey::new_unique();
         (
             sample_billing_config(),

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/fee_quoter.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/fee_quoter.rs
@@ -5,7 +5,6 @@ use anchor_spl::{token::spl_token::native_mint, token_interface};
 use ethnum::U256;
 use solana_program::{program::invoke_signed, system_instruction};
 
-use crate::v1::price_math::get_validated_token_price;
 use crate::{
     BillingTokenConfig, CcipRouterError, DestChain, PerChainPerTokenConfig, Solana2AnyMessage,
     SolanaTokenAmount, TimestampedPackedU224, FEE_BILLING_SIGNER_SEEDS,
@@ -13,6 +12,7 @@ use crate::{
 
 use super::messages::ramps::validate_solana2any;
 use super::pools::CCIP_LOCK_OR_BURN_V1_RET_BYTES;
+use super::price_math::get_validated_token_price;
 use super::price_math::{Exponential, Usd18Decimals};
 
 /// Any2EVMRampMessage struct has 10 fields, including 3 variable unnested arrays (data, receiver and tokenAmounts).

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/mod.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/mod.rs
@@ -4,7 +4,6 @@
 pub mod admin;
 pub mod offramp;
 pub mod onramp;
-pub mod price_math;
 pub mod token_admin_registry;
 
 /////////////////////
@@ -16,3 +15,4 @@ mod messages;
 mod ocr3base;
 mod ocr3impl;
 mod pools;
+mod price_math;

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/mod.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/mod.rs
@@ -4,6 +4,7 @@
 pub mod admin;
 pub mod offramp;
 pub mod onramp;
+pub mod price_math;
 pub mod token_admin_registry;
 
 /////////////////////
@@ -15,4 +16,3 @@ mod messages;
 mod ocr3base;
 mod ocr3impl;
 mod pools;
-mod price_math;

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/pools.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/pools.rs
@@ -401,18 +401,18 @@ mod tests {
             ],
         };
 
-        assert_eq!(state.is_writable(0), false);
-        assert_eq!(state.is_writable(128), false);
-        assert_eq!(state.is_writable(255), false);
+        assert!(!state.is_writable(0));
+        assert!(!state.is_writable(128));
+        assert!(!state.is_writable(255));
 
         assert_eq!(state.writable_indexes[0].count_ones(), 3);
         assert_eq!(state.writable_indexes[1].count_ones(), 3);
 
-        assert_eq!(state.is_writable(7), true);
-        assert_eq!(state.is_writable(2), true);
-        assert_eq!(state.is_writable(4), true);
-        assert_eq!(state.is_writable(128 + 8), true);
-        assert_eq!(state.is_writable(128 + 56), true);
-        assert_eq!(state.is_writable(128 + 100), true);
+        assert!(state.is_writable(7));
+        assert!(state.is_writable(2));
+        assert!(state.is_writable(4));
+        assert!(state.is_writable(128 + 8));
+        assert!(state.is_writable(128 + 56));
+        assert!(state.is_writable(128 + 100));
     }
 }

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/price_math.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/price_math.rs
@@ -1,8 +1,9 @@
+use anchor_lang::prelude::*;
 use std::ops::{Add, AddAssign, Mul};
 
 use ethnum::U256;
 
-use crate::{SolanaTokenAmount, TimestampedPackedU224};
+use crate::{BillingTokenConfig, CcipRouterError, SolanaTokenAmount, TimestampedPackedU224};
 
 pub trait Exponential {
     fn e(self, exponent: u8) -> U256;
@@ -17,6 +18,21 @@ impl<T: Into<u32>> Exponential for T {
 // USD with 18 decimals (i.e. $8 -> 8e18)
 #[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Usd18Decimals(pub U256);
+
+pub fn get_validated_token_price(token_config: &BillingTokenConfig) -> Result<Usd18Decimals> {
+    let timestamp = token_config.usd_per_token.timestamp;
+    let price: Usd18Decimals = (&token_config.usd_per_token).into();
+
+    // NOTE: There's no validation done with respect to token price staleness since data feeds are not
+    // supported in solana. Only the existence of `any` timestamp is checked, to ensure the price
+    // was set at least once.
+    require!(
+        price.0 != 0 && timestamp != 0,
+        CcipRouterError::InvalidTokenPrice
+    );
+
+    Ok(price)
+}
 
 impl Usd18Decimals {
     pub const ZERO: Self = Self(U256::ZERO);
@@ -44,11 +60,11 @@ impl AddAssign for Usd18Decimals {
     }
 }
 
-impl Mul<U256> for Usd18Decimals {
+impl<T: Into<U256>> Mul<T> for Usd18Decimals {
     type Output = Self;
 
-    fn mul(mut self, rhs: U256) -> Self::Output {
-        self.0 *= rhs;
+    fn mul(mut self, rhs: T) -> Self::Output {
+        self.0 *= rhs.into();
         self
     }
 }

--- a/chains/solana/contracts/programs/ccip-router/src/lib.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/lib.rs
@@ -60,6 +60,8 @@ pub mod ccip_router {
         default_allow_out_of_order_execution: bool,
         enable_execution_after: i64,
         fee_aggregator: Pubkey,
+        link_token_mint: Pubkey,
+        max_fee_juels_per_msg: u128,
     ) -> Result<()> {
         let mut config = ctx.accounts.config.load_init()?;
         require!(config.version == 0, CcipRouterError::InvalidInputs); // assert uninitialized state - AccountLoader doesn't work with constraint
@@ -67,6 +69,8 @@ pub mod ccip_router {
         config.solana_chain_selector = solana_chain_selector;
         config.default_gas_limit = default_gas_limit;
         config.enable_manual_execution_after = enable_execution_after;
+        config.link_token_mint = link_token_mint;
+        config.max_fee_juels_per_msg = max_fee_juels_per_msg;
 
         if default_allow_out_of_order_execution {
             config.default_allow_out_of_order_execution = 1;
@@ -664,4 +668,8 @@ pub enum CcipRouterError {
     UnsupportedToken,
     #[msg("Inputs are missing token configuration")]
     InvalidInputsMissingTokenConfig,
+    #[msg("Message fee is too high")]
+    MessageFeeTooHigh,
+    #[msg("Source token data is too large")]
+    SourceTokenDataTooLarge,
 }

--- a/chains/solana/contracts/programs/ccip-router/src/lib.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/lib.rs
@@ -53,6 +53,7 @@ pub mod ccip_router {
     /// * `default_gas_limit` - The default gas limit for other destination chains.
     /// * `default_allow_out_of_order_execution` - Whether out-of-order execution is allowed by default for other destination chains.
     /// * `enable_execution_after` - The minimum amount of time required between a message has been committed and can be manually executed.
+    #[allow(clippy::too_many_arguments)]
     pub fn initialize(
         ctx: Context<InitializeCCIPRouter>,
         solana_chain_selector: u64,

--- a/chains/solana/contracts/programs/ccip-router/src/messages.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/messages.rs
@@ -104,7 +104,7 @@ pub struct Solana2AnyRampMessage {
     pub token_amounts: Vec<Solana2AnyTokenTransfer>,
 }
 
-#[derive(Clone, AnchorSerialize, AnchorDeserialize, Default)]
+#[derive(Debug, Clone, AnchorSerialize, AnchorDeserialize, Default)]
 pub struct Solana2AnyTokenTransfer {
     // The source pool address. This value is trusted as it was obtained through the onRamp. It can be relied
     // upon by the destination pool to validate the source pool.

--- a/chains/solana/contracts/programs/ccip-router/src/messages.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/messages.rs
@@ -1,7 +1,5 @@
 use anchor_lang::prelude::*;
 
-use crate::{v1::price_math::get_validated_token_price, BillingTokenConfig, CcipRouterError};
-
 pub const CHAIN_FAMILY_SELECTOR_EVM: u32 = 0x2812d52c;
 
 #[derive(Clone, Copy, AnchorSerialize, AnchorDeserialize)]
@@ -162,25 +160,6 @@ pub struct Solana2AnyMessage {
 pub struct SolanaTokenAmount {
     pub token: Pubkey,
     pub amount: u64, // u64 - amount local to solana
-}
-
-impl SolanaTokenAmount {
-    pub fn convert(
-        &self,
-        source_config: &BillingTokenConfig,
-        target_config: &BillingTokenConfig,
-    ) -> Result<SolanaTokenAmount> {
-        assert!(source_config.mint == self.token);
-        let source_price = get_validated_token_price(source_config)?;
-        let target_price = get_validated_token_price(target_config)?;
-
-        Ok(SolanaTokenAmount {
-            token: target_config.mint,
-            amount: ((source_price * self.amount).0 / target_price.0)
-                .try_into()
-                .map_err(|_| CcipRouterError::InvalidTokenPrice)?,
-        })
-    }
 }
 
 #[derive(Clone, Copy, AnchorSerialize, AnchorDeserialize)]

--- a/chains/solana/contracts/programs/ccip-router/src/state.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/state.rs
@@ -21,6 +21,8 @@ pub struct Config {
     // TODO: token pool global config
 
     // TODO: billing global configs'
+    pub max_fee_juels_per_msg: u128,
+    pub link_token_mint: Pubkey,
     pub fee_aggregator: Pubkey, // Allowed address to withdraw billed fees to (will use ATAs derived from it)
 }
 

--- a/chains/solana/contracts/target/idl/ccip_router.json
+++ b/chains/solana/contracts/target/idl/ccip_router.json
@@ -98,6 +98,14 @@
         {
           "name": "feeAggregator",
           "type": "publicKey"
+        },
+        {
+          "name": "linkTokenMint",
+          "type": "publicKey"
+        },
+        {
+          "name": "maxFeeJuelsPerMsg",
+          "type": "u128"
         }
       ]
     },
@@ -1190,6 +1198,11 @@
           "isSigner": false
         },
         {
+          "name": "linkTokenConfig",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
           "name": "feeTokenUserAssociatedAccount",
           "isMut": false,
           "isSigner": false,
@@ -1548,6 +1561,14 @@
                 2
               ]
             }
+          },
+          {
+            "name": "maxFeeJuelsPerMsg",
+            "type": "u128"
+          },
+          {
+            "name": "linkTokenMint",
+            "type": "publicKey"
           },
           {
             "name": "feeAggregator",
@@ -2886,6 +2907,12 @@
           },
           {
             "name": "InvalidInputsMissingTokenConfig"
+          },
+          {
+            "name": "MessageFeeTooHigh"
+          },
+          {
+            "name": "SourceTokenDataTooLarge"
           }
         ]
       }

--- a/chains/solana/contracts/tests/txsizing_test.go
+++ b/chains/solana/contracts/tests/txsizing_test.go
@@ -109,6 +109,7 @@ func TestTransactionSizing(t *testing.T) {
 			routerTable["billingTokenProgram"],
 			routerTable["billingTokenMint"],
 			routerTable["billingTokenConfig"],
+			mustRandomPubkey(), // link billing config
 			mustRandomPubkey(), // user billing token ATA
 			routerTable["routerBillingTokenATA"],
 			routerTable["routerBillingSigner"],

--- a/chains/solana/gobindings/ccip_router/CcipSend.go
+++ b/chains/solana/gobindings/ccip_router/CcipSend.go
@@ -44,22 +44,24 @@ type CcipSend struct {
 	//
 	// [7] = [] feeTokenConfig
 	//
-	// [8] = [] feeTokenUserAssociatedAccount
+	// [8] = [] linkTokenConfig
+	//
+	// [9] = [] feeTokenUserAssociatedAccount
 	// ··········· CHECK this is the associated token account for the user paying the fee.
 	// ··········· If paying with native SOL, this must be the zero address.
 	//
-	// [9] = [WRITE] feeTokenReceiver
+	// [10] = [WRITE] feeTokenReceiver
 	//
-	// [10] = [] feeBillingSigner
+	// [11] = [] feeBillingSigner
 	//
-	// [11] = [WRITE] tokenPoolsSigner
+	// [12] = [WRITE] tokenPoolsSigner
 	ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
 }
 
 // NewCcipSendInstructionBuilder creates a new `CcipSend` instruction builder.
 func NewCcipSendInstructionBuilder() *CcipSend {
 	nd := &CcipSend{
-		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 12),
+		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 13),
 	}
 	return nd
 }
@@ -164,11 +166,22 @@ func (inst *CcipSend) GetFeeTokenConfigAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice[7]
 }
 
+// SetLinkTokenConfigAccount sets the "linkTokenConfig" account.
+func (inst *CcipSend) SetLinkTokenConfigAccount(linkTokenConfig ag_solanago.PublicKey) *CcipSend {
+	inst.AccountMetaSlice[8] = ag_solanago.Meta(linkTokenConfig)
+	return inst
+}
+
+// GetLinkTokenConfigAccount gets the "linkTokenConfig" account.
+func (inst *CcipSend) GetLinkTokenConfigAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[8]
+}
+
 // SetFeeTokenUserAssociatedAccountAccount sets the "feeTokenUserAssociatedAccount" account.
 // CHECK this is the associated token account for the user paying the fee.
 // If paying with native SOL, this must be the zero address.
 func (inst *CcipSend) SetFeeTokenUserAssociatedAccountAccount(feeTokenUserAssociatedAccount ag_solanago.PublicKey) *CcipSend {
-	inst.AccountMetaSlice[8] = ag_solanago.Meta(feeTokenUserAssociatedAccount)
+	inst.AccountMetaSlice[9] = ag_solanago.Meta(feeTokenUserAssociatedAccount)
 	return inst
 }
 
@@ -176,40 +189,40 @@ func (inst *CcipSend) SetFeeTokenUserAssociatedAccountAccount(feeTokenUserAssoci
 // CHECK this is the associated token account for the user paying the fee.
 // If paying with native SOL, this must be the zero address.
 func (inst *CcipSend) GetFeeTokenUserAssociatedAccountAccount() *ag_solanago.AccountMeta {
-	return inst.AccountMetaSlice[8]
+	return inst.AccountMetaSlice[9]
 }
 
 // SetFeeTokenReceiverAccount sets the "feeTokenReceiver" account.
 func (inst *CcipSend) SetFeeTokenReceiverAccount(feeTokenReceiver ag_solanago.PublicKey) *CcipSend {
-	inst.AccountMetaSlice[9] = ag_solanago.Meta(feeTokenReceiver).WRITE()
+	inst.AccountMetaSlice[10] = ag_solanago.Meta(feeTokenReceiver).WRITE()
 	return inst
 }
 
 // GetFeeTokenReceiverAccount gets the "feeTokenReceiver" account.
 func (inst *CcipSend) GetFeeTokenReceiverAccount() *ag_solanago.AccountMeta {
-	return inst.AccountMetaSlice[9]
+	return inst.AccountMetaSlice[10]
 }
 
 // SetFeeBillingSignerAccount sets the "feeBillingSigner" account.
 func (inst *CcipSend) SetFeeBillingSignerAccount(feeBillingSigner ag_solanago.PublicKey) *CcipSend {
-	inst.AccountMetaSlice[10] = ag_solanago.Meta(feeBillingSigner)
+	inst.AccountMetaSlice[11] = ag_solanago.Meta(feeBillingSigner)
 	return inst
 }
 
 // GetFeeBillingSignerAccount gets the "feeBillingSigner" account.
 func (inst *CcipSend) GetFeeBillingSignerAccount() *ag_solanago.AccountMeta {
-	return inst.AccountMetaSlice[10]
+	return inst.AccountMetaSlice[11]
 }
 
 // SetTokenPoolsSignerAccount sets the "tokenPoolsSigner" account.
 func (inst *CcipSend) SetTokenPoolsSignerAccount(tokenPoolsSigner ag_solanago.PublicKey) *CcipSend {
-	inst.AccountMetaSlice[11] = ag_solanago.Meta(tokenPoolsSigner).WRITE()
+	inst.AccountMetaSlice[12] = ag_solanago.Meta(tokenPoolsSigner).WRITE()
 	return inst
 }
 
 // GetTokenPoolsSignerAccount gets the "tokenPoolsSigner" account.
 func (inst *CcipSend) GetTokenPoolsSignerAccount() *ag_solanago.AccountMeta {
-	return inst.AccountMetaSlice[11]
+	return inst.AccountMetaSlice[12]
 }
 
 func (inst CcipSend) Build() *Instruction {
@@ -267,15 +280,18 @@ func (inst *CcipSend) Validate() error {
 			return errors.New("accounts.FeeTokenConfig is not set")
 		}
 		if inst.AccountMetaSlice[8] == nil {
-			return errors.New("accounts.FeeTokenUserAssociatedAccount is not set")
+			return errors.New("accounts.LinkTokenConfig is not set")
 		}
 		if inst.AccountMetaSlice[9] == nil {
-			return errors.New("accounts.FeeTokenReceiver is not set")
+			return errors.New("accounts.FeeTokenUserAssociatedAccount is not set")
 		}
 		if inst.AccountMetaSlice[10] == nil {
-			return errors.New("accounts.FeeBillingSigner is not set")
+			return errors.New("accounts.FeeTokenReceiver is not set")
 		}
 		if inst.AccountMetaSlice[11] == nil {
+			return errors.New("accounts.FeeBillingSigner is not set")
+		}
+		if inst.AccountMetaSlice[12] == nil {
 			return errors.New("accounts.TokenPoolsSigner is not set")
 		}
 	}
@@ -297,7 +313,7 @@ func (inst *CcipSend) EncodeToTree(parent ag_treeout.Branches) {
 					})
 
 					// Accounts of the instruction:
-					instructionBranch.Child("Accounts[len=12]").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+					instructionBranch.Child("Accounts[len=13]").ParentFunc(func(accountsBranch ag_treeout.Branches) {
 						accountsBranch.Child(ag_format.Meta("                config", inst.AccountMetaSlice[0]))
 						accountsBranch.Child(ag_format.Meta("        destChainState", inst.AccountMetaSlice[1]))
 						accountsBranch.Child(ag_format.Meta("                 nonce", inst.AccountMetaSlice[2]))
@@ -306,10 +322,11 @@ func (inst *CcipSend) EncodeToTree(parent ag_treeout.Branches) {
 						accountsBranch.Child(ag_format.Meta("       feeTokenProgram", inst.AccountMetaSlice[5]))
 						accountsBranch.Child(ag_format.Meta("          feeTokenMint", inst.AccountMetaSlice[6]))
 						accountsBranch.Child(ag_format.Meta("        feeTokenConfig", inst.AccountMetaSlice[7]))
-						accountsBranch.Child(ag_format.Meta("feeTokenUserAssociated", inst.AccountMetaSlice[8]))
-						accountsBranch.Child(ag_format.Meta("      feeTokenReceiver", inst.AccountMetaSlice[9]))
-						accountsBranch.Child(ag_format.Meta("      feeBillingSigner", inst.AccountMetaSlice[10]))
-						accountsBranch.Child(ag_format.Meta("      tokenPoolsSigner", inst.AccountMetaSlice[11]))
+						accountsBranch.Child(ag_format.Meta("       linkTokenConfig", inst.AccountMetaSlice[8]))
+						accountsBranch.Child(ag_format.Meta("feeTokenUserAssociated", inst.AccountMetaSlice[9]))
+						accountsBranch.Child(ag_format.Meta("      feeTokenReceiver", inst.AccountMetaSlice[10]))
+						accountsBranch.Child(ag_format.Meta("      feeBillingSigner", inst.AccountMetaSlice[11]))
+						accountsBranch.Child(ag_format.Meta("      tokenPoolsSigner", inst.AccountMetaSlice[12]))
 					})
 				})
 		})
@@ -356,6 +373,7 @@ func NewCcipSendInstruction(
 	feeTokenProgram ag_solanago.PublicKey,
 	feeTokenMint ag_solanago.PublicKey,
 	feeTokenConfig ag_solanago.PublicKey,
+	linkTokenConfig ag_solanago.PublicKey,
 	feeTokenUserAssociatedAccount ag_solanago.PublicKey,
 	feeTokenReceiver ag_solanago.PublicKey,
 	feeBillingSigner ag_solanago.PublicKey,
@@ -371,6 +389,7 @@ func NewCcipSendInstruction(
 		SetFeeTokenProgramAccount(feeTokenProgram).
 		SetFeeTokenMintAccount(feeTokenMint).
 		SetFeeTokenConfigAccount(feeTokenConfig).
+		SetLinkTokenConfigAccount(linkTokenConfig).
 		SetFeeTokenUserAssociatedAccountAccount(feeTokenUserAssociatedAccount).
 		SetFeeTokenReceiverAccount(feeTokenReceiver).
 		SetFeeBillingSignerAccount(feeBillingSigner).

--- a/chains/solana/gobindings/ccip_router/Initialize.go
+++ b/chains/solana/gobindings/ccip_router/Initialize.go
@@ -27,6 +27,8 @@ type Initialize struct {
 	DefaultAllowOutOfOrderExecution *bool
 	EnableExecutionAfter            *int64
 	FeeAggregator                   *ag_solanago.PublicKey
+	LinkTokenMint                   *ag_solanago.PublicKey
+	MaxFeeJuelsPerMsg               *ag_binary.Uint128
 
 	// [0] = [WRITE] config
 	//
@@ -81,6 +83,18 @@ func (inst *Initialize) SetEnableExecutionAfter(enableExecutionAfter int64) *Ini
 // SetFeeAggregator sets the "feeAggregator" parameter.
 func (inst *Initialize) SetFeeAggregator(feeAggregator ag_solanago.PublicKey) *Initialize {
 	inst.FeeAggregator = &feeAggregator
+	return inst
+}
+
+// SetLinkTokenMint sets the "linkTokenMint" parameter.
+func (inst *Initialize) SetLinkTokenMint(linkTokenMint ag_solanago.PublicKey) *Initialize {
+	inst.LinkTokenMint = &linkTokenMint
+	return inst
+}
+
+// SetMaxFeeJuelsPerMsg sets the "maxFeeJuelsPerMsg" parameter.
+func (inst *Initialize) SetMaxFeeJuelsPerMsg(maxFeeJuelsPerMsg ag_binary.Uint128) *Initialize {
+	inst.MaxFeeJuelsPerMsg = &maxFeeJuelsPerMsg
 	return inst
 }
 
@@ -207,6 +221,12 @@ func (inst *Initialize) Validate() error {
 		if inst.FeeAggregator == nil {
 			return errors.New("FeeAggregator parameter is not set")
 		}
+		if inst.LinkTokenMint == nil {
+			return errors.New("LinkTokenMint parameter is not set")
+		}
+		if inst.MaxFeeJuelsPerMsg == nil {
+			return errors.New("MaxFeeJuelsPerMsg parameter is not set")
+		}
 	}
 
 	// Check whether all (required) accounts are set:
@@ -248,12 +268,14 @@ func (inst *Initialize) EncodeToTree(parent ag_treeout.Branches) {
 				ParentFunc(func(instructionBranch ag_treeout.Branches) {
 
 					// Parameters of the instruction:
-					instructionBranch.Child("Params[len=5]").ParentFunc(func(paramsBranch ag_treeout.Branches) {
+					instructionBranch.Child("Params[len=7]").ParentFunc(func(paramsBranch ag_treeout.Branches) {
 						paramsBranch.Child(ag_format.Param("            SolanaChainSelector", *inst.SolanaChainSelector))
 						paramsBranch.Child(ag_format.Param("                DefaultGasLimit", *inst.DefaultGasLimit))
 						paramsBranch.Child(ag_format.Param("DefaultAllowOutOfOrderExecution", *inst.DefaultAllowOutOfOrderExecution))
 						paramsBranch.Child(ag_format.Param("           EnableExecutionAfter", *inst.EnableExecutionAfter))
 						paramsBranch.Child(ag_format.Param("                  FeeAggregator", *inst.FeeAggregator))
+						paramsBranch.Child(ag_format.Param("                  LinkTokenMint", *inst.LinkTokenMint))
+						paramsBranch.Child(ag_format.Param("              MaxFeeJuelsPerMsg", *inst.MaxFeeJuelsPerMsg))
 					})
 
 					// Accounts of the instruction:
@@ -297,6 +319,16 @@ func (obj Initialize) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error)
 	if err != nil {
 		return err
 	}
+	// Serialize `LinkTokenMint` param:
+	err = encoder.Encode(obj.LinkTokenMint)
+	if err != nil {
+		return err
+	}
+	// Serialize `MaxFeeJuelsPerMsg` param:
+	err = encoder.Encode(obj.MaxFeeJuelsPerMsg)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 func (obj *Initialize) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
@@ -325,6 +357,16 @@ func (obj *Initialize) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err err
 	if err != nil {
 		return err
 	}
+	// Deserialize `LinkTokenMint`:
+	err = decoder.Decode(&obj.LinkTokenMint)
+	if err != nil {
+		return err
+	}
+	// Deserialize `MaxFeeJuelsPerMsg`:
+	err = decoder.Decode(&obj.MaxFeeJuelsPerMsg)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -336,6 +378,8 @@ func NewInitializeInstruction(
 	defaultAllowOutOfOrderExecution bool,
 	enableExecutionAfter int64,
 	feeAggregator ag_solanago.PublicKey,
+	linkTokenMint ag_solanago.PublicKey,
+	maxFeeJuelsPerMsg ag_binary.Uint128,
 	// Accounts:
 	config ag_solanago.PublicKey,
 	state ag_solanago.PublicKey,
@@ -351,6 +395,8 @@ func NewInitializeInstruction(
 		SetDefaultAllowOutOfOrderExecution(defaultAllowOutOfOrderExecution).
 		SetEnableExecutionAfter(enableExecutionAfter).
 		SetFeeAggregator(feeAggregator).
+		SetLinkTokenMint(linkTokenMint).
+		SetMaxFeeJuelsPerMsg(maxFeeJuelsPerMsg).
 		SetConfigAccount(config).
 		SetStateAccount(state).
 		SetAuthorityAccount(authority).

--- a/chains/solana/gobindings/ccip_router/accounts.go
+++ b/chains/solana/gobindings/ccip_router/accounts.go
@@ -20,6 +20,8 @@ type Config struct {
 	EnableManualExecutionAfter      int64
 	Padding2                        [8]uint8
 	Ocr3                            [2]Ocr3Config
+	MaxFeeJuelsPerMsg               ag_binary.Uint128
+	LinkTokenMint                   ag_solanago.PublicKey
 	FeeAggregator                   ag_solanago.PublicKey
 }
 
@@ -83,6 +85,16 @@ func (obj Config) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	}
 	// Serialize `Ocr3` param:
 	err = encoder.Encode(obj.Ocr3)
+	if err != nil {
+		return err
+	}
+	// Serialize `MaxFeeJuelsPerMsg` param:
+	err = encoder.Encode(obj.MaxFeeJuelsPerMsg)
+	if err != nil {
+		return err
+	}
+	// Serialize `LinkTokenMint` param:
+	err = encoder.Encode(obj.LinkTokenMint)
 	if err != nil {
 		return err
 	}
@@ -160,6 +172,16 @@ func (obj *Config) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) 
 	}
 	// Deserialize `Ocr3`:
 	err = decoder.Decode(&obj.Ocr3)
+	if err != nil {
+		return err
+	}
+	// Deserialize `MaxFeeJuelsPerMsg`:
+	err = decoder.Decode(&obj.MaxFeeJuelsPerMsg)
+	if err != nil {
+		return err
+	}
+	// Deserialize `LinkTokenMint`:
+	err = decoder.Decode(&obj.LinkTokenMint)
 	if err != nil {
 		return err
 	}

--- a/chains/solana/gobindings/ccip_router/types.go
+++ b/chains/solana/gobindings/ccip_router/types.go
@@ -1977,6 +1977,8 @@ const (
 	InsufficientFunds_CcipRouterError
 	UnsupportedToken_CcipRouterError
 	InvalidInputsMissingTokenConfig_CcipRouterError
+	MessageFeeTooHigh_CcipRouterError
+	SourceTokenDataTooLarge_CcipRouterError
 )
 
 func (value CcipRouterError) String() string {
@@ -2055,6 +2057,10 @@ func (value CcipRouterError) String() string {
 		return "UnsupportedToken"
 	case InvalidInputsMissingTokenConfig_CcipRouterError:
 		return "InvalidInputsMissingTokenConfig"
+	case MessageFeeTooHigh_CcipRouterError:
+		return "MessageFeeTooHigh"
+	case SourceTokenDataTooLarge_CcipRouterError:
+		return "SourceTokenDataTooLarge"
 	default:
 		return ""
 	}


### PR DESCRIPTION
~Requesting this as a draft for now, before I get started on the unit tests, as I want to run some of the decisions by the team before investing time on them.~ Ready for review now.

From what I can tell, this effectively ports the behaviour present in `processMessageArgs`. However, I've organized it in a significantly different way, because I felt like `processMessageArgs` was quite coupled to EVM tradeoffs and architecture, and it didn't quite make sense to port 1:1 as a function. Namely:

* `processMessageArgs` first performs some fee validation (ensuring a maximum fee in LINK). This appears misplaced and I have made it part of `ccip_send` instead. I suspect this validation is done here in EVM simply because of processMessageArgs being visible from outside the contract, but won't be necessary with the monolithic Solana approach. Doing this required expanding the configuration (and ccip_send context) with the LINK mint address.
* `processMessageArgs` then performs some parsing/processing of byte args. This also doesn't seem necessary in Solana as the client is calling the `ccip_send` instruction using structured data where the extra args are already in `Solana2AnyMessage`, so I've simple excluded this part (ironically, since it's the only behaviour that matches the function's name).
* In the end, `processMessageArgs` performs some validation on the lock/burn output data to construct the dest chain token transfers. Part of this work was already done, but I've ported over remaining checks on data length and on gas overhead values. However, I did *not* port validation over the dest family chain, as this is done before during `get_fee`.
