### PR TITLE
Prevent exec observation early errors [CCIP-4801]

### DIFF
--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -31,7 +31,7 @@ jobs:
             name: "Fee Boosting Test"
           - cmd: cd integration-tests/smoke/ccip && go test ccip_batching_test.go -timeout 12m -test.parallel=2 -count=1 -json
             name: "Batching Test"
-          - cmd: cd integration-tests/contracts && go test ccipreader_test.go -timeout 5m -test.parallel=1 -count=1 -json
+          - cmd: cd integration-tests/smoke/ccip && go test ccip_reader_test.go -timeout 5m -test.parallel=1 -count=1 -json
             name: "CCIPReader Test"
     
     name: Integration Tests (${{ matrix.type.name }})

--- a/execute/costlymessages/costly_messages.go
+++ b/execute/costlymessages/costly_messages.go
@@ -471,4 +471,15 @@ func calculateMessageMaxDAGas(
 	return dataGas
 }
 
+type NoopObserver struct{}
+
+func (n *NoopObserver) Observe(
+	_ context.Context,
+	_ []cciptypes.Message,
+	_ map[cciptypes.Bytes32]time.Time,
+) ([]cciptypes.Bytes32, error) {
+	costlyMessages := make([]cciptypes.Bytes32, 0)
+	return costlyMessages, nil
+}
+
 var _ MessageExecCostUSD18Calculator = &CCIPMessageExecCostUSD18Calculator{}

--- a/execute/observation.go
+++ b/execute/observation.go
@@ -250,7 +250,7 @@ func (p *Plugin) getMessagesObservation(
 
 	costlyMessages, err := p.costlyMessageObserver.Observe(ctx, messageObs.Flatten(), messageTimestamps)
 	if err != nil {
-		p.lggr.Errorw("unable to observe costly messages", "err", err)
+		return exectypes.Observation{}, fmt.Errorf("unable to observe costly messages: %w", err)
 	}
 
 	hashes, err := exectypes.GetHashes(ctx, messageObs, p.msgHasher)

--- a/execute/observation.go
+++ b/execute/observation.go
@@ -173,7 +173,9 @@ func regroup(commitData []exectypes.CommitData) exectypes.CommitObservations {
 
 // intersectCommitReportsAndMessages filters out commit reports that have no messages or have missing messages.
 // as all messages for each report are required to be present in the observation, otherwise merkle proofs will fail.
-func intersectCommitReportsAndMessages(msgObs exectypes.MessageObservations, commitObs exectypes.CommitObservations) (exectypes.MessageObservations, exectypes.CommitObservations) {
+func intersectCommitReportsAndMessages(msgObs exectypes.MessageObservations,
+	commitObs exectypes.CommitObservations,
+) (exectypes.MessageObservations, exectypes.CommitObservations) {
 	filteredCommitReports := make(exectypes.CommitObservations)
 	filteredMsgs := msgObs
 	for srcChain, reports := range commitObs {

--- a/execute/observation.go
+++ b/execute/observation.go
@@ -247,9 +247,11 @@ func (p *Plugin) getMessagesObservation(
 
 	tkData, err1 := p.tokenDataObserver.Observe(ctx, messageObs)
 	if err1 != nil {
-		p.lggr.Errorw("unable to complete token data processing", "err", err1)
+		return exectypes.Observation{}, fmt.Errorf("unable to process token data %w", err1)
 	}
 
+	// validating before continuing with heavy operations afterwards like truncation and costly messages
+	// all messages should have a token data observation even if it's empty
 	if validateTokenDataObservations(messageObs, tkData) != nil {
 		return exectypes.Observation{}, fmt.Errorf("invalid token data observations")
 	}

--- a/execute/observation_test.go
+++ b/execute/observation_test.go
@@ -232,9 +232,9 @@ func Test_readAllMessages(t *testing.T) {
 				},
 			},
 			expectedTimestamps: map[cciptypes.Bytes32]time.Time{
-				cciptypes.Bytes32{0x01}: timestamp,
-				cciptypes.Bytes32{0x02}: timestamp,
-				cciptypes.Bytes32{0x03}: timestamp,
+				{0x01}: timestamp,
+				{0x02}: timestamp,
+				{0x03}: timestamp,
 			},
 			expectedError: false,
 		},

--- a/execute/observation_test.go
+++ b/execute/observation_test.go
@@ -1,19 +1,26 @@
 package execute
 
 import (
-	"testing"
-
+	"context"
+	"github.com/smartcontractkit/chainlink-ccip/execute/costlymessages"
 	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
+	"github.com/smartcontractkit/chainlink-ccip/execute/optimizers"
+	"github.com/smartcontractkit/chainlink-ccip/execute/tokendata"
+	"github.com/smartcontractkit/chainlink-ccip/internal/mocks"
+	readerpkg_mock "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/reader"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 func Test_filterCommitReports(t *testing.T) {
 	tests := []struct {
-		name      string
-		msgObs    exectypes.MessageObservations
-		commitObs exectypes.CommitObservations
-		want      exectypes.CommitObservations
+		name       string
+		msgObs     exectypes.MessageObservations
+		commitObs  exectypes.CommitObservations
+		want       exectypes.CommitObservations
+		wantedMsgs exectypes.MessageObservations
 	}{
 		{
 			name:   "no messages",
@@ -26,7 +33,8 @@ func Test_filterCommitReports(t *testing.T) {
 					},
 				},
 			},
-			want: exectypes.CommitObservations{},
+			want:       exectypes.CommitObservations{},
+			wantedMsgs: exectypes.MessageObservations{},
 		},
 		{
 			name: "missing messages",
@@ -44,7 +52,8 @@ func Test_filterCommitReports(t *testing.T) {
 					},
 				},
 			},
-			want: exectypes.CommitObservations{},
+			want:       exectypes.CommitObservations{},
+			wantedMsgs: exectypes.MessageObservations{},
 		},
 		{
 			name: "valid messages",
@@ -71,6 +80,13 @@ func Test_filterCommitReports(t *testing.T) {
 					},
 				},
 			},
+			wantedMsgs: exectypes.MessageObservations{
+				1: {
+					1: cciptypes.Message{},
+					2: cciptypes.Message{},
+					3: cciptypes.Message{},
+				},
+			},
 		},
 		{
 			name: "mixed valid and invalid messages",
@@ -79,6 +95,7 @@ func Test_filterCommitReports(t *testing.T) {
 					1: cciptypes.Message{},
 					2: cciptypes.Message{},
 					3: cciptypes.Message{},
+					4: cciptypes.Message{},
 				},
 			},
 			commitObs: exectypes.CommitObservations{
@@ -101,13 +118,163 @@ func Test_filterCommitReports(t *testing.T) {
 					},
 				},
 			},
+			wantedMsgs: exectypes.MessageObservations{
+				1: {
+					1: cciptypes.Message{},
+					2: cciptypes.Message{},
+					3: cciptypes.Message{},
+				},
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := filterCommitReports(tt.msgObs, tt.commitObs)
-			assert.Equal(t, tt.want, got)
+			_, got := intersectCommitReportsAndMessages(tt.msgObs, tt.commitObs)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_getMessagesObservation(t *testing.T) {
+	ctx := context.Background()
+
+	// Create mock objects
+	ccipReader := readerpkg_mock.NewMockCCIPReader(t)
+	msgHasher := mocks.NewMessageHasher()
+	tokenDataObserver := tokendata.NoopTokenDataObserver{}
+	costlyMessageObserver := costlymessages.NoopObserver{}
+	observationOptimizer := optimizers.NewObservationOptimizer(maxObservationLength)
+
+	//emptyMsgHash, err := msgHasher.Hash(ctx, cciptypes.Message{})
+	//require.NoError(t, err)
+	// Set up the plugin with mock objects
+	plugin := &Plugin{
+		lggr:                  mocks.NullLogger,
+		ccipReader:            ccipReader,
+		msgHasher:             msgHasher,
+		tokenDataObserver:     &tokenDataObserver,
+		costlyMessageObserver: &costlyMessageObserver,
+		observationOptimizer:  observationOptimizer,
+	}
+
+	tests := []struct {
+		name            string
+		previousOutcome exectypes.Outcome
+		expectedObs     exectypes.Observation
+		expectedError   bool
+	}{
+		{
+			name: "no commit reports",
+			previousOutcome: exectypes.Outcome{
+				CommitReports: []exectypes.CommitData{},
+			},
+			expectedObs:   exectypes.Observation{},
+			expectedError: false,
+		},
+		{
+			name: "valid commit reports",
+			previousOutcome: exectypes.Outcome{
+				CommitReports: []exectypes.CommitData{
+					{
+						SourceChain:         1,
+						SequenceNumberRange: cciptypes.NewSeqNumRange(1, 3),
+					},
+				},
+			},
+			expectedObs: exectypes.Observation{
+				CommitReports: exectypes.CommitObservations{
+					1: []exectypes.CommitData{
+						{
+							SourceChain:         1,
+							SequenceNumberRange: cciptypes.NewSeqNumRange(1, 3),
+						},
+					},
+				},
+				Messages: exectypes.MessageObservations{
+					1: {
+						1: cciptypes.Message{Header: cciptypes.RampMessageHeader{SequenceNumber: 1}},
+						2: cciptypes.Message{Header: cciptypes.RampMessageHeader{SequenceNumber: 2}},
+						3: cciptypes.Message{Header: cciptypes.RampMessageHeader{SequenceNumber: 3}},
+					},
+				},
+				CostlyMessages: []cciptypes.Bytes32{},
+				TokenData: exectypes.TokenDataObservations{
+					1: {
+						1: exectypes.NewMessageTokenData(),
+						2: exectypes.NewMessageTokenData(),
+						3: exectypes.NewMessageTokenData(),
+					},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "multiple commit reports with one missing messages",
+			previousOutcome: exectypes.Outcome{
+				CommitReports: []exectypes.CommitData{
+					{
+						SourceChain:         1,
+						SequenceNumberRange: cciptypes.NewSeqNumRange(1, 3),
+					},
+					{
+						SourceChain:         1,
+						SequenceNumberRange: cciptypes.NewSeqNumRange(6, 10),
+					},
+				},
+			},
+			expectedObs: exectypes.Observation{
+				CommitReports: exectypes.CommitObservations{
+					1: []exectypes.CommitData{
+						{
+							SourceChain:         1,
+							SequenceNumberRange: cciptypes.NewSeqNumRange(1, 3),
+						},
+					},
+				},
+				Messages: exectypes.MessageObservations{
+					1: {
+						1: cciptypes.Message{Header: cciptypes.RampMessageHeader{SequenceNumber: 1}},
+						2: cciptypes.Message{Header: cciptypes.RampMessageHeader{SequenceNumber: 2}},
+						3: cciptypes.Message{Header: cciptypes.RampMessageHeader{SequenceNumber: 3}},
+					},
+				},
+				CostlyMessages: []cciptypes.Bytes32{},
+				TokenData: exectypes.TokenDataObservations{
+					1: {
+						1: exectypes.NewMessageTokenData(),
+						2: exectypes.NewMessageTokenData(),
+						3: exectypes.NewMessageTokenData(),
+					},
+				},
+			},
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up mock expectations
+			ccipReader.On("MsgsBetweenSeqNums", ctx, cciptypes.ChainSelector(1), cciptypes.NewSeqNumRange(1, 3)).Return([]cciptypes.Message{
+				{Header: cciptypes.RampMessageHeader{SequenceNumber: 1}},
+				{Header: cciptypes.RampMessageHeader{SequenceNumber: 2}},
+				{Header: cciptypes.RampMessageHeader{SequenceNumber: 3}},
+			}, nil).Maybe()
+
+			// missing message 5 and 6
+			ccipReader.On("MsgsBetweenSeqNums", ctx, cciptypes.ChainSelector(1), cciptypes.NewSeqNumRange(6, 10)).Return([]cciptypes.Message{
+				{Header: cciptypes.RampMessageHeader{SequenceNumber: 6}},
+			}, nil).Maybe()
+
+			observation := exectypes.Observation{}
+			observation, err := plugin.getMessagesObservation(ctx, tt.previousOutcome, observation)
+			if tt.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				observation.Hashes = nil
+				assert.Equal(t, tt.expectedObs, observation)
+			}
 		})
 	}
 }

--- a/execute/observation_test.go
+++ b/execute/observation_test.go
@@ -1,0 +1,113 @@
+package execute
+
+import (
+	"testing"
+
+	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
+	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_filterCommitReports(t *testing.T) {
+	tests := []struct {
+		name      string
+		msgObs    exectypes.MessageObservations
+		commitObs exectypes.CommitObservations
+		want      exectypes.CommitObservations
+	}{
+		{
+			name:   "no messages",
+			msgObs: exectypes.MessageObservations{},
+			commitObs: exectypes.CommitObservations{
+				1: []exectypes.CommitData{
+					{
+						SourceChain:         1,
+						SequenceNumberRange: cciptypes.NewSeqNumRange(1, 10),
+					},
+				},
+			},
+			want: exectypes.CommitObservations{},
+		},
+		{
+			name: "missing messages",
+			msgObs: exectypes.MessageObservations{
+				1: {
+					1: cciptypes.Message{},
+					2: cciptypes.Message{},
+				},
+			},
+			commitObs: exectypes.CommitObservations{
+				1: []exectypes.CommitData{
+					{
+						SourceChain:         1,
+						SequenceNumberRange: cciptypes.NewSeqNumRange(1, 3),
+					},
+				},
+			},
+			want: exectypes.CommitObservations{},
+		},
+		{
+			name: "valid messages",
+			msgObs: exectypes.MessageObservations{
+				1: {
+					1: cciptypes.Message{},
+					2: cciptypes.Message{},
+					3: cciptypes.Message{},
+				},
+			},
+			commitObs: exectypes.CommitObservations{
+				1: []exectypes.CommitData{
+					{
+						SourceChain:         1,
+						SequenceNumberRange: cciptypes.NewSeqNumRange(1, 3),
+					},
+				},
+			},
+			want: exectypes.CommitObservations{
+				1: []exectypes.CommitData{
+					{
+						SourceChain:         1,
+						SequenceNumberRange: cciptypes.NewSeqNumRange(1, 3),
+					},
+				},
+			},
+		},
+		{
+			name: "mixed valid and invalid messages",
+			msgObs: exectypes.MessageObservations{
+				1: {
+					1: cciptypes.Message{},
+					2: cciptypes.Message{},
+					3: cciptypes.Message{},
+				},
+			},
+			commitObs: exectypes.CommitObservations{
+				1: []exectypes.CommitData{
+					{
+						SourceChain:         1,
+						SequenceNumberRange: cciptypes.NewSeqNumRange(1, 3),
+					},
+					{
+						SourceChain:         1,
+						SequenceNumberRange: cciptypes.NewSeqNumRange(4, 5),
+					},
+				},
+			},
+			want: exectypes.CommitObservations{
+				1: []exectypes.CommitData{
+					{
+						SourceChain:         1,
+						SequenceNumberRange: cciptypes.NewSeqNumRange(1, 3),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterCommitReports(tt.msgObs, tt.commitObs)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/execute/observation_test.go
+++ b/execute/observation_test.go
@@ -2,6 +2,11 @@ package execute
 
 import (
 	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/smartcontractkit/chainlink-ccip/execute/costlymessages"
 	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
 	"github.com/smartcontractkit/chainlink-ccip/execute/optimizers"
@@ -9,9 +14,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/internal/mocks"
 	readerpkg_mock "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/reader"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func Test_filterCommitReports(t *testing.T) {
@@ -255,14 +257,16 @@ func Test_getMessagesObservation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Set up mock expectations
-			ccipReader.On("MsgsBetweenSeqNums", ctx, cciptypes.ChainSelector(1), cciptypes.NewSeqNumRange(1, 3)).Return([]cciptypes.Message{
+			ccipReader.On("MsgsBetweenSeqNums", ctx, cciptypes.ChainSelector(1),
+				cciptypes.NewSeqNumRange(1, 3)).Return([]cciptypes.Message{
 				{Header: cciptypes.RampMessageHeader{SequenceNumber: 1}},
 				{Header: cciptypes.RampMessageHeader{SequenceNumber: 2}},
 				{Header: cciptypes.RampMessageHeader{SequenceNumber: 3}},
 			}, nil).Maybe()
 
 			// missing message 5 and 6
-			ccipReader.On("MsgsBetweenSeqNums", ctx, cciptypes.ChainSelector(1), cciptypes.NewSeqNumRange(6, 10)).Return([]cciptypes.Message{
+			ccipReader.On("MsgsBetweenSeqNums", ctx, cciptypes.ChainSelector(1),
+				cciptypes.NewSeqNumRange(6, 10)).Return([]cciptypes.Message{
 				{Header: cciptypes.RampMessageHeader{SequenceNumber: 6}},
 			}, nil).Maybe()
 

--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -251,7 +251,9 @@ func selectReport(
 		// The builder may attach metadata to the commit report.
 		commitReports[i], err = builder.Add(ctx, commitReport)
 		if err != nil {
-			return nil, nil, fmt.Errorf("unable to add report to builder: %w", err)
+			pendingReports++
+			lggr.Errorw("unable to add report to builder", "err", err)
+			continue
 		}
 
 		selectedReports = append(selectedReports, commitReports[i])

--- a/execute/plugin_functions.go
+++ b/execute/plugin_functions.go
@@ -599,13 +599,13 @@ func getConsensusObservation(
 func getMessageTimestampMap(
 	commitReportCache map[cciptypes.ChainSelector][]exectypes.CommitData,
 	messages exectypes.MessageObservations,
-) (map[cciptypes.Bytes32]time.Time, error) {
+) map[cciptypes.Bytes32]time.Time {
 	messageTimestamps := make(map[cciptypes.Bytes32]time.Time)
 
 	for chainSel, SeqNumToMsg := range messages {
 		commitData, ok := commitReportCache[chainSel]
 		if !ok {
-			return nil, fmt.Errorf("missing commit data for chain %s", chainSel)
+			continue
 		}
 
 		for seqNum, msg := range SeqNumToMsg {
@@ -617,5 +617,5 @@ func getMessageTimestampMap(
 		}
 	}
 
-	return messageTimestamps, nil
+	return messageTimestamps
 }

--- a/execute/plugin_functions.go
+++ b/execute/plugin_functions.go
@@ -3,8 +3,9 @@ package execute
 import (
 	"errors"
 	"fmt"
-	mapset "github.com/deckarep/golang-set/v2"
 	"sort"
+
+	mapset "github.com/deckarep/golang-set/v2"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 

--- a/execute/plugin_functions.go
+++ b/execute/plugin_functions.go
@@ -3,10 +3,8 @@ package execute
 import (
 	"errors"
 	"fmt"
-	"sort"
-	"time"
-
 	mapset "github.com/deckarep/golang-set/v2"
+	"sort"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
@@ -590,30 +588,4 @@ func getConsensusObservation(
 	)
 
 	return observation, nil
-}
-
-// getMessageTimestampMap returns a map of message IDs to their timestamps.
-// cciptypes.Message does not contain a timestamp, so we need to derive the timestamp from the commit data.
-func getMessageTimestampMap(
-	commitReportCache map[cciptypes.ChainSelector][]exectypes.CommitData,
-	messages exectypes.MessageObservations,
-) map[cciptypes.Bytes32]time.Time {
-	messageTimestamps := make(map[cciptypes.Bytes32]time.Time)
-
-	for chainSel, SeqNumToMsg := range messages {
-		commitData, ok := commitReportCache[chainSel]
-		if !ok {
-			continue
-		}
-
-		for seqNum, msg := range SeqNumToMsg {
-			for _, commit := range commitData {
-				if commit.SequenceNumberRange.Contains(seqNum) {
-					messageTimestamps[msg.Header.MessageID] = commit.Timestamp
-				}
-			}
-		}
-	}
-
-	return messageTimestamps
 }

--- a/execute/plugin_functions_test.go
+++ b/execute/plugin_functions_test.go
@@ -2,11 +2,9 @@ package execute
 
 import (
 	"fmt"
-	"testing"
-	"time"
-
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/stretchr/testify/assert"
+	"testing"
 
 	"github.com/smartcontractkit/libocr/commontypes"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
@@ -1233,80 +1231,6 @@ func Test_mergeCostlyMessages(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := mergeCostlyMessages(tt.aos, tt.fChainDest)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func Test_getMessageTimestampMap(t *testing.T) {
-	tests := []struct {
-		name              string
-		commitReportCache map[cciptypes.ChainSelector][]exectypes.CommitData
-		obs               exectypes.MessageObservations
-		want              map[cciptypes.Bytes32]time.Time
-		wantErr           assert.ErrorAssertionFunc
-	}{
-		{
-			name:              "empty",
-			commitReportCache: map[cciptypes.ChainSelector][]exectypes.CommitData{},
-			obs:               exectypes.MessageObservations{},
-			want:              map[cciptypes.Bytes32]time.Time{},
-			wantErr:           assert.NoError,
-		},
-		{
-			name:              "missing commit data for a chain",
-			commitReportCache: map[cciptypes.ChainSelector][]exectypes.CommitData{},
-			obs: exectypes.MessageObservations{
-				1: {
-					1: {
-						Header: cciptypes.RampMessageHeader{
-							MessageID: cciptypes.Bytes32{0x01},
-						},
-					},
-				},
-			},
-			want:    map[cciptypes.Bytes32]time.Time{},
-			wantErr: assert.NoError,
-		},
-		{
-			name: "happy path",
-			commitReportCache: map[cciptypes.ChainSelector][]exectypes.CommitData{
-				1: {
-					{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(1, 10),
-						Timestamp:           time.Unix(1, 0),
-					},
-					{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(15, 25),
-						Timestamp:           time.Unix(2, 0),
-					},
-				},
-			},
-			obs: exectypes.MessageObservations{
-				1: {
-					1: {
-						Header: cciptypes.RampMessageHeader{
-							MessageID: cciptypes.Bytes32{0x01},
-						},
-					},
-					16: {
-						Header: cciptypes.RampMessageHeader{
-							MessageID: cciptypes.Bytes32{0x04},
-						},
-					},
-				},
-			},
-			want: map[cciptypes.Bytes32]time.Time{
-				{0x01}: time.Unix(1, 0),
-				{0x04}: time.Unix(2, 0),
-			},
-			wantErr: assert.NoError,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := getMessageTimestampMap(tt.commitReportCache, tt.obs)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/execute/plugin_functions_test.go
+++ b/execute/plugin_functions_test.go
@@ -2,9 +2,10 @@ package execute
 
 import (
 	"fmt"
+	"testing"
+
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/stretchr/testify/assert"
-	"testing"
 
 	"github.com/smartcontractkit/libocr/commontypes"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"

--- a/execute/plugin_functions_test.go
+++ b/execute/plugin_functions_test.go
@@ -1268,8 +1268,8 @@ func Test_getMessageTimestampMap(t *testing.T) {
 					},
 				},
 			},
-			want:    nil,
-			wantErr: assert.Error,
+			want:    map[cciptypes.Bytes32]time.Time{},
+			wantErr: assert.NoError,
 		},
 		{
 			name: "happy path",
@@ -1309,10 +1309,7 @@ func Test_getMessageTimestampMap(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getMessageTimestampMap(tt.commitReportCache, tt.obs)
-			if !tt.wantErr(t, err, "getMessageTimestampMap(...)") {
-				return
-			}
+			got := getMessageTimestampMap(tt.commitReportCache, tt.obs)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/execute/tokendata/observer.go
+++ b/execute/tokendata/observer.go
@@ -146,7 +146,8 @@ func (c *compositeTokenDataObserver) Observe(
 		}
 		tokenDataObservations, err = merge(tokenDataObservations, tokenData)
 		if err != nil {
-			return nil, err
+			c.lggr.Error("Error while merging token data",
+				"error", err)
 		}
 	}
 	return tokenDataObservations, nil
@@ -203,6 +204,8 @@ func (c *compositeTokenDataObserver) initTokenDataObservations(
 	return tokenObservation
 }
 
+// merge merges token data from two observations, it's used to combine token data from multiple observers.
+// In case of token data mismatch, it returns an error and the base observation.
 func merge(
 	base exectypes.TokenDataObservations,
 	from exectypes.TokenDataObservations,
@@ -210,7 +213,7 @@ func merge(
 	for chainSelector, chainObservations := range from {
 		for seq, messageTokenData := range chainObservations {
 			if len(messageTokenData.TokenData) != len(base[chainSelector][seq].TokenData) {
-				return nil, errors.New("token data length mismatch")
+				return base, errors.New("token data length mismatch")
 			}
 
 			// Merge only TokenData created by the observer


### PR DESCRIPTION
Allow observation to continue even when having errors fetching some messages or commit reports.

For token data we don't fail on merge errors, keep in mind that we currently have only usdc token data observer only anyways so hitting this error is unlikely in the near future.