### PR TITLE
[CCIP-4827] Allow intermittent errors while merging during exec outcome phase. Skip failed ones and continue processing the rest.

### DIFF
--- a/execute/outcome.go
+++ b/execute/outcome.go
@@ -34,7 +34,10 @@ func (p *Plugin) Outcome(
 		return nil, fmt.Errorf("unable to decode previous outcome: %w", err)
 	}
 
-	decodedAos := decodeAttributedObservations(p.lggr, aos)
+	decodedAos, err := decodeAttributedObservations(aos)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode observations: %w", err)
+	}
 
 	// discovery processor disabled by setting it to nil.
 	if p.discovery != nil {

--- a/execute/outcome.go
+++ b/execute/outcome.go
@@ -34,10 +34,7 @@ func (p *Plugin) Outcome(
 		return nil, fmt.Errorf("unable to decode previous outcome: %w", err)
 	}
 
-	decodedAos, err := decodeAttributedObservations(aos)
-	if err != nil {
-		return nil, fmt.Errorf("unable to decode observations: %w", err)
-	}
+	decodedAos := decodeAttributedObservations(p.lggr, aos)
 
 	// discovery processor disabled by setting it to nil.
 	if p.discovery != nil {
@@ -60,6 +57,10 @@ func (p *Plugin) Outcome(
 	fChain, err := p.homeChain.GetFChain()
 	if err != nil {
 		return ocr3types.Outcome{}, fmt.Errorf("unable to get FChain: %w", err)
+	}
+	_, ok := fChain[p.destChain] // check if the destination chain is in the FChain.
+	if !ok {
+		return ocr3types.Outcome{}, fmt.Errorf("destination chain %d is not in FChain", p.destChain)
 	}
 
 	observation, err := getConsensusObservation(p.lggr, decodedAos, p.destChain, p.reportingCfg.F, fChain)

--- a/execute/outcome.go
+++ b/execute/outcome.go
@@ -22,6 +22,8 @@ import (
 
 // Outcome collects the reports from the two phases and constructs the final outcome. Part of the outcome is a fully
 // formed report that will be encoded for final transmission in the reporting phase.
+//
+//nolint:gocyclo
 func (p *Plugin) Outcome(
 	ctx context.Context, outctx ocr3types.OutcomeContext, query types.Query, aos []types.AttributedObservation,
 ) (ocr3types.Outcome, error) {

--- a/execute/plugin_functions.go
+++ b/execute/plugin_functions.go
@@ -244,28 +244,20 @@ func filterOutExecutedMessages(
 }
 
 func decodeAttributedObservations(
-	lggr logger.Logger,
 	aos []types.AttributedObservation,
-) []plugincommon.AttributedObservation[exectypes.Observation] {
-	decoded := make([]plugincommon.AttributedObservation[exectypes.Observation], 0)
-	for _, ao := range aos {
+) ([]plugincommon.AttributedObservation[exectypes.Observation], error) {
+	decoded := make([]plugincommon.AttributedObservation[exectypes.Observation], len(aos))
+	for i, ao := range aos {
 		observation, err := exectypes.DecodeObservation(ao.Observation)
-
 		if err != nil {
-			lggr.Errorw("failed to decode observation",
-				"observer", ao.Observer,
-				"error", err,
-			)
-			continue
+			return nil, err
 		}
-		decoded = append(decoded,
-			plugincommon.AttributedObservation[exectypes.Observation]{
-				Observation: observation,
-				OracleID:    ao.Observer,
-			},
-		)
+		decoded[i] = plugincommon.AttributedObservation[exectypes.Observation]{
+			Observation: observation,
+			OracleID:    ao.Observer,
+		}
 	}
-	return decoded
+	return decoded, nil
 }
 
 func mergeMessageObservations(

--- a/execute/plugin_functions_test.go
+++ b/execute/plugin_functions_test.go
@@ -616,13 +616,16 @@ func Test_decodeAttributedObservations(t *testing.T) {
 					Observation: []byte("invalid"),
 				},
 			},
-			want:    []plugincommon.AttributedObservation[exectypes.Observation]{},
-			wantErr: assert.NoError,
+			want:    nil,
+			wantErr: assert.Error,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := decodeAttributedObservations(logger.Test(t), tt.args)
+			got, err := decodeAttributedObservations(tt.args)
+			if !tt.wantErr(t, err, fmt.Sprintf("decodeAttributedObservations(%v)", tt.args)) {
+				return
+			}
 			assert.Equalf(t, tt.want, got, "decodeAttributedObservations(%v)", tt.args)
 		})
 	}

--- a/execute/plugin_functions_test.go
+++ b/execute/plugin_functions_test.go
@@ -6,8 +6,6 @@ import (
 	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
-	"github.com/stretchr/testify/require"
-
 	"github.com/stretchr/testify/assert"
 
 	"github.com/smartcontractkit/libocr/commontypes"
@@ -1147,8 +1145,7 @@ func Test_mergeTokenDataObservation(t *testing.T) {
 				})
 			}
 
-			obs, err := mergeTokenObservations(ao, fChain)
-			require.NoError(t, err)
+			obs := mergeTokenObservations(logger.Test(t), ao, fChain)
 
 			for seqNum, exp := range tc.expected {
 				mtd, ok := obs[chainSelector][seqNum]

--- a/execute/plugin_functions_test.go
+++ b/execute/plugin_functions_test.go
@@ -618,16 +618,13 @@ func Test_decodeAttributedObservations(t *testing.T) {
 					Observation: []byte("invalid"),
 				},
 			},
-			want:    nil,
-			wantErr: assert.Error,
+			want:    []plugincommon.AttributedObservation[exectypes.Observation]{},
+			wantErr: assert.NoError,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := decodeAttributedObservations(tt.args)
-			if !tt.wantErr(t, err, fmt.Sprintf("decodeAttributedObservations(%v)", tt.args)) {
-				return
-			}
+			got := decodeAttributedObservations(logger.Test(t), tt.args)
 			assert.Equalf(t, tt.want, got, "decodeAttributedObservations(%v)", tt.args)
 		})
 	}

--- a/execute/plugin_test.go
+++ b/execute/plugin_test.go
@@ -330,26 +330,18 @@ func TestPlugin_Outcome_DestFChainNotAvailable(t *testing.T) {
 
 func TestPlugin_Outcome_BadObservationEncoding(t *testing.T) {
 	ctx := tests.Context(t)
-	mockHomeChain := reader_mock.NewMockHomeChain(t)
-	expectedFChain := map[cciptypes.ChainSelector]int{
-		0: 1,
-		2: 2,
-	}
-	mockHomeChain.EXPECT().GetFChain().Return(expectedFChain, nil)
-
 	p := &Plugin{
-		lggr:      logger.Test(t),
-		homeChain: mockHomeChain,
+		lggr: logger.Test(t),
 	}
-	outcome, err := p.Outcome(ctx, ocr3types.OutcomeContext{}, nil,
+	_, err := p.Outcome(ctx, ocr3types.OutcomeContext{}, nil,
 		[]types.AttributedObservation{
 			{
 				Observation: []byte("not a valid observation"),
 				Observer:    0,
 			},
 		})
-	require.NoError(t, err)
-	require.Len(t, outcome, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unable to decode observations: invalid character")
 }
 
 func TestPlugin_Outcome_BelowF(t *testing.T) {


### PR DESCRIPTION
Allow intermittent errors while merging during exec outcome phase. Skip failed ones and continue processing the rest.

We want the plugin to be available and resilient enough that if something is missing for one chain it won't affect all other chains. Same if one observer's observation had issues, we don't need to stop other observations from being processed.