### PR TITLE
pluginconfig: better err msg for relativeBoostPerWaitHour

### DIFF
--- a/pluginconfig/execute.go
+++ b/pluginconfig/execute.go
@@ -3,6 +3,7 @@ package pluginconfig
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
@@ -81,7 +82,7 @@ func (e *ExecuteOffchainConfig) Validate() error {
 	}
 
 	if e.RelativeBoostPerWaitHour > 1 || e.RelativeBoostPerWaitHour < 0 {
-		return errors.New("RelativeBoostPerWaitHour must be <= 1 and >= 0")
+		return fmt.Errorf("RelativeBoostPerWaitHour must be <= 1 and >= 0, got: %f", e.RelativeBoostPerWaitHour)
 	}
 	set := make(map[string]struct{})
 	for _, ob := range e.TokenDataObservers {


### PR DESCRIPTION
Log the offending relativeBoostPerWaitHour param when logging an error.