### PR TITLE
CCIP-4873: Add RMN client metrics

### DIFF
--- a/commit/merkleroot/query_test.go
+++ b/commit/merkleroot/query_test.go
@@ -298,11 +298,12 @@ func TestProcessor_Query(t *testing.T) {
 			}
 
 			w := Processor{
-				offchainCfg:   tc.cfg,
-				destChain:     tc.destChain,
-				ccipReader:    ccipReader,
-				rmnController: tc.rmnClient(t),
-				lggr:          logger.Test(t),
+				offchainCfg:     tc.cfg,
+				destChain:       tc.destChain,
+				ccipReader:      ccipReader,
+				rmnController:   tc.rmnClient(t),
+				lggr:            logger.Test(t),
+				metricsReporter: NoopMetrics{},
 			}
 
 			w.rmnControllerCfgDigest = tc.prevOutcome.RMNRemoteCfg.ConfigDigest // skip rmn controller init

--- a/commit/merkleroot/rmn/controller_test.go
+++ b/commit/merkleroot/rmn/controller_test.go
@@ -431,6 +431,7 @@ func TestClient_ComputeReportSignatures(t *testing.T) {
 			reportsInitialRequestTimerDuration:      time.Minute,
 			ed25519Verifier:                         signatureVerifierAlwaysTrue{},
 			rmnCrypto:                               signatureVerifierAlwaysTrue{},
+			metricsReporter:                         NoopMetrics{},
 		}
 
 		updateRequests := []*rmnpb.FixedDestLaneUpdateRequest{

--- a/commit/merkleroot/rmn/metrics.go
+++ b/commit/merkleroot/rmn/metrics.go
@@ -1,0 +1,14 @@
+package rmn
+
+const (
+	RmnMethodObservation     = "observation"
+	RmnMethodReportSignature = "report_signature"
+)
+
+type MetricsReporter interface {
+	TrackRmnRequest(method string, latency float64, nodeID uint64, err string)
+}
+
+type NoopMetrics struct{}
+
+func (n NoopMetrics) TrackRmnRequest(string, float64, uint64, string) {}

--- a/commit/merkleroot/types.go
+++ b/commit/merkleroot/types.go
@@ -198,6 +198,7 @@ func (p processorState) String() string {
 type MetricsReporter interface {
 	TrackMerkleObservation(obs Observation, state string)
 	TrackMerkleOutcome(outcome Outcome, state string)
+	TrackRmnReport(latency float64, success bool)
 }
 
 type NoopMetrics struct{}
@@ -205,3 +206,5 @@ type NoopMetrics struct{}
 func (n NoopMetrics) TrackMerkleObservation(Observation, string) {}
 
 func (n NoopMetrics) TrackMerkleOutcome(Outcome, string) {}
+
+func (n NoopMetrics) TrackRmnReport(float64, bool) {}

--- a/commit/metrics/reporter.go
+++ b/commit/metrics/reporter.go
@@ -24,6 +24,8 @@ type Reporter interface {
 
 	TrackMerkleObservation(obs merkleroot.Observation, state string)
 	TrackMerkleOutcome(outcome merkleroot.Outcome, state string)
+	TrackRmnReport(latency float64, success bool)
+	TrackRmnRequest(method string, latency float64, nodeID uint64, err string)
 
 	TrackChainFeeObservation(obs chainfee.Observation)
 	TrackChainFeeOutcome(outcome chainfee.Outcome)
@@ -50,6 +52,10 @@ func (n *Noop) TrackChainFeeOutcome(chainfee.Outcome) {}
 func (n *Noop) TrackMerkleObservation(merkleroot.Observation, string) {}
 
 func (n *Noop) TrackMerkleOutcome(merkleroot.Outcome, string) {}
+
+func (n *Noop) TrackRmnReport(float64, bool) {}
+
+func (n *Noop) TrackRmnRequest(string, float64, uint64, string) {}
 
 func (n *Noop) TrackTokenPricesObservation(tokenprice.Observation) {}
 

--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -101,6 +101,7 @@ func NewPlugin(
 		rmnHomeReader,
 		observationsInitialRequestTimerDuration(reportingCfg.MaxDurationQuery),
 		reportsInitialRequestTimerDuration(reportingCfg.MaxDurationQuery),
+		reporter,
 	)
 
 	merkleRootProcessor := merkleroot.NewProcessor(


### PR DESCRIPTION
Adds client-side metrics for individual RMN calls. These calls are asynchronous and use RageP2P. To support this functionality, we introduce state to store inflight requests in this change. The inflight request store maps request IDs to the timestamp the request was made and the node ID of the RMN node the request was sent to.

When we get a response back for a specific request ID, we look it up in the inflight request store and mark the latency of the request. On a timeout of the entire RMN report flow, we iterate through the inflight request store and mark metrics for all inflight requests that have not received a response.

Metrics are tagged with the node ID, which allows us to correlate slow or failed requests with specific nodes.