### PR TITLE
[CCIP-4929][CCIP-4830] More exec plugin observation validations

### DIFF
--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -196,7 +196,8 @@ func (p *Plugin) ValidateObservation(
 		return fmt.Errorf("validate observer reading eligibility: %w", err)
 	}
 
-	if err := validateObservedSequenceNumbers(decodedObservation.CommitReports); err != nil {
+	err = validateObservedSequenceNumbers(decodedObservation.CommitReports, decodedObservation.Messages)
+	if err != nil {
 		return fmt.Errorf("validate observed sequence numbers: %w", err)
 	}
 

--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -241,6 +241,11 @@ func (p *Plugin) ValidateObservation(
 		if err = validateTokenDataObservations(decodedObservation.Messages, decodedObservation.TokenData); err != nil {
 			return fmt.Errorf("validate token data observations: %w", err)
 		}
+
+		err = validateCostlyMessagesObservations(decodedObservation.Messages, decodedObservation.CostlyMessages)
+		if err != nil {
+			return fmt.Errorf("validate costly messages: %w", err)
+		}
 	}
 
 	return nil

--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -178,6 +178,7 @@ func getPendingExecutedReports(
 	return groupedCommits, nil
 }
 
+//nolint:gocyclo
 func (p *Plugin) ValidateObservation(
 	ctx context.Context, outctx ocr3types.OutcomeContext, query types.Query, ao types.AttributedObservation,
 ) error {

--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -225,7 +225,7 @@ func (p *Plugin) ValidateObservation(
 		return fmt.Errorf("validate observed sequence numbers: %w", err)
 	}
 
-        // check message related validations when states can contain messages
+	// check message related validations when states can contain messages
 	if state == exectypes.GetMessages || state == exectypes.Filter {
 		err = validateMsgsReadingEligibility(supportedChains, decodedObservation.Messages)
 		if err != nil {

--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -219,7 +219,7 @@ func (p *Plugin) ValidateObservation(
 		return fmt.Errorf("validate commit reports reading eligibility: %w", err)
 	}
 
-	err = validateObservedSequenceNumbers(decodedObservation.CommitReports, decodedObservation.Messages)
+	err = validateObservedSequenceNumbers(decodedObservation.CommitReports)
 	if err != nil {
 		return fmt.Errorf("validate observed sequence numbers: %w", err)
 	}
@@ -230,6 +230,10 @@ func (p *Plugin) ValidateObservation(
 			return fmt.Errorf("validate observer reading eligibility: %w", err)
 		}
 
+		err = validateMessagesConformToCommitReports(decodedObservation.CommitReports, decodedObservation.Messages)
+		if err != nil {
+			return fmt.Errorf("validate messages conform to commit reports: %w", err)
+		}
 		if err = validateHashesExist(decodedObservation.Messages, decodedObservation.Hashes); err != nil {
 			return fmt.Errorf("validate hashes exist: %w", err)
 		}

--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -225,6 +225,7 @@ func (p *Plugin) ValidateObservation(
 		return fmt.Errorf("validate observed sequence numbers: %w", err)
 	}
 
+        // check message related validations when states can contain messages
 	if state == exectypes.GetMessages || state == exectypes.Filter {
 		err = validateMsgsReadingEligibility(supportedChains, decodedObservation.Messages)
 		if err != nil {

--- a/execute/plugin_functions.go
+++ b/execute/plugin_functions.go
@@ -20,6 +20,8 @@ import (
 	plugintypes2 "github.com/smartcontractkit/chainlink-ccip/plugintypes"
 )
 
+// validateCommitReportsReadingEligibility validates that all commit reports' source chains are supported
+// by observer
 func validateCommitReportsReadingEligibility(
 	supportedChains mapset.Set[cciptypes.ChainSelector],
 	observedData exectypes.CommitObservations,
@@ -85,6 +87,7 @@ func validateTokenDataObservations(
 	return nil
 }
 
+// validateCostlyMessagesObservations validates that all costly messages belong to already observed messages
 func validateCostlyMessagesObservations(
 	observedMsgs exectypes.MessageObservations,
 	costlyMessages []cciptypes.Bytes32,

--- a/execute/plugin_functions.go
+++ b/execute/plugin_functions.go
@@ -20,8 +20,26 @@ import (
 	plugintypes2 "github.com/smartcontractkit/chainlink-ccip/plugintypes"
 )
 
-// validateObserverReadingEligibility checks if the observer is eligible to observe the messages it observed.
-func validateObserverReadingEligibility(
+func validateCommitReportsReadingEligibility(
+	supportedChains mapset.Set[cciptypes.ChainSelector],
+	observedData exectypes.CommitObservations,
+) error {
+	for chainSel := range observedData {
+		if !supportedChains.Contains(chainSel) {
+			return fmt.Errorf("observer not allowed to read from chain %d", chainSel)
+		}
+		for _, data := range observedData[chainSel] {
+			if data.SourceChain != chainSel {
+				return fmt.Errorf("observer not allowed to read from chain %d", data.SourceChain)
+			}
+		}
+	}
+
+	return nil
+}
+
+// validateMsgsReadingEligibility checks if the observer is eligible to observe the messages it observed.
+func validateMsgsReadingEligibility(
 	supportedChains mapset.Set[cciptypes.ChainSelector],
 	observedMsgs exectypes.MessageObservations,
 ) error {

--- a/execute/plugin_functions.go
+++ b/execute/plugin_functions.go
@@ -20,8 +20,7 @@ import (
 	plugintypes2 "github.com/smartcontractkit/chainlink-ccip/plugintypes"
 )
 
-// validateCommitReportsReadingEligibility validates that all commit reports' source chains are supported
-// by observer
+// validateCommitReportsReadingEligibility validates that all commit reports' source chains are supported by observer
 func validateCommitReportsReadingEligibility(
 	supportedChains mapset.Set[cciptypes.ChainSelector],
 	observedData exectypes.CommitObservations,
@@ -40,7 +39,7 @@ func validateCommitReportsReadingEligibility(
 	return nil
 }
 
-// validateMsgsReadingEligibility checks if the observer is eligible to observe the messages it observed.
+// validateMsgsReadingEligibility checks all observed messages are from supported chains
 func validateMsgsReadingEligibility(
 	supportedChains mapset.Set[cciptypes.ChainSelector],
 	observedMsgs exectypes.MessageObservations,
@@ -58,6 +57,7 @@ func validateMsgsReadingEligibility(
 	return nil
 }
 
+// validateTokenDataObservations validates that all token data observations belong to already observed messages
 func validateTokenDataObservations(
 	observedMsgs exectypes.MessageObservations,
 	tokenData exectypes.TokenDataObservations,
@@ -132,6 +132,9 @@ func validateHashesExist(
 	return nil
 }
 
+// validateMessagesConformToCommitReports cross-checks messages and reports
+// 1. checks if the messages observed are exactly the same as the messages in the commit reports. No more and no less.
+// 2. checks all reports have their messages observed.
 func validateMessagesConformToCommitReports(
 	observedData exectypes.CommitObservations,
 	observedMsgs exectypes.MessageObservations,
@@ -148,7 +151,7 @@ func validateMessagesConformToCommitReports(
 				_, ok = msgsMap[seqNum]
 				if !ok {
 					return fmt.Errorf("no message observed for sequence number %d, "+
-						"while report's range sholud include it", seqNum)
+						"while report's range sholud include it for chain %d", seqNum, chain)
 				}
 				msgsCount++
 			}

--- a/execute/plugin_functions.go
+++ b/execute/plugin_functions.go
@@ -121,7 +121,6 @@ func validateHashesExist(
 			return fmt.Errorf("hash not found for chain %d", chain)
 		}
 
-		// hashes lengths can be larger than the observed messages in case of observation truncation.
 		for seq, msg := range msgs {
 			if _, ok := hashes[chain][seq]; !ok {
 				return fmt.Errorf("hash not found for message %s", msg)

--- a/execute/plugin_functions_test.go
+++ b/execute/plugin_functions_test.go
@@ -206,7 +206,7 @@ func Test_validateMessagesConformToCommitReports(t *testing.T) {
 				},
 			},
 			observedMsgs: exectypes.MessageObservations{
-				1: EmptyMessagesMapForRanges([]cciptypes.SeqNumRange{{1, 2}, {5, 10}}),
+				1: emptyMessagesMapForRanges([]cciptypes.SeqNumRange{{1, 2}, {5, 10}}),
 			},
 			expErr: true,
 		},
@@ -229,8 +229,8 @@ func Test_validateMessagesConformToCommitReports(t *testing.T) {
 				},
 			},
 			observedMsgs: exectypes.MessageObservations{
-				1: EmptyMessagesMapForRange(1, 3),
-				2: EmptyMessagesMapForRange(11, 15),
+				1: emptyMessagesMapForRange(1, 3),
+				2: emptyMessagesMapForRange(11, 15),
 			},
 		},
 		{
@@ -253,7 +253,7 @@ func Test_validateMessagesConformToCommitReports(t *testing.T) {
 				},
 			},
 			observedMsgs: exectypes.MessageObservations{
-				1: EmptyMessagesMapForRanges([]cciptypes.SeqNumRange{{1, 3}, {4, 6}, {8, 10}}),
+				1: emptyMessagesMapForRanges([]cciptypes.SeqNumRange{{1, 3}, {4, 6}, {8, 10}}),
 			},
 		},
 		{
@@ -267,7 +267,7 @@ func Test_validateMessagesConformToCommitReports(t *testing.T) {
 				},
 			},
 			observedMsgs: exectypes.MessageObservations{
-				1: EmptyMessagesMapForRange(1, 4),
+				1: emptyMessagesMapForRange(1, 4),
 			},
 			expErr: true,
 		},
@@ -282,7 +282,7 @@ func Test_validateMessagesConformToCommitReports(t *testing.T) {
 				},
 			},
 			observedMsgs: exectypes.MessageObservations{
-				1: EmptyMessagesMapForRange(1, 2),
+				1: emptyMessagesMapForRange(1, 2),
 			},
 			expErr: true,
 		},
@@ -1370,19 +1370,19 @@ func Test_allSeqNrsObserved(t *testing.T) {
 	}{
 		{
 			name:        "all sequence numbers observed",
-			msgs:        EmptyMessagesForRange(1, 3),
+			msgs:        emptyMessagesForRange(1, 3),
 			numberRange: cciptypes.NewSeqNumRange(1, 3),
 			want:        true,
 		},
 		{
 			name:        "missing sequence number",
-			msgs:        []cciptypes.Message{EmptyMessagesForRange(1, 1)[0], EmptyMessagesForRange(3, 3)[0]},
+			msgs:        []cciptypes.Message{emptyMessagesForRange(1, 1)[0], emptyMessagesForRange(3, 3)[0]},
 			numberRange: cciptypes.NewSeqNumRange(1, 3),
 			want:        false,
 		},
 		{
 			name:        "extra sequence number",
-			msgs:        EmptyMessagesForRange(1, 4),
+			msgs:        emptyMessagesForRange(1, 4),
 			numberRange: cciptypes.NewSeqNumRange(1, 3),
 			want:        false,
 		},
@@ -1394,7 +1394,7 @@ func Test_allSeqNrsObserved(t *testing.T) {
 		},
 		{
 			name:        "empty range",
-			msgs:        EmptyMessagesForRange(1, 4),
+			msgs:        emptyMessagesForRange(1, 4),
 			numberRange: cciptypes.NewSeqNumRange(0, 0),
 			want:        false,
 		},

--- a/execute/plugin_functions_test.go
+++ b/execute/plugin_functions_test.go
@@ -81,7 +81,6 @@ func Test_validateObservedSequenceNumbers(t *testing.T) {
 	testCases := []struct {
 		name         string
 		observedData map[cciptypes.ChainSelector][]exectypes.CommitData
-		observedMsgs exectypes.MessageObservations
 		expErr       bool
 	}{
 		{
@@ -162,6 +161,37 @@ func Test_validateObservedSequenceNumbers(t *testing.T) {
 			name:         "EmptyObservedData",
 			observedData: map[cciptypes.ChainSelector][]exectypes.CommitData{},
 		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateObservedSequenceNumbers(tc.observedData)
+			if tc.expErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func Test_validateMessagesConformToCommitReports(t *testing.T) {
+	testCases := []struct {
+		name         string
+		observedData map[cciptypes.ChainSelector][]exectypes.CommitData
+		observedMsgs exectypes.MessageObservations
+		expErr       bool
+	}{
+		{
+			name: "NoCommitData",
+			observedData: map[cciptypes.ChainSelector][]exectypes.CommitData{
+				1: {},
+			},
+		},
+		{
+			name:         "EmptyObservedData",
+			observedData: map[cciptypes.ChainSelector][]exectypes.CommitData{},
+		},
 		// Tests with messages
 		{
 			name: "Gap in Sequence Numbers",
@@ -207,7 +237,7 @@ func Test_validateObservedSequenceNumbers(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateObservedSequenceNumbers(tc.observedData, tc.observedMsgs)
+			err := validateMessagesConformToCommitReports(tc.observedData, tc.observedMsgs)
 			if tc.expErr {
 				assert.Error(t, err)
 				return
@@ -216,7 +246,6 @@ func Test_validateObservedSequenceNumbers(t *testing.T) {
 		})
 	}
 }
-
 func Test_computeRanges(t *testing.T) {
 	type args struct {
 		reports []exectypes.CommitData

--- a/execute/plugin_functions_test.go
+++ b/execute/plugin_functions_test.go
@@ -66,7 +66,7 @@ func Test_validateObserverReadingEligibility(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateObserverReadingEligibility(tc.observerCfg, tc.observedMsgs)
+			err := validateMsgsReadingEligibility(tc.observerCfg, tc.observedMsgs)
 			if len(tc.expErr) != 0 {
 				assert.Error(t, err)
 				assert.ErrorContains(t, err, tc.expErr)

--- a/execute/plugin_functions_test.go
+++ b/execute/plugin_functions_test.go
@@ -81,6 +81,7 @@ func Test_validateObservedSequenceNumbers(t *testing.T) {
 	testCases := []struct {
 		name         string
 		observedData map[cciptypes.ChainSelector][]exectypes.CommitData
+		observedMsgs exectypes.MessageObservations
 		expErr       bool
 	}{
 		{
@@ -91,7 +92,6 @@ func Test_validateObservedSequenceNumbers(t *testing.T) {
 						MerkleRoot:          cciptypes.Bytes32{1},
 						SequenceNumberRange: cciptypes.SeqNumRange{1, 3},
 						ExecutedMessages:    []cciptypes.SeqNum{1, 2, 3},
-						Messages:            EmptyMessagesForRange(1, 3),
 					},
 				},
 				2: {
@@ -99,7 +99,6 @@ func Test_validateObservedSequenceNumbers(t *testing.T) {
 						MerkleRoot:          cciptypes.Bytes32{2},
 						SequenceNumberRange: cciptypes.SeqNumRange{11, 15},
 						ExecutedMessages:    []cciptypes.SeqNum{11, 12, 13},
-						Messages:            EmptyMessagesForRange(11, 15),
 					},
 				},
 			},
@@ -112,13 +111,11 @@ func Test_validateObservedSequenceNumbers(t *testing.T) {
 						MerkleRoot:          cciptypes.Bytes32{1},
 						SequenceNumberRange: cciptypes.SeqNumRange{1, 10},
 						ExecutedMessages:    []cciptypes.SeqNum{1, 2, 3},
-						Messages:            EmptyMessagesForRange(1, 10),
 					},
 					{
 						MerkleRoot:          cciptypes.Bytes32{1},
 						SequenceNumberRange: cciptypes.SeqNumRange{11, 20},
 						ExecutedMessages:    []cciptypes.SeqNum{11, 12, 13},
-						Messages:            EmptyMessagesForRange(11, 20),
 					},
 				},
 			},
@@ -132,13 +129,11 @@ func Test_validateObservedSequenceNumbers(t *testing.T) {
 						MerkleRoot:          cciptypes.Bytes32{1},
 						SequenceNumberRange: cciptypes.SeqNumRange{1, 10},
 						ExecutedMessages:    []cciptypes.SeqNum{1, 2, 3},
-						Messages:            EmptyMessagesForRange(1, 10),
 					},
 					{
 						MerkleRoot:          cciptypes.Bytes32{2},
 						SequenceNumberRange: cciptypes.SeqNumRange{5, 15},
 						ExecutedMessages:    []cciptypes.SeqNum{6, 7, 8},
-						Messages:            EmptyMessagesForRange(5, 15),
 					},
 				},
 			},
@@ -152,7 +147,6 @@ func Test_validateObservedSequenceNumbers(t *testing.T) {
 						MerkleRoot:          cciptypes.Bytes32{1},
 						SequenceNumberRange: cciptypes.SeqNumRange{1, 10},
 						ExecutedMessages:    []cciptypes.SeqNum{1, 2, 11},
-						Messages:            EmptyMessagesForRange(1, 10),
 					},
 				},
 			},
@@ -168,6 +162,7 @@ func Test_validateObservedSequenceNumbers(t *testing.T) {
 			name:         "EmptyObservedData",
 			observedData: map[cciptypes.ChainSelector][]exectypes.CommitData{},
 		},
+		// Tests with messages
 		{
 			name: "Gap in Sequence Numbers",
 			observedData: map[cciptypes.ChainSelector][]exectypes.CommitData{
@@ -176,18 +171,43 @@ func Test_validateObservedSequenceNumbers(t *testing.T) {
 						MerkleRoot:          cciptypes.Bytes32{1},
 						SequenceNumberRange: cciptypes.SeqNumRange{1, 4},
 						ExecutedMessages:    []cciptypes.SeqNum{1, 2},
-						// Missing message 4
-						Messages: EmptyMessagesForRange(1, 3),
+						SourceChain:         1,
 					},
 				},
 			},
+			observedMsgs: exectypes.MessageObservations{
+				1: EmptyMessagesMapForRange(1, 3),
+			},
 			expErr: true,
+		},
+		{
+			name: "ValidData with messages",
+			observedData: map[cciptypes.ChainSelector][]exectypes.CommitData{
+				1: {
+					{
+						MerkleRoot:          cciptypes.Bytes32{1},
+						SequenceNumberRange: cciptypes.SeqNumRange{1, 3},
+						ExecutedMessages:    []cciptypes.SeqNum{1, 2, 3},
+					},
+				},
+				2: {
+					{
+						MerkleRoot:          cciptypes.Bytes32{2},
+						SequenceNumberRange: cciptypes.SeqNumRange{11, 15},
+						ExecutedMessages:    []cciptypes.SeqNum{11, 12, 13},
+					},
+				},
+			},
+			observedMsgs: exectypes.MessageObservations{
+				1: EmptyMessagesMapForRange(1, 3),
+				2: EmptyMessagesMapForRange(11, 15),
+			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateObservedSequenceNumbers(tc.observedData)
+			err := validateObservedSequenceNumbers(tc.observedData, tc.observedMsgs)
 			if tc.expErr {
 				assert.Error(t, err)
 				return

--- a/execute/plugin_test.go
+++ b/execute/plugin_test.go
@@ -215,7 +215,7 @@ func TestPlugin_ValidateObservation_SupportedChainsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "error finding supported chains by node: oracle ID 0 not found in oracleIDToP2pID")
 }
 
-func TestPlugin_ValidateObservation_IneligibleObserver(t *testing.T) {
+func TestPlugin_ValidateObservation_IneligibleMessageObserver(t *testing.T) {
 	ctx := tests.Context(t)
 	lggr := logger.Test(t)
 
@@ -242,11 +242,54 @@ func TestPlugin_ValidateObservation_IneligibleObserver(t *testing.T) {
 	}, nil, nil, nil, dt.Observation{}, nil)
 	encoded, err := observation.Encode()
 	require.NoError(t, err)
-	err = p.ValidateObservation(ctx, ocr3types.OutcomeContext{}, types.Query{}, types.AttributedObservation{
+
+	prevOutcome := exectypes.Outcome{
+		State: exectypes.GetCommitReports,
+	}
+	encodedPrevOutcome, err := prevOutcome.Encode()
+	require.NoError(t, err)
+	err = p.ValidateObservation(ctx, ocr3types.OutcomeContext{PreviousOutcome: encodedPrevOutcome}, types.Query{}, types.AttributedObservation{
 		Observation: encoded,
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "validate observer reading eligibility: observer not allowed to read from chain 0")
+}
+
+func TestPlugin_ValidateObservation_IneligibleCommitReportsObserver(t *testing.T) {
+	ctx := tests.Context(t)
+	lggr := logger.Test(t)
+
+	mockHomeChain := reader_mock.NewMockHomeChain(t)
+	mockHomeChain.EXPECT().GetSupportedChainsForPeer(mock.Anything).Return(mapset.NewSet[cciptypes.ChainSelector](), nil)
+	defer mockHomeChain.AssertExpectations(t)
+
+	p := &Plugin{
+		homeChain: mockHomeChain,
+		oracleIDToP2pID: map[commontypes.OracleID]libocrtypes.PeerID{
+			0: {},
+		},
+		lggr: lggr,
+	}
+
+	commitReports := map[cciptypes.ChainSelector][]exectypes.CommitData{
+		1: {
+			{
+				MerkleRoot:          cciptypes.Bytes32{},
+				SequenceNumberRange: cciptypes.NewSeqNumRange(1, 2),
+				SourceChain:         1,
+			},
+		},
+	}
+	observation := exectypes.NewObservation(
+		commitReports, nil, nil, nil, nil, dt.Observation{}, nil,
+	)
+	encoded, err := observation.Encode()
+	require.NoError(t, err)
+	err = p.ValidateObservation(ctx, ocr3types.OutcomeContext{}, types.Query{}, types.AttributedObservation{
+		Observation: encoded,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "validate commit reports reading eligibility: observer not allowed to read from chain 1")
 }
 
 func TestPlugin_ValidateObservation_ValidateObservedSeqNum_Error(t *testing.T) {
@@ -254,7 +297,7 @@ func TestPlugin_ValidateObservation_ValidateObservedSeqNum_Error(t *testing.T) {
 	lggr := logger.Test(t)
 
 	mockHomeChain := reader_mock.NewMockHomeChain(t)
-	mockHomeChain.EXPECT().GetSupportedChainsForPeer(mock.Anything).Return(mapset.NewSet(cciptypes.ChainSelector(0)), nil)
+	mockHomeChain.EXPECT().GetSupportedChainsForPeer(mock.Anything).Return(mapset.NewSet(cciptypes.ChainSelector(1)), nil)
 
 	p := &Plugin{
 		lggr:      lggr,
@@ -268,8 +311,8 @@ func TestPlugin_ValidateObservation_ValidateObservedSeqNum_Error(t *testing.T) {
 	root := cciptypes.Bytes32{}
 	commitReports := map[cciptypes.ChainSelector][]exectypes.CommitData{
 		1: {
-			{MerkleRoot: root, SequenceNumberRange: cciptypes.NewSeqNumRange(1, 2)},
-			{MerkleRoot: root, SequenceNumberRange: cciptypes.NewSeqNumRange(1, 5)},
+			{MerkleRoot: root, SequenceNumberRange: cciptypes.NewSeqNumRange(1, 2), SourceChain: 1},
+			{MerkleRoot: root, SequenceNumberRange: cciptypes.NewSeqNumRange(1, 5), SourceChain: 1},
 		},
 	}
 	observation := exectypes.NewObservation(

--- a/execute/plugin_test.go
+++ b/execute/plugin_test.go
@@ -268,8 +268,8 @@ func TestPlugin_ValidateObservation_ValidateObservedSeqNum_Error(t *testing.T) {
 	root := cciptypes.Bytes32{}
 	commitReports := map[cciptypes.ChainSelector][]exectypes.CommitData{
 		1: {
-			{MerkleRoot: root, SequenceNumberRange: cciptypes.NewSeqNumRange(1, 2), Messages: EmptyMessagesForRange(1, 2)},
-			{MerkleRoot: root, SequenceNumberRange: cciptypes.NewSeqNumRange(1, 5), Messages: EmptyMessagesForRange(1, 5)},
+			{MerkleRoot: root, SequenceNumberRange: cciptypes.NewSeqNumRange(1, 2)},
+			{MerkleRoot: root, SequenceNumberRange: cciptypes.NewSeqNumRange(1, 5)},
 		},
 	}
 	observation := exectypes.NewObservation(

--- a/execute/plugin_test.go
+++ b/execute/plugin_test.go
@@ -248,9 +248,10 @@ func TestPlugin_ValidateObservation_IneligibleMessageObserver(t *testing.T) {
 	}
 	encodedPrevOutcome, err := prevOutcome.Encode()
 	require.NoError(t, err)
-	err = p.ValidateObservation(ctx, ocr3types.OutcomeContext{PreviousOutcome: encodedPrevOutcome}, types.Query{}, types.AttributedObservation{
-		Observation: encoded,
-	})
+	err = p.ValidateObservation(ctx, ocr3types.OutcomeContext{PreviousOutcome: encodedPrevOutcome}, types.Query{},
+		types.AttributedObservation{
+			Observation: encoded,
+		})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "validate observer reading eligibility: observer not allowed to read from chain 0")
 }
@@ -289,7 +290,9 @@ func TestPlugin_ValidateObservation_IneligibleCommitReportsObserver(t *testing.T
 		Observation: encoded,
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "validate commit reports reading eligibility: observer not allowed to read from chain 1")
+	assert.Contains(t,
+		err.Error(),
+		"validate commit reports reading eligibility: observer not allowed to read from chain 1")
 }
 
 func TestPlugin_ValidateObservation_ValidateObservedSeqNum_Error(t *testing.T) {

--- a/execute/test_utils.go
+++ b/execute/test_utils.go
@@ -543,3 +543,16 @@ func EmptyMessagesForRange(start, end uint64) []cciptypes.Message {
 	}
 	return messages
 }
+
+func EmptyMessagesMapForRange(start, end uint64) map[cciptypes.SeqNum]cciptypes.Message {
+	messages := make(map[cciptypes.SeqNum]cciptypes.Message)
+	for i := start; i <= end; i++ {
+		messages[cciptypes.SeqNum(i)] = cciptypes.Message{
+			Header: cciptypes.RampMessageHeader{
+				MessageID:      cciptypes.Bytes32{byte(i)},
+				SequenceNumber: cciptypes.SeqNum(i),
+			},
+		}
+	}
+	return messages
+}

--- a/execute/test_utils.go
+++ b/execute/test_utils.go
@@ -531,7 +531,7 @@ func (t *timeMachine) SetNow(now time.Time) {
 	t.now = now
 }
 
-func EmptyMessagesForRange(start, end uint64) []cciptypes.Message {
+func emptyMessagesForRange(start, end uint64) []cciptypes.Message {
 	messages := make([]cciptypes.Message, end-start+1)
 	for i := start; i <= end; i++ {
 		messages[i-start] = cciptypes.Message{
@@ -544,7 +544,7 @@ func EmptyMessagesForRange(start, end uint64) []cciptypes.Message {
 	return messages
 }
 
-func EmptyMessagesMapForRange(start, end uint64) map[cciptypes.SeqNum]cciptypes.Message {
+func emptyMessagesMapForRange(start, end uint64) map[cciptypes.SeqNum]cciptypes.Message {
 	messages := make(map[cciptypes.SeqNum]cciptypes.Message)
 	for i := start; i <= end; i++ {
 		messages[cciptypes.SeqNum(i)] = cciptypes.Message{
@@ -557,7 +557,7 @@ func EmptyMessagesMapForRange(start, end uint64) map[cciptypes.SeqNum]cciptypes.
 	return messages
 }
 
-func EmptyMessagesMapForRanges(ranges []cciptypes.SeqNumRange) map[cciptypes.SeqNum]cciptypes.Message {
+func emptyMessagesMapForRanges(ranges []cciptypes.SeqNumRange) map[cciptypes.SeqNum]cciptypes.Message {
 	messages := make(map[cciptypes.SeqNum]cciptypes.Message)
 	for _, r := range ranges {
 		for i := r.Start(); i <= r.End(); i++ {

--- a/execute/test_utils.go
+++ b/execute/test_utils.go
@@ -556,3 +556,18 @@ func EmptyMessagesMapForRange(start, end uint64) map[cciptypes.SeqNum]cciptypes.
 	}
 	return messages
 }
+
+func EmptyMessagesMapForRanges(ranges []cciptypes.SeqNumRange) map[cciptypes.SeqNum]cciptypes.Message {
+	messages := make(map[cciptypes.SeqNum]cciptypes.Message)
+	for _, r := range ranges {
+		for i := r.Start(); i <= r.End(); i++ {
+			messages[i] = cciptypes.Message{
+				Header: cciptypes.RampMessageHeader{
+					MessageID:      cciptypes.Bytes32{byte(i)},
+					SequenceNumber: i,
+				},
+			}
+		}
+	}
+	return messages
+}


### PR DESCRIPTION
* Validate states invariants in validate observations
* Cross-check all messages against all reports

core ref: 1cc219caca76662777aedb9ebdb2bfe9d1bfa5a3