### PR TITLE
pkg/reader: add more ctx to error msgs

### DIFF
--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -1345,8 +1345,10 @@ func (r *ccipChainReader) getOnRampDestChainConfig(
 				&resp,
 			)
 			if err != nil {
-				return fmt.Errorf("get onramp dest chain config, source chain: %d, dest chain: %d: %w",
-					chainSel, r.destChain, err)
+				return fmt.Errorf(
+					"get onramp dest chain config, source chain: %d: %w",
+					chainSel, err,
+				)
 			}
 			mu.Lock()
 			result[chainSel] = resp

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -396,7 +396,8 @@ func (r *ccipChainReader) GetExpectedNextSequenceNumber(
 		&expectedNextSequenceNumber,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("failed to get expected next sequence number from onramp: %w", err)
+		return 0, fmt.Errorf("failed to get expected next sequence number from onramp, source chain: %d, dest chain: %d: %w",
+			sourceChainSelector, destChainSelector, err)
 	}
 
 	return cciptypes.SeqNum(expectedNextSequenceNumber), nil
@@ -571,7 +572,6 @@ func (r *ccipChainReader) GetWrappedNativeTokenPriceUSD(
 			primitives.Unconfirmed,
 			nil,
 			&nativeTokenAddress)
-
 		if err != nil {
 			r.lggr.Warnw("failed to get native token address", "chain", chain, "err", err)
 			continue
@@ -1035,7 +1035,6 @@ func (r *ccipChainReader) getFeeQuoterTokenPriceUSD(ctx context.Context, tokenAd
 		},
 		&timestampedPrice,
 	)
-
 	if err != nil {
 		return cciptypes.BigInt{}, fmt.Errorf("failed to get token price, addr: %v, err: %w", tokenAddr, err)
 	}
@@ -1110,7 +1109,8 @@ func (r *ccipChainReader) getOffRampSourceChainsConfig(
 				&resp,
 			)
 			if err != nil {
-				return fmt.Errorf("failed to get source chain config: %w", err)
+				return fmt.Errorf("failed to get source chain config for source chain %d: %w",
+					chainSel, err)
 			}
 
 			enabled, err := resp.check()
@@ -1163,7 +1163,8 @@ func (r *ccipChainReader) getAllOffRampSourceChainsConfig(
 		&resp,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get source chain configs: %w", err)
+		return nil, fmt.Errorf("failed to get source chain configs for source chain %d: %w",
+			chain, err)
 	}
 
 	if len(resp.SourceChainConfigs) != len(resp.Selectors) {
@@ -1287,7 +1288,7 @@ func (r *ccipChainReader) getOnRampDynamicConfigs(
 				"chain", chainSel,
 				"resp", resp)
 			if err != nil {
-				return fmt.Errorf("failed to get onramp dynamic config: %w", err)
+				return fmt.Errorf("get onramp dynamic config for chain %d: %w", chainSel, err)
 			}
 			mu.Lock()
 			result[chainSel] = resp
@@ -1344,7 +1345,8 @@ func (r *ccipChainReader) getOnRampDestChainConfig(
 				&resp,
 			)
 			if err != nil {
-				return fmt.Errorf("failed to get onramp dest chain config: %w", err)
+				return fmt.Errorf("get onramp dest chain config, source chain: %d, dest chain: %d: %w",
+					chainSel, r.destChain, err)
 			}
 			mu.Lock()
 			result[chainSel] = resp
@@ -1434,7 +1436,7 @@ func (r *ccipChainReader) getFeeQuoterDestChainConfig(
 	)
 
 	if err != nil {
-		return cciptypes.FeeQuoterDestChainConfig{}, fmt.Errorf("failed to get dest chain config: %w", err)
+		return cciptypes.FeeQuoterDestChainConfig{}, fmt.Errorf("get dest chain config for source chain %d: %w", chainSelector, err)
 	}
 
 	return destChainConfig, nil
@@ -1482,6 +1484,7 @@ func (r *ccipChainReader) GetLatestPriceSeqNr(ctx context.Context) (uint64, erro
 	if err := validateExtendedReaderExistence(r.contractReaders, r.destChain); err != nil {
 		return 0, fmt.Errorf("validate dest=%d extended reader existence: %w", r.destChain, err)
 	}
+
 	var latestSeqNr uint64
 	err := r.contractReaders[r.destChain].ExtendedGetLatestValue(
 		ctx,
@@ -1491,7 +1494,6 @@ func (r *ccipChainReader) GetLatestPriceSeqNr(ctx context.Context) (uint64, erro
 		map[string]any{},
 		&latestSeqNr,
 	)
-
 	if err != nil {
 		return 0, fmt.Errorf("get latest price sequence number: %w", err)
 	}
@@ -1532,7 +1534,6 @@ func (r *ccipChainReader) GetOffRampConfigDigest(ctx context.Context, pluginType
 		},
 		&resp,
 	)
-
 	if err != nil {
 		return [32]byte{}, fmt.Errorf("get latest config digest: %w", err)
 	}

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -1436,7 +1436,9 @@ func (r *ccipChainReader) getFeeQuoterDestChainConfig(
 	)
 
 	if err != nil {
-		return cciptypes.FeeQuoterDestChainConfig{}, fmt.Errorf("get dest chain config for source chain %d: %w", chainSelector, err)
+		return cciptypes.FeeQuoterDestChainConfig{},
+			fmt.Errorf("get dest chain config for source chain %d: %w",
+				chainSelector, err)
 	}
 
 	return destChainConfig, nil


### PR DESCRIPTION
The error messages generated by the CCIP reader code are pretty opaque and hard to follow especially when multiple source chains are involved.

Add source/dest chain selectors to error messages where its otherwise ambiguous.