### PR TITLE
Fail consensus for missing thresholds

### DIFF
--- a/internal/plugincommon/consensus/consensus.go
+++ b/internal/plugincommon/consensus/consensus.go
@@ -59,7 +59,7 @@ func GetConsensusMapAggregator[K comparable, T any](
 	consensus := make(map[K]T)
 
 	for key, values := range items {
-		if thresh, ok := f.Get(key); ok && len(values) < int(thresh) {
+		if thresh, ok := f.Get(key); !ok || len(values) < int(thresh) {
 			lggr.Debugf("could not reach consensus on %s for key %v", objectName, key)
 			continue
 		}


### PR DESCRIPTION
If the key does not exist in the f mapping the key will not be skipped and the aggregator function will be called which could result in adding invalid data to the final consensus mapping.

core ref: 1cc219caca76662777aedb9ebdb2bfe9d1bfa5a3