### PR TITLE
pkg/logutil: ctx-aware logging, add seq nr to all commit logs

### DIFF
--- a/commit/chainfee/outcome_test.go
+++ b/commit/chainfee/outcome_test.go
@@ -81,7 +81,7 @@ func TestGetConsensusObservation(t *testing.T) {
 	// 3 oracles, same observations, will pass destChain 2f+1 for chain selector 1
 	aos := sameObs(3, obsNeedUpdate)
 
-	consensusObs, err := p.getConsensusObservation(aos)
+	consensusObs, err := p.getConsensusObservation(lggr, aos)
 	require.NoError(t, err)
 	assert.Equal(t, fChains[1], consensusObs.FChain[1])
 	assert.Equal(t, fChains[2], consensusObs.FChain[2])
@@ -98,7 +98,7 @@ func TestGetConsensusObservation(t *testing.T) {
 	// 5 oracles, same observations, will pass destChain 2f+1 for both chain selectors
 	aos = sameObs(5, obsNeedUpdate)
 
-	consensusObs, err = p.getConsensusObservation(aos)
+	consensusObs, err = p.getConsensusObservation(lggr, aos)
 	require.NoError(t, err)
 	assert.Equal(t, fChains[1], consensusObs.FChain[1])
 	assert.Equal(t, fChains[2], consensusObs.FChain[2])

--- a/commit/factory.go
+++ b/commit/factory.go
@@ -189,7 +189,7 @@ func (p *PluginFactory) NewReportingPlugin(ctx context.Context, config ocr3types
 		rmnHomeReader = readerpkg.NewRMNHomePoller(
 			rmnCr,
 			rmnHomeBoundContract,
-			logutil.WithContext(lggr, "RMNHomePoller"),
+			logutil.WithComponent(lggr, "RMNHomePoller"),
 			5*time.Second,
 		)
 
@@ -204,7 +204,7 @@ func (p *PluginFactory) NewReportingPlugin(ctx context.Context, config ocr3types
 
 	ccipReader := readerpkg.NewCCIPChainReader(
 		ctx,
-		logutil.WithContext(lggr, "CCIPReader"),
+		logutil.WithComponent(lggr, "CCIPReader"),
 		readers,
 		p.chainWriters,
 		p.ocrConfig.Config.ChainSelector,
@@ -228,7 +228,7 @@ func (p *PluginFactory) NewReportingPlugin(ctx context.Context, config ocr3types
 	}
 
 	onChainTokenPricesReader := readerpkg.NewPriceReader(
-		logutil.WithContext(lggr, "PriceReader"),
+		logutil.WithComponent(lggr, "PriceReader"),
 		readers,
 		offchainConfig.TokenInfo,
 		ccipReader,

--- a/commit/merkleroot/query.go
+++ b/commit/merkleroot/query.go
@@ -8,9 +8,12 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn"
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn/rmnpb"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/logutil"
 )
 
 func (p *Processor) Query(ctx context.Context, prevOutcome Outcome) (Query, error) {
+	lggr := logutil.WithContextValues(ctx, p.lggr)
+
 	if !p.offchainCfg.RMNEnabled {
 		return Query{}, nil
 	}
@@ -24,7 +27,7 @@ func (p *Processor) Query(ctx context.Context, prevOutcome Outcome) (Query, erro
 		return Query{}, fmt.Errorf("RMN report config is empty")
 	}
 
-	if err := p.prepareRMNController(ctx, prevOutcome); err != nil {
+	if err := p.prepareRMNController(ctx, lggr, prevOutcome); err != nil {
 		return Query{}, fmt.Errorf("initialize RMN controller: %w", err)
 	}
 

--- a/commit/merkleroot/rmn/peerclient.go
+++ b/commit/merkleroot/rmn/peerclient.go
@@ -134,6 +134,7 @@ func (r *peerClient) Close() error {
 	return nil
 }
 
+// TODO: pass in ctx to get OCR seqNr. Then can include seqNr in the log.
 func (r *peerClient) Send(rmnNode rmntypes.HomeNodeInfo, request []byte) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -254,12 +254,6 @@ func (p *Plugin) Observation(
 		return nil, fmt.Errorf("decode query: %w", err)
 	}
 
-	lggr = logger.With(
-		lggr,
-		"prevOutcome", prevOutcome,
-		"decodedQuery", decodedQ,
-	)
-
 	merkleRootObs, err := p.merkleRootProcessor.Observation(ctx, prevOutcome.MerkleRootOutcome, decodedQ.MerkleRootQuery)
 	if err != nil {
 		lggr.Errorw("get merkle root processor observation",

--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -86,7 +86,7 @@ func NewPlugin(
 	}
 
 	chainSupport := plugincommon.NewChainSupport(
-		logutil.WithContext(lggr, "ChainSupport"),
+		logutil.WithComponent(lggr, "ChainSupport"),
 		homeChain,
 		oracleIDToP2pID,
 		reportingCfg.OracleID,
@@ -94,7 +94,7 @@ func NewPlugin(
 	)
 
 	rmnController := rmn.NewController(
-		logutil.WithContext(lggr, "RMNController"),
+		logutil.WithComponent(lggr, "RMNController"),
 		rmnCrypto,
 		offchainCfg.SignObservationPrefix,
 		rmnPeerClient,
@@ -106,7 +106,7 @@ func NewPlugin(
 	merkleRootProcessor := merkleroot.NewProcessor(
 		reportingCfg.OracleID,
 		oracleIDToP2pID,
-		logutil.WithContext(lggr, "MerkleRoot"),
+		logutil.WithComponent(lggr, "MerkleRoot"),
 		offchainCfg,
 		destChain,
 		homeChain,
@@ -122,7 +122,7 @@ func NewPlugin(
 
 	tokenPriceProcessor := tokenprice.NewProcessor(
 		reportingCfg.OracleID,
-		logutil.WithContext(lggr, "TokenPrice"),
+		logutil.WithComponent(lggr, "TokenPrice"),
 		offchainCfg,
 		destChain,
 		chainSupport,
@@ -133,7 +133,7 @@ func NewPlugin(
 	)
 
 	discoveryProcessor := discovery.NewContractDiscoveryProcessor(
-		logutil.WithContext(lggr, "Discovery"),
+		logutil.WithComponent(lggr, "Discovery"),
 		&ccipReader,
 		homeChain,
 		destChain,
@@ -142,7 +142,7 @@ func NewPlugin(
 	)
 
 	chainFeeProcessr := chainfee.NewProcessor(
-		logutil.WithContext(lggr, "ChainFee"),
+		logutil.WithComponent(lggr, "ChainFee"),
 		reportingCfg.OracleID,
 		destChain,
 		homeChain,
@@ -157,7 +157,7 @@ func NewPlugin(
 		donID:               donID,
 		oracleID:            reportingCfg.OracleID,
 		oracleIDToP2PID:     oracleIDToP2pID,
-		lggr:                logutil.WithContext(lggr, "Plugin"),
+		lggr:                logutil.WithComponent(lggr, "Plugin"),
 		offchainCfg:         offchainCfg,
 		tokenPricesReader:   tokenPricesReader,
 		ccipReader:          ccipReader,

--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -216,13 +216,17 @@ func (p *Plugin) ObservationQuorum(
 func (p *Plugin) Observation(
 	ctx context.Context, outCtx ocr3types.OutcomeContext, q types.Query,
 ) (types.Observation, error) {
+	// Ensure that sequence number is in the context for consumption by all
+	// downstream processors and the ccip reader.
+	ctx, lggr := logutil.WithOCRSeqNr(ctx, p.lggr, outCtx.SeqNr)
+
 	var discoveryObs dt.Observation
 	var err error
 
 	if p.discoveryProcessor != nil {
 		discoveryObs, err = p.discoveryProcessor.Observation(ctx, dt.Outcome{}, dt.Query{})
 		if err != nil {
-			p.lggr.Errorw("failed to discover contracts", "err", err)
+			lggr.Errorw("failed to discover contracts", "err", err)
 		}
 	}
 
@@ -234,8 +238,8 @@ func (p *Plugin) Observation(
 			return nil, fmt.Errorf("encode discovery observation: %w, observation: %+v", err, obs)
 		}
 
-		p.lggr.Infow("contracts not initialized, only making discovery observations", "discoveryObs", discoveryObs)
-		p.lggr.Debugw("commit plugin making observation", "encodedObservation", encoded, "observation", obs)
+		lggr.Infow("contracts not initialized, only making discovery observations", "discoveryObs", discoveryObs)
+		lggr.Infow("commit plugin making observation", "encodedObservation", encoded, "observation", obs)
 
 		return encoded, nil
 	}
@@ -250,43 +254,56 @@ func (p *Plugin) Observation(
 		return nil, fmt.Errorf("decode query: %w", err)
 	}
 
+	lggr = logger.With(
+		lggr,
+		"prevOutcome", prevOutcome,
+		"decodedQuery", decodedQ,
+	)
+
 	merkleRootObs, err := p.merkleRootProcessor.Observation(ctx, prevOutcome.MerkleRootOutcome, decodedQ.MerkleRootQuery)
 	if err != nil {
-		p.lggr.Errorw("get merkle root processor observation",
-			"err", err, "prevOutcome", prevOutcome.MerkleRootOutcome, "decodedQ", decodedQ.MerkleRootQuery)
+		lggr.Errorw("get merkle root processor observation",
+			"err", err,
+			"prevMerkleRootOutcome", prevOutcome.MerkleRootOutcome,
+			"decodedQ", decodedQ.MerkleRootQuery,
+		)
 	}
 
-	tokenPriceObs, chainFeeObs := p.getPriceRelatedObservations(ctx, outCtx, prevOutcome, decodedQ)
+	tokenPriceObs, chainFeeObs := p.getPriceRelatedObservations(ctx, lggr, prevOutcome, decodedQ)
 
 	obs := committypes.Observation{
 		MerkleRootObs: merkleRootObs,
 		TokenPriceObs: tokenPriceObs,
 		DiscoveryObs:  discoveryObs,
 		ChainFeeObs:   chainFeeObs,
-		FChain:        p.ObserveFChain(),
+		FChain:        p.ObserveFChain(lggr),
 	}
 
 	p.metricsReporter.TrackObservation(obs)
 
 	encoded, err := obs.Encode()
 	if err != nil {
-		return nil, fmt.Errorf("encode observation: %w, observation: %+v", err, obs)
+		return nil, fmt.Errorf("encode observation: %w, observation: %+v, seq nr: %d", err, obs, outCtx.SeqNr)
 	}
 
-	p.lggr.Debugw("Commit plugin making observation", "encodedObservation", encoded, "observation", obs)
+	lggr.Infow("Commit plugin making observation", "encodedObservation", encoded, "observation", obs)
 	return encoded, nil
 }
 
 func (p *Plugin) getPriceRelatedObservations(
-	ctx context.Context, outCtx ocr3types.OutcomeContext, prevOutcome committypes.Outcome, decodedQ committypes.Query,
+	ctx context.Context,
+	lggr logger.Logger,
+	prevOutcome committypes.Outcome,
+	decodedQ committypes.Query,
 ) (tokenprice.Observation, chainfee.Observation) {
 	waitingForPriceUpdatesToMakeItOnchain := prevOutcome.MainOutcome.InflightPriceOcrSequenceNumber > 0
 
 	// If we are waiting for price updates to make it onchain, but we have no more checks remaining, stop waiting.
 	if waitingForPriceUpdatesToMakeItOnchain && prevOutcome.MainOutcome.RemainingPriceChecks == 0 {
-		p.lggr.Warnw("no more price checks remaining, prices of previous outcome did not make it through",
+		lggr.Warnw(
+			"no more price checks remaining, prices of previous outcome did not make it through",
 			"inflightPriceOcrSequenceNumber", prevOutcome.MainOutcome.InflightPriceOcrSequenceNumber,
-			"currentOcrSequenceNumber", outCtx.SeqNr)
+		)
 		waitingForPriceUpdatesToMakeItOnchain = false
 	}
 
@@ -294,22 +311,21 @@ func (p *Plugin) getPriceRelatedObservations(
 	if waitingForPriceUpdatesToMakeItOnchain {
 		latestPriceOcrSeqNum, err := p.ccipReader.GetLatestPriceSeqNr(ctx)
 		if err != nil {
-			p.lggr.Errorw("get latest price sequence number", "err", err)
+			lggr.Errorw("get latest price sequence number", "err", err)
 			return tokenprice.Observation{}, chainfee.Observation{}
 		}
 
 		if cciptypes.SeqNum(latestPriceOcrSeqNum) >= prevOutcome.MainOutcome.InflightPriceOcrSequenceNumber {
-			p.lggr.Infow("previous price report made it through", "ocrSeqNum", latestPriceOcrSeqNum)
+			lggr.Infow("previous price report made it through", "ocrSeqNum", latestPriceOcrSeqNum)
 			waitingForPriceUpdatesToMakeItOnchain = false
 		}
 	}
 
 	// If we are still waiting for price updates to make it onchain, don't make any price observations.
 	if waitingForPriceUpdatesToMakeItOnchain {
-		p.lggr.Infow("waiting for price updates to make it onchain, no prices observed in this round",
+		lggr.Infow("waiting for price updates to make it onchain, no prices observed in this round",
 			"inflightPriceOcrSequenceNumber", prevOutcome.MainOutcome.InflightPriceOcrSequenceNumber,
 			"remainingPriceChecks", prevOutcome.MainOutcome.RemainingPriceChecks,
-			"currentOcrSequenceNumber", outCtx.SeqNr,
 		)
 		return tokenprice.Observation{}, chainfee.Observation{}
 	}
@@ -320,23 +336,23 @@ func (p *Plugin) getPriceRelatedObservations(
 
 	tokenPriceObs, err = p.tokenPriceProcessor.Observation(ctx, prevOutcome.TokenPriceOutcome, decodedQ.TokenPriceQuery)
 	if err != nil {
-		p.lggr.Errorw("get token price processor observation", "err", err,
-			"prevOutcome", prevOutcome.TokenPriceOutcome, "decodedQ", decodedQ.TokenPriceQuery)
+		lggr.Errorw("get token price processor observation", "err", err,
+			"prevTokenPriceOutcome", prevOutcome.TokenPriceOutcome)
 	}
 
 	chainFeeObs, err = p.chainFeeProcessor.Observation(ctx, prevOutcome.ChainFeeOutcome, decodedQ.ChainFeeQuery)
 	if err != nil {
-		p.lggr.Errorw("get gas prices processor observation",
-			"err", err, "prevOutcome", prevOutcome.ChainFeeOutcome, "decodedQ", decodedQ.ChainFeeQuery)
+		lggr.Errorw("get gas prices processor observation",
+			"err", err, "prevChainFeeOutcome", prevOutcome.ChainFeeOutcome)
 	}
 
 	return tokenPriceObs, chainFeeObs
 }
 
-func (p *Plugin) ObserveFChain() map[cciptypes.ChainSelector]int {
+func (p *Plugin) ObserveFChain(lggr logger.Logger) map[cciptypes.ChainSelector]int {
 	fChain, err := p.homeChain.GetFChain()
 	if err != nil {
-		p.lggr.Errorw("call to GetFChain failed", "err", err)
+		lggr.Errorw("call to GetFChain failed", "err", err)
 		return map[cciptypes.ChainSelector]int{}
 	}
 	return fChain
@@ -345,7 +361,8 @@ func (p *Plugin) ObserveFChain() map[cciptypes.ChainSelector]int {
 func (p *Plugin) Outcome(
 	ctx context.Context, outCtx ocr3types.OutcomeContext, q types.Query, aos []types.AttributedObservation,
 ) (ocr3types.Outcome, error) {
-	p.lggr.Debugw("performing outcome", "outctx", outCtx, "query", q, "attributedObservations", aos)
+	ctx, lggr := logutil.WithOCRSeqNr(ctx, p.lggr, outCtx.SeqNr)
+	lggr.Debugw("commit plugin performing outcome", "attributedObservations", aos)
 
 	prevOutcome, err := committypes.DecodeOutcome(outCtx.PreviousOutcome)
 	if err != nil {
@@ -365,11 +382,11 @@ func (p *Plugin) Outcome(
 	for _, ao := range aos {
 		obs, err := committypes.DecodeCommitPluginObservation(ao.Observation)
 		if err != nil {
-			p.lggr.Warnw("failed to decode observation, observation skipped", "err", err)
+			lggr.Warnw("failed to decode observation, observation skipped", "err", err)
 			continue
 		}
 
-		p.lggr.Debugw("Commit plugin outcome decoded observation", "observation", obs)
+		lggr.Debugw("Commit plugin outcome decoded observation", "observation", obs)
 
 		merkleRootObservations = append(merkleRootObservations, attributedMerkleRootObservation{
 			OracleID: ao.Observer, Observation: obs.MerkleRootObs})
@@ -385,13 +402,13 @@ func (p *Plugin) Outcome(
 	}
 
 	if p.discoveryProcessor != nil {
-		p.lggr.Infow("Processing discovery observations", "discoveryObservations", discoveryObservations)
+		lggr.Infow("Processing discovery observations", "discoveryObservations", discoveryObservations)
 
 		// The outcome phase of the discovery processor is binding contracts to the chain reader. This is the reason
 		// we ignore the outcome of the discovery processor.
 		_, err = p.discoveryProcessor.Outcome(ctx, dt.Outcome{}, dt.Query{}, discoveryObservations)
 		if err != nil {
-			return nil, fmt.Errorf("discovery processor outcome: %w", err)
+			return nil, fmt.Errorf("discovery processor outcome: %w, seqNr: %d", err, outCtx.SeqNr)
 		}
 		p.contractsInitialized.Store(true)
 	}
@@ -403,7 +420,7 @@ func (p *Plugin) Outcome(
 		merkleRootObservations,
 	)
 	if err != nil {
-		p.lggr.Errorw(" get merkle roots outcome", "err", err)
+		lggr.Errorw("failed to get merkle roots outcome", "err", err)
 	}
 
 	tokenPriceOutcome, err := p.tokenPriceProcessor.Outcome(
@@ -413,7 +430,7 @@ func (p *Plugin) Outcome(
 		tokenPricesObservations,
 	)
 	if err != nil {
-		p.lggr.Warnw("failed to get token prices outcome", "err", err)
+		lggr.Warnw("failed to get token prices outcome", "err", err)
 	}
 
 	chainFeeOutcome, err := p.chainFeeProcessor.Outcome(
@@ -423,7 +440,7 @@ func (p *Plugin) Outcome(
 		chainFeeObservations,
 	)
 	if err != nil {
-		p.lggr.Warnw("failed to get gas prices outcome", "err", err)
+		lggr.Warnw("failed to get gas prices outcome", "err", err)
 	}
 
 	out := committypes.Outcome{
@@ -433,6 +450,9 @@ func (p *Plugin) Outcome(
 		MainOutcome:       p.getMainOutcome(outCtx, prevOutcome, tokenPriceOutcome, chainFeeOutcome),
 	}
 	p.metricsReporter.TrackOutcome(out)
+
+	lggr.Infow("Commit plugin finished outcome", "outcome", out)
+
 	return out.Encode()
 }
 
@@ -465,6 +485,8 @@ func (p *Plugin) getMainOutcome(
 }
 
 func (p *Plugin) Close() error {
+	p.lggr.Infow("closing commit plugin")
+
 	return services.CloseAll(
 		p.merkleRootProcessor,
 		p.tokenPriceProcessor,

--- a/commit/plugin_e2e_test.go
+++ b/commit/plugin_e2e_test.go
@@ -228,18 +228,18 @@ func TestPlugin_E2E_AllNodesAgree_MerkleRoots(t *testing.T) {
 				if i == 0 {
 					reportCodec = n.reportCodec
 				}
-				prepareCcipReaderMock(params.ctx, n.ccipReader, false, tc.enableDiscovery, true)
+				prepareCcipReaderMock(n.ccipReader, false, tc.enableDiscovery, true)
 
 				if len(tc.offRampNextSeqNumDefaultOverrideKeys) > 0 {
 					require.Equal(t, len(tc.offRampNextSeqNumDefaultOverrideKeys), len(tc.offRampNextSeqNumDefaultOverrideValues))
-					n.ccipReader.EXPECT().NextSeqNum(params.ctx, tc.offRampNextSeqNumDefaultOverrideKeys).Unset()
+					n.ccipReader.EXPECT().NextSeqNum(mock.Anything, tc.offRampNextSeqNumDefaultOverrideKeys).Unset()
 					n.ccipReader.EXPECT().
-						NextSeqNum(params.ctx, tc.offRampNextSeqNumDefaultOverrideKeys).
+						NextSeqNum(mock.Anything, tc.offRampNextSeqNumDefaultOverrideKeys).
 						Return(tc.offRampNextSeqNumDefaultOverrideValues, nil).
 						Maybe()
 				}
 
-				preparePriceReaderMock(params.ctx, n.priceReader)
+				preparePriceReaderMock(n.priceReader)
 			}
 
 			encodedPrevOutcome, err := tc.prevOutcome.Encode()
@@ -290,14 +290,14 @@ func TestPlugin_E2E_AllNodesAgree_TokenPrices(t *testing.T) {
 			mockPriceReader: func(m *readerpkg_mock.MockPriceReader) {
 				m.EXPECT().
 					// tokens need to be ordered, plugin checks all tokens from commit offchain config
-					GetFeedPricesUSD(params.ctx, []ccipocr3.UnknownEncodedAddress{arbAddr, ethAddr}).
+					GetFeedPricesUSD(mock.Anything, []ccipocr3.UnknownEncodedAddress{arbAddr, ethAddr}).
 					Return(map[ccipocr3.UnknownEncodedAddress]*big.Int{
 						arbAddr: arbPrice,
 						ethAddr: ethPrice,
 					}, nil).Maybe()
 
 				m.EXPECT().
-					GetFeeQuoterTokenUpdates(params.ctx, mock.Anything, mock.Anything).
+					GetFeeQuoterTokenUpdates(mock.Anything, mock.Anything, mock.Anything).
 					Return(
 						map[ccipocr3.UnknownEncodedAddress]plugintypes.TimestampedBig{}, nil,
 					).
@@ -346,7 +346,7 @@ func TestPlugin_E2E_AllNodesAgree_TokenPrices(t *testing.T) {
 			mockPriceReader: func(m *readerpkg_mock.MockPriceReader) {
 				m.EXPECT().
 					// tokens need to be ordered, plugin checks all tokens from commit offchain config
-					GetFeedPricesUSD(params.ctx, []ccipocr3.UnknownEncodedAddress{arbAddr, ethAddr}).
+					GetFeedPricesUSD(mock.Anything, []ccipocr3.UnknownEncodedAddress{arbAddr, ethAddr}).
 					Return(map[ccipocr3.UnknownEncodedAddress]*big.Int{
 						arbAddr: arbPrice,
 						ethAddr: ethPrice,
@@ -355,7 +355,7 @@ func TestPlugin_E2E_AllNodesAgree_TokenPrices(t *testing.T) {
 
 				// Arb is fresh, will not be updated
 				m.EXPECT().
-					GetFeeQuoterTokenUpdates(params.ctx, mock.Anything, mock.Anything).
+					GetFeeQuoterTokenUpdates(mock.Anything, mock.Anything, mock.Anything).
 					Return(
 						map[ccipocr3.UnknownEncodedAddress]plugintypes.TimestampedBig{
 							arbAddr: {Value: ccipocr3.NewBigInt(arbPrice), Timestamp: time.Now()},
@@ -375,14 +375,14 @@ func TestPlugin_E2E_AllNodesAgree_TokenPrices(t *testing.T) {
 			mockPriceReader: func(m *readerpkg_mock.MockPriceReader) {
 				m.EXPECT().
 					// tokens need to be ordered, plugin checks all tokens from commit offchain config
-					GetFeedPricesUSD(params.ctx, []ccipocr3.UnknownEncodedAddress{arbAddr, ethAddr}).
+					GetFeedPricesUSD(mock.Anything, []ccipocr3.UnknownEncodedAddress{arbAddr, ethAddr}).
 					Return(map[ccipocr3.UnknownEncodedAddress]*big.Int{
 						arbAddr: arbPrice,
 						ethAddr: ethPrice,
 					}, nil).Maybe()
 
 				m.EXPECT().
-					GetFeeQuoterTokenUpdates(params.ctx, mock.Anything, mock.Anything).
+					GetFeeQuoterTokenUpdates(mock.Anything, mock.Anything, mock.Anything).
 					Return(
 						map[ccipocr3.UnknownEncodedAddress]plugintypes.TimestampedBig{
 							// Arb is fresh, will not be updated
@@ -433,7 +433,7 @@ func TestPlugin_E2E_AllNodesAgree_TokenPrices(t *testing.T) {
 					reportCodec = n.reportCodec
 				}
 
-				prepareCcipReaderMock(params.ctx, n.ccipReader, true, false, true)
+				prepareCcipReaderMock(n.ccipReader, true, false, true)
 				tc.mockPriceReader(n.priceReader)
 			}
 
@@ -504,7 +504,7 @@ func TestPlugin_E2E_AllNodesAgree_ChainFee(t *testing.T) {
 			expTransmittedReportLen: 1,
 			mockCCIPReader: func(m *readerpkg_mock.MockCCIPReader) {
 				m.EXPECT().
-					GetChainsFeeComponents(params.ctx, mock.Anything).
+					GetChainsFeeComponents(mock.Anything, mock.Anything).
 					Return(
 						map[ccipocr3.ChainSelector]types.ChainFeeComponents{
 							sourceChain1: newFeeComponents,
@@ -512,7 +512,7 @@ func TestPlugin_E2E_AllNodesAgree_ChainFee(t *testing.T) {
 						})
 
 				m.EXPECT().
-					GetWrappedNativeTokenPriceUSD(params.ctx, mock.Anything).
+					GetWrappedNativeTokenPriceUSD(mock.Anything, mock.Anything).
 					Return(map[ccipocr3.ChainSelector]ccipocr3.BigInt{
 						sourceChain1: newNativePrice,
 						sourceChain2: newNativePrice,
@@ -530,14 +530,14 @@ func TestPlugin_E2E_AllNodesAgree_ChainFee(t *testing.T) {
 			expTransmittedReportLen: 1,
 			mockCCIPReader: func(m *readerpkg_mock.MockCCIPReader) {
 				m.EXPECT().
-					GetChainsFeeComponents(params.ctx, mock.Anything).
+					GetChainsFeeComponents(mock.Anything, mock.Anything).
 					Return(
 						map[ccipocr3.ChainSelector]types.ChainFeeComponents{
 							sourceChain1: newFeeComponents,
 						})
 
 				m.EXPECT().
-					GetWrappedNativeTokenPriceUSD(params.ctx, mock.Anything).
+					GetWrappedNativeTokenPriceUSD(mock.Anything, mock.Anything).
 					Return(map[ccipocr3.ChainSelector]ccipocr3.BigInt{
 						sourceChain1: newNativePrice,
 						sourceChain2: newNativePrice,
@@ -573,14 +573,14 @@ func TestPlugin_E2E_AllNodesAgree_ChainFee(t *testing.T) {
 			expTransmittedReportLen: 1,
 			mockCCIPReader: func(m *readerpkg_mock.MockCCIPReader) {
 				m.EXPECT().
-					GetChainsFeeComponents(params.ctx, mock.Anything).
+					GetChainsFeeComponents(mock.Anything, mock.Anything).
 					Return(
 						map[ccipocr3.ChainSelector]types.ChainFeeComponents{
 							sourceChain1: newFeeComponents,
 						})
 
 				m.EXPECT().
-					GetWrappedNativeTokenPriceUSD(params.ctx, mock.Anything).
+					GetWrappedNativeTokenPriceUSD(mock.Anything, mock.Anything).
 					Return(map[ccipocr3.ChainSelector]ccipocr3.BigInt{
 						sourceChain1: newNativePrice,
 					})
@@ -607,14 +607,14 @@ func TestPlugin_E2E_AllNodesAgree_ChainFee(t *testing.T) {
 			expTransmittedReportLen: 1,
 			mockCCIPReader: func(m *readerpkg_mock.MockCCIPReader) {
 				m.EXPECT().
-					GetChainsFeeComponents(params.ctx, mock.Anything).
+					GetChainsFeeComponents(mock.Anything, mock.Anything).
 					Return(
 						map[ccipocr3.ChainSelector]types.ChainFeeComponents{
 							sourceChain1: newFeeComponents2,
 						})
 
 				m.EXPECT().
-					GetWrappedNativeTokenPriceUSD(params.ctx, mock.Anything).
+					GetWrappedNativeTokenPriceUSD(mock.Anything, mock.Anything).
 					Return(map[ccipocr3.ChainSelector]ccipocr3.BigInt{
 						sourceChain1: newNativePrice2,
 					})
@@ -641,23 +641,23 @@ func TestPlugin_E2E_AllNodesAgree_ChainFee(t *testing.T) {
 			expTransmittedReportLen: 1,
 			mockCCIPReader: func(m *readerpkg_mock.MockCCIPReader) {
 				m.EXPECT().
-					GetChainsFeeComponents(params.ctx, mock.Anything).
+					GetChainsFeeComponents(mock.Anything, mock.Anything).
 					Return(
 						map[ccipocr3.ChainSelector]types.ChainFeeComponents{
 							sourceChain1: newFeeComponents2,
 						})
 				m.EXPECT().
-					GetWrappedNativeTokenPriceUSD(params.ctx, mock.Anything).
+					GetWrappedNativeTokenPriceUSD(mock.Anything, mock.Anything).
 					Return(map[ccipocr3.ChainSelector]ccipocr3.BigInt{
 						sourceChain1: newNativePrice2,
 					})
 
-				m.EXPECT().GetChainFeePriceUpdate(params.ctx, mock.Anything).Unset()
+				m.EXPECT().GetChainFeePriceUpdate(mock.Anything, mock.Anything).Unset()
 				elapsed, err := time.ParseDuration("3h")
 				require.NoError(t, err)
 				t := time.Now().UTC().Add(-elapsed)
 				m.EXPECT().
-					GetChainFeePriceUpdate(params.ctx, mock.Anything).
+					GetChainFeePriceUpdate(mock.Anything, mock.Anything).
 					Return(map[ccipocr3.ChainSelector]plugintypes.TimestampedBig{
 						sourceChain1: {
 							Timestamp: t,
@@ -675,9 +675,9 @@ func TestPlugin_E2E_AllNodesAgree_ChainFee(t *testing.T) {
 				n := setupNode(paramsCp)
 				nodes[i] = n.node
 
-				prepareCcipReaderMock(params.ctx, n.ccipReader, true, false, false)
+				prepareCcipReaderMock(n.ccipReader, true, false, false)
 
-				preparePriceReaderMock(params.ctx, n.priceReader)
+				preparePriceReaderMock(n.priceReader)
 
 				tc.mockCCIPReader(n.ccipReader)
 			}
@@ -707,25 +707,24 @@ func normalizeOutcome(o committypes.Outcome) committypes.Outcome {
 }
 
 func prepareCcipReaderMock(
-	ctx context.Context,
 	ccipReader *readerpkg_mock.MockCCIPReader,
 	mockEmptySeqNrs bool,
 	enableDiscovery bool,
-	mockChainFee bool) {
-
+	mockChainFee bool,
+) {
 	if mockChainFee {
 		ccipReader.EXPECT().
-			GetChainsFeeComponents(ctx, mock.Anything).
+			GetChainsFeeComponents(mock.Anything, mock.Anything).
 			Return(map[ccipocr3.ChainSelector]types.ChainFeeComponents{}).Maybe()
 		ccipReader.EXPECT().
-			GetWrappedNativeTokenPriceUSD(ctx, mock.Anything).
+			GetWrappedNativeTokenPriceUSD(mock.Anything, mock.Anything).
 			Return(map[ccipocr3.ChainSelector]ccipocr3.BigInt{}).Maybe()
 	}
 	ccipReader.EXPECT().
-		GetLatestPriceSeqNr(ctx).
+		GetLatestPriceSeqNr(mock.Anything).
 		Return(0, nil).Maybe()
 	ccipReader.EXPECT().
-		GetChainFeePriceUpdate(ctx, mock.Anything).
+		GetChainFeePriceUpdate(mock.Anything, mock.Anything).
 		Return(map[ccipocr3.ChainSelector]plugintypes.TimestampedBig{}).Maybe()
 	ccipReader.EXPECT().
 		GetContractAddress(mock.Anything, mock.Anything).
@@ -734,8 +733,9 @@ func prepareCcipReaderMock(
 		Return(&reader2.CurseInfo{}, nil).Maybe()
 
 	if mockEmptySeqNrs {
-		ccipReader.EXPECT().NextSeqNum(ctx, mock.Anything).Unset()
-		ccipReader.EXPECT().NextSeqNum(ctx, mock.Anything).Return(map[ccipocr3.ChainSelector]ccipocr3.SeqNum{}, nil).
+		ccipReader.EXPECT().NextSeqNum(mock.Anything, mock.Anything).Unset()
+		ccipReader.EXPECT().NextSeqNum(mock.Anything, mock.Anything).
+			Return(map[ccipocr3.ChainSelector]ccipocr3.SeqNum{}, nil).
 			Maybe()
 	}
 
@@ -745,16 +745,16 @@ func prepareCcipReaderMock(
 	}
 }
 
-func preparePriceReaderMock(ctx context.Context, priceReader *readerpkg_mock.MockPriceReader) {
+func preparePriceReaderMock(priceReader *readerpkg_mock.MockPriceReader) {
 	priceReader.EXPECT().
-		GetFeeQuoterTokenUpdates(ctx, mock.Anything, mock.Anything).
+		GetFeeQuoterTokenUpdates(mock.Anything, mock.Anything, mock.Anything).
 		Return(
 			map[ccipocr3.UnknownEncodedAddress]plugintypes.TimestampedBig{}, nil,
 		).
 		Maybe()
 
 	priceReader.EXPECT().
-		GetFeedPricesUSD(ctx, mock.Anything).
+		GetFeedPricesUSD(mock.Anything, mock.Anything).
 		Return(map[ccipocr3.UnknownEncodedAddress]*big.Int{}, nil).Maybe()
 }
 
@@ -850,7 +850,7 @@ func setupNode(params SetupNodeParams) nodeSetup {
 			})
 		}
 
-		ccipReader.EXPECT().MsgsBetweenSeqNums(params.ctx, sourceChain,
+		ccipReader.EXPECT().MsgsBetweenSeqNums(mock.Anything, sourceChain,
 			ccipocr3.NewSeqNumRange(offRampNextSeqNum, offRampNextSeqNum)).
 			Return(newMsgs, nil).Maybe()
 
@@ -864,21 +864,21 @@ func setupNode(params SetupNodeParams) nodeSetup {
 		seqNumsOfChainsWithNewMsgs[chainSel] = params.offRampNextSeqNum[chainSel]
 	}
 	if len(chainsWithNewMsgs) > 0 {
-		ccipReader.EXPECT().NextSeqNum(params.ctx, chainsWithNewMsgs).Return(seqNumsOfChainsWithNewMsgs, nil).Maybe()
+		ccipReader.EXPECT().NextSeqNum(mock.Anything, chainsWithNewMsgs).Return(seqNumsOfChainsWithNewMsgs, nil).Maybe()
 	}
-	ccipReader.EXPECT().NextSeqNum(params.ctx, sourceChains).Return(offRampNextSeqNums, nil).Maybe()
+	ccipReader.EXPECT().NextSeqNum(mock.Anything, sourceChains).Return(offRampNextSeqNums, nil).Maybe()
 
 	for _, ch := range sourceChains {
 		ccipReader.EXPECT().GetExpectedNextSequenceNumber(
-			params.ctx, ch, destChain).Return(params.offRampNextSeqNum[ch]+1, nil).Maybe()
+			mock.Anything, ch, destChain).Return(params.offRampNextSeqNum[ch]+1, nil).Maybe()
 	}
 
 	ccipReader.EXPECT().
-		GetRMNRemoteConfig(params.ctx, mock.Anything).
+		GetRMNRemoteConfig(mock.Anything, mock.Anything).
 		Return(params.rmnReportCfg, nil).Maybe()
 
 	ccipReader.EXPECT().
-		GetOffRampConfigDigest(params.ctx, consts.PluginTypeCommit).
+		GetOffRampConfigDigest(mock.Anything, consts.PluginTypeCommit).
 		Return(params.reportingCfg.ConfigDigest, nil).Maybe()
 
 	p := NewPlugin(

--- a/commit/report.go
+++ b/commit/report.go
@@ -19,6 +19,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon/consensus"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/logutil"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
 
@@ -41,13 +42,15 @@ func (ri *ReportInfo) Decode(encodedReportInfo []byte) error {
 func (p *Plugin) Reports(
 	ctx context.Context, seqNr uint64, outcomeBytes ocr3types.Outcome,
 ) ([]ocr3types.ReportPlus[[]byte], error) {
+	ctx, lggr := logutil.WithOCRSeqNr(ctx, p.lggr, seqNr)
+
 	outcome, err := committypes.DecodeOutcome(outcomeBytes)
 	if err != nil {
-		p.lggr.Errorw("failed to decode Outcome", "outcome", string(outcomeBytes), "err", err)
+		lggr.Errorw("failed to decode Outcome", "outcome", string(outcomeBytes), "err", err)
 		return nil, fmt.Errorf("decode outcome: %w", err)
 	}
 
-	p.lggr.Infow("generating report",
+	lggr.Infow("generating report",
 		"roots", outcome.MerkleRootOutcome.RootsToReport,
 		"tokenPriceUpdates", outcome.TokenPriceOutcome.TokenPrices,
 		"gasPriceUpdates", outcome.ChainFeeOutcome.GasPrices,
@@ -79,7 +82,7 @@ func (p *Plugin) Reports(
 	}
 
 	if rep.IsEmpty() {
-		p.lggr.Infow("empty report", "report", rep)
+		lggr.Infow("empty report", "report", rep)
 		return []ocr3types.ReportPlus[[]byte]{}, nil
 	}
 
@@ -101,8 +104,10 @@ func (p *Plugin) Reports(
 	if err != nil {
 		return nil, fmt.Errorf("get transmission schedule: %w", err)
 	}
-	p.lggr.Debugw("transmission schedule override",
+	lggr.Debugw("transmission schedule override",
 		"transmissionSchedule", transmissionSchedule, "oracleIDToP2PID", p.oracleIDToP2PID)
+
+	lggr.Infow("commit plugin generated reports", "report", rep, "reportInfo", repInfo)
 
 	return []ocr3types.ReportPlus[[]byte]{
 		{
@@ -123,17 +128,16 @@ func (p *Plugin) Reports(
 //nolint:gocyclo
 func (p *Plugin) validateReport(
 	ctx context.Context,
+	lggr logger.Logger,
 	seqNr uint64,
 	r ocr3types.ReportWithInfo[[]byte],
 ) (bool, cciptypes.CommitPluginReport, error) {
-	lggr := logger.With(p.lggr, "seqNr", seqNr)
-
 	if r.Report == nil {
 		lggr.Warn("nil report")
 		return false, cciptypes.CommitPluginReport{}, nil
 	}
 
-	decodedReport, err := p.decodeReport(ctx, r.Report)
+	decodedReport, err := p.decodeReport(ctx, lggr, r.Report)
 	if err != nil {
 		return false, cciptypes.CommitPluginReport{}, fmt.Errorf("decode report: %w, report: %x", err, r.Report)
 	}
@@ -180,12 +184,12 @@ func (p *Plugin) validateReport(
 		return false, cciptypes.CommitPluginReport{}, nil
 	}
 
-	latestSeqNr, err := p.ccipReader.GetLatestPriceSeqNr(ctx)
+	latestPriceSeqNr, err := p.ccipReader.GetLatestPriceSeqNr(ctx)
 	if err != nil {
 		return false, cciptypes.CommitPluginReport{}, fmt.Errorf("get latest price seq nr: %w", err)
 	}
 
-	if p.isStaleReport(seqNr, latestSeqNr, decodedReport) {
+	if p.isStaleReport(lggr, seqNr, latestPriceSeqNr, decodedReport) {
 		return false, cciptypes.CommitPluginReport{}, nil
 	}
 
@@ -202,24 +206,25 @@ func (p *Plugin) validateReport(
 func (p *Plugin) ShouldAcceptAttestedReport(
 	ctx context.Context, seqNr uint64, r ocr3types.ReportWithInfo[[]byte],
 ) (bool, error) {
-	valid, decodedReport, err := p.validateReport(ctx, seqNr, r)
+	ctx, lggr := logutil.WithOCRSeqNr(ctx, p.lggr, seqNr)
+
+	valid, decodedReport, err := p.validateReport(ctx, lggr, seqNr, r)
 	if err != nil {
 		return false, fmt.Errorf("validating report: %w", err)
 	}
 
 	if !valid {
-		p.lggr.Infow("report is not accepted", "seqNr", seqNr)
+		lggr.Infow("report is not accepted")
 		return false, nil
 	}
 
 	// TODO: consider doing this in validateReport,
 	// will end up doing it in both ShouldAccept and ShouldTransmit.
-	if isCursed, err := p.checkReportCursed(ctx, decodedReport); err != nil || isCursed {
+	if isCursed, err := p.checkReportCursed(ctx, lggr, decodedReport); err != nil || isCursed {
 		return false, err
 	}
 
-	p.lggr.Infow("ShouldAcceptedAttestedReport passed checks",
-		"seqNr", seqNr,
+	lggr.Infow("ShouldAcceptedAttestedReport passed checks",
 		"timestamp", time.Now().UTC(),
 		"rootsLen", len(decodedReport.MerkleRoots),
 		"tokenPriceUpdatesLen", len(decodedReport.PriceUpdates.TokenPriceUpdates),
@@ -228,33 +233,49 @@ func (p *Plugin) ShouldAcceptAttestedReport(
 	return true, nil
 }
 
-func (p *Plugin) decodeReport(ctx context.Context, report []byte) (cciptypes.CommitPluginReport, error) {
+func (p *Plugin) decodeReport(
+	ctx context.Context,
+	lggr logger.Logger,
+	report []byte,
+) (cciptypes.CommitPluginReport, error) {
 	decodedReport, err := p.reportCodec.Decode(ctx, report)
 	if err != nil {
-		return cciptypes.CommitPluginReport{}, fmt.Errorf("decode commit plugin report: %w", err)
+		return cciptypes.CommitPluginReport{},
+			fmt.Errorf("decode commit plugin report: %w", err)
 	}
 	if decodedReport.IsEmpty() {
-		p.lggr.Infow("empty report")
+		lggr.Infow("empty report")
 	}
 	return decodedReport, nil
 }
 
-func (p *Plugin) isStaleReport(seqNr, latestSeqNr uint64, decodedReport cciptypes.CommitPluginReport) bool {
-	if seqNr <= latestSeqNr && len(decodedReport.MerkleRoots) == 0 {
-		p.lggr.Infow("skipping stale report", "seqNr", seqNr, "latestSeqNr", latestSeqNr)
+func (p *Plugin) isStaleReport(
+	lggr logger.Logger,
+	seqNr,
+	latestPriceSeqNr uint64,
+	decodedReport cciptypes.CommitPluginReport,
+) bool {
+	if seqNr <= latestPriceSeqNr && len(decodedReport.MerkleRoots) == 0 {
+		lggr.Infow(
+			"skipping stale report due to stale price seq nr and no merkle roots",
+			"latestPriceSeqNr", latestPriceSeqNr)
 		return true
 	}
 	return false
 }
 
-func (p *Plugin) checkReportCursed(ctx context.Context, decodedReport cciptypes.CommitPluginReport) (bool, error) {
+func (p *Plugin) checkReportCursed(
+	ctx context.Context,
+	lggr logger.Logger,
+	decodedReport cciptypes.CommitPluginReport,
+) (bool, error) {
 	sourceChains := slicelib.Map(decodedReport.MerkleRoots,
 		func(r cciptypes.MerkleRootChain) cciptypes.ChainSelector {
 			return r.ChainSel
 		})
-	isCursed, err := plugincommon.IsReportCursed(ctx, p.lggr, p.ccipReader, p.chainSupport.DestChain(), sourceChains)
+	isCursed, err := plugincommon.IsReportCursed(ctx, lggr, p.ccipReader, p.chainSupport.DestChain(), sourceChains)
 	if err != nil {
-		p.lggr.Errorw("report not accepted due to curse checking error", "err", err)
+		lggr.Errorw("report not accepted due to curse checking error", "err", err)
 		return false, err
 	}
 	return isCursed, nil
@@ -263,17 +284,19 @@ func (p *Plugin) checkReportCursed(ctx context.Context, decodedReport cciptypes.
 func (p *Plugin) ShouldTransmitAcceptedReport(
 	ctx context.Context, seqNr uint64, r ocr3types.ReportWithInfo[[]byte],
 ) (bool, error) {
-	valid, decodedReport, err := p.validateReport(ctx, seqNr, r)
+	ctx, lggr := logutil.WithOCRSeqNr(ctx, p.lggr, seqNr)
+
+	valid, decodedReport, err := p.validateReport(ctx, lggr, seqNr, r)
 	if err != nil {
 		return false, fmt.Errorf("validating report: %w", err)
 	}
 
 	if !valid {
-		p.lggr.Infow("report not valid, not transmitting", "seqNr", seqNr)
+		lggr.Infow("report not valid, not transmitting")
 		return false, nil
 	}
 
-	p.lggr.Infow("ShouldTransmitAcceptedReport passed checks",
+	lggr.Infow("ShouldTransmitAcceptedReport passed checks",
 		"seqNr", seqNr,
 		"timestamp", time.Now().UTC(),
 		"rootsLen", len(decodedReport.MerkleRoots),

--- a/commit/report_test.go
+++ b/commit/report_test.go
@@ -247,7 +247,7 @@ func Test_Plugin_isStaleReport(t *testing.T) {
 			report := ccipocr3.CommitPluginReport{
 				MerkleRoots: make([]ccipocr3.MerkleRootChain, tc.lenMerkleRoots),
 			}
-			stale := p.isStaleReport(tc.reportSeqNum, tc.onChainSeqNum, report)
+			stale := p.isStaleReport(p.lggr, tc.reportSeqNum, tc.onChainSeqNum, report)
 			require.Equal(t, tc.shouldBeStale, stale)
 		})
 	}

--- a/commit/tokenprice/outcome_test.go
+++ b/commit/tokenprice/outcome_test.go
@@ -75,7 +75,7 @@ func TestGetConsensusObservation(t *testing.T) {
 		{OracleID: 3, Observation: obs},
 	}
 
-	consensusObs, err := p.getConsensusObservation(aos)
+	consensusObs, err := p.getConsensusObservation(lggr, aos)
 	assert.NoError(t, err)
 	assert.Equal(t, fChains[destChainSel], fChains[destChainSel])
 	assert.Equal(t, fChains[feedChainSel], fChains[feedChainSel])
@@ -95,7 +95,7 @@ func TestGetConsensusObservation(t *testing.T) {
 		{OracleID: 5, Observation: obs},
 	}
 
-	consensusObs, err = p.getConsensusObservation(aos)
+	consensusObs, err = p.getConsensusObservation(lggr, aos)
 	assert.NoError(t, err)
 	assert.Equal(t, fChains[destChainSel], consensusObs.FChain[destChainSel])
 	assert.Equal(t, fChains[feedChainSel], consensusObs.FChain[feedChainSel])
@@ -125,7 +125,7 @@ func TestSelectTokensForUpdate(t *testing.T) {
 	// tokenB will be updated because of deviation
 	// tokenC will be updated because it's not available on feeQuoter
 	// tokenD will not be updated because it's same price and time is not passed
-	tokenPrices := p.selectTokensForUpdate(conObs)
+	tokenPrices := p.selectTokensForUpdate(lggr, conObs)
 	assert.Len(t, tokenPrices, 3)
 	assert.Equal(t, conObs.FeedTokenPrices[tokenA], tokenPrices[0])
 	assert.Equal(t, conObs.FeedTokenPrices[tokenB], tokenPrices[1])

--- a/execute/factory.go
+++ b/execute/factory.go
@@ -163,7 +163,7 @@ func (p PluginFactory) NewReportingPlugin(
 
 	ccipReader := readerpkg.NewCCIPChainReader(
 		ctx,
-		logutil.WithContext(lggr, "CCIPReader"),
+		logutil.WithComponent(lggr, "CCIPReader"),
 		readers,
 		p.chainWriters,
 		p.ocrConfig.Config.ChainSelector,
@@ -172,7 +172,7 @@ func (p PluginFactory) NewReportingPlugin(
 
 	tokenDataObserver, err := tokendata.NewConfigBasedCompositeObservers(
 		ctx,
-		logutil.WithContext(lggr, "TokenDataObserver"),
+		logutil.WithComponent(lggr, "TokenDataObserver"),
 		p.ocrConfig.Config.ChainSelector,
 		offchainConfig.TokenDataObservers,
 		p.tokenDataEncoder,
@@ -183,7 +183,7 @@ func (p PluginFactory) NewReportingPlugin(
 	}
 
 	costlyMessageObserver := costlymessages.NewObserverWithDefaults(
-		logutil.WithContext(lggr, "CostlyMessages"),
+		logutil.WithComponent(lggr, "CostlyMessages"),
 		true,
 		ccipReader,
 		offchainConfig.RelativeBoostPerWaitHour,

--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -94,10 +94,10 @@ func NewPlugin(
 		homeChain:             homeChain,
 		tokenDataObserver:     tokenDataObserver,
 		estimateProvider:      estimateProvider,
-		lggr:                  logutil.WithContext(lggr, "Plugin"),
+		lggr:                  logutil.WithComponent(lggr, "Plugin"),
 		costlyMessageObserver: costlyMessageObserver,
 		discovery: discovery.NewContractDiscoveryProcessor(
-			logutil.WithContext(lggr, "Discovery"),
+			logutil.WithComponent(lggr, "Discovery"),
 			&ccipReader,
 			homeChain,
 			destChain,
@@ -105,7 +105,7 @@ func NewPlugin(
 			oracleIDToP2pID,
 		),
 		chainSupport: plugincommon.NewChainSupport(
-			logutil.WithContext(lggr, "ChainSupport"),
+			logutil.WithComponent(lggr, "ChainSupport"),
 			homeChain,
 			oracleIDToP2pID,
 			reportingCfg.OracleID,

--- a/mocks/commit/merkleroot/observer.go
+++ b/mocks/commit/merkleroot/observer.go
@@ -27,17 +27,17 @@ func (_m *MockObserver) EXPECT() *MockObserver_Expecter {
 	return &MockObserver_Expecter{mock: &_m.Mock}
 }
 
-// ObserveFChain provides a mock function with given fields:
-func (_m *MockObserver) ObserveFChain() map[ccipocr3.ChainSelector]int {
-	ret := _m.Called()
+// ObserveFChain provides a mock function with given fields: ctx
+func (_m *MockObserver) ObserveFChain(ctx context.Context) map[ccipocr3.ChainSelector]int {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ObserveFChain")
 	}
 
 	var r0 map[ccipocr3.ChainSelector]int
-	if rf, ok := ret.Get(0).(func() map[ccipocr3.ChainSelector]int); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) map[ccipocr3.ChainSelector]int); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[ccipocr3.ChainSelector]int)
@@ -53,13 +53,14 @@ type MockObserver_ObserveFChain_Call struct {
 }
 
 // ObserveFChain is a helper method to define mock.On call
-func (_e *MockObserver_Expecter) ObserveFChain() *MockObserver_ObserveFChain_Call {
-	return &MockObserver_ObserveFChain_Call{Call: _e.mock.On("ObserveFChain")}
+//   - ctx context.Context
+func (_e *MockObserver_Expecter) ObserveFChain(ctx interface{}) *MockObserver_ObserveFChain_Call {
+	return &MockObserver_ObserveFChain_Call{Call: _e.mock.On("ObserveFChain", ctx)}
 }
 
-func (_c *MockObserver_ObserveFChain_Call) Run(run func()) *MockObserver_ObserveFChain_Call {
+func (_c *MockObserver_ObserveFChain_Call) Run(run func(ctx context.Context)) *MockObserver_ObserveFChain_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -69,7 +70,7 @@ func (_c *MockObserver_ObserveFChain_Call) Return(_a0 map[ccipocr3.ChainSelector
 	return _c
 }
 
-func (_c *MockObserver_ObserveFChain_Call) RunAndReturn(run func() map[ccipocr3.ChainSelector]int) *MockObserver_ObserveFChain_Call {
+func (_c *MockObserver_ObserveFChain_Call) RunAndReturn(run func(context.Context) map[ccipocr3.ChainSelector]int) *MockObserver_ObserveFChain_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/logutil/logutil.go
+++ b/pkg/logutil/logutil.go
@@ -1,6 +1,8 @@
 package logutil
 
 import (
+	"context"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/libocr/commontypes"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
@@ -27,4 +29,55 @@ func WithPluginConstants(
 		"donID", donID,
 		"configDigest", configDigest,
 	)
+}
+
+type ContextKey string
+
+const (
+	// ocrSeqNrKey refers to the OCR sequence number.
+	// Linter complains if this is a plain "string" type.
+	ocrSeqNrKey ContextKey = "ocrSeqNr"
+
+	ocrSeqNrLoggerKey = "ocrSeqNr"
+)
+
+// WithOCRSeqNr returns a context.Context and logger with the OCR sequence number set
+// in both the context and the logger fields.
+func WithOCRSeqNr(
+	ctx context.Context,
+	lggr logger.Logger,
+	ocrSeqNr uint64,
+) (context.Context, logger.Logger) {
+	newCtx := ctxWithOCRSeqNr(ctx, ocrSeqNr)
+	newLggr := WithContextValues(newCtx, lggr)
+	return newCtx, newLggr
+}
+
+// ctxWithOCRSeqNr returns a context.Context with the OCR sequence number appropriately set.
+func ctxWithOCRSeqNr(ctx context.Context, seqNr uint64) context.Context {
+	return context.WithValue(ctx, ocrSeqNrKey, seqNr)
+}
+
+// WithContextValues returns a logger with the OCR sequence number set to the correct log field key.
+// It assumes that the given ctx has the OCR sequence number set, if not the field will be set to
+// 0 in the log field.
+func WithContextValues(
+	ctx context.Context,
+	lggr logger.Logger,
+) logger.Logger {
+	return logger.With(
+		lggr,
+		ocrSeqNrLoggerKey, GetSeqNr(ctx),
+	)
+}
+
+// GetSeqNr returns the sequence number from the context.
+// 0 is returned if the sequence number is not set.
+// Note that this isn't confusing because 0 is an invalid sequence number.
+func GetSeqNr(ctx context.Context) uint64 {
+	seqNr, ok := ctx.Value(ocrSeqNrKey).(uint64)
+	if !ok {
+		return 0
+	}
+	return seqNr
 }

--- a/pkg/logutil/logutil.go
+++ b/pkg/logutil/logutil.go
@@ -8,9 +8,11 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 )
 
-// WithContext adds the "processor" field. Do not call multiple times.
-func WithContext(lggr logger.Logger, processor string) logger.Logger {
-	return logger.With(lggr, "context", processor)
+// WithComponent returns a logger with the component log field set.
+// Components can be any object that uses a logger.
+// Do not call multiple times.
+func WithComponent(lggr logger.Logger, processor string) logger.Logger {
+	return logger.With(lggr, componentLoggerKey, processor)
 }
 
 // WithPluginConstants adds the plugin name, donID and oracleID. Maybe more in the future.
@@ -24,21 +26,30 @@ func WithPluginConstants(
 ) logger.Logger {
 	return logger.With(
 		lggr,
-		"plugin", plugin,
-		"oracleID", oracleID,
-		"donID", donID,
-		"configDigest", configDigest,
+		pluginLoggerKey, plugin,
+		oracleIDLoggerKey, oracleID,
+		donIDLoggerKey, donID,
+		configDigestLoggerKey, configDigest,
 	)
 }
 
 type ContextKey string
 
 const (
+	// Standardized logger field keys.
+	// These should be sufficiently different from the ephemeral log
+	// keys that are added inline to log calls, in order to avoid
+	// collisions.
+	ocrSeqNrLoggerKey     = "ocrSeqNr"
+	componentLoggerKey    = "component"
+	pluginLoggerKey       = "plugin"
+	oracleIDLoggerKey     = "oracleID"
+	donIDLoggerKey        = "donID"
+	configDigestLoggerKey = "configDigest"
+
 	// ocrSeqNrKey refers to the OCR sequence number.
 	// Linter complains if this is a plain "string" type.
-	ocrSeqNrKey ContextKey = "ocrSeqNr"
-
-	ocrSeqNrLoggerKey = "ocrSeqNr"
+	ocrSeqNrKey = ContextKey(ocrSeqNrLoggerKey)
 )
 
 // WithOCRSeqNr returns a context.Context and logger with the OCR sequence number set

--- a/pkg/logutil/logutil.go
+++ b/pkg/logutil/logutil.go
@@ -8,6 +8,26 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 )
 
+// Type to use as context keys, regular string type can't be used.
+type contextKey string
+
+const (
+	// Standardized logger field keys.
+	// These should be sufficiently different from the ephemeral log
+	// keys that are added inline to log calls, in order to avoid
+	// collisions.
+	ocrSeqNrLoggerKey     = "ocrSeqNr"
+	componentLoggerKey    = "component"
+	pluginLoggerKey       = "plugin"
+	oracleIDLoggerKey     = "oracleID"
+	donIDLoggerKey        = "donID"
+	configDigestLoggerKey = "configDigest"
+
+	// ocrSeqNrKey refers to the OCR sequence number.
+	// Linter complains if this is a plain "string" type.
+	ocrSeqNrKey = contextKey(ocrSeqNrLoggerKey)
+)
+
 // WithComponent returns a logger with the component log field set.
 // Components can be any object that uses a logger.
 // Do not call multiple times.
@@ -32,25 +52,6 @@ func WithPluginConstants(
 		configDigestLoggerKey, configDigest,
 	)
 }
-
-type ContextKey string
-
-const (
-	// Standardized logger field keys.
-	// These should be sufficiently different from the ephemeral log
-	// keys that are added inline to log calls, in order to avoid
-	// collisions.
-	ocrSeqNrLoggerKey     = "ocrSeqNr"
-	componentLoggerKey    = "component"
-	pluginLoggerKey       = "plugin"
-	oracleIDLoggerKey     = "oracleID"
-	donIDLoggerKey        = "donID"
-	configDigestLoggerKey = "configDigest"
-
-	// ocrSeqNrKey refers to the OCR sequence number.
-	// Linter complains if this is a plain "string" type.
-	ocrSeqNrKey = ContextKey(ocrSeqNrLoggerKey)
-)
 
 // WithOCRSeqNr returns a context.Context and logger with the OCR sequence number set
 // in both the context and the logger fields.

--- a/pkg/logutil/logutil_test.go
+++ b/pkg/logutil/logutil_test.go
@@ -23,10 +23,10 @@ func TestLogWrapper(t *testing.T) {
 	digest[31] = 31
 
 	expected := map[string]interface{}{
-		"donID":        donID,
-		"oracleID":     oracleID,
-		"plugin":       "TestPlugin",
-		"configDigest": digest.String(),
+		donIDLoggerKey:        donID,
+		oracleIDLoggerKey:     oracleID,
+		pluginLoggerKey:       "TestPlugin",
+		configDigestLoggerKey: digest.String(),
 	}
 
 	// Initial wrapping of base logger.
@@ -37,29 +37,12 @@ func TestLogWrapper(t *testing.T) {
 	require.Equal(t, expected, hook.All()[0].ContextMap())
 
 	// Second wrapping.
-	wrapped2 := WithContext(wrapped, "TestProcessor")
-	expected["context"] = "TestProcessor"
+	wrapped2 := WithComponent(wrapped, "TestProcessor")
+	expected[componentLoggerKey] = "TestProcessor"
 	wrapped2.Info("The space bar.")
 	require.Equal(t, hook.Len(), 2)
 	require.Len(t, hook.All()[1].Context, len(expected))
 	require.Equal(t, expected, hook.All()[1].ContextMap())
-}
-
-func TestNamed(t *testing.T) {
-	lggr, hook := logger.TestObserved(t, zapcore.DebugLevel)
-
-	// Name the base logger.
-	namedLggr := logger.Named(lggr, "ElToroLoco")
-	namedLggr.Info("Monster Jam")
-	require.Equal(t, 1, hook.Len())
-	require.Equal(t, "ElToroLoco", hook.All()[0].LoggerName)
-
-	// Name the named logger.
-	namedLggr2 := logger.Named(namedLggr, "ObiWan")
-	namedLggr2.Info("Star Wars")
-
-	require.Equal(t, 2, hook.Len())
-	require.Equal(t, "ElToroLoco.ObiWan", hook.All()[1].LoggerName)
 }
 
 func TestLogCopy(t *testing.T) {
@@ -72,10 +55,10 @@ func TestLogCopy(t *testing.T) {
 	digest[31] = 31
 
 	expected := map[string]interface{}{
-		"donID":        donID,
-		"oracleID":     oracleID,
-		"plugin":       "TestPlugin",
-		"configDigest": digest.String(),
+		donIDLoggerKey:        donID,
+		oracleIDLoggerKey:     oracleID,
+		pluginLoggerKey:       "TestPlugin",
+		configDigestLoggerKey: digest.String(),
 	}
 
 	// Initial wrapping of base logger.
@@ -86,8 +69,8 @@ func TestLogCopy(t *testing.T) {
 
 	// Second wrapping.
 	logCopy := wrapped
-	wrapped2 := WithContext(logCopy, "TestProcessor")
-	expected["context"] = "TestProcessor"
+	wrapped2 := WithComponent(logCopy, "TestProcessor")
+	expected[componentLoggerKey] = "TestProcessor"
 	wrapped2.Info("The space bar.")
 	require.Equal(t, hook.Len(), 2)
 	require.Len(t, hook.All()[1].Context, len(expected))

--- a/pkg/reader/ccip_test.go
+++ b/pkg/reader/ccip_test.go
@@ -515,22 +515,32 @@ func TestCCIPChainReader_DiscoverContracts_HappyPath_Round1(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, expectedContractAddresses, contractAddresses)
-	require.Equal(t, 3, hook.Len())
+	require.Equal(t, 5, hook.Len())
 
 	assert.Contains(
 		t,
-		"appending RMN remote contract address",
 		hook.All()[0].Message,
+		"appending router contract address",
 	)
 	assert.Contains(
 		t,
-		"unable to lookup source fee quoters, this is expected during initialization",
 		hook.All()[1].Message,
+		"appending RMN remote contract address",
 	)
 	assert.Contains(
 		t,
-		"unable to lookup source routers, this is expected during initialization",
 		hook.All()[2].Message,
+		"appending fee quoter contract address",
+	)
+	assert.Contains(
+		t,
+		hook.All()[3].Message,
+		"unable to lookup source fee quoters, this is expected during initialization",
+	)
+	assert.Contains(
+		t,
+		hook.All()[4].Message,
+		"unable to lookup source routers, this is expected during initialization",
 	)
 }
 

--- a/pkg/reader/price_reader.go
+++ b/pkg/reader/price_reader.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/logutil"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
 )
@@ -81,16 +82,17 @@ func (pr *priceReader) GetFeeQuoterTokenUpdates(
 	tokens []ccipocr3.UnknownEncodedAddress,
 	chain ccipocr3.ChainSelector,
 ) (map[ccipocr3.UnknownEncodedAddress]plugintypes.TimestampedBig, error) {
+	lggr := logutil.WithContextValues(ctx, pr.lggr)
 	updates := make([]plugintypes.TimestampedUnixBig, len(tokens))
 	updateMap := make(map[ccipocr3.UnknownEncodedAddress]plugintypes.TimestampedBig)
 
 	feeQuoterAddress, err := pr.ccipReader.GetContractAddress(consts.ContractNameFeeQuoter, chain)
 	if err != nil {
-		pr.lggr.Debugw("failed to get fee quoter address.", "chain", chain, "err", err)
+		lggr.Debugw("failed to get fee quoter address.", "chain", chain, "err", err)
 		return updateMap, nil
 	}
 
-	pr.lggr.Infow("getting fee quoter token updates",
+	lggr.Infow("getting fee quoter token updates",
 		"tokens", tokens,
 		"chain", chain,
 		"feeQuoterAddress", typeconv.AddressBytesToString(feeQuoterAddress, uint64(chain)),
@@ -100,7 +102,7 @@ func (pr *priceReader) GetFeeQuoterTokenUpdates(
 	for _, token := range tokens {
 		byteToken, err := typeconv.AddressStringToBytes(string(token), uint64(chain))
 		if err != nil {
-			pr.lggr.Warnw("failed to convert token address to bytes", "token", token, "err", err)
+			lggr.Warnw("failed to convert token address to bytes", "token", token, "err", err)
 			continue
 		}
 
@@ -114,7 +116,7 @@ func (pr *priceReader) GetFeeQuoterTokenUpdates(
 
 	cr, ok := pr.chainReaders[chain]
 	if !ok {
-		pr.lggr.Warnw("contract reader not found", "chain", chain)
+		lggr.Warnw("contract reader not found", "chain", chain)
 		return nil, nil
 	}
 	// MethodNameFeeQuoterGetTokenPrices returns an empty update with
@@ -135,7 +137,7 @@ func (pr *priceReader) GetFeeQuoterTokenUpdates(
 	for i, token := range tokens {
 		// token not available on fee quoter
 		if updates[i].Timestamp == 0 || updates[i].Value == nil || updates[i].Value.Cmp(big.NewInt(0)) == 0 {
-			pr.lggr.Debugw("empty fee quoter update found",
+			lggr.Debugw("empty fee quoter update found",
 				"chain", chain,
 				"token", token,
 			)
@@ -152,9 +154,10 @@ func (pr *priceReader) GetFeedPricesUSD(
 	ctx context.Context,
 	tokens []ccipocr3.UnknownEncodedAddress,
 ) (map[ccipocr3.UnknownEncodedAddress]*big.Int, error) {
+	lggr := logutil.WithContextValues(ctx, pr.lggr)
 	prices := make(map[ccipocr3.UnknownEncodedAddress]*big.Int, len(tokens))
 	if pr.feedChainReader() == nil {
-		pr.lggr.Debug("node does not support feed chain")
+		lggr.Debug("node does not support feed chain")
 		return prices, nil
 	}
 
@@ -174,21 +177,21 @@ func (pr *priceReader) GetFeedPricesUSD(
 	for boundContract, tokens := range contractTokenMap {
 		contractResults, ok := results[boundContract]
 		if !ok || len(contractResults) != priceReaderOperationCount {
-			pr.lggr.Errorf("invalid results for contract %s", boundContract.Address)
+			lggr.Errorf("invalid results for contract %s", boundContract.Address)
 			continue
 		}
 
 		// Get price data
 		latestRoundData, err := pr.getPriceData(contractResults[0], boundContract)
 		if err != nil {
-			pr.lggr.Errorw("calling getPriceData", err)
+			lggr.Errorw("calling getPriceData", err)
 			continue
 		}
 
 		// Get decimals
 		decimals, err := pr.getDecimals(contractResults[1], boundContract)
 		if err != nil {
-			pr.lggr.Errorw("calling getPriceData", err)
+			lggr.Errorw("calling getPriceData", err)
 			continue
 		}
 
@@ -200,7 +203,7 @@ func (pr *priceReader) GetFeedPricesUSD(
 			tokenInfo := pr.tokenInfo[token]
 			price := calculateUsdPer1e18TokenAmount(normalizedContractPrice, tokenInfo.Decimals)
 			if price == nil {
-				pr.lggr.Errorw("failed to calculate price", "token", token)
+				lggr.Errorw("failed to calculate price", "token", token)
 				continue
 			}
 			prices[token] = price


### PR DESCRIPTION
Ticket: https://smartcontract-it.atlassian.net/browse/CCIP-4877

In order to build more readable logs, we include the OCR sequence number in the context that is provided by libocr. This means that all downstream components, i.e the ccip reader, processors, etc. will be able to extract the sequence number and include it as a field in their loggers.