### PR TITLE
Prevent early errors for some ccipreader functions

### DIFF
--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -31,7 +31,7 @@ jobs:
             name: "Fee Boosting Test"
           - cmd: cd integration-tests/smoke/ccip && go test ccip_batching_test.go -timeout 12m -test.parallel=2 -count=1 -json
             name: "Batching Test"
-          - cmd: cd integration-tests/contracts && go test ccipreader_test.go -timeout 5m -test.parallel=1 -count=1 -json
+          - cmd: cd integration-tests/smoke/ccip && go test ccip_reader_test.go -timeout 5m -test.parallel=1 -count=1 -json
             name: "CCIPReader Test"
     
     name: Integration Tests (${{ matrix.type.name }})

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -1276,9 +1276,12 @@ func (r *ccipChainReader) getOnRampDynamicConfigs(
 			if err != nil {
 				if errors.Is(err, contractreader.ErrNoBindings) {
 					// ErrNoBindings is an allowable error.
-					r.lggr.Infow("unable to lookup source fee quoters (onRamp dynamic config), this is expected during initialization", "err", err)
+					r.lggr.Infow(
+						"unable to lookup source fee quoters (onRamp dynamic config), "+
+							"this is expected during initialization", "err", err)
 				} else {
-					r.lggr.Errorw("unable to lookup source fee quoters (onRamp dynamic config)", "chain", chainSel, "err", err)
+					r.lggr.Errorw("unable to lookup source fee quoters (onRamp dynamic config)",
+						"chain", chainSel, "err", err)
 				}
 				return
 			}
@@ -1338,9 +1341,11 @@ func (r *ccipChainReader) getOnRampDestChainConfig(
 			if err != nil {
 				if errors.Is(err, contractreader.ErrNoBindings) {
 					// ErrNoBindings is an allowable error.
-					r.lggr.Infow("unable to lookup source routers (onRamp dest chain config), this is expected during initialization", "chain", chainSel, "err", err)
+					r.lggr.Infow("unable to lookup source routers (onRamp dest chain config), "+
+						"this is expected during initialization", "chain", chainSel, "err", err)
 				} else {
-					r.lggr.Errorw("unable to lookup source routers (onRamp dest chain config)", "chain", chainSel, "err", err)
+					r.lggr.Errorw("unable to lookup source routers (onRamp dest chain config)",
+						"chain", chainSel, "err", err)
 				}
 				return
 			}

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -495,7 +495,8 @@ func (r *ccipChainReader) Nonces(
 
 			val, ok := returnVal.(*uint64)
 			if !ok || val == nil {
-				return nil, fmt.Errorf("invalid nonce value returned for address %s", address)
+				r.lggr.Errorw("invalid nonce value returned", "address", address)
+				continue
 			}
 
 			res[address] = *val
@@ -1244,16 +1245,16 @@ func (r *ccipChainReader) getOnRampDynamicConfigs(
 	srcChains []cciptypes.ChainSelector,
 ) map[cciptypes.ChainSelector]getOnRampDynamicConfigResponse {
 	result := make(map[cciptypes.ChainSelector]getOnRampDynamicConfigResponse)
-	if err := validateExtendedReaderExistence(r.contractReaders, srcChains...); err != nil {
-		r.lggr.Errorw("validate extended reader existence", "err", err)
-		return result
-	}
 
 	mu := new(sync.Mutex)
 	wg := new(sync.WaitGroup)
 	for _, chainSel := range srcChains {
 		// no onramp for the destination chain
 		if chainSel == r.destChain {
+			continue
+		}
+		if r.contractReaders[chainSel] == nil {
+			r.lggr.Errorw("contract reader not found", "chain", chainSel)
 			continue
 		}
 
@@ -1308,16 +1309,16 @@ func (r *ccipChainReader) getOnRampDestChainConfig(
 	srcChains []cciptypes.ChainSelector,
 ) map[cciptypes.ChainSelector]onRampDestChainConfig {
 	result := make(map[cciptypes.ChainSelector]onRampDestChainConfig)
-	if err := validateExtendedReaderExistence(r.contractReaders, srcChains...); err != nil {
-		r.lggr.Errorw("validate extended reader existence", "err", err)
-		return result
-	}
 
 	mu := new(sync.Mutex)
 	wg := new(sync.WaitGroup)
 	for _, chainSel := range srcChains {
 		// no onramp for the destination chain
 		if chainSel == r.destChain {
+			continue
+		}
+		if r.contractReaders[chainSel] == nil {
+			r.lggr.Errorw("contract reader not found", "chain", chainSel)
 			continue
 		}
 

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -1295,7 +1295,7 @@ func (r *ccipChainReader) getOnRampDynamicConfigs(
 				"resp", resp)
 			if err != nil {
 				if errors.Is(err, contractreader.ErrNoBindings) {
-					// ErrNoBindings is an allowable error.
+					// ErrNoBindings is an allowable error during initialization
 					lggr.Infow(
 						"unable to lookup source fee quoters (onRamp dynamic config), "+
 							"this is expected during initialization", "err", err)
@@ -1360,7 +1360,7 @@ func (r *ccipChainReader) getOnRampDestChainConfig(
 			)
 			if err != nil {
 				if errors.Is(err, contractreader.ErrNoBindings) {
-					// ErrNoBindings is an allowable error.
+					// ErrNoBindings is an allowable error during initialization
 					r.lggr.Infow("unable to lookup source routers (onRamp dest chain config), "+
 						"this is expected during initialization", "chain", chainSel, "err", err)
 				} else {

--- a/pkg/reader/ccip_test.go
+++ b/pkg/reader/ccip_test.go
@@ -515,7 +515,7 @@ func TestCCIPChainReader_DiscoverContracts_HappyPath_Round1(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, expectedContractAddresses, contractAddresses)
-	require.Equal(t, 3, hook.Len())
+	require.Equal(t, 5, hook.Len())
 
 	assert.Contains(
 		t,
@@ -524,13 +524,23 @@ func TestCCIPChainReader_DiscoverContracts_HappyPath_Round1(t *testing.T) {
 	)
 	assert.Contains(
 		t,
-		"unable to lookup source fee quoters, this is expected during initialization",
+		"unable to lookup source fee quoters (onRamp dynamic config), this is expected during initialization",
 		hook.All()[1].Message,
 	)
 	assert.Contains(
 		t,
-		"unable to lookup source routers, this is expected during initialization",
+		"unable to lookup source fee quoters (onRamp dynamic config), this is expected during initialization",
 		hook.All()[2].Message,
+	)
+	assert.Contains(
+		t,
+		"unable to lookup source routers (onRamp dest chain config), this is expected during initialization",
+		hook.All()[3].Message,
+	)
+	assert.Contains(
+		t,
+		"unable to lookup source routers (onRamp dest chain config), this is expected during initialization",
+		hook.All()[4].Message,
 	)
 }
 


### PR DESCRIPTION
Instead of using error groups while discovering contracts, use workgroup and log errors while continuing to check other contract addresses.