### PR TITLE
Refactor: Cleanup related to blue/green versions support [NONEVM-1114]

### DIFF
--- a/chains/solana/contracts/programs/ccip-router/src/context.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/context.rs
@@ -99,6 +99,12 @@ impl MerkleRoot {
 #[instruction(destination_chain_selector: u64, message: SVM2AnyMessage)]
 pub struct GetFee<'info> {
     #[account(
+        seeds = [CONFIG_SEED],
+        bump,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs, // validate state version
+    )]
+    pub config: AccountLoader<'info, Config>,
+    #[account(
         seeds = [DEST_CHAIN_STATE_SEED, destination_chain_selector.to_le_bytes().as_ref()],
         bump,
         constraint = valid_version(dest_chain_state.version, MAX_CHAINSTATE_V) @ CcipRouterError::InvalidInputs, // validate state version

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/merkle.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/merkle.rs
@@ -4,7 +4,7 @@ pub const LEAF_DOMAIN_SEPARATOR: [u8; 32] = [0; 32];
 const MAX_NUM_HASHES: usize = 128; // TODO: Change this to 256 when supporting commit reports with 256 messages
 
 #[derive(Debug)]
-pub enum MerkleError {
+pub(super) enum MerkleError {
     InvalidProof,
 }
 
@@ -16,7 +16,7 @@ fn hash_pair(hash1: &[u8; 32], hash2: &[u8; 32]) -> [u8; 32] {
     }
 }
 
-pub fn calculate_merkle_root(
+pub(super) fn calculate_merkle_root(
     hashed_leaf: [u8; 32],
     proofs: Vec<[u8; 32]>,
 ) -> Result<[u8; 32], MerkleError> {

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/messages.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/messages.rs
@@ -185,14 +185,6 @@ pub mod ramps {
             single.to_be_bytes()[4..32].try_into().unwrap()
         }
 
-        impl TimestampedPackedU224 {
-            pub fn from_single(timestamp: i64, single: U256) -> Self {
-                let mut value = [0u8; 28];
-                value.clone_from_slice(&single.to_be_bytes()[4..32]);
-                Self { value, timestamp }
-            }
-        }
-
         #[test]
         fn message_not_validated_for_disabled_destination_chain() {
             let mut chain = sample_dest_chain();

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/ocr3base.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/ocr3base.rs
@@ -2,11 +2,9 @@ use anchor_lang::prelude::*;
 use anchor_lang::solana_program::sysvar;
 use anchor_lang::solana_program::{keccak, secp256k1_recover::*};
 
-use crate::ocr3base::{ConfigSet, Ocr3Error, Transmitted};
+use crate::ocr3base::{ConfigSet, Ocr3Error, Transmitted, MAX_ORACLES};
 use crate::state::{Ocr3Config, Ocr3ConfigInfo};
 
-#[constant]
-pub const MAX_ORACLES: usize = 16; // can set a maximum of 16 transmitters + 16 signers simultaneously in a single set config tx
 pub const MAX_SIGNERS: usize = MAX_ORACLES;
 pub const MAX_TRANSMITTERS: usize = MAX_ORACLES;
 

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/onramp.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/onramp.rs
@@ -4,14 +4,14 @@ use anchor_lang::prelude::*;
 use anchor_spl::token_interface;
 
 use super::fee_quoter::{fee_for_msg, transfer_fee, wrap_native_sol};
+use super::merkle::LEAF_DOMAIN_SEPARATOR;
 use super::messages::pools::{LockOrBurnInV1, LockOrBurnOutV1};
 use super::pools::{
     calculate_token_pool_account_indices, interact_with_pool, transfer_token,
     validate_and_parse_token_accounts, TokenAccounts, CCIP_LOCK_OR_BURN_V1_RET_BYTES,
 };
+use super::price_math::get_validated_token_price;
 
-use crate::v1::merkle::LEAF_DOMAIN_SEPARATOR;
-use crate::v1::price_math::get_validated_token_price;
 use crate::{
     AnyExtraArgs, BillingTokenConfig, CCIPMessageSent, CcipRouterError, CcipSend, Config,
     DestChainConfig, ExtraArgsInput, GetFee, Nonce, PerChainPerTokenConfig, RampMessageHeader,

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/token_admin_registry.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/token_admin_registry.rs
@@ -2,12 +2,14 @@ use anchor_lang::prelude::*;
 use anchor_spl::associated_token::get_associated_token_address_with_program_id;
 use solana_program::{address_lookup_table::state::AddressLookupTable, log::sol_log};
 
+use super::pools::token_admin_registry_writable;
+
 use crate::{
-    v1::pools::token_admin_registry_writable, AcceptAdminRoleTokenAdminRegistry,
-    AdministratorRegistered, AdministratorTransferRequested, AdministratorTransferred,
-    CcipRouterError, ModifyTokenAdminRegistry, PoolSet, RegisterTokenAdminRegistryViaGetCCIPAdmin,
-    RegisterTokenAdminRegistryViaOwner, SetPoolTokenAdminRegistry, CCIP_TOKENPOOL_CONFIG,
-    CCIP_TOKENPOOL_SIGNER, FEE_BILLING_TOKEN_CONFIG, TOKEN_ADMIN_REGISTRY_SEED,
+    AcceptAdminRoleTokenAdminRegistry, AdministratorRegistered, AdministratorTransferRequested,
+    AdministratorTransferred, CcipRouterError, ModifyTokenAdminRegistry, PoolSet,
+    RegisterTokenAdminRegistryViaGetCCIPAdmin, RegisterTokenAdminRegistryViaOwner,
+    SetPoolTokenAdminRegistry, CCIP_TOKENPOOL_CONFIG, CCIP_TOKENPOOL_SIGNER,
+    FEE_BILLING_TOKEN_CONFIG, TOKEN_ADMIN_REGISTRY_SEED,
 };
 
 const MINIMUM_TOKEN_POOL_ACCOUNTS: usize = 9;

--- a/chains/solana/contracts/programs/ccip-router/src/ocr3base.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/ocr3base.rs
@@ -1,5 +1,8 @@
 use anchor_lang::prelude::*;
 
+#[constant]
+pub const MAX_ORACLES: usize = 16; // can set a maximum of 16 transmitters + 16 signers simultaneously in a single set config tx
+
 #[error_code]
 pub enum Ocr3Error {
     #[msg("Invalid config: F must be positive")]

--- a/chains/solana/contracts/programs/ccip-router/src/token_context.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/token_context.rs
@@ -48,6 +48,12 @@ pub struct RegisterTokenAdminRegistryViaGetCCIPAdmin<'info> {
 #[derive(Accounts)]
 pub struct RegisterTokenAdminRegistryViaOwner<'info> {
     #[account(
+        seeds = [CONFIG_SEED],
+        bump,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs,
+    )]
+    pub config: AccountLoader<'info, Config>,
+    #[account(
         init,
         seeds = [TOKEN_ADMIN_REGISTRY_SEED, mint.key().as_ref()],
         bump,
@@ -70,6 +76,12 @@ pub struct RegisterTokenAdminRegistryViaOwner<'info> {
 #[instruction(mint: Pubkey)]
 pub struct ModifyTokenAdminRegistry<'info> {
     #[account(
+        seeds = [CONFIG_SEED],
+        bump,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs,
+    )]
+    pub config: AccountLoader<'info, Config>,
+    #[account(
         mut,
         seeds = [TOKEN_ADMIN_REGISTRY_SEED, mint.as_ref()],
         bump,
@@ -83,6 +95,12 @@ pub struct ModifyTokenAdminRegistry<'info> {
 #[derive(Accounts)]
 #[instruction(mint: Pubkey)]
 pub struct SetPoolTokenAdminRegistry<'info> {
+    #[account(
+        seeds = [CONFIG_SEED],
+        bump,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs,
+    )]
+    pub config: AccountLoader<'info, Config>,
     #[account(
         mut,
         seeds = [TOKEN_ADMIN_REGISTRY_SEED, mint.as_ref()],
@@ -99,6 +117,12 @@ pub struct SetPoolTokenAdminRegistry<'info> {
 #[derive(Accounts)]
 #[instruction(mint: Pubkey)]
 pub struct AcceptAdminRoleTokenAdminRegistry<'info> {
+    #[account(
+        seeds = [CONFIG_SEED],
+        bump,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs,
+    )]
+    pub config: AccountLoader<'info, Config>,
     #[account(
         mut,
         seeds = [TOKEN_ADMIN_REGISTRY_SEED, mint.as_ref()],

--- a/chains/solana/contracts/target/idl/ccip_router.json
+++ b/chains/solana/contracts/target/idl/ccip_router.json
@@ -623,6 +623,11 @@
       ],
       "accounts": [
         {
+          "name": "config",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
           "name": "tokenAdminRegistry",
           "isMut": true,
           "isSigner": false
@@ -660,6 +665,11 @@
         "* `is_writable` - index of account in lookup table that is writable"
       ],
       "accounts": [
+        {
+          "name": "config",
+          "isMut": false,
+          "isSigner": false
+        },
         {
           "name": "tokenAdminRegistry",
           "isMut": true,
@@ -702,6 +712,11 @@
       ],
       "accounts": [
         {
+          "name": "config",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
           "name": "tokenAdminRegistry",
           "isMut": true,
           "isSigner": false
@@ -736,6 +751,11 @@
         "* `mint` - The public key of the token mint."
       ],
       "accounts": [
+        {
+          "name": "config",
+          "isMut": false,
+          "isSigner": false
+        },
         {
           "name": "tokenAdminRegistry",
           "isMut": true,
@@ -1053,6 +1073,11 @@
         "The fee amount in u64."
       ],
       "accounts": [
+        {
+          "name": "config",
+          "isMut": false,
+          "isSigner": false
+        },
         {
           "name": "destChainState",
           "isMut": false,

--- a/chains/solana/contracts/target/idl/ccip_router.json
+++ b/chains/solana/contracts/target/idl/ccip_router.json
@@ -2647,17 +2647,6 @@
       }
     },
     {
-      "name": "MerkleError",
-      "type": {
-        "kind": "enum",
-        "variants": [
-          {
-            "name": "InvalidProof"
-          }
-        ]
-      }
-    },
-    {
       "name": "MessageExecutionState",
       "type": {
         "kind": "enum",

--- a/chains/solana/contracts/tests/ccip/ccip_router_test.go
+++ b/chains/solana/contracts/tests/ccip/ccip_router_test.go
@@ -1486,6 +1486,7 @@ func TestCCIPRouter(t *testing.T) {
 					instruction, err := ccip_router.NewSetPoolInstruction(
 						token0.Mint.PublicKey(),
 						token0.WritableIndexes,
+						config.RouterConfigPDA,
 						token0.AdminRegistry,
 						token0.PoolLookupTable,
 						user.PublicKey(),
@@ -1500,6 +1501,7 @@ func TestCCIPRouter(t *testing.T) {
 					instruction, err := ccip_router.NewSetPoolInstruction(
 						token0.Mint.PublicKey(),
 						token0.WritableIndexes,
+						config.RouterConfigPDA,
 						token0.AdminRegistry,
 						token0.PoolLookupTable,
 						transmitter.PublicKey(),
@@ -1513,6 +1515,7 @@ func TestCCIPRouter(t *testing.T) {
 					instruction, err := ccip_router.NewSetPoolInstruction(
 						token0.Mint.PublicKey(),
 						token0.WritableIndexes,
+						config.RouterConfigPDA,
 						token0.AdminRegistry,
 						token0.PoolLookupTable,
 						anotherAdmin.PublicKey(),
@@ -1526,6 +1529,7 @@ func TestCCIPRouter(t *testing.T) {
 					instruction, err := ccip_router.NewSetPoolInstruction(
 						token0.Mint.PublicKey(),
 						token0.WritableIndexes,
+						config.RouterConfigPDA,
 						token0.AdminRegistry,
 						token1.PoolLookupTable, // accounts do not match the expected mint related accounts
 						anotherAdmin.PublicKey(),
@@ -1539,6 +1543,7 @@ func TestCCIPRouter(t *testing.T) {
 					base := ccip_router.NewSetPoolInstruction(
 						token0.Mint.PublicKey(),
 						token0.WritableIndexes,
+						config.RouterConfigPDA,
 						token0.AdminRegistry,
 						token0.PoolLookupTable,
 						tokenPoolAdmin.PublicKey(),
@@ -1564,6 +1569,7 @@ func TestCCIPRouter(t *testing.T) {
 					instruction, err := ccip_router.NewSetPoolInstruction(
 						token0.Mint.PublicKey(),
 						token0.WritableIndexes,
+						config.RouterConfigPDA,
 						token0.AdminRegistry,
 						solana.PublicKey{},
 						tokenPoolAdmin.PublicKey(),
@@ -1585,6 +1591,7 @@ func TestCCIPRouter(t *testing.T) {
 					instruction, err = ccip_router.NewSetPoolInstruction(
 						token0.Mint.PublicKey(),
 						token0.WritableIndexes,
+						config.RouterConfigPDA,
 						token0.AdminRegistry,
 						token0.PoolLookupTable,
 						tokenPoolAdmin.PublicKey(),
@@ -1600,6 +1607,7 @@ func TestCCIPRouter(t *testing.T) {
 					instruction, err := ccip_router.NewTransferAdminRoleTokenAdminRegistryInstruction(
 						token0.Mint.PublicKey(),
 						anotherTokenPoolAdmin.PublicKey(),
+						config.RouterConfigPDA,
 						token0.AdminRegistry,
 						user.PublicKey(),
 					).ValidateAndBuild()
@@ -1612,6 +1620,7 @@ func TestCCIPRouter(t *testing.T) {
 					instruction, err := ccip_router.NewTransferAdminRoleTokenAdminRegistryInstruction(
 						token0.Mint.PublicKey(),
 						anotherTokenPoolAdmin.PublicKey(),
+						config.RouterConfigPDA,
 						token0.AdminRegistry,
 						tokenPoolAdmin.PublicKey(),
 					).ValidateAndBuild()
@@ -1632,6 +1641,7 @@ func TestCCIPRouter(t *testing.T) {
 					instruction, err = ccip_router.NewSetPoolInstruction(
 						token0.Mint.PublicKey(),
 						token0.WritableIndexes,
+						config.RouterConfigPDA,
 						token0.AdminRegistry,
 						token0.PoolLookupTable,
 						tokenPoolAdmin.PublicKey(),
@@ -1644,6 +1654,7 @@ func TestCCIPRouter(t *testing.T) {
 					instruction, err = ccip_router.NewSetPoolInstruction(
 						token0.Mint.PublicKey(),
 						token0.WritableIndexes,
+						config.RouterConfigPDA,
 						token0.AdminRegistry,
 						token0.PoolLookupTable,
 						anotherTokenPoolAdmin.PublicKey(),
@@ -1656,6 +1667,7 @@ func TestCCIPRouter(t *testing.T) {
 				t.Run("When new admin accepts the token admin registry, it succeeds and permissions are updated", func(t *testing.T) {
 					instruction, err := ccip_router.NewAcceptAdminRoleTokenAdminRegistryInstruction(
 						token0.Mint.PublicKey(),
+						config.RouterConfigPDA,
 						token0.AdminRegistry,
 						anotherTokenPoolAdmin.PublicKey(),
 					).ValidateAndBuild()
@@ -1676,6 +1688,7 @@ func TestCCIPRouter(t *testing.T) {
 					instruction, err = ccip_router.NewSetPoolInstruction(
 						token0.Mint.PublicKey(),
 						token0.WritableIndexes,
+						config.RouterConfigPDA,
 						token0.AdminRegistry,
 						token0.PoolLookupTable,
 						tokenPoolAdmin.PublicKey(),
@@ -1688,6 +1701,7 @@ func TestCCIPRouter(t *testing.T) {
 					instruction, err = ccip_router.NewSetPoolInstruction(
 						token0.Mint.PublicKey(),
 						token0.WritableIndexes,
+						config.RouterConfigPDA,
 						token0.AdminRegistry,
 						token0.PoolLookupTable,
 						anotherTokenPoolAdmin.PublicKey(),
@@ -1703,6 +1717,7 @@ func TestCCIPRouter(t *testing.T) {
 			t.Run("register token admin registry via token mint authority", func(t *testing.T) {
 				t.Run("When any user wants to set up the token admin registry, it fails", func(t *testing.T) {
 					instruction, err := ccip_router.NewRegisterTokenAdminRegistryViaOwnerInstruction(
+						config.RouterConfigPDA,
 						token1.AdminRegistry,
 						token1.Mint.PublicKey(),
 						user.PublicKey(),
@@ -1716,6 +1731,7 @@ func TestCCIPRouter(t *testing.T) {
 				t.Run("When transmitter wants to set up the token admin registry, it fails", func(t *testing.T) {
 					transmitter := getTransmitter()
 					instruction, err := ccip_router.NewRegisterTokenAdminRegistryViaOwnerInstruction(
+						config.RouterConfigPDA,
 						token1.AdminRegistry,
 						token1.Mint.PublicKey(),
 						transmitter.PublicKey(),
@@ -1728,6 +1744,7 @@ func TestCCIPRouter(t *testing.T) {
 
 				t.Run("When admin wants to set up the token admin registry, it fails", func(t *testing.T) {
 					instruction, err := ccip_router.NewRegisterTokenAdminRegistryViaOwnerInstruction(
+						config.RouterConfigPDA,
 						token1.AdminRegistry,
 						token1.Mint.PublicKey(),
 						anotherAdmin.PublicKey(),
@@ -1740,6 +1757,7 @@ func TestCCIPRouter(t *testing.T) {
 
 				t.Run("When invalid mint_authority wants to set up the token admin registry, it fails", func(t *testing.T) {
 					instruction, err := ccip_router.NewRegisterTokenAdminRegistryViaOwnerInstruction(
+						config.RouterConfigPDA,
 						token1.AdminRegistry,
 						token1.Mint.PublicKey(),
 						tokenPoolAdmin.PublicKey(), // invalid
@@ -1752,6 +1770,7 @@ func TestCCIPRouter(t *testing.T) {
 
 				t.Run("When token mint_authority wants to set up the token admin registry, it succeeds", func(t *testing.T) {
 					instruction, err := ccip_router.NewRegisterTokenAdminRegistryViaOwnerInstruction(
+						config.RouterConfigPDA,
 						token1.AdminRegistry,
 						token1.Mint.PublicKey(),
 						anotherTokenPoolAdmin.PublicKey(),
@@ -1777,6 +1796,7 @@ func TestCCIPRouter(t *testing.T) {
 					instruction, err := ccip_router.NewSetPoolInstruction(
 						token1.Mint.PublicKey(),
 						token1.WritableIndexes,
+						config.RouterConfigPDA,
 						token1.AdminRegistry,
 						token1.PoolLookupTable,
 						anotherTokenPoolAdmin.PublicKey(),
@@ -1801,6 +1821,7 @@ func TestCCIPRouter(t *testing.T) {
 					instruction, err := ccip_router.NewTransferAdminRoleTokenAdminRegistryInstruction(
 						token1.Mint.PublicKey(),
 						tokenPoolAdmin.PublicKey(),
+						config.RouterConfigPDA,
 						token1.AdminRegistry,
 						tokenPoolAdmin.PublicKey(),
 					).ValidateAndBuild()
@@ -1812,6 +1833,7 @@ func TestCCIPRouter(t *testing.T) {
 					instruction, err := ccip_router.NewTransferAdminRoleTokenAdminRegistryInstruction(
 						token1.Mint.PublicKey(),
 						tokenPoolAdmin.PublicKey(),
+						config.RouterConfigPDA,
 						token1.AdminRegistry,
 						anotherTokenPoolAdmin.PublicKey(),
 					).ValidateAndBuild()
@@ -1832,6 +1854,7 @@ func TestCCIPRouter(t *testing.T) {
 					instruction, err = ccip_router.NewSetPoolInstruction(
 						token1.Mint.PublicKey(),
 						token1.WritableIndexes,
+						config.RouterConfigPDA,
 						token1.AdminRegistry,
 						token1.PoolLookupTable,
 						anotherTokenPoolAdmin.PublicKey(),
@@ -1844,6 +1867,7 @@ func TestCCIPRouter(t *testing.T) {
 					instruction, err = ccip_router.NewSetPoolInstruction(
 						token1.Mint.PublicKey(),
 						token1.WritableIndexes,
+						config.RouterConfigPDA,
 						token1.AdminRegistry,
 						token1.PoolLookupTable,
 						tokenPoolAdmin.PublicKey(),
@@ -1856,6 +1880,7 @@ func TestCCIPRouter(t *testing.T) {
 				t.Run("When new admin accepts the token admin registry, it succeeds and permissions are updated", func(t *testing.T) {
 					instruction, err := ccip_router.NewAcceptAdminRoleTokenAdminRegistryInstruction(
 						token1.Mint.PublicKey(),
+						config.RouterConfigPDA,
 						token1.AdminRegistry,
 						tokenPoolAdmin.PublicKey(),
 					).ValidateAndBuild()
@@ -1876,6 +1901,7 @@ func TestCCIPRouter(t *testing.T) {
 					instruction, err = ccip_router.NewSetPoolInstruction(
 						token1.Mint.PublicKey(),
 						token1.WritableIndexes,
+						config.RouterConfigPDA,
 						token1.AdminRegistry,
 						token1.PoolLookupTable,
 						anotherTokenPoolAdmin.PublicKey(),
@@ -1888,6 +1914,7 @@ func TestCCIPRouter(t *testing.T) {
 					instruction, err = ccip_router.NewSetPoolInstruction(
 						token1.Mint.PublicKey(),
 						token1.WritableIndexes,
+						config.RouterConfigPDA,
 						token1.AdminRegistry,
 						token1.PoolLookupTable,
 						tokenPoolAdmin.PublicKey(),
@@ -1946,7 +1973,7 @@ func TestCCIPRouter(t *testing.T) {
 				FeeToken: wsol.mint,
 			}
 
-			raw := ccip_router.NewGetFeeInstruction(config.EvmChainSelector, message, config.EvmDestChainStatePDA, wsol.billingConfigPDA)
+			raw := ccip_router.NewGetFeeInstruction(config.EvmChainSelector, message, config.RouterConfigPDA, config.EvmDestChainStatePDA, wsol.billingConfigPDA)
 			instruction, err := raw.ValidateAndBuild()
 			require.NoError(t, err)
 
@@ -1978,7 +2005,7 @@ func TestCCIPRouter(t *testing.T) {
 			require.NoError(t, err)
 			testutils.SendAndConfirm(ctx, t, solanaGoClient, []solana.Instruction{ix}, anotherAdmin, config.DefaultCommitment)
 
-			raw := ccip_router.NewGetFeeInstruction(config.EvmChainSelector, message, config.EvmDestChainStatePDA, wsol.billingConfigPDA)
+			raw := ccip_router.NewGetFeeInstruction(config.EvmChainSelector, message, config.RouterConfigPDA, config.EvmDestChainStatePDA, wsol.billingConfigPDA)
 			raw.AccountMetaSlice.Append(solana.Meta(token0BillingConfigPda))
 			raw.AccountMetaSlice.Append(solana.Meta(token0PerChainPerConfigPda))
 			instruction, err := raw.ValidateAndBuild()
@@ -2005,7 +2032,7 @@ func TestCCIPRouter(t *testing.T) {
 					FeeToken: wsol.mint,
 				}
 
-				raw := ccip_router.NewGetFeeInstruction(config.EvmChainSelector, message, config.EvmDestChainStatePDA, wsol.billingConfigPDA)
+				raw := ccip_router.NewGetFeeInstruction(config.EvmChainSelector, message, config.RouterConfigPDA, config.EvmDestChainStatePDA, wsol.billingConfigPDA)
 				instruction, err := raw.ValidateAndBuild()
 				require.NoError(t, err)
 
@@ -2884,7 +2911,7 @@ func TestCCIPRouter(t *testing.T) {
 						Receiver: validReceiverAddress[:],
 						Data:     []byte{4, 5, 6},
 					}
-					rawGetFeeIx := ccip_router.NewGetFeeInstruction(config.EvmChainSelector, message, config.EvmDestChainStatePDA, token.billingConfigPDA)
+					rawGetFeeIx := ccip_router.NewGetFeeInstruction(config.EvmChainSelector, message, config.RouterConfigPDA, config.EvmDestChainStatePDA, token.billingConfigPDA)
 					ix, err := rawGetFeeIx.ValidateAndBuild()
 					require.NoError(t, err)
 
@@ -2979,7 +3006,7 @@ func TestCCIPRouter(t *testing.T) {
 			}
 
 			// getFee
-			rawGetFeeIx := ccip_router.NewGetFeeInstruction(config.EvmChainSelector, message, config.EvmDestChainStatePDA, wsol.billingConfigPDA)
+			rawGetFeeIx := ccip_router.NewGetFeeInstruction(config.EvmChainSelector, message, config.RouterConfigPDA, config.EvmDestChainStatePDA, wsol.billingConfigPDA)
 			ix, err := rawGetFeeIx.ValidateAndBuild()
 			require.NoError(t, err)
 

--- a/chains/solana/gobindings/ccip_router/AcceptAdminRoleTokenAdminRegistry.go
+++ b/chains/solana/gobindings/ccip_router/AcceptAdminRoleTokenAdminRegistry.go
@@ -21,16 +21,18 @@ import (
 type AcceptAdminRoleTokenAdminRegistry struct {
 	Mint *ag_solanago.PublicKey
 
-	// [0] = [WRITE] tokenAdminRegistry
+	// [0] = [] config
 	//
-	// [1] = [WRITE, SIGNER] authority
+	// [1] = [WRITE] tokenAdminRegistry
+	//
+	// [2] = [WRITE, SIGNER] authority
 	ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
 }
 
 // NewAcceptAdminRoleTokenAdminRegistryInstructionBuilder creates a new `AcceptAdminRoleTokenAdminRegistry` instruction builder.
 func NewAcceptAdminRoleTokenAdminRegistryInstructionBuilder() *AcceptAdminRoleTokenAdminRegistry {
 	nd := &AcceptAdminRoleTokenAdminRegistry{
-		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 2),
+		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 3),
 	}
 	return nd
 }
@@ -41,26 +43,37 @@ func (inst *AcceptAdminRoleTokenAdminRegistry) SetMint(mint ag_solanago.PublicKe
 	return inst
 }
 
+// SetConfigAccount sets the "config" account.
+func (inst *AcceptAdminRoleTokenAdminRegistry) SetConfigAccount(config ag_solanago.PublicKey) *AcceptAdminRoleTokenAdminRegistry {
+	inst.AccountMetaSlice[0] = ag_solanago.Meta(config)
+	return inst
+}
+
+// GetConfigAccount gets the "config" account.
+func (inst *AcceptAdminRoleTokenAdminRegistry) GetConfigAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[0]
+}
+
 // SetTokenAdminRegistryAccount sets the "tokenAdminRegistry" account.
 func (inst *AcceptAdminRoleTokenAdminRegistry) SetTokenAdminRegistryAccount(tokenAdminRegistry ag_solanago.PublicKey) *AcceptAdminRoleTokenAdminRegistry {
-	inst.AccountMetaSlice[0] = ag_solanago.Meta(tokenAdminRegistry).WRITE()
+	inst.AccountMetaSlice[1] = ag_solanago.Meta(tokenAdminRegistry).WRITE()
 	return inst
 }
 
 // GetTokenAdminRegistryAccount gets the "tokenAdminRegistry" account.
 func (inst *AcceptAdminRoleTokenAdminRegistry) GetTokenAdminRegistryAccount() *ag_solanago.AccountMeta {
-	return inst.AccountMetaSlice[0]
+	return inst.AccountMetaSlice[1]
 }
 
 // SetAuthorityAccount sets the "authority" account.
 func (inst *AcceptAdminRoleTokenAdminRegistry) SetAuthorityAccount(authority ag_solanago.PublicKey) *AcceptAdminRoleTokenAdminRegistry {
-	inst.AccountMetaSlice[1] = ag_solanago.Meta(authority).WRITE().SIGNER()
+	inst.AccountMetaSlice[2] = ag_solanago.Meta(authority).WRITE().SIGNER()
 	return inst
 }
 
 // GetAuthorityAccount gets the "authority" account.
 func (inst *AcceptAdminRoleTokenAdminRegistry) GetAuthorityAccount() *ag_solanago.AccountMeta {
-	return inst.AccountMetaSlice[1]
+	return inst.AccountMetaSlice[2]
 }
 
 func (inst AcceptAdminRoleTokenAdminRegistry) Build() *Instruction {
@@ -91,9 +104,12 @@ func (inst *AcceptAdminRoleTokenAdminRegistry) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
-			return errors.New("accounts.TokenAdminRegistry is not set")
+			return errors.New("accounts.Config is not set")
 		}
 		if inst.AccountMetaSlice[1] == nil {
+			return errors.New("accounts.TokenAdminRegistry is not set")
+		}
+		if inst.AccountMetaSlice[2] == nil {
 			return errors.New("accounts.Authority is not set")
 		}
 	}
@@ -114,9 +130,10 @@ func (inst *AcceptAdminRoleTokenAdminRegistry) EncodeToTree(parent ag_treeout.Br
 					})
 
 					// Accounts of the instruction:
-					instructionBranch.Child("Accounts[len=2]").ParentFunc(func(accountsBranch ag_treeout.Branches) {
-						accountsBranch.Child(ag_format.Meta("tokenAdminRegistry", inst.AccountMetaSlice[0]))
-						accountsBranch.Child(ag_format.Meta("         authority", inst.AccountMetaSlice[1]))
+					instructionBranch.Child("Accounts[len=3]").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("            config", inst.AccountMetaSlice[0]))
+						accountsBranch.Child(ag_format.Meta("tokenAdminRegistry", inst.AccountMetaSlice[1]))
+						accountsBranch.Child(ag_format.Meta("         authority", inst.AccountMetaSlice[2]))
 					})
 				})
 		})
@@ -144,10 +161,12 @@ func NewAcceptAdminRoleTokenAdminRegistryInstruction(
 	// Parameters:
 	mint ag_solanago.PublicKey,
 	// Accounts:
+	config ag_solanago.PublicKey,
 	tokenAdminRegistry ag_solanago.PublicKey,
 	authority ag_solanago.PublicKey) *AcceptAdminRoleTokenAdminRegistry {
 	return NewAcceptAdminRoleTokenAdminRegistryInstructionBuilder().
 		SetMint(mint).
+		SetConfigAccount(config).
 		SetTokenAdminRegistryAccount(tokenAdminRegistry).
 		SetAuthorityAccount(authority)
 }

--- a/chains/solana/gobindings/ccip_router/GetFee.go
+++ b/chains/solana/gobindings/ccip_router/GetFee.go
@@ -36,16 +36,18 @@ type GetFee struct {
 	DestChainSelector *uint64
 	Message           *SVM2AnyMessage
 
-	// [0] = [] destChainState
+	// [0] = [] config
 	//
-	// [1] = [] billingTokenConfig
+	// [1] = [] destChainState
+	//
+	// [2] = [] billingTokenConfig
 	ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
 }
 
 // NewGetFeeInstructionBuilder creates a new `GetFee` instruction builder.
 func NewGetFeeInstructionBuilder() *GetFee {
 	nd := &GetFee{
-		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 2),
+		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 3),
 	}
 	return nd
 }
@@ -62,26 +64,37 @@ func (inst *GetFee) SetMessage(message SVM2AnyMessage) *GetFee {
 	return inst
 }
 
+// SetConfigAccount sets the "config" account.
+func (inst *GetFee) SetConfigAccount(config ag_solanago.PublicKey) *GetFee {
+	inst.AccountMetaSlice[0] = ag_solanago.Meta(config)
+	return inst
+}
+
+// GetConfigAccount gets the "config" account.
+func (inst *GetFee) GetConfigAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[0]
+}
+
 // SetDestChainStateAccount sets the "destChainState" account.
 func (inst *GetFee) SetDestChainStateAccount(destChainState ag_solanago.PublicKey) *GetFee {
-	inst.AccountMetaSlice[0] = ag_solanago.Meta(destChainState)
+	inst.AccountMetaSlice[1] = ag_solanago.Meta(destChainState)
 	return inst
 }
 
 // GetDestChainStateAccount gets the "destChainState" account.
 func (inst *GetFee) GetDestChainStateAccount() *ag_solanago.AccountMeta {
-	return inst.AccountMetaSlice[0]
+	return inst.AccountMetaSlice[1]
 }
 
 // SetBillingTokenConfigAccount sets the "billingTokenConfig" account.
 func (inst *GetFee) SetBillingTokenConfigAccount(billingTokenConfig ag_solanago.PublicKey) *GetFee {
-	inst.AccountMetaSlice[1] = ag_solanago.Meta(billingTokenConfig)
+	inst.AccountMetaSlice[2] = ag_solanago.Meta(billingTokenConfig)
 	return inst
 }
 
 // GetBillingTokenConfigAccount gets the "billingTokenConfig" account.
 func (inst *GetFee) GetBillingTokenConfigAccount() *ag_solanago.AccountMeta {
-	return inst.AccountMetaSlice[1]
+	return inst.AccountMetaSlice[2]
 }
 
 func (inst GetFee) Build() *Instruction {
@@ -115,9 +128,12 @@ func (inst *GetFee) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
-			return errors.New("accounts.DestChainState is not set")
+			return errors.New("accounts.Config is not set")
 		}
 		if inst.AccountMetaSlice[1] == nil {
+			return errors.New("accounts.DestChainState is not set")
+		}
+		if inst.AccountMetaSlice[2] == nil {
 			return errors.New("accounts.BillingTokenConfig is not set")
 		}
 	}
@@ -139,9 +155,10 @@ func (inst *GetFee) EncodeToTree(parent ag_treeout.Branches) {
 					})
 
 					// Accounts of the instruction:
-					instructionBranch.Child("Accounts[len=2]").ParentFunc(func(accountsBranch ag_treeout.Branches) {
-						accountsBranch.Child(ag_format.Meta("    destChainState", inst.AccountMetaSlice[0]))
-						accountsBranch.Child(ag_format.Meta("billingTokenConfig", inst.AccountMetaSlice[1]))
+					instructionBranch.Child("Accounts[len=3]").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("            config", inst.AccountMetaSlice[0]))
+						accountsBranch.Child(ag_format.Meta("    destChainState", inst.AccountMetaSlice[1]))
+						accountsBranch.Child(ag_format.Meta("billingTokenConfig", inst.AccountMetaSlice[2]))
 					})
 				})
 		})
@@ -180,11 +197,13 @@ func NewGetFeeInstruction(
 	destChainSelector uint64,
 	message SVM2AnyMessage,
 	// Accounts:
+	config ag_solanago.PublicKey,
 	destChainState ag_solanago.PublicKey,
 	billingTokenConfig ag_solanago.PublicKey) *GetFee {
 	return NewGetFeeInstructionBuilder().
 		SetDestChainSelector(destChainSelector).
 		SetMessage(message).
+		SetConfigAccount(config).
 		SetDestChainStateAccount(destChainState).
 		SetBillingTokenConfigAccount(billingTokenConfig)
 }

--- a/chains/solana/gobindings/ccip_router/RegisterTokenAdminRegistryViaOwner.go
+++ b/chains/solana/gobindings/ccip_router/RegisterTokenAdminRegistryViaOwner.go
@@ -19,66 +19,79 @@ import (
 // * `ctx` - The context containing the accounts required for registration.
 type RegisterTokenAdminRegistryViaOwner struct {
 
-	// [0] = [WRITE] tokenAdminRegistry
+	// [0] = [] config
 	//
-	// [1] = [WRITE] mint
+	// [1] = [WRITE] tokenAdminRegistry
 	//
-	// [2] = [WRITE, SIGNER] authority
+	// [2] = [WRITE] mint
 	//
-	// [3] = [] systemProgram
+	// [3] = [WRITE, SIGNER] authority
+	//
+	// [4] = [] systemProgram
 	ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
 }
 
 // NewRegisterTokenAdminRegistryViaOwnerInstructionBuilder creates a new `RegisterTokenAdminRegistryViaOwner` instruction builder.
 func NewRegisterTokenAdminRegistryViaOwnerInstructionBuilder() *RegisterTokenAdminRegistryViaOwner {
 	nd := &RegisterTokenAdminRegistryViaOwner{
-		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 4),
+		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 5),
 	}
 	return nd
 }
 
+// SetConfigAccount sets the "config" account.
+func (inst *RegisterTokenAdminRegistryViaOwner) SetConfigAccount(config ag_solanago.PublicKey) *RegisterTokenAdminRegistryViaOwner {
+	inst.AccountMetaSlice[0] = ag_solanago.Meta(config)
+	return inst
+}
+
+// GetConfigAccount gets the "config" account.
+func (inst *RegisterTokenAdminRegistryViaOwner) GetConfigAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[0]
+}
+
 // SetTokenAdminRegistryAccount sets the "tokenAdminRegistry" account.
 func (inst *RegisterTokenAdminRegistryViaOwner) SetTokenAdminRegistryAccount(tokenAdminRegistry ag_solanago.PublicKey) *RegisterTokenAdminRegistryViaOwner {
-	inst.AccountMetaSlice[0] = ag_solanago.Meta(tokenAdminRegistry).WRITE()
+	inst.AccountMetaSlice[1] = ag_solanago.Meta(tokenAdminRegistry).WRITE()
 	return inst
 }
 
 // GetTokenAdminRegistryAccount gets the "tokenAdminRegistry" account.
 func (inst *RegisterTokenAdminRegistryViaOwner) GetTokenAdminRegistryAccount() *ag_solanago.AccountMeta {
-	return inst.AccountMetaSlice[0]
+	return inst.AccountMetaSlice[1]
 }
 
 // SetMintAccount sets the "mint" account.
 func (inst *RegisterTokenAdminRegistryViaOwner) SetMintAccount(mint ag_solanago.PublicKey) *RegisterTokenAdminRegistryViaOwner {
-	inst.AccountMetaSlice[1] = ag_solanago.Meta(mint).WRITE()
+	inst.AccountMetaSlice[2] = ag_solanago.Meta(mint).WRITE()
 	return inst
 }
 
 // GetMintAccount gets the "mint" account.
 func (inst *RegisterTokenAdminRegistryViaOwner) GetMintAccount() *ag_solanago.AccountMeta {
-	return inst.AccountMetaSlice[1]
+	return inst.AccountMetaSlice[2]
 }
 
 // SetAuthorityAccount sets the "authority" account.
 func (inst *RegisterTokenAdminRegistryViaOwner) SetAuthorityAccount(authority ag_solanago.PublicKey) *RegisterTokenAdminRegistryViaOwner {
-	inst.AccountMetaSlice[2] = ag_solanago.Meta(authority).WRITE().SIGNER()
+	inst.AccountMetaSlice[3] = ag_solanago.Meta(authority).WRITE().SIGNER()
 	return inst
 }
 
 // GetAuthorityAccount gets the "authority" account.
 func (inst *RegisterTokenAdminRegistryViaOwner) GetAuthorityAccount() *ag_solanago.AccountMeta {
-	return inst.AccountMetaSlice[2]
+	return inst.AccountMetaSlice[3]
 }
 
 // SetSystemProgramAccount sets the "systemProgram" account.
 func (inst *RegisterTokenAdminRegistryViaOwner) SetSystemProgramAccount(systemProgram ag_solanago.PublicKey) *RegisterTokenAdminRegistryViaOwner {
-	inst.AccountMetaSlice[3] = ag_solanago.Meta(systemProgram)
+	inst.AccountMetaSlice[4] = ag_solanago.Meta(systemProgram)
 	return inst
 }
 
 // GetSystemProgramAccount gets the "systemProgram" account.
 func (inst *RegisterTokenAdminRegistryViaOwner) GetSystemProgramAccount() *ag_solanago.AccountMeta {
-	return inst.AccountMetaSlice[3]
+	return inst.AccountMetaSlice[4]
 }
 
 func (inst RegisterTokenAdminRegistryViaOwner) Build() *Instruction {
@@ -102,15 +115,18 @@ func (inst *RegisterTokenAdminRegistryViaOwner) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
-			return errors.New("accounts.TokenAdminRegistry is not set")
+			return errors.New("accounts.Config is not set")
 		}
 		if inst.AccountMetaSlice[1] == nil {
-			return errors.New("accounts.Mint is not set")
+			return errors.New("accounts.TokenAdminRegistry is not set")
 		}
 		if inst.AccountMetaSlice[2] == nil {
-			return errors.New("accounts.Authority is not set")
+			return errors.New("accounts.Mint is not set")
 		}
 		if inst.AccountMetaSlice[3] == nil {
+			return errors.New("accounts.Authority is not set")
+		}
+		if inst.AccountMetaSlice[4] == nil {
 			return errors.New("accounts.SystemProgram is not set")
 		}
 	}
@@ -129,11 +145,12 @@ func (inst *RegisterTokenAdminRegistryViaOwner) EncodeToTree(parent ag_treeout.B
 					instructionBranch.Child("Params[len=0]").ParentFunc(func(paramsBranch ag_treeout.Branches) {})
 
 					// Accounts of the instruction:
-					instructionBranch.Child("Accounts[len=4]").ParentFunc(func(accountsBranch ag_treeout.Branches) {
-						accountsBranch.Child(ag_format.Meta("tokenAdminRegistry", inst.AccountMetaSlice[0]))
-						accountsBranch.Child(ag_format.Meta("              mint", inst.AccountMetaSlice[1]))
-						accountsBranch.Child(ag_format.Meta("         authority", inst.AccountMetaSlice[2]))
-						accountsBranch.Child(ag_format.Meta("     systemProgram", inst.AccountMetaSlice[3]))
+					instructionBranch.Child("Accounts[len=5]").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("            config", inst.AccountMetaSlice[0]))
+						accountsBranch.Child(ag_format.Meta("tokenAdminRegistry", inst.AccountMetaSlice[1]))
+						accountsBranch.Child(ag_format.Meta("              mint", inst.AccountMetaSlice[2]))
+						accountsBranch.Child(ag_format.Meta("         authority", inst.AccountMetaSlice[3]))
+						accountsBranch.Child(ag_format.Meta("     systemProgram", inst.AccountMetaSlice[4]))
 					})
 				})
 		})
@@ -149,11 +166,13 @@ func (obj *RegisterTokenAdminRegistryViaOwner) UnmarshalWithDecoder(decoder *ag_
 // NewRegisterTokenAdminRegistryViaOwnerInstruction declares a new RegisterTokenAdminRegistryViaOwner instruction with the provided parameters and accounts.
 func NewRegisterTokenAdminRegistryViaOwnerInstruction(
 	// Accounts:
+	config ag_solanago.PublicKey,
 	tokenAdminRegistry ag_solanago.PublicKey,
 	mint ag_solanago.PublicKey,
 	authority ag_solanago.PublicKey,
 	systemProgram ag_solanago.PublicKey) *RegisterTokenAdminRegistryViaOwner {
 	return NewRegisterTokenAdminRegistryViaOwnerInstructionBuilder().
+		SetConfigAccount(config).
 		SetTokenAdminRegistryAccount(tokenAdminRegistry).
 		SetMintAccount(mint).
 		SetAuthorityAccount(authority).

--- a/chains/solana/gobindings/ccip_router/TransferAdminRoleTokenAdminRegistry.go
+++ b/chains/solana/gobindings/ccip_router/TransferAdminRoleTokenAdminRegistry.go
@@ -23,16 +23,18 @@ type TransferAdminRoleTokenAdminRegistry struct {
 	Mint     *ag_solanago.PublicKey
 	NewAdmin *ag_solanago.PublicKey
 
-	// [0] = [WRITE] tokenAdminRegistry
+	// [0] = [] config
 	//
-	// [1] = [WRITE, SIGNER] authority
+	// [1] = [WRITE] tokenAdminRegistry
+	//
+	// [2] = [WRITE, SIGNER] authority
 	ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
 }
 
 // NewTransferAdminRoleTokenAdminRegistryInstructionBuilder creates a new `TransferAdminRoleTokenAdminRegistry` instruction builder.
 func NewTransferAdminRoleTokenAdminRegistryInstructionBuilder() *TransferAdminRoleTokenAdminRegistry {
 	nd := &TransferAdminRoleTokenAdminRegistry{
-		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 2),
+		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 3),
 	}
 	return nd
 }
@@ -49,26 +51,37 @@ func (inst *TransferAdminRoleTokenAdminRegistry) SetNewAdmin(newAdmin ag_solanag
 	return inst
 }
 
+// SetConfigAccount sets the "config" account.
+func (inst *TransferAdminRoleTokenAdminRegistry) SetConfigAccount(config ag_solanago.PublicKey) *TransferAdminRoleTokenAdminRegistry {
+	inst.AccountMetaSlice[0] = ag_solanago.Meta(config)
+	return inst
+}
+
+// GetConfigAccount gets the "config" account.
+func (inst *TransferAdminRoleTokenAdminRegistry) GetConfigAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[0]
+}
+
 // SetTokenAdminRegistryAccount sets the "tokenAdminRegistry" account.
 func (inst *TransferAdminRoleTokenAdminRegistry) SetTokenAdminRegistryAccount(tokenAdminRegistry ag_solanago.PublicKey) *TransferAdminRoleTokenAdminRegistry {
-	inst.AccountMetaSlice[0] = ag_solanago.Meta(tokenAdminRegistry).WRITE()
+	inst.AccountMetaSlice[1] = ag_solanago.Meta(tokenAdminRegistry).WRITE()
 	return inst
 }
 
 // GetTokenAdminRegistryAccount gets the "tokenAdminRegistry" account.
 func (inst *TransferAdminRoleTokenAdminRegistry) GetTokenAdminRegistryAccount() *ag_solanago.AccountMeta {
-	return inst.AccountMetaSlice[0]
+	return inst.AccountMetaSlice[1]
 }
 
 // SetAuthorityAccount sets the "authority" account.
 func (inst *TransferAdminRoleTokenAdminRegistry) SetAuthorityAccount(authority ag_solanago.PublicKey) *TransferAdminRoleTokenAdminRegistry {
-	inst.AccountMetaSlice[1] = ag_solanago.Meta(authority).WRITE().SIGNER()
+	inst.AccountMetaSlice[2] = ag_solanago.Meta(authority).WRITE().SIGNER()
 	return inst
 }
 
 // GetAuthorityAccount gets the "authority" account.
 func (inst *TransferAdminRoleTokenAdminRegistry) GetAuthorityAccount() *ag_solanago.AccountMeta {
-	return inst.AccountMetaSlice[1]
+	return inst.AccountMetaSlice[2]
 }
 
 func (inst TransferAdminRoleTokenAdminRegistry) Build() *Instruction {
@@ -102,9 +115,12 @@ func (inst *TransferAdminRoleTokenAdminRegistry) Validate() error {
 	// Check whether all (required) accounts are set:
 	{
 		if inst.AccountMetaSlice[0] == nil {
-			return errors.New("accounts.TokenAdminRegistry is not set")
+			return errors.New("accounts.Config is not set")
 		}
 		if inst.AccountMetaSlice[1] == nil {
+			return errors.New("accounts.TokenAdminRegistry is not set")
+		}
+		if inst.AccountMetaSlice[2] == nil {
 			return errors.New("accounts.Authority is not set")
 		}
 	}
@@ -126,9 +142,10 @@ func (inst *TransferAdminRoleTokenAdminRegistry) EncodeToTree(parent ag_treeout.
 					})
 
 					// Accounts of the instruction:
-					instructionBranch.Child("Accounts[len=2]").ParentFunc(func(accountsBranch ag_treeout.Branches) {
-						accountsBranch.Child(ag_format.Meta("tokenAdminRegistry", inst.AccountMetaSlice[0]))
-						accountsBranch.Child(ag_format.Meta("         authority", inst.AccountMetaSlice[1]))
+					instructionBranch.Child("Accounts[len=3]").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+						accountsBranch.Child(ag_format.Meta("            config", inst.AccountMetaSlice[0]))
+						accountsBranch.Child(ag_format.Meta("tokenAdminRegistry", inst.AccountMetaSlice[1]))
+						accountsBranch.Child(ag_format.Meta("         authority", inst.AccountMetaSlice[2]))
 					})
 				})
 		})
@@ -167,11 +184,13 @@ func NewTransferAdminRoleTokenAdminRegistryInstruction(
 	mint ag_solanago.PublicKey,
 	newAdmin ag_solanago.PublicKey,
 	// Accounts:
+	config ag_solanago.PublicKey,
 	tokenAdminRegistry ag_solanago.PublicKey,
 	authority ag_solanago.PublicKey) *TransferAdminRoleTokenAdminRegistry {
 	return NewTransferAdminRoleTokenAdminRegistryInstructionBuilder().
 		SetMint(mint).
 		SetNewAdmin(newAdmin).
+		SetConfigAccount(config).
 		SetTokenAdminRegistryAccount(tokenAdminRegistry).
 		SetAuthorityAccount(authority)
 }

--- a/chains/solana/gobindings/ccip_router/types.go
+++ b/chains/solana/gobindings/ccip_router/types.go
@@ -1596,21 +1596,6 @@ func (value OcrPluginType) String() string {
 	}
 }
 
-type MerkleError ag_binary.BorshEnum
-
-const (
-	InvalidProof_MerkleError MerkleError = iota
-)
-
-func (value MerkleError) String() string {
-	switch value {
-	case InvalidProof_MerkleError:
-		return "InvalidProof"
-	default:
-		return ""
-	}
-}
-
 type MessageExecutionState ag_binary.BorshEnum
 
 const (


### PR DESCRIPTION
_Continues with refactor started in #414, #418, #432, #437, #442 & #454_

This PR does a few unrelated small fixes here and there, I recommend reviewers look at it commit-by-commit. I've made each commit its own fix, with a one-liner title explaining the idea. 

However, here's the list of changes with some additional info:
- Adds the `config` account to all methods that did not have them. This will allow us to configure the routing layer in each method, so we can do blue/green upgrades and shift traffic between versions. ⚠️ _This is an interface change_
- Removes internal error from the IDL by restricting its visibility. Similar to what was done in #454, just for another error.
- Removes code in the versioned-module tests that was implementing a method on `TimestampedPackedU224`, as that is an interface struct for us (meaning users have to send it in) so it's not versioned, and that could have leaked its implementation across versions. It was dead code anyway, so it was easy to remove.
- The `MAX_ORACLES` constant was already explicitly added to the IDL, so I moved it out of the versioned module, as it is thus part of our interface.
- There were some imports in the versioned module that were getting versioned module via `use crate::v1::...`, thus making it break if we ever copy-paste that into a `v2` module. Now, they just `use super::...`, making it explicitly contained within their own module even if we copy-paste.