### PR TITLE
[Solana][NONEVM-1147] Denominate ccip_send fees in LINK

### DIFF
--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/config.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/config.rs
@@ -121,75 +121,75 @@ mod tests {
         let cases = vec![
             // No address configured
             ConfigTestCase {
-                config_on_ramps: empty_config.clone(),
+                config_on_ramps: empty_config,
                 given_on_ramp: vec![],
                 expected: false,
             },
             ConfigTestCase {
-                config_on_ramps: empty_config.clone(),
+                config_on_ramps: empty_config,
                 given_on_ramp: vec![1; 64],
                 expected: false,
             },
             ConfigTestCase {
-                config_on_ramps: empty_config.clone(),
+                config_on_ramps: empty_config,
                 given_on_ramp: vec![4; 64],
                 expected: false,
             },
             // One address configured
             ConfigTestCase {
-                config_on_ramps: one_address_config.clone(),
+                config_on_ramps: one_address_config,
                 given_on_ramp: vec![],
                 expected: false,
             },
             ConfigTestCase {
-                config_on_ramps: one_address_config.clone(),
+                config_on_ramps: one_address_config,
                 given_on_ramp: vec![1; 64],
                 expected: true,
             },
             ConfigTestCase {
-                config_on_ramps: one_address_config.clone(),
+                config_on_ramps: one_address_config,
                 given_on_ramp: vec![4; 64],
                 expected: false,
             },
             // Two addresses configured
             ConfigTestCase {
-                config_on_ramps: two_addresses_config.clone(),
+                config_on_ramps: two_addresses_config,
                 given_on_ramp: vec![],
                 expected: false,
             },
             ConfigTestCase {
-                config_on_ramps: two_addresses_config.clone(),
+                config_on_ramps: two_addresses_config,
                 given_on_ramp: vec![2; 64],
                 expected: true,
             },
             ConfigTestCase {
-                config_on_ramps: two_addresses_config.clone(),
+                config_on_ramps: two_addresses_config,
                 given_on_ramp: vec![3; 64],
                 expected: true,
             },
             ConfigTestCase {
-                config_on_ramps: two_addresses_config.clone(),
+                config_on_ramps: two_addresses_config,
                 given_on_ramp: [vec![2; 32], vec![3; 32]].concat(),
                 expected: false,
             },
             // Two addresses configured with smaller addresses
             ConfigTestCase {
-                config_on_ramps: two_smaller_addresses_config.clone(),
+                config_on_ramps: two_smaller_addresses_config,
                 given_on_ramp: vec![],
                 expected: false,
             },
             ConfigTestCase {
-                config_on_ramps: two_smaller_addresses_config.clone(),
+                config_on_ramps: two_smaller_addresses_config,
                 given_on_ramp: vec![0; 32],
                 expected: false,
             },
             ConfigTestCase {
-                config_on_ramps: two_smaller_addresses_config.clone(),
+                config_on_ramps: two_smaller_addresses_config,
                 given_on_ramp: vec![4; 32],
                 expected: true,
             },
             ConfigTestCase {
-                config_on_ramps: two_smaller_addresses_config.clone(),
+                config_on_ramps: two_smaller_addresses_config,
                 given_on_ramp: vec![5; 32],
                 expected: true,
             },

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/messages.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/messages.rs
@@ -1,5 +1,8 @@
 pub mod pools {
-    use crate::{TOKENPOOL_LOCK_OR_BURN_DISCRIMINATOR, TOKENPOOL_RELEASE_OR_MINT_DISCRIMINATOR};
+    use crate::{
+        CrossChainAmount, TOKENPOOL_LOCK_OR_BURN_DISCRIMINATOR,
+        TOKENPOOL_RELEASE_OR_MINT_DISCRIMINATOR,
+    };
 
     use super::super::pools::ToTxData;
     use anchor_lang::prelude::*;
@@ -27,8 +30,8 @@ pub mod pools {
         pub original_sender: Vec<u8>, //          The original sender of the tx on the source chain
         pub remote_chain_selector: u64, // ─╮ The chain ID of the source chain
         pub receiver: Pubkey, // ───────────╯ The Token Associated Account that will receive the tokens on the destination chain.
-        pub amount: [u8; 32], // LE u256 amount - The amount of tokens to release or mint, denominated in the source token's decimals, pool expected to handle conversation to solana token specifics
-        pub local_token: Pubkey, //            The address of the Token Mint Account on SVM
+        pub amount: CrossChainAmount, // LE u256 amount - The amount of tokens to release or mint, denominated in the source token's decimals, pool expected to handle conversation to solana token specifics
+        pub local_token: Pubkey,      //            The address of the Token Mint Account on SVM
         /// @dev WARNING: sourcePoolAddress should be checked prior to any processing of funds. Make sure it matches the
         /// expected pool address for the given remoteChainSelector.
         pub source_pool_address: Vec<u8>, //       The address bytes of the source pool

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/offramp.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/offramp.rs
@@ -824,6 +824,8 @@ mod execution_state {
 
 #[cfg(test)]
 mod tests {
+    use ethnum::U256;
+
     use super::*;
     use crate::{Any2SVMRampMessage, Any2SVMTokenTransfer, SVMExtraArgs};
 
@@ -858,7 +860,7 @@ mod tests {
                 .unwrap(),
                 dest_gas_amount: 100,
                 extra_data: vec![4, 5, 6],
-                amount: [1; 32],
+                amount: U256::from_le_bytes([1; 32]).into(),
             }]
             .to_vec(),
             extra_args: SVMExtraArgs {

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/pools.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/pools.rs
@@ -314,13 +314,6 @@ pub fn get_balance<'a>(token_account: &'a AccountInfo<'a>) -> Result<u64> {
     Ok(acc.amount)
 }
 
-// pack u64 into LE u256 for cross-chain amount
-pub fn u64_to_le_u256(v: u64) -> [u8; 32] {
-    let mut out: [u8; 32] = [0; 32];
-    out[..8].copy_from_slice(v.to_le_bytes().as_slice());
-    out
-}
-
 pub mod token_admin_registry_writable {
     use crate::TokenAdminRegistry;
 

--- a/chains/solana/contracts/target/idl/ccip_router.json
+++ b/chains/solana/contracts/target/idl/ccip_router.json
@@ -2115,15 +2115,23 @@
             "type": "publicKey"
           },
           {
-            "name": "feeTokenAmount",
-            "type": "u64"
-          },
-          {
             "name": "tokenAmounts",
             "type": {
               "vec": {
                 "defined": "SVM2AnyTokenTransfer"
               }
+            }
+          },
+          {
+            "name": "feeTokenAmount",
+            "type": {
+              "defined": "CrossChainAmount"
+            }
+          },
+          {
+            "name": "feeValueJuels",
+            "type": {
+              "defined": "CrossChainAmount"
             }
           }
         ]
@@ -2149,10 +2157,7 @@
           {
             "name": "amount",
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
+              "defined": "CrossChainAmount"
             }
           },
           {
@@ -2186,10 +2191,7 @@
           {
             "name": "amount",
             "type": {
-              "array": [
-                "u8",
-                32
-              ]
+              "defined": "CrossChainAmount"
             }
           }
         ]
@@ -2260,6 +2262,23 @@
             "name": "allowOutOfOrderExecution",
             "type": {
               "option": "bool"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "CrossChainAmount",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "leBytes",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
             }
           }
         ]

--- a/chains/solana/contracts/tests/ccip/ccip_router_test.go
+++ b/chains/solana/contracts/tests/ccip/ccip_router_test.go
@@ -899,10 +899,15 @@ func TestCCIPRouter(t *testing.T) {
 
 			// Any nonzero timestamp is valid (for now)
 			validTimestamp := int64(100)
-			value := [28]uint8{}
+			bigValue := [28]uint8{}
 			bigNum, ok := new(big.Int).SetString("19816680000000000000", 10)
 			require.True(t, ok)
-			bigNum.FillBytes(value[:])
+			bigNum.FillBytes(bigValue[:])
+
+			smallValue := [28]uint8{}
+			smallNum, ok := new(big.Int).SetString("1981668000000000000", 10)
+			require.True(t, ok)
+			smallNum.FillBytes(smallValue[:])
 
 			testTokens := []TestToken{
 				{
@@ -911,7 +916,7 @@ func TestCCIPRouter(t *testing.T) {
 						Enabled: true,
 						Mint:    solana.SolMint,
 						UsdPerToken: ccip_router.TimestampedPackedU224{
-							Value:     value,
+							Value:     smallValue,
 							Timestamp: validTimestamp,
 						},
 						PremiumMultiplierWeiPerEth: 9000000,
@@ -922,7 +927,7 @@ func TestCCIPRouter(t *testing.T) {
 						Enabled: true,
 						Mint:    token2022.mint,
 						UsdPerToken: ccip_router.TimestampedPackedU224{
-							Value:     value,
+							Value:     bigValue,
 							Timestamp: validTimestamp,
 						},
 						PremiumMultiplierWeiPerEth: 11000000,
@@ -2688,10 +2693,16 @@ func TestCCIPRouter(t *testing.T) {
 			require.NoError(t, common.ParseEvent(result.Meta.LogMessages, "CCIPMessageSent", &ccipMessageSentEvent, config.PrintEvents))
 			require.Equal(t, 1, len(ccipMessageSentEvent.Message.TokenAmounts))
 			ta := ccipMessageSentEvent.Message.TokenAmounts[0]
+
+			require.Equal(t, wsol.mint, ccipMessageSentEvent.Message.FeeToken)
+			require.Equal(t, tokens.ToLittleEndianU256(36333028), ccipMessageSentEvent.Message.FeeTokenAmount.LeBytes)
+			// The difference is the ratio between the fee token value (wsol) and link token value (signified by token2022 in these tests).
+			// Since they have been configured in the test setup to differ by a factor of 10, so does the token amount and its value in juels
+			require.Equal(t, tokens.ToLittleEndianU256(3633302), ccipMessageSentEvent.Message.FeeValueJuels.LeBytes)
 			require.Equal(t, token0.PoolConfig, ta.SourcePoolAddress)
 			require.Equal(t, []byte{1, 2, 3}, ta.DestTokenAddress)
 			require.Equal(t, 0, len(ta.ExtraData))
-			require.Equal(t, tokens.ToLittleEndianU256(1), ta.Amount)
+			require.Equal(t, tokens.ToLittleEndianU256(1), ta.Amount.LeBytes)
 			require.Equal(t, 32, len(ta.DestExecData))
 			expectedDestExecData := make([]byte, 32)
 			// Token0 billing had DestGasOverhead set to 100 during setup
@@ -4932,7 +4943,7 @@ func TestCCIPRouter(t *testing.T) {
 				message.TokenAmounts = []ccip_router.Any2SVMTokenTransfer{{
 					SourcePoolAddress: []byte{1, 2, 3},
 					DestTokenAddress:  token0.Mint.PublicKey(),
-					Amount:            tokens.ToLittleEndianU256(1),
+					Amount:            ccip_router.CrossChainAmount{LeBytes: tokens.ToLittleEndianU256(1)},
 				}}
 				rootBytes, err := ccip.HashAnyToSVMMessage(message, config.OnRampAddress)
 				require.NoError(t, err)
@@ -5401,7 +5412,7 @@ func TestCCIPRouter(t *testing.T) {
 				message.TokenAmounts = []ccip_router.Any2SVMTokenTransfer{{
 					SourcePoolAddress: []byte{1, 2, 3},
 					DestTokenAddress:  token0.Mint.PublicKey(),
-					Amount:            tokens.ToLittleEndianU256(1),
+					Amount:            ccip_router.CrossChainAmount{LeBytes: tokens.ToLittleEndianU256(1)},
 				}}
 				message.Receiver = receiver.PublicKey()
 				rootBytes, err := ccip.HashAnyToSVMMessage(message, config.OnRampAddress)

--- a/chains/solana/contracts/tests/txsizing_test.go
+++ b/chains/solana/contracts/tests/txsizing_test.go
@@ -88,7 +88,7 @@ func TestTransactionSizing(t *testing.T) {
 	sendSingleMinimalToken := ccip_router.SVM2AnyMessage{
 		Receiver: make([]byte, 20),
 		Data:     []byte{},
-		TokenAmounts: []ccip_router.SVMTokenAmount{ccip_router.SVMTokenAmount{
+		TokenAmounts: []ccip_router.SVMTokenAmount{{
 			Token:  [32]byte{},
 			Amount: 0,
 		}}, // one token
@@ -210,7 +210,7 @@ func TestTransactionSizing(t *testing.T) {
 				DestTokenAddress:  [32]byte{},
 				DestGasAmount:     0,
 				ExtraData:         []byte{},
-				Amount:            [32]uint8{},
+				Amount:            ccip_router.CrossChainAmount{LeBytes: [32]uint8{}},
 			}},
 			ExtraArgs: ccip_router.SVMExtraArgs{
 				ComputeUnits:     0,

--- a/chains/solana/gobindings/ccip_router/types.go
+++ b/chains/solana/gobindings/ccip_router/types.go
@@ -509,8 +509,9 @@ type SVM2AnyRampMessage struct {
 	Receiver       []byte
 	ExtraArgs      AnyExtraArgs
 	FeeToken       ag_solanago.PublicKey
-	FeeTokenAmount uint64
 	TokenAmounts   []SVM2AnyTokenTransfer
+	FeeTokenAmount CrossChainAmount
+	FeeValueJuels  CrossChainAmount
 }
 
 func (obj SVM2AnyRampMessage) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
@@ -544,13 +545,18 @@ func (obj SVM2AnyRampMessage) MarshalWithEncoder(encoder *ag_binary.Encoder) (er
 	if err != nil {
 		return err
 	}
+	// Serialize `TokenAmounts` param:
+	err = encoder.Encode(obj.TokenAmounts)
+	if err != nil {
+		return err
+	}
 	// Serialize `FeeTokenAmount` param:
 	err = encoder.Encode(obj.FeeTokenAmount)
 	if err != nil {
 		return err
 	}
-	// Serialize `TokenAmounts` param:
-	err = encoder.Encode(obj.TokenAmounts)
+	// Serialize `FeeValueJuels` param:
+	err = encoder.Encode(obj.FeeValueJuels)
 	if err != nil {
 		return err
 	}
@@ -588,13 +594,18 @@ func (obj *SVM2AnyRampMessage) UnmarshalWithDecoder(decoder *ag_binary.Decoder) 
 	if err != nil {
 		return err
 	}
+	// Deserialize `TokenAmounts`:
+	err = decoder.Decode(&obj.TokenAmounts)
+	if err != nil {
+		return err
+	}
 	// Deserialize `FeeTokenAmount`:
 	err = decoder.Decode(&obj.FeeTokenAmount)
 	if err != nil {
 		return err
 	}
-	// Deserialize `TokenAmounts`:
-	err = decoder.Decode(&obj.TokenAmounts)
+	// Deserialize `FeeValueJuels`:
+	err = decoder.Decode(&obj.FeeValueJuels)
 	if err != nil {
 		return err
 	}
@@ -605,7 +616,7 @@ type SVM2AnyTokenTransfer struct {
 	SourcePoolAddress ag_solanago.PublicKey
 	DestTokenAddress  []byte
 	ExtraData         []byte
-	Amount            [32]uint8
+	Amount            CrossChainAmount
 	DestExecData      []byte
 }
 
@@ -672,7 +683,7 @@ type Any2SVMTokenTransfer struct {
 	DestTokenAddress  ag_solanago.PublicKey
 	DestGasAmount     uint32
 	ExtraData         []byte
-	Amount            [32]uint8
+	Amount            CrossChainAmount
 }
 
 func (obj Any2SVMTokenTransfer) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
@@ -903,6 +914,28 @@ func (obj *ExtraArgsInput) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err
 				return err
 			}
 		}
+	}
+	return nil
+}
+
+type CrossChainAmount struct {
+	LeBytes [32]uint8
+}
+
+func (obj CrossChainAmount) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `LeBytes` param:
+	err = encoder.Encode(obj.LeBytes)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (obj *CrossChainAmount) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `LeBytes`:
+	err = decoder.Decode(&obj.LeBytes)
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/chains/solana/utils/ccip/ccip_messages.go
+++ b/chains/solana/utils/ccip/ccip_messages.go
@@ -245,6 +245,9 @@ func HashSVMToAnyMessage(msg ccip_router.SVM2AnyRampMessage) ([]byte, error) {
 	if err := binary.Write(hash, binary.BigEndian, msg.FeeTokenAmount); err != nil {
 		return nil, err
 	}
+	if err := binary.Write(hash, binary.BigEndian, msg.FeeValueJuels); err != nil {
+		return nil, err
+	}
 	if _, err := hash.Write([]byte{uint8(len(msg.Receiver))}); err != nil { //nolint:gosec
 		return nil, err
 	}

--- a/chains/solana/utils/ccip/ccip_messages_test.go
+++ b/chains/solana/utils/ccip/ccip_messages_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/contracts/tests/config"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_router"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
 )
 
 func TestMessageHashing(t *testing.T) {
@@ -48,7 +49,7 @@ func TestMessageHashing(t *testing.T) {
 					DestTokenAddress:  solana.MustPublicKeyFromBase58("DS2tt4BX7YwCw7yrDNwbAdnYrxjeCPeGJbHmZEYC8RTc"),
 					DestGasAmount:     100,
 					ExtraData:         []byte{4, 5, 6},
-					Amount:            tokenAmount,
+					Amount:            ccip_router.CrossChainAmount{LeBytes: tokenAmount},
 				},
 			},
 		}, config.OnRampAddress)
@@ -76,18 +77,19 @@ func TestMessageHashing(t *testing.T) {
 				AllowOutOfOrderExecution: true,
 			},
 			FeeToken:       solana.MustPublicKeyFromBase58("DS2tt4BX7YwCw7yrDNwbAdnYrxjeCPeGJbHmZEYC8RTb"),
-			FeeTokenAmount: 50,
+			FeeTokenAmount: ccip_router.CrossChainAmount{LeBytes: tokens.ToLittleEndianU256(50)},
+			FeeValueJuels:  ccip_router.CrossChainAmount{LeBytes: tokens.ToLittleEndianU256(500)},
 			TokenAmounts: []ccip_router.SVM2AnyTokenTransfer{
 				{
 					SourcePoolAddress: solana.MustPublicKeyFromBase58("DS2tt4BX7YwCw7yrDNwbAdnYrxjeCPeGJbHmZEYC8RTc"),
 					DestTokenAddress:  []byte{0, 1, 2, 3},
 					ExtraData:         []byte{4, 5, 6},
-					Amount:            tokenAmount,
+					Amount:            ccip_router.CrossChainAmount{LeBytes: tokenAmount},
 					DestExecData:      []byte{4, 5, 6},
 				},
 			},
 		})
 		require.NoError(t, err)
-		require.Equal(t, "df0890c0fb144ce4dee6556f2cd41382676f75e7292b61eca658b1d122a36f58", hex.EncodeToString(h))
+		require.Equal(t, "877ba2a7329fe40e5f73b697eff78577988a72216e6c96b57335c97f92e14268", hex.EncodeToString(h))
 	})
 }


### PR DESCRIPTION
Adds some extra little bit of type safety with a wrapper around the anchor-serializable U256 for cross-chain communications.