### PR TITLE
[CCIP-4920] execute: use set ocr ctx in log fields

### DIFF
--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -157,7 +157,7 @@ func NewPlugin(
 		donID:               donID,
 		oracleID:            reportingCfg.OracleID,
 		oracleIDToP2PID:     oracleIDToP2pID,
-		lggr:                logutil.WithComponent(lggr, "Plugin"),
+		lggr:                logutil.WithComponent(lggr, "CommitPlugin"),
 		offchainCfg:         offchainCfg,
 		tokenPricesReader:   tokenPricesReader,
 		ccipReader:          ccipReader,

--- a/execute/costlymessages/costly_messages.go
+++ b/execute/costlymessages/costly_messages.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/mathslib"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/logutil"
 	readerpkg "github.com/smartcontractkit/chainlink-ccip/pkg/reader"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
@@ -92,8 +93,10 @@ func (o *observer) Observe(
 	messages []cciptypes.Message,
 	messageTimestamps map[cciptypes.Bytes32]time.Time,
 ) ([]cciptypes.Bytes32, error) {
+	lggr := logutil.WithContextValues(ctx, o.lggr)
+
 	if !o.enabled {
-		o.lggr.Infof("Observer is disabled")
+		lggr.Infof("Observer is disabled")
 		return nil, nil
 	}
 
@@ -122,7 +125,7 @@ func (o *observer) Observe(
 			return nil, fmt.Errorf("missing exec cost for message %s", msg.Header.MessageID)
 		}
 		if fee.Cmp(execCost) < 0 {
-			o.lggr.Warnw("Message is too costly to execute", "messageID",
+			lggr.Warnw("Message is too costly to execute", "messageID",
 				msg.Header.MessageID.String(), "fee", fee, "execCost", execCost, "seqNum", msg.Header.SequenceNumber)
 			costlyMessages = append(costlyMessages, msg.Header.MessageID)
 		}
@@ -296,6 +299,8 @@ func (c *CCIPMessageFeeUSD18Calculator) MessageFeeUSD18(
 	messages []cciptypes.Message,
 	messageTimeStamps map[cciptypes.Bytes32]time.Time,
 ) (map[cciptypes.Bytes32]plugintypes.USD18, error) {
+	lggr := logutil.WithContextValues(ctx, c.lggr)
+
 	linkPriceUSD, err := c.ccipReader.LinkPriceUSD(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get LINK price in USD: %w", err)
@@ -311,7 +316,7 @@ func (c *CCIPMessageFeeUSD18Calculator) MessageFeeUSD18(
 		if !ok {
 			// If a timestamp is missing we can't do fee boosting, but we still record the fee. In the worst case, the
 			// message will not be executed (as it will be considered too costly).
-			c.lggr.Warnw("missing timestamp for message", "messageID", msg.Header.MessageID)
+			lggr.Warnw("missing timestamp for message", "messageID", msg.Header.MessageID)
 		} else {
 			feeUSD18 = waitBoostedFee(c.now().Sub(timestamp), feeUSD18, c.relativeBoostPerWaitHour)
 		}
@@ -351,6 +356,8 @@ func (c *CCIPMessageExecCostUSD18Calculator) MessageExecCostUSD18(
 	ctx context.Context,
 	messages []cciptypes.Message,
 ) (map[cciptypes.Bytes32]plugintypes.USD18, error) {
+	lggr := logutil.WithContextValues(ctx, c.lggr)
+
 	if len(messages) == 0 {
 		return nil, fmt.Errorf("no messages provided")
 	}
@@ -367,7 +374,7 @@ func (c *CCIPMessageExecCostUSD18Calculator) MessageExecCostUSD18(
 		return nil, fmt.Errorf("missing data availability fee")
 	}
 
-	executionFee, daFee, err := c.getFeesUSD18(ctx, feeComponents, messages[0].Header.DestChainSelector)
+	executionFee, daFee, err := c.getFeesUSD18(ctx, lggr, feeComponents, messages[0].Header.DestChainSelector)
 	if err != nil {
 		return nil, fmt.Errorf("unable to convert fee components to USD18: %w", err)
 	}
@@ -389,6 +396,7 @@ func (c *CCIPMessageExecCostUSD18Calculator) MessageExecCostUSD18(
 
 func (c *CCIPMessageExecCostUSD18Calculator) getFeesUSD18(
 	ctx context.Context,
+	lggr logger.Logger,
 	feeComponents types.ChainFeeComponents,
 	destChainSelector cciptypes.ChainSelector,
 ) (plugintypes.USD18, plugintypes.USD18, error) {
@@ -406,7 +414,8 @@ func (c *CCIPMessageExecCostUSD18Calculator) getFeesUSD18(
 	executionFee := mathslib.CalculateUsdPerUnitGas(feeComponents.ExecutionFee, nativeTokenPrice.Int)
 	dataAvailabilityFee := mathslib.CalculateUsdPerUnitGas(feeComponents.DataAvailabilityFee, nativeTokenPrice.Int)
 
-	c.lggr.Debugw("Fee calculation", "nativeTokenPrice", nativeTokenPrice,
+	lggr.Debugw("Fee calculation",
+		"nativeTokenPrice", nativeTokenPrice,
 		"feeComponents.ExecutionFee", feeComponents.ExecutionFee,
 		"feeComponents.DataAvailabilityFee", feeComponents.DataAvailabilityFee,
 		"executionFee", executionFee,

--- a/execute/observation_test.go
+++ b/execute/observation_test.go
@@ -170,7 +170,7 @@ func Test_getMessagesObservation(t *testing.T) {
 			}, nil).Maybe()
 
 			observation := exectypes.Observation{}
-			observation, err := plugin.getMessagesObservation(ctx, tt.previousOutcome, observation)
+			observation, err := plugin.getMessagesObservation(ctx, plugin.lggr, tt.previousOutcome, observation)
 			if tt.expectedError {
 				require.Error(t, err)
 			} else {

--- a/execute/outcome.go
+++ b/execute/outcome.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink-ccip/execute/internal"
 
 	mapset "github.com/deckarep/golang-set/v2"
@@ -17,6 +19,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/slicelib"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
 	dt "github.com/smartcontractkit/chainlink-ccip/internal/plugincommon/discovery/discoverytypes"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/logutil"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
 
@@ -27,7 +30,11 @@ import (
 func (p *Plugin) Outcome(
 	ctx context.Context, outctx ocr3types.OutcomeContext, query types.Query, aos []types.AttributedObservation,
 ) (ocr3types.Outcome, error) {
-	p.lggr.Debugw("Execute plugin performing outcome",
+	// Ensure that sequence number is in the context for consumption by all
+	// downstream processors and the ccip reader.
+	ctx, lggr := logutil.WithOCRInfo(ctx, p.lggr, outctx.SeqNr, logutil.PhaseOutcome)
+
+	lggr.Debugw("Execute plugin performing outcome",
 		"outctx", outctx,
 		"query", query,
 		"attributedObservations", aos)
@@ -68,7 +75,7 @@ func (p *Plugin) Outcome(
 		return ocr3types.Outcome{}, fmt.Errorf("destination chain %d is not in FChain", p.destChain)
 	}
 
-	observation, err := getConsensusObservation(p.lggr, decodedAos, p.destChain, p.reportingCfg.F, fChain)
+	observation, err := getConsensusObservation(lggr, decodedAos, p.destChain, p.reportingCfg.F, fChain)
 	if err != nil {
 		return ocr3types.Outcome{}, fmt.Errorf("unable to get consensus observation: %w", err)
 	}
@@ -79,15 +86,15 @@ func (p *Plugin) Outcome(
 	case exectypes.GetCommitReports:
 		outcome = p.getCommitReportsOutcome(observation)
 	case exectypes.GetMessages:
-		outcome = p.getMessagesOutcome(observation)
+		outcome = p.getMessagesOutcome(lggr, observation)
 	case exectypes.Filter:
-		outcome, err = p.getFilterOutcome(ctx, observation, previousOutcome)
+		outcome, err = p.getFilterOutcome(ctx, lggr, observation, previousOutcome)
 	default:
 		panic("unknown state")
 	}
 
 	if err != nil {
-		p.lggr.Warnw(
+		lggr.Warnw(
 			fmt.Sprintf("[oracle %d] exec outcome error", p.reportingCfg.OracleID),
 			"err", err)
 		return nil, fmt.Errorf("unable to get outcome: %w", err)
@@ -96,7 +103,7 @@ func (p *Plugin) Outcome(
 	// This may happen if there is nothing to observe, or during startup when the contracts have
 	// been discovered. In the latter case, getCommitReportsOutcome will return an empty outcome.
 	if outcome.IsEmpty() {
-		p.lggr.Warnw(
+		lggr.Warnw(
 			fmt.Sprintf("[oracle %d] exec outcome: empty outcome", p.reportingCfg.OracleID),
 			"execPluginState", state)
 		if p.contractsInitialized {
@@ -106,7 +113,7 @@ func (p *Plugin) Outcome(
 	}
 
 	p.observer.TrackOutcome(outcome, state)
-	p.lggr.Infow("generated outcome", "execPluginState", state, "outcome", outcome)
+	lggr.Infow("generated outcome", "execPluginState", state, "outcome", outcome)
 
 	return outcome.Encode()
 }
@@ -127,6 +134,7 @@ func (p *Plugin) getCommitReportsOutcome(observation exectypes.Observation) exec
 }
 
 func (p *Plugin) getMessagesOutcome(
+	lggr logger.Logger,
 	observation exectypes.Observation,
 ) exectypes.Outcome {
 	commitReports := make([]exectypes.CommitData, 0)
@@ -137,11 +145,11 @@ func (p *Plugin) getMessagesOutcome(
 
 	// First ensure that all observed messages has hashes and token data.
 	if err := validateHashesExist(observation.Messages, observation.Hashes); err != nil {
-		p.lggr.Errorw("validate hashes exist: %w", err)
+		lggr.Errorw("validate hashes exist: %w", err)
 		return exectypes.Outcome{}
 	}
 	if err := validateTokenDataObservations(observation.Messages, observation.TokenData); err != nil {
-		p.lggr.Errorw("validate token data observations: %w", err)
+		lggr.Errorw("validate token data observations: %w", err)
 		return exectypes.Outcome{}
 	}
 
@@ -178,13 +186,14 @@ func (p *Plugin) getMessagesOutcome(
 
 func (p *Plugin) getFilterOutcome(
 	ctx context.Context,
+	lggr logger.Logger,
 	observation exectypes.Observation,
 	previousOutcome exectypes.Outcome,
 ) (exectypes.Outcome, error) {
 	commitReports := previousOutcome.CommitReports
 
 	builder := report.NewBuilder(
-		p.lggr,
+		lggr,
 		p.msgHasher,
 		p.reportCodec,
 		p.estimateProvider,
@@ -196,7 +205,7 @@ func (p *Plugin) getFilterOutcome(
 
 	outcomeReports, selectedReports, err := selectReport(
 		ctx,
-		p.lggr,
+		lggr,
 		commitReports,
 		builder)
 	if err != nil {

--- a/execute/plugin_test.go
+++ b/execute/plugin_test.go
@@ -285,7 +285,9 @@ func TestPlugin_ValidateObservation_ValidateObservedSeqNum_Error(t *testing.T) {
 }
 
 func TestPlugin_Observation_BadPreviousOutcome(t *testing.T) {
-	p := &Plugin{}
+	p := &Plugin{
+		lggr: logger.Test(t),
+	}
 	_, err := p.Observation(context.Background(), ocr3types.OutcomeContext{
 		PreviousOutcome: []byte("not a valid observation"),
 	}, nil)
@@ -448,7 +450,9 @@ func TestPlugin_Outcome_MessagesMergeError(t *testing.T) {
 
 func TestPlugin_Reports_UnableToParse(t *testing.T) {
 	ctx := tests.Context(t)
-	p := &Plugin{}
+	p := &Plugin{
+		lggr: logger.Test(t),
+	}
 	_, err := p.Reports(ctx, 0, ocr3types.Outcome("not a valid observation"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unable to decode outcome")
@@ -459,7 +463,7 @@ func TestPlugin_Reports_UnableToEncode(t *testing.T) {
 	codec := codec_mocks.NewMockExecutePluginCodec(t)
 	codec.On("Encode", mock.Anything, mock.Anything).
 		Return(nil, fmt.Errorf("test error"))
-	p := &Plugin{reportCodec: codec}
+	p := &Plugin{reportCodec: codec, lggr: logger.Test(t)}
 	report, err := exectypes.NewOutcome(exectypes.Unknown, nil, cciptypes.ExecutePluginReport{}).Encode()
 	require.NoError(t, err)
 

--- a/execute/tokendata/usdc/attestation.go
+++ b/execute/tokendata/usdc/attestation.go
@@ -8,6 +8,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/hashutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
+	"github.com/smartcontractkit/chainlink-ccip/pkg/logutil"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/reader"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
@@ -90,13 +91,14 @@ func (s *sequentialAttestationClient) Attestations(
 	ctx context.Context,
 	messagesByChain map[cciptypes.ChainSelector]map[reader.MessageTokenID]cciptypes.Bytes,
 ) (map[cciptypes.ChainSelector]map[reader.MessageTokenID]AttestationStatus, error) {
+	lggr := logutil.WithContextValues(ctx, s.lggr)
 	outcome := make(map[cciptypes.ChainSelector]map[reader.MessageTokenID]AttestationStatus)
 
 	for chainSelector, messagesByTokenID := range messagesByChain {
 		outcome[chainSelector] = make(map[reader.MessageTokenID]AttestationStatus)
 
 		for tokenID, message := range messagesByTokenID {
-			s.lggr.Debugw(
+			lggr.Debugw(
 				"Fetching attestation from the API",
 				"chainSelector", chainSelector,
 				"message", message,

--- a/execute/tokendata/usdc/http.go
+++ b/execute/tokendata/usdc/http.go
@@ -189,7 +189,11 @@ func (h *httpClient) Get(ctx context.Context, messageHash cciptypes.Bytes32) (cc
 	return response, httpStatus, err
 }
 
-func (h *httpClient) callAPI(ctx context.Context, lggr logger.Logger, url url.URL) (cciptypes.Bytes, HTTPStatus, error) {
+func (h *httpClient) callAPI(
+	ctx context.Context,
+	lggr logger.Logger,
+	url url.URL,
+) (cciptypes.Bytes, HTTPStatus, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
 	if err != nil {
 		return nil, http.StatusBadRequest, err


### PR DESCRIPTION
Like commit, include seqNr and ocrPhase in the log fields for exec and all downstream components used.