### PR TITLE
CCIP-4951 Reduce polling by RMNHome background routine

### DIFF
--- a/commit/factory.go
+++ b/commit/factory.go
@@ -153,13 +153,12 @@ func (p *PluginFactory) NewReportingPlugin(ctx context.Context, config ocr3types
 				fmt.Errorf("failed to find contract reader for home chain %d", p.homeChainSelector)
 		}
 
-		rmnHomeReader, err = readerpkg.GetRMNHomePoller(
+		rmnHomeReader, err = readerpkg.NewRMNHome(
 			ctx,
 			lggr,
 			p.homeChainSelector,
 			rmnHomeAddress,
 			rmnCr,
-			readerpkg.HomeChainPollingInterval,
 		)
 		if err != nil {
 			return nil, ocr3types.ReportingPluginInfo{}, fmt.Errorf("failed to initialize RMNHome reader: %w", err)

--- a/commit/factory.go
+++ b/commit/factory.go
@@ -153,9 +153,10 @@ func (p *PluginFactory) NewReportingPlugin(ctx context.Context, config ocr3types
 				fmt.Errorf("failed to find contract reader for home chain %d", p.homeChainSelector)
 		}
 
-		rmnHomeReader, err = readerpkg.NewRMNHome(
+		rmnHomeReader, err = readerpkg.NewRMNHomeChainReader(
 			ctx,
 			lggr,
+			readerpkg.HomeChainPollingInterval,
 			p.homeChainSelector,
 			rmnHomeAddress,
 			rmnCr,

--- a/commit/factory.go
+++ b/commit/factory.go
@@ -164,6 +164,10 @@ func (p *PluginFactory) NewReportingPlugin(ctx context.Context, config ocr3types
 		if err != nil {
 			return nil, ocr3types.ReportingPluginInfo{}, fmt.Errorf("failed to initialize RMNHome reader: %w", err)
 		}
+
+		if err := rmnHomeReader.Start(ctx); err != nil {
+			return nil, ocr3types.ReportingPluginInfo{}, fmt.Errorf("failed to start RMNHome: %w", err)
+		}
 	}
 
 	if err := validateOcrConfig(p.ocrConfig.Config); err != nil {

--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -3,6 +3,7 @@ package commit
 import (
 	"context"
 	"fmt"
+	"io"
 	"sync/atomic"
 	"time"
 
@@ -492,13 +493,20 @@ func (p *Plugin) getMainOutcome(
 func (p *Plugin) Close() error {
 	p.lggr.Infow("closing commit plugin")
 
-	return services.CloseAll(
+	closeable := []io.Closer{
 		p.merkleRootProcessor,
 		p.tokenPriceProcessor,
 		p.chainFeeProcessor,
 		p.discoveryProcessor,
-		p.rmnHomeReader,
-	)
+	}
+
+	// Chains without RMN don't initialize the RMNHomeReader
+	// TODO Consider initializing rmnHomeReader anyway but using some noop implementation
+	if p.rmnHomeReader != nil {
+		closeable = append(closeable, p.rmnHomeReader)
+	}
+
+	return services.CloseAll(closeable...)
 }
 
 // Assuming that we have to delegate a specific amount of time to the observation requests and the report requests.

--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -492,6 +492,7 @@ func (p *Plugin) Close() error {
 		p.tokenPriceProcessor,
 		p.chainFeeProcessor,
 		p.discoveryProcessor,
+		p.rmnHomeReader,
 	)
 }
 

--- a/internal/libs/testhelpers/rand/rand.go
+++ b/internal/libs/testhelpers/rand/rand.go
@@ -75,7 +75,10 @@ func stringToBytes32(s string) cciptypes.Bytes32 {
 }
 
 func RandomAddress() cciptypes.UnknownEncodedAddress {
-	b := make([]byte, 20)
-	_, _ = rand.Read(b) // Assignment for errcheck. Only used in tests so we can ignore.
-	return cciptypes.UnknownEncodedAddress(cciptypes.Bytes(b).String())
+	b := RandomAddressBytes()
+	return cciptypes.UnknownEncodedAddress(b.String())
+}
+
+func RandomAddressBytes() cciptypes.Bytes {
+	return cciptypes.Bytes(RandomBytes(20))
 }

--- a/pkg/reader/helpers.go
+++ b/pkg/reader/helpers.go
@@ -16,7 +16,7 @@ import (
 const (
 	// HomeChainPollingInterval is the interval at which the home chain is polled for updates.
 	// It should be used by RMNHome and CCIPHome to poll the home chain for updates.
-	// Ethereum was selected for the home chain for CCIP, therefore pooling more frequent
+	// Ethereum was selected for the home chain for CCIP, therefore polling more frequent
 	// than block time doesn't bring any value.
 	// We selected 15 seconds for simplicity, but this could be extended even further as
 	// we accept some delay when fetching the configuration updates.

--- a/pkg/reader/helpers.go
+++ b/pkg/reader/helpers.go
@@ -3,6 +3,7 @@ package reader
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
@@ -10,6 +11,17 @@ import (
 	typeconv "github.com/smartcontractkit/chainlink-ccip/internal/libs/typeconv"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+)
+
+const (
+	// HomeChainPollingInterval is the interval at which the home chain is polled for updates.
+	// It should be used by RMNHome and CCIPHome to poll the home chain for updates.
+	// Ethereum was selected for the home chain for CCIP, therefore pooling more frequent
+	// than block time doesn't bring any value.
+	// We selected 15 seconds for simplicity, but this could be extended even further as
+	// we accept some delay when fetching the configuration updates.
+	// It's advised to use wrap that interval with some jitter to avoid congestion.
+	HomeChainPollingInterval = 15 * time.Second
 )
 
 // bindable is a helper interface to represent all different types of contract readers.

--- a/pkg/reader/rmn_home.go
+++ b/pkg/reader/rmn_home.go
@@ -97,7 +97,7 @@ func GetRMNHomePoller(
 	hexEncodedAddr := " 0x" + hex.EncodeToString(rmnHomeAddress)
 	key := fmt.Sprintf("%s-%s", rmnHomeChainSelector.String(), hexEncodedAddr)
 
-	instance, ok := instances[key]
+	instance, ok := getInstance(key)
 	if ok {
 		lggr.Infow("RMNHomePoller already exists, reusing instance",
 			"chainSelector", rmnHomeChainSelector,
@@ -128,6 +128,19 @@ func GetRMNHomePoller(
 
 	instances[key] = rmnHomeReader
 	return rmnHomeReader, nil
+}
+
+func getInstance(key string) (*rmnHomePoller, bool) {
+	instance, ok := instances[key]
+	if !ok {
+		return nil, false
+	}
+
+	if err := instance.sync.Ready(); err != nil {
+		return nil, false
+	}
+
+	return instance, ok
 }
 
 func newRMNHomePoller(

--- a/pkg/reader/rmn_home.go
+++ b/pkg/reader/rmn_home.go
@@ -44,9 +44,9 @@ type rmnHome struct {
 	bgPoller *rmnHomePoller
 }
 
-// NewRMNHomeChainReader creates a new RMNHome and starts it immediately. RMNHome is very lightweight layer
+// NewRMNHomeChainReader creates a new RMNHome. RMNHome is very lightweight layer
 // on top of RMNHomePoller. Every consumer should follow the `Service` pattern in which they
-// are responsible for properly closing the service when done. (using Close() method)
+// are responsible for properly starting and closing the service when done. (using Start()/Close() methods)
 //
 // RMNHome is a smart component that behind the scenes share the same RMNHomePoller instance.
 // Whenever all RMNHome instances are closed, the underlying RMNHomePoller instance is also closed.
@@ -72,12 +72,7 @@ func NewRMNHomeChainReader(
 		return nil, fmt.Errorf("failed to create RMNHomePoller: %w", err)
 	}
 
-	rmn := &rmnHome{bgPoller: bgPoller}
-
-	if err := rmn.Start(ctx); err != nil {
-		return nil, fmt.Errorf("failed to start RMNHome: %w", err)
-	}
-	return rmn, nil
+	return &rmnHome{bgPoller: bgPoller}, nil
 }
 
 func (r *rmnHome) Start(ctx context.Context) error {

--- a/pkg/reader/rmn_home.go
+++ b/pkg/reader/rmn_home.go
@@ -2,32 +2,21 @@ package reader
 
 import (
 	"context"
-	"crypto/ed25519"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
-	"sync"
-	"time"
-
-	mapset "github.com/deckarep/golang-set/v2"
-	ragep2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
-	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
 
 	rmntypes "github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn/types"
-	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
-	"github.com/smartcontractkit/chainlink-ccip/pkg/logutil"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
 
 const (
 	rmnMaxSizeCommittee = 256 // bitmap is 256 bits making the max committee size 256
-	MaxFailedPolls      = uint(10)
+	maxFailedPolls      = uint32(10)
 )
 
 type HomeNodeInfo = rmntypes.HomeNodeInfo
@@ -49,259 +38,55 @@ type RMNHome interface {
 	services.Service
 }
 
-var (
-	instances   = make(map[string]*rmnHomePoller)
-	instancesMu sync.Mutex
-)
-
-type rmnHomeState struct {
-	activeConfigDigest    cciptypes.Bytes32
-	candidateConfigDigest cciptypes.Bytes32
-	rmnHomeConfig         map[cciptypes.Bytes32]rmntypes.HomeConfig
+type rmnHome struct {
+	sync     services.StateMachine
+	bgPoller *rmnHomePoller
 }
 
-// rmnHomePoller polls the RMNHome contract for the latest RMNHomeConfigs
-// It is running in the background with a polling interval of pollingDuration
-type rmnHomePoller struct {
-	wg                   sync.WaitGroup
-	stopCh               services.StopChan
-	sync                 services.StateMachine
-	mutex                *sync.RWMutex
-	contractReader       contractreader.ContractReaderFacade
-	rmnHomeBoundContract types.BoundContract
-	lggr                 logger.Logger
-	rmnHomeState         rmnHomeState
-	failedPolls          uint
-	pollingDuration      time.Duration // How frequently the poller fetches the chain configs
-}
-
-// GetRMNHomePoller returns a rmnHomePoller instance if it already exists, else creates a new one.
-// Returned rmnHomePoller is always started, therefore user of that API doesn't need to care about
-// concurrency and accidentally starting the same poller multiple times.
+// NewRMNHome creates a new RMNHome and starts it immediately. RMNHome is very lightweight layer
+// on top of RMNHomePoller. Every consumer should follow the `Service` pattern in which they
+// are responsible for properly closing the service when done. (using Close() method)
 //
-// In most of the cases, there is going to be only a single RMNHome deployed on a single chain. However,
-// OCR3Config allows to pass different RMNHome addresses for different chains. Therefore, we need to
-// support that and maintain a separate rmnHomePoller for each RMNHome address.
-// Having a singleton here is aimed to reduce the background polling to the underlying RPC node.
-func GetRMNHomePoller(
+// RMNHome is a smart component that behind the scenes share the same RMNHomePoller instance.
+// Whenever all RMNHome instances are closed, the underlying RMNHomePoller instance is also closed.
+// As long as RMNHome remembers to Close() upon termination there should not be any orphaned poller instances
+// working in the background
+func NewRMNHome(
 	ctx context.Context,
 	lggr logger.Logger,
 	rmnHomeChainSelector cciptypes.ChainSelector,
 	rmnHomeAddress []byte,
 	contractReader contractreader.ContractReaderFacade,
-	pollingInterval time.Duration,
 ) (RMNHome, error) {
-	instancesMu.Lock()
-	defer instancesMu.Unlock()
-
-	hexEncodedAddr := " 0x" + hex.EncodeToString(rmnHomeAddress)
-	key := fmt.Sprintf("%s-%s", rmnHomeChainSelector.String(), hexEncodedAddr)
-
-	instance, ok := getInstance(key)
-	if ok {
-		lggr.Infow("RMNHomePoller already exists, reusing instance",
-			"chainSelector", rmnHomeChainSelector,
-			"address", hexEncodedAddr,
-		)
-		return instance, nil
-	}
-
-	rmnHomeBoundContract := types.BoundContract{
-		Address: hexEncodedAddr,
-		Name:    consts.ContractNameRMNHome,
-	}
-
-	if err := contractReader.Bind(ctx, []types.BoundContract{rmnHomeBoundContract}); err != nil {
-		return nil, fmt.Errorf("failed to bind RMNHome contract: %w", err)
-	}
-
-	rmnHomeReader := newRMNHomePoller(
+	bgPoller, err := getRMNHomePoller(
+		ctx,
+		lggr,
+		rmnHomeChainSelector,
+		rmnHomeAddress,
 		contractReader,
-		rmnHomeBoundContract,
-		logutil.WithComponent(lggr, "RMNHomePoller"),
-		pollingInterval,
+		HomeChainPollingInterval,
 	)
-
-	if err := rmnHomeReader.Start(ctx); err != nil {
-		return nil, fmt.Errorf("failed to start RMNHome reader: %w", err)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create RMNHomePoller: %w", err)
 	}
 
-	instances[key] = rmnHomeReader
-	return rmnHomeReader, nil
+	rmn := &rmnHome{bgPoller: bgPoller}
+
+	if err := rmn.Start(ctx); err != nil {
+		return nil, fmt.Errorf("failed to start RMNHome: %w", err)
+	}
+	return rmn, nil
 }
 
-func getInstance(key string) (*rmnHomePoller, bool) {
-	instance, ok := instances[key]
-	if !ok {
-		return nil, false
-	}
-
-	if err := instance.sync.Ready(); err != nil {
-		return nil, false
-	}
-
-	return instance, ok
-}
-
-func newRMNHomePoller(
-	contractReader contractreader.ContractReaderFacade,
-	rmnHomeBoundContract types.BoundContract,
-	lggr logger.Logger,
-	pollingInterval time.Duration,
-) *rmnHomePoller {
-	return &rmnHomePoller{
-		stopCh:               make(chan struct{}),
-		contractReader:       contractReader,
-		rmnHomeBoundContract: rmnHomeBoundContract,
-		rmnHomeState:         rmnHomeState{},
-		mutex:                &sync.RWMutex{},
-		failedPolls:          0,
-		lggr:                 lggr,
-		pollingDuration:      pollingInterval,
-	}
-}
-
-func (r *rmnHomePoller) Start(context.Context) error {
+func (r *rmnHome) Start(ctx context.Context) error {
 	return r.sync.StartOnce(r.Name(), func() error {
-		r.lggr.Infow("Start Polling RMNHome")
-		r.wg.Add(1)
-		go r.poll()
-		return nil
+		return r.bgPoller.Start(ctx, r)
 	})
 }
 
-func (r *rmnHomePoller) poll() {
-	defer r.wg.Done()
-	ctx, cancel := r.stopCh.NewCtx()
-	defer cancel()
-	// Initial fetch once poll is called before any ticks
-	if err := r.fetchAndSetRmnHomeConfigs(ctx); err != nil {
-		// Just log, don't return error as we want to keep polling
-		r.lggr.Errorw("Initial fetch of on-chain configs failed", "err", err)
-	}
-
-	ticker := time.NewTicker(r.pollingDuration)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			r.mutex.Lock()
-			r.failedPolls = 0
-			r.mutex.Unlock()
-			return
-		case <-ticker.C:
-			if err := r.fetchAndSetRmnHomeConfigs(ctx); err != nil {
-				r.mutex.Lock()
-				r.failedPolls++
-				r.mutex.Unlock()
-			} else {
-				r.mutex.Lock()
-				r.failedPolls = 0
-				r.mutex.Unlock()
-			}
-		}
-	}
-}
-
-func (r *rmnHomePoller) fetchAndSetRmnHomeConfigs(ctx context.Context) error {
-	var activeAndCandidateConfigs GetAllConfigsResponse
-	err := r.contractReader.GetLatestValue(
-		ctx,
-		r.rmnHomeBoundContract.ReadIdentifier(consts.MethodNameGetAllConfigs),
-		primitives.Unconfirmed,
-		map[string]interface{}{},
-		&activeAndCandidateConfigs,
-	)
-	if err != nil {
-		return fmt.Errorf("error fetching RMNHomeConfig: %w", err)
-	}
-	r.lggr.Infow("Fetched RMNHomeConfigs",
-		"activeConfig", activeAndCandidateConfigs.ActiveConfig.ConfigDigest,
-		"candidateConfig", activeAndCandidateConfigs.CandidateConfig.ConfigDigest,
-	)
-
-	if activeAndCandidateConfigs.ActiveConfig.ConfigDigest.IsEmpty() &&
-		activeAndCandidateConfigs.CandidateConfig.ConfigDigest.IsEmpty() {
-		return fmt.Errorf("both active and candidate config digests are empty")
-	}
-
-	r.setRMNHomeState(
-		activeAndCandidateConfigs.ActiveConfig.ConfigDigest,
-		activeAndCandidateConfigs.CandidateConfig.ConfigDigest,
-		convertOnChainConfigToRMNHomeChainConfig(
-			r.lggr,
-			activeAndCandidateConfigs.ActiveConfig,
-			activeAndCandidateConfigs.CandidateConfig,
-		),
-	)
-
-	return nil
-}
-
-func (r *rmnHomePoller) setRMNHomeState(
-	activeConfigDigest cciptypes.Bytes32,
-	candidateConfigDigest cciptypes.Bytes32,
-	rmnHomeConfig map[cciptypes.Bytes32]rmntypes.HomeConfig) {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	s := &r.rmnHomeState
-
-	s.activeConfigDigest = activeConfigDigest
-	s.candidateConfigDigest = candidateConfigDigest
-	s.rmnHomeConfig = rmnHomeConfig
-}
-
-func (r *rmnHomePoller) GetRMNNodesInfo(configDigest cciptypes.Bytes32) ([]rmntypes.HomeNodeInfo, error) {
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
-	_, ok := r.rmnHomeState.rmnHomeConfig[configDigest]
-	if !ok {
-		return nil, fmt.Errorf("configDigest %s not found in RMNHomeConfig", configDigest)
-
-	}
-	return r.rmnHomeState.rmnHomeConfig[configDigest].Nodes, nil
-}
-
-func (r *rmnHomePoller) IsRMNHomeConfigDigestSet(configDigest cciptypes.Bytes32) bool {
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
-	_, ok := r.rmnHomeState.rmnHomeConfig[configDigest]
-	return ok
-}
-
-func (r *rmnHomePoller) GetFObserve(configDigest cciptypes.Bytes32) (map[cciptypes.ChainSelector]int, error) {
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
-	_, ok := r.rmnHomeState.rmnHomeConfig[configDigest]
-	if !ok {
-		return nil, fmt.Errorf("configDigest %s not found in RMNHomeConfig", configDigest)
-	}
-	return r.rmnHomeState.rmnHomeConfig[configDigest].SourceChainF, nil
-}
-
-func (r *rmnHomePoller) GetOffChainConfig(configDigest cciptypes.Bytes32) (cciptypes.Bytes, error) {
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
-	cfg, ok := r.rmnHomeState.rmnHomeConfig[configDigest]
-	if !ok {
-		return nil, fmt.Errorf("configDigest %s not found in RMNHomeConfig", configDigest)
-	}
-	return cfg.OffchainConfig, nil
-}
-
-func (r *rmnHomePoller) GetAllConfigDigests() (
-	activeConfigDigest cciptypes.Bytes32,
-	candidateConfigDigest cciptypes.Bytes32) {
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
-	return r.rmnHomeState.activeConfigDigest, r.rmnHomeState.candidateConfigDigest
-}
-
-func (r *rmnHomePoller) Close() error {
+func (r *rmnHome) Close() error {
 	err := r.sync.StopOnce(r.Name(), func() error {
-		defer r.wg.Wait()
-		close(r.stopCh)
-		return nil
+		return r.bgPoller.Close(r)
 	})
 
 	if errors.Is(err, services.ErrAlreadyStopped) {
@@ -311,121 +96,57 @@ func (r *rmnHomePoller) Close() error {
 	return err
 }
 
-func (r *rmnHomePoller) Ready() error {
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
+func (r *rmnHome) GetRMNNodesInfo(configDigest cciptypes.Bytes32) ([]rmntypes.HomeNodeInfo, error) {
+	state := r.bgPoller.getRMNHomeState()
+	_, ok := state.rmnHomeConfig[configDigest]
+	if !ok {
+		return nil, fmt.Errorf("configDigest %s not found in RMNHomeConfig", configDigest)
+
+	}
+	return state.rmnHomeConfig[configDigest].Nodes, nil
+}
+
+func (r *rmnHome) IsRMNHomeConfigDigestSet(configDigest cciptypes.Bytes32) bool {
+	_, ok := r.bgPoller.getRMNHomeState().rmnHomeConfig[configDigest]
+	return ok
+}
+
+func (r *rmnHome) GetFObserve(configDigest cciptypes.Bytes32) (map[cciptypes.ChainSelector]int, error) {
+	state := r.bgPoller.getRMNHomeState()
+	_, ok := state.rmnHomeConfig[configDigest]
+	if !ok {
+		return nil, fmt.Errorf("configDigest %s not found in RMNHomeConfig", configDigest)
+	}
+	return state.rmnHomeConfig[configDigest].SourceChainF, nil
+}
+
+func (r *rmnHome) GetOffChainConfig(configDigest cciptypes.Bytes32) (cciptypes.Bytes, error) {
+	state := r.bgPoller.getRMNHomeState()
+	cfg, ok := state.rmnHomeConfig[configDigest]
+	if !ok {
+		return nil, fmt.Errorf("configDigest %s not found in RMNHomeConfig", configDigest)
+	}
+	return cfg.OffchainConfig, nil
+}
+
+func (r *rmnHome) GetAllConfigDigests() (
+	activeConfigDigest cciptypes.Bytes32,
+	candidateConfigDigest cciptypes.Bytes32,
+) {
+	state := r.bgPoller.getRMNHomeState()
+	return state.activeConfigDigest, state.candidateConfigDigest
+}
+
+func (r *rmnHome) Ready() error {
 	return r.sync.Ready()
 }
 
-func (r *rmnHomePoller) HealthReport() map[string]error {
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
-	if r.failedPolls >= MaxFailedPolls {
-		err := fmt.Errorf("polling failed %d times in a row (maximum allowed: %d)", r.failedPolls, MaxFailedPolls)
-		r.sync.SvcErrBuffer.Append(err)
-	}
-	return map[string]error{r.Name(): r.sync.Healthy()}
+func (r *rmnHome) HealthReport() map[string]error {
+	return r.bgPoller.HealthReport()
 }
 
-func (r *rmnHomePoller) Name() string {
-	return r.lggr.Name()
-}
-
-func validate(config VersionedConfig) error {
-	// check if the versionesconfigwithdigests are set (can be empty)
-	if config.ConfigDigest.IsEmpty() {
-		return fmt.Errorf("configDigest is empty")
-	}
-	return nil
-}
-
-func convertOnChainConfigToRMNHomeChainConfig(
-	lggr logger.Logger,
-	primaryConfig VersionedConfig,
-	secondaryConfig VersionedConfig,
-) map[cciptypes.Bytes32]rmntypes.HomeConfig {
-	if primaryConfig.ConfigDigest.IsEmpty() && secondaryConfig.ConfigDigest.IsEmpty() {
-		lggr.Warnw("no on chain RMNHomeConfigs found, both digests are empty")
-		return map[cciptypes.Bytes32]rmntypes.HomeConfig{}
-	}
-
-	versionedConfigWithDigests := []VersionedConfig{primaryConfig}
-	if !secondaryConfig.ConfigDigest.IsEmpty() {
-		versionedConfigWithDigests = append(versionedConfigWithDigests, secondaryConfig)
-	}
-
-	rmnHomeConfigs := make(map[cciptypes.Bytes32]rmntypes.HomeConfig)
-	for _, versionedConfig := range versionedConfigWithDigests {
-		err := validate(versionedConfig)
-		if err != nil {
-			lggr.Warnw("invalid on chain RMNHomeConfig", "err", err)
-			continue
-		}
-
-		nodes := make([]rmntypes.HomeNodeInfo, len(versionedConfig.StaticConfig.Nodes))
-		for i, node := range versionedConfig.StaticConfig.Nodes {
-			pubKey := ed25519.PublicKey(node.OffchainPublicKey[:])
-
-			nodes[i] = rmntypes.HomeNodeInfo{
-				ID:                    rmntypes.NodeID(i),
-				PeerID:                ragep2ptypes.PeerID(node.PeerID),
-				OffchainPublicKey:     &pubKey,
-				SupportedSourceChains: mapset.NewSet[cciptypes.ChainSelector](),
-				StreamNamePrefix:      "ccip-rmn/v1_6/", // todo: when contract is updated, this should be fetched from the contract
-			}
-		}
-
-		homeFMap := make(map[cciptypes.ChainSelector]int)
-
-		for _, chain := range versionedConfig.DynamicConfig.SourceChains {
-			homeFMap[chain.ChainSelector] = int(chain.FObserve)
-			for j := 0; j < len(nodes); j++ {
-				isObserver, err := IsNodeObserver(chain, j, len(nodes))
-				if err != nil {
-					lggr.Warnw("failed to check if node is observer", "err", err)
-					continue
-				}
-				if isObserver {
-					nodes[j].SupportedSourceChains.Add(chain.ChainSelector)
-				}
-			}
-		}
-
-		rmnHomeConfigs[versionedConfig.ConfigDigest] = rmntypes.HomeConfig{
-			Nodes:          nodes,
-			SourceChainF:   homeFMap,
-			ConfigDigest:   versionedConfig.ConfigDigest,
-			OffchainConfig: versionedConfig.DynamicConfig.OffchainConfig,
-		}
-	}
-	return rmnHomeConfigs
-}
-
-// IsNodeObserver checks if a node is an observer for the given source chain
-func IsNodeObserver(sourceChain SourceChain, nodeIndex int, totalNodes int) (bool, error) {
-	if totalNodes > rmnMaxSizeCommittee || totalNodes <= 0 {
-		return false, fmt.Errorf("invalid total nodes: %d", totalNodes)
-	}
-
-	if nodeIndex < 0 || nodeIndex >= totalNodes {
-		return false, fmt.Errorf("invalid node index: %d", nodeIndex)
-	}
-
-	// Validate the bitmap
-	maxValidBitmap := new(big.Int).Lsh(big.NewInt(1), uint(totalNodes))
-	maxValidBitmap.Sub(maxValidBitmap, big.NewInt(1))
-	if sourceChain.ObserverNodesBitmap.Cmp(maxValidBitmap) > 0 {
-		return false, fmt.Errorf("invalid observer nodes bitmap")
-	}
-
-	// Create a big.Int with 1 shifted left by nodeIndex
-	mask := new(big.Int).Lsh(big.NewInt(1), uint(nodeIndex))
-
-	// Perform the bitwise AND operation
-	result := new(big.Int).And(sourceChain.ObserverNodesBitmap, mask)
-
-	// Check if the result equals the mask
-	return result.Cmp(mask) == 0, nil
+func (r *rmnHome) Name() string {
+	return "RMNHome"
 }
 
 // GetAllConfigsResponse mirrors RMNHome.sol's getAllConfigs() return value.
@@ -466,4 +187,4 @@ type SourceChain struct {
 	ObserverNodesBitmap *big.Int                `json:"observerNodesBitmap"`
 }
 
-var _ RMNHome = (*rmnHomePoller)(nil)
+var _ RMNHome = (*rmnHome)(nil)

--- a/pkg/reader/rmn_home.go
+++ b/pkg/reader/rmn_home.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
@@ -43,7 +44,7 @@ type rmnHome struct {
 	bgPoller *rmnHomePoller
 }
 
-// NewRMNHome creates a new RMNHome and starts it immediately. RMNHome is very lightweight layer
+// NewRMNHomeChainReader creates a new RMNHome and starts it immediately. RMNHome is very lightweight layer
 // on top of RMNHomePoller. Every consumer should follow the `Service` pattern in which they
 // are responsible for properly closing the service when done. (using Close() method)
 //
@@ -51,9 +52,10 @@ type rmnHome struct {
 // Whenever all RMNHome instances are closed, the underlying RMNHomePoller instance is also closed.
 // As long as RMNHome remembers to Close() upon termination there should not be any orphaned poller instances
 // working in the background
-func NewRMNHome(
+func NewRMNHomeChainReader(
 	ctx context.Context,
 	lggr logger.Logger,
+	pollingInterval time.Duration,
 	rmnHomeChainSelector cciptypes.ChainSelector,
 	rmnHomeAddress []byte,
 	contractReader contractreader.ContractReaderFacade,
@@ -64,7 +66,7 @@ func NewRMNHome(
 		rmnHomeChainSelector,
 		rmnHomeAddress,
 		contractReader,
-		HomeChainPollingInterval,
+		pollingInterval,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create RMNHomePoller: %w", err)

--- a/pkg/reader/rmn_home_poller.go
+++ b/pkg/reader/rmn_home_poller.go
@@ -1,0 +1,385 @@
+package reader
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math/big"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
+	ragep2ptypes "github.com/smartcontractkit/libocr/ragep2p/types"
+
+	rmntypes "github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn/types"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/logutil"
+	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+)
+
+var (
+	instances   = make(map[string]*rmnHomePoller)
+	instancesMu sync.Mutex
+)
+
+type rmnHomeState struct {
+	activeConfigDigest    cciptypes.Bytes32
+	candidateConfigDigest cciptypes.Bytes32
+	rmnHomeConfig         map[cciptypes.Bytes32]rmntypes.HomeConfig
+}
+
+// rmnHomePoller polls the RMNHome contract for the latest RMNHomeConfigs
+// It is running in the background with a polling interval of pollingDuration.
+// In order to reduce a pressure on the underlying RPC node and redundancy there always should be a single
+// instance for particular chain/address pair. Please see getRMNHomePoller for more details.
+type rmnHomePoller struct {
+	lggr                 logger.Logger
+	contractReader       contractreader.ContractReaderFacade
+	rmnHomeBoundContract types.BoundContract
+	pollingDuration      time.Duration
+
+	// Background polling
+	sync   services.StateMachine
+	stopCh services.StopChan
+	wg     sync.WaitGroup
+
+	// State
+	observers      []RMNHome
+	observersMu    *sync.RWMutex
+	rmnHomeState   rmnHomeState
+	rmnHomeStateMu *sync.RWMutex
+	failedPolls    atomic.Uint32
+}
+
+// getRMNHomePoller returns a rmnHomePoller instance if it already exists, else creates a new one.
+// Returned rmnHomePoller is always started, therefore user of that API doesn't need to care about
+// concurrency and accidentally starting the same poller multiple times.
+//
+// In most of the cases, there is going to be only a single RMNHome deployed on a single chain. However,
+// OCR3Config allows to pass different RMNHome addresses for different chains. Therefore, we need to
+// support that and maintain a separate rmnHomePoller for each RMNHome address.
+// Having a singleton here is aimed to reduce the background polling to the underlying RPC node.
+func getRMNHomePoller(
+	ctx context.Context,
+	lggr logger.Logger,
+	rmnHomeChainSelector cciptypes.ChainSelector,
+	rmnHomeAddress []byte,
+	contractReader contractreader.ContractReaderFacade,
+	pollingInterval time.Duration,
+) (*rmnHomePoller, error) {
+	instancesMu.Lock()
+	defer instancesMu.Unlock()
+
+	hexEncodedAddr := " 0x" + hex.EncodeToString(rmnHomeAddress)
+	key := fmt.Sprintf("%s-%s", rmnHomeChainSelector.String(), hexEncodedAddr)
+
+	instance, ok := getInstance(key)
+	if ok {
+		lggr.Infow("RMNHomePoller already exists, reusing instance",
+			"chainSelector", rmnHomeChainSelector,
+			"address", hexEncodedAddr,
+		)
+		return instance, nil
+	}
+
+	rmnHomeBoundContract := types.BoundContract{
+		Address: hexEncodedAddr,
+		Name:    consts.ContractNameRMNHome,
+	}
+
+	if err := contractReader.Bind(ctx, []types.BoundContract{rmnHomeBoundContract}); err != nil {
+		return nil, fmt.Errorf("failed to bind RMNHome contract: %w", err)
+	}
+
+	rmnHomeReader := newRMNHomePoller(
+		logutil.WithComponent(lggr, "RMNHomePoller"),
+		contractReader,
+		rmnHomeBoundContract,
+		pollingInterval,
+	)
+
+	instances[key] = rmnHomeReader
+	return rmnHomeReader, nil
+}
+
+func getInstance(key string) (*rmnHomePoller, bool) {
+	instance, ok := instances[key]
+	if !ok {
+		return nil, false
+	}
+
+	if err := instance.sync.Ready(); err != nil {
+		return nil, false
+	}
+
+	return instance, ok
+}
+
+// newRMNHomePoller creates a new rmnHomePoller instance. Only meant to be used by getRMNHomePoller
+// or in tests. Never use that directly in the production code otherwise it will create to exhaustive polling.
+func newRMNHomePoller(
+	lggr logger.Logger,
+	contractReader contractreader.ContractReaderFacade,
+	rmnHomeBoundContract types.BoundContract,
+	pollingInterval time.Duration,
+) *rmnHomePoller {
+	return &rmnHomePoller{
+		stopCh:               make(chan struct{}),
+		contractReader:       contractReader,
+		rmnHomeBoundContract: rmnHomeBoundContract,
+		rmnHomeState:         rmnHomeState{},
+		observersMu:          &sync.RWMutex{},
+		rmnHomeStateMu:       &sync.RWMutex{},
+		failedPolls:          atomic.Uint32{},
+		lggr:                 lggr,
+		pollingDuration:      pollingInterval,
+	}
+}
+
+func (r *rmnHomePoller) Start(_ context.Context, caller RMNHome) error {
+	r.observersMu.Lock()
+	defer r.observersMu.Unlock()
+
+	r.observers = append(r.observers, caller)
+
+	if len(r.observers) > 1 {
+		return nil
+	}
+
+	return r.sync.StartOnce(r.Name(), func() error {
+		r.lggr.Infow("Start Polling RMNHome")
+		r.wg.Add(1)
+		go r.poll()
+		return nil
+	})
+}
+
+func (r *rmnHomePoller) Close(caller RMNHome) error {
+	r.observersMu.Lock()
+	defer r.observersMu.Unlock()
+
+	r.observers = slices.DeleteFunc(r.observers, func(r RMNHome) bool {
+		return r == caller
+	})
+
+	if len(r.observers) > 0 {
+		return nil
+	}
+
+	err := r.sync.StopOnce(r.Name(), func() error {
+		defer r.wg.Wait()
+		close(r.stopCh)
+		return nil
+	})
+
+	if errors.Is(err, services.ErrAlreadyStopped) {
+		return nil
+	}
+
+	return err
+}
+
+func (r *rmnHomePoller) Ready() error {
+	return r.sync.Ready()
+}
+
+func (r *rmnHomePoller) HealthReport() map[string]error {
+	if r.failedPolls.Load() >= maxFailedPolls {
+		err := fmt.Errorf("polling failed %d times in a row (maximum allowed: %d)", r.failedPolls, maxFailedPolls)
+		r.sync.SvcErrBuffer.Append(err)
+	}
+	return map[string]error{r.Name(): r.sync.Healthy()}
+}
+
+func (r *rmnHomePoller) Name() string {
+	return r.lggr.Name()
+}
+
+func (r *rmnHomePoller) poll() {
+	defer r.wg.Done()
+	ctx, cancel := r.stopCh.NewCtx()
+	defer cancel()
+	// Initial fetch once poll is called before any ticks
+	if err := r.fetchAndSetRmnHomeConfigs(ctx); err != nil {
+		// Just log, don't return error as we want to keep polling
+		r.lggr.Errorw("Initial fetch of on-chain configs failed", "err", err)
+	}
+
+	ticker := time.NewTicker(r.pollingDuration)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			r.failedPolls.Store(0)
+			return
+		case <-ticker.C:
+			if err := r.fetchAndSetRmnHomeConfigs(ctx); err != nil {
+				r.failedPolls.Add(1)
+			} else {
+				r.failedPolls.Store(0)
+			}
+		}
+	}
+}
+
+func (r *rmnHomePoller) fetchAndSetRmnHomeConfigs(ctx context.Context) error {
+	var activeAndCandidateConfigs GetAllConfigsResponse
+	err := r.contractReader.GetLatestValue(
+		ctx,
+		r.rmnHomeBoundContract.ReadIdentifier(consts.MethodNameGetAllConfigs),
+		primitives.Unconfirmed,
+		map[string]interface{}{},
+		&activeAndCandidateConfigs,
+	)
+	if err != nil {
+		return fmt.Errorf("error fetching RMNHomeConfig: %w", err)
+	}
+	r.lggr.Infow("Fetched RMNHomeConfigs",
+		"activeConfig", activeAndCandidateConfigs.ActiveConfig.ConfigDigest,
+		"candidateConfig", activeAndCandidateConfigs.CandidateConfig.ConfigDigest,
+	)
+
+	if activeAndCandidateConfigs.ActiveConfig.ConfigDigest.IsEmpty() &&
+		activeAndCandidateConfigs.CandidateConfig.ConfigDigest.IsEmpty() {
+		return fmt.Errorf("both active and candidate config digests are empty")
+	}
+
+	r.setRMNHomeState(
+		activeAndCandidateConfigs.ActiveConfig.ConfigDigest,
+		activeAndCandidateConfigs.CandidateConfig.ConfigDigest,
+		convertOnChainConfigToRMNHomeChainConfig(
+			r.lggr,
+			activeAndCandidateConfigs.ActiveConfig,
+			activeAndCandidateConfigs.CandidateConfig,
+		),
+	)
+
+	return nil
+}
+
+func (r *rmnHomePoller) getRMNHomeState() rmnHomeState {
+	r.rmnHomeStateMu.RLock()
+	defer r.rmnHomeStateMu.RUnlock()
+
+	return r.rmnHomeState
+}
+
+func (r *rmnHomePoller) setRMNHomeState(
+	activeConfigDigest cciptypes.Bytes32,
+	candidateConfigDigest cciptypes.Bytes32,
+	rmnHomeConfig map[cciptypes.Bytes32]rmntypes.HomeConfig,
+) {
+	r.rmnHomeStateMu.Lock()
+	defer r.rmnHomeStateMu.Unlock()
+
+	s := &r.rmnHomeState
+	s.activeConfigDigest = activeConfigDigest
+	s.candidateConfigDigest = candidateConfigDigest
+	s.rmnHomeConfig = rmnHomeConfig
+}
+
+func validate(config VersionedConfig) error {
+	// check if the versionesconfigwithdigests are set (can be empty)
+	if config.ConfigDigest.IsEmpty() {
+		return fmt.Errorf("configDigest is empty")
+	}
+	return nil
+}
+
+func convertOnChainConfigToRMNHomeChainConfig(
+	lggr logger.Logger,
+	primaryConfig VersionedConfig,
+	secondaryConfig VersionedConfig,
+) map[cciptypes.Bytes32]rmntypes.HomeConfig {
+	if primaryConfig.ConfigDigest.IsEmpty() && secondaryConfig.ConfigDigest.IsEmpty() {
+		lggr.Warnw("no on chain RMNHomeConfigs found, both digests are empty")
+		return map[cciptypes.Bytes32]rmntypes.HomeConfig{}
+	}
+
+	versionedConfigWithDigests := []VersionedConfig{primaryConfig}
+	if !secondaryConfig.ConfigDigest.IsEmpty() {
+		versionedConfigWithDigests = append(versionedConfigWithDigests, secondaryConfig)
+	}
+
+	rmnHomeConfigs := make(map[cciptypes.Bytes32]rmntypes.HomeConfig)
+	for _, versionedConfig := range versionedConfigWithDigests {
+		err := validate(versionedConfig)
+		if err != nil {
+			lggr.Warnw("invalid on chain RMNHomeConfig", "err", err)
+			continue
+		}
+
+		nodes := make([]rmntypes.HomeNodeInfo, len(versionedConfig.StaticConfig.Nodes))
+		for i, node := range versionedConfig.StaticConfig.Nodes {
+			pubKey := ed25519.PublicKey(node.OffchainPublicKey[:])
+
+			nodes[i] = rmntypes.HomeNodeInfo{
+				ID:                    rmntypes.NodeID(i),
+				PeerID:                ragep2ptypes.PeerID(node.PeerID),
+				OffchainPublicKey:     &pubKey,
+				SupportedSourceChains: mapset.NewSet[cciptypes.ChainSelector](),
+				StreamNamePrefix:      "ccip-rmn/v1_6/", // todo: when contract is updated, this should be fetched from the contract
+			}
+		}
+
+		homeFMap := make(map[cciptypes.ChainSelector]int)
+
+		for _, chain := range versionedConfig.DynamicConfig.SourceChains {
+			homeFMap[chain.ChainSelector] = int(chain.FObserve)
+			for j := 0; j < len(nodes); j++ {
+				isObserver, err := IsNodeObserver(chain, j, len(nodes))
+				if err != nil {
+					lggr.Warnw("failed to check if node is observer", "err", err)
+					continue
+				}
+				if isObserver {
+					nodes[j].SupportedSourceChains.Add(chain.ChainSelector)
+				}
+			}
+		}
+
+		rmnHomeConfigs[versionedConfig.ConfigDigest] = rmntypes.HomeConfig{
+			Nodes:          nodes,
+			SourceChainF:   homeFMap,
+			ConfigDigest:   versionedConfig.ConfigDigest,
+			OffchainConfig: versionedConfig.DynamicConfig.OffchainConfig,
+		}
+	}
+	return rmnHomeConfigs
+}
+
+// IsNodeObserver checks if a node is an observer for the given source chain
+func IsNodeObserver(sourceChain SourceChain, nodeIndex int, totalNodes int) (bool, error) {
+	if totalNodes > rmnMaxSizeCommittee || totalNodes <= 0 {
+		return false, fmt.Errorf("invalid total nodes: %d", totalNodes)
+	}
+
+	if nodeIndex < 0 || nodeIndex >= totalNodes {
+		return false, fmt.Errorf("invalid node index: %d", nodeIndex)
+	}
+
+	// Validate the bitmap
+	maxValidBitmap := new(big.Int).Lsh(big.NewInt(1), uint(totalNodes))
+	maxValidBitmap.Sub(maxValidBitmap, big.NewInt(1))
+	if sourceChain.ObserverNodesBitmap.Cmp(maxValidBitmap) > 0 {
+		return false, fmt.Errorf("invalid observer nodes bitmap")
+	}
+
+	// Create a big.Int with 1 shifted left by nodeIndex
+	mask := new(big.Int).Lsh(big.NewInt(1), uint(nodeIndex))
+
+	// Perform the bitwise AND operation
+	result := new(big.Int).And(sourceChain.ObserverNodesBitmap, mask)
+
+	// Check if the result equals the mask
+	return result.Cmp(mask) == 0, nil
+}

--- a/pkg/reader/rmn_home_poller.go
+++ b/pkg/reader/rmn_home_poller.go
@@ -337,7 +337,7 @@ func convertOnChainConfigToRMNHomeChainConfig(
 		for _, chain := range versionedConfig.DynamicConfig.SourceChains {
 			homeFMap[chain.ChainSelector] = int(chain.FObserve)
 			for j := 0; j < len(nodes); j++ {
-				isObserver, err := IsNodeObserver(chain, j, len(nodes))
+				isObserver, err := isNodeObserver(chain, j, len(nodes))
 				if err != nil {
 					lggr.Warnw("failed to check if node is observer", "err", err)
 					continue
@@ -358,8 +358,8 @@ func convertOnChainConfigToRMNHomeChainConfig(
 	return rmnHomeConfigs
 }
 
-// IsNodeObserver checks if a node is an observer for the given source chain
-func IsNodeObserver(sourceChain SourceChain, nodeIndex int, totalNodes int) (bool, error) {
+// isNodeObserver checks if a node is an observer for the given source chain
+func isNodeObserver(sourceChain SourceChain, nodeIndex int, totalNodes int) (bool, error) {
 	if totalNodes > rmnMaxSizeCommittee || totalNodes <= 0 {
 		return false, fmt.Errorf("invalid total nodes: %d", totalNodes)
 	}

--- a/pkg/reader/rmn_home_poller.go
+++ b/pkg/reader/rmn_home_poller.go
@@ -54,7 +54,7 @@ type rmnHomePoller struct {
 
 	// State
 	observers      []RMNHome
-	observersMu    *sync.RWMutex
+	observersMu    *sync.Mutex
 	rmnHomeState   rmnHomeState
 	rmnHomeStateMu *sync.RWMutex
 	failedPolls    atomic.Uint32
@@ -117,7 +117,7 @@ func getInstance(key string) (*rmnHomePoller, bool) {
 		return nil, false
 	}
 
-	if err := instance.sync.Ready(); err != nil {
+	if notStopped := instance.sync.IfNotStopped(func() {}); !notStopped {
 		return nil, false
 	}
 
@@ -137,7 +137,7 @@ func newRMNHomePoller(
 		contractReader:       contractReader,
 		rmnHomeBoundContract: rmnHomeBoundContract,
 		rmnHomeState:         rmnHomeState{},
-		observersMu:          &sync.RWMutex{},
+		observersMu:          &sync.Mutex{},
 		rmnHomeStateMu:       &sync.RWMutex{},
 		failedPolls:          atomic.Uint32{},
 		lggr:                 lggr,

--- a/pkg/reader/rmn_home_poller.go
+++ b/pkg/reader/rmn_home_poller.go
@@ -79,7 +79,7 @@ func getRMNHomePoller(
 	instancesMu.Lock()
 	defer instancesMu.Unlock()
 
-	hexEncodedAddr := " 0x" + hex.EncodeToString(rmnHomeAddress)
+	hexEncodedAddr := "0x" + hex.EncodeToString(rmnHomeAddress)
 	key := fmt.Sprintf("%s-%s", rmnHomeChainSelector.String(), hexEncodedAddr)
 
 	instance, ok := getInstance(key)

--- a/pkg/reader/rmn_home_poller.go
+++ b/pkg/reader/rmn_home_poller.go
@@ -193,8 +193,9 @@ func (r *rmnHomePoller) Ready() error {
 }
 
 func (r *rmnHomePoller) HealthReport() map[string]error {
-	if r.failedPolls.Load() >= maxFailedPolls {
-		err := fmt.Errorf("polling failed %d times in a row (maximum allowed: %d)", r.failedPolls, maxFailedPolls)
+	f := r.failedPolls.Load()
+	if f >= maxFailedPolls {
+		err := fmt.Errorf("polling failed %d times in a row (maximum allowed: %d)", f, maxFailedPolls)
 		r.sync.SvcErrBuffer.Append(err)
 	}
 	return map[string]error{r.Name(): r.sync.Healthy()}

--- a/pkg/reader/rmn_home_poller_test.go
+++ b/pkg/reader/rmn_home_poller_test.go
@@ -1,0 +1,475 @@
+package reader
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+
+	readermock "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/contractreader"
+	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+)
+
+var (
+	rmnHomeBoundContract = types.BoundContract{
+		Address: "0xRMNHomeFakeAddress",
+		Name:    consts.ContractNameRMNHome,
+	}
+)
+
+func TestRMNHomeChainConfigPoller_Ready(t *testing.T) {
+	homeChainReader := readermock.NewMockContractReaderFacade(t)
+	configPoller := newRMNHomeForTests(t, homeChainReader, rmnHomeBoundContract, 1*time.Millisecond)
+
+	// Return any result as we are testing the ready method
+	homeChainReader.On(
+		"GetLatestValue",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything).Return(fmt.Errorf("error"))
+
+	// Initially it's not ready
+	require.Error(t, configPoller.Ready())
+
+	require.NoError(t, configPoller.Start(context.Background()))
+	// After starting it's ready
+	require.NoError(t, configPoller.Ready())
+
+	require.NoError(t, configPoller.Close())
+}
+
+func TestRMNHomePoller_HealthReport(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		failedPolls uint32
+		wantErr     bool
+	}{
+		{
+			name:        "Healthy state",
+			failedPolls: 0,
+			wantErr:     false,
+		},
+		{
+			name:        "Unhealthy state",
+			failedPolls: maxFailedPolls,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			homeChainReader := readermock.NewMockContractReaderFacade(t)
+
+			homeChainReader.On("GetLatestValue",
+				mock.Anything,
+				mock.Anything,
+				mock.Anything,
+				mock.Anything,
+				mock.Anything,
+			).Run(func(args mock.Arguments) {
+				result := args.Get(4).(*GetAllConfigsResponse)
+				*result = GetAllConfigsResponse{
+					ActiveConfig: VersionedConfig{
+						ConfigDigest:  [32]byte{1},
+						Version:       1,
+						StaticConfig:  StaticConfig{Nodes: []Node{}},
+						DynamicConfig: DynamicConfig{SourceChains: []SourceChain{}},
+					},
+				}
+			}).Return(nil)
+
+			poller := newRMNHomeForTests(
+				t,
+				homeChainReader,
+				rmnHomeBoundContract,
+				10*time.Millisecond,
+			)
+
+			require.NoError(t, poller.Start(context.Background()))
+
+			// Wait for the initial fetch to complete
+			require.Eventually(t, func() bool {
+				return homeChainReader.AssertCalled(
+					t,
+					"GetLatestValue",
+					mock.Anything,
+					mock.Anything,
+					mock.Anything,
+					mock.Anything,
+					mock.Anything)
+			}, 5*time.Second, 10*time.Millisecond, "GetLatestValue was not called within the expected timeframe")
+
+			poller.bgPoller.failedPolls.Store(tt.failedPolls)
+
+			report := poller.HealthReport()
+
+			require.Len(t, report, 1)
+			err := report[poller.bgPoller.Name()]
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "polling failed")
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.NoError(t, poller.Close())
+		})
+	}
+}
+
+func Test_RMNHomePollingWorking(t *testing.T) {
+	tests := []struct {
+		name              string
+		primaryEmpty      bool
+		secondaryEmpty    bool
+		expectedCallCount int
+	}{
+		{
+			name:              "Both configs non-empty",
+			primaryEmpty:      false,
+			secondaryEmpty:    false,
+			expectedCallCount: 4,
+		},
+		{
+			name:              "Primary config empty",
+			primaryEmpty:      true,
+			secondaryEmpty:    false,
+			expectedCallCount: 4,
+		},
+		{
+			name:              "Secondary config empty",
+			primaryEmpty:      false,
+			secondaryEmpty:    true,
+			expectedCallCount: 4,
+		},
+		{
+			name:              "Both configs empty",
+			primaryEmpty:      true,
+			secondaryEmpty:    true,
+			expectedCallCount: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			primaryConfig, secondaryConfig := createTestRMNHomeConfigs(tt.primaryEmpty, tt.secondaryEmpty)
+			rmnHomeOnChainConfigs := GetAllConfigsResponse{
+				primaryConfig,
+				secondaryConfig,
+			}
+
+			homeChainReader := readermock.NewMockContractReaderFacade(t)
+			homeChainReader.On(
+				"GetLatestValue",
+				mock.Anything,
+				rmnHomeBoundContract.ReadIdentifier(consts.MethodNameGetAllConfigs),
+				mock.Anything,
+				mock.Anything,
+				mock.Anything,
+			).Run(
+				func(args mock.Arguments) {
+					arg := args.Get(4).(*GetAllConfigsResponse)
+					*arg = rmnHomeOnChainConfigs
+				}).Return(nil)
+
+			defer homeChainReader.AssertExpectations(t)
+
+			var (
+				tickTime       = 2 * time.Millisecond
+				totalSleepTime = tickTime * 20
+			)
+
+			configPoller := newRMNHomeForTests(
+				t,
+				homeChainReader,
+				rmnHomeBoundContract,
+				tickTime,
+			)
+
+			require.NoError(t, configPoller.Start(context.Background()))
+			// sleep to allow polling to happen
+			time.Sleep(totalSleepTime)
+			require.NoError(t, configPoller.Close())
+
+			calls := homeChainReader.Calls
+			callCount := 0
+			for _, call := range calls {
+				if call.Method == "GetLatestValue" {
+					callCount++
+				}
+			}
+			require.GreaterOrEqual(t, callCount, tt.expectedCallCount)
+
+			for i, config := range []VersionedConfig{primaryConfig, secondaryConfig} {
+				isEmpty := (i == 0 && tt.primaryEmpty) || (i == 1 && tt.secondaryEmpty)
+
+				rmnNodes, err := configPoller.GetRMNNodesInfo(config.ConfigDigest)
+				if isEmpty {
+					require.Error(t, err)
+					require.Empty(t, rmnNodes)
+				} else {
+					require.NoError(t, err)
+					require.NotEmpty(t, rmnNodes)
+				}
+
+				isValid := configPoller.IsRMNHomeConfigDigestSet(config.ConfigDigest)
+				if isEmpty {
+					require.False(t, isValid)
+				} else {
+					require.True(t, isValid)
+				}
+
+				offchainConfig, err := configPoller.GetOffChainConfig(config.ConfigDigest)
+				if isEmpty {
+					require.Error(t, err)
+					require.Empty(t, offchainConfig)
+				} else {
+					require.NoError(t, err)
+					require.NotEmpty(t, offchainConfig)
+				}
+
+				minObsMap, err := configPoller.GetFObserve(config.ConfigDigest)
+				if isEmpty {
+					require.Error(t, err)
+					require.Empty(t, minObsMap)
+				} else {
+					require.NoError(t, err)
+					require.Len(t, minObsMap, 1)
+					expectedChainSelector := cciptypes.ChainSelector(uint64(i + 1))
+					minObs, exists := minObsMap[expectedChainSelector]
+					require.True(t, exists)
+					require.Equal(t, i+1, minObs)
+				}
+
+				activeConfigDigest, candidateConfigDigest := configPoller.GetAllConfigDigests()
+				require.Equal(t, primaryConfig.ConfigDigest, activeConfigDigest)
+				require.Equal(t, secondaryConfig.ConfigDigest, candidateConfigDigest)
+
+			}
+		})
+	}
+}
+
+func Test_RMNHomePoller_Close(t *testing.T) {
+	homeChainReader := readermock.NewMockContractReaderFacade(t)
+	poller := newRMNHomeForTests(
+		t,
+		homeChainReader,
+		rmnHomeBoundContract,
+		10*time.Millisecond,
+	)
+
+	homeChainReader.On("GetLatestValue",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	).Run(func(args mock.Arguments) {
+		result := args.Get(4).(*GetAllConfigsResponse)
+		*result = GetAllConfigsResponse{
+			ActiveConfig: VersionedConfig{
+				ConfigDigest:  [32]byte{1},
+				Version:       1,
+				StaticConfig:  StaticConfig{Nodes: []Node{}},
+				DynamicConfig: DynamicConfig{SourceChains: []SourceChain{}},
+			},
+		}
+	}).Return(nil)
+
+	ctx := tests.Context(t)
+	require.NoError(t, poller.Start(ctx))
+
+	err1 := poller.Close()
+	require.NoError(t, err1)
+	err2 := poller.Close()
+	require.NoError(t, err2)
+	err3 := poller.Close()
+	require.NoError(t, err3)
+}
+
+func TestIsNodeObserver(t *testing.T) {
+	tests := []struct {
+		name           string
+		sourceChain    SourceChain
+		nodeIndex      int
+		totalNodes     int
+		expectedResult bool
+		expectedError  string
+	}{
+		{
+			name: "Node is observer",
+			sourceChain: SourceChain{
+				ChainSelector:       cciptypes.ChainSelector(1),
+				FObserve:            3,
+				ObserverNodesBitmap: big.NewInt(7), // 111 in binary
+			},
+			nodeIndex:      1,
+			totalNodes:     3,
+			expectedResult: true,
+			expectedError:  "",
+		},
+		{
+			name: "Node is not observer",
+			sourceChain: SourceChain{
+				ChainSelector:       cciptypes.ChainSelector(1),
+				FObserve:            3,
+				ObserverNodesBitmap: big.NewInt(5), // 101 in binary
+			},
+			nodeIndex:      1,
+			totalNodes:     3,
+			expectedResult: false,
+			expectedError:  "",
+		},
+		{
+			name: "Node index out of range (high)",
+			sourceChain: SourceChain{
+				ChainSelector:       cciptypes.ChainSelector(1),
+				FObserve:            3,
+				ObserverNodesBitmap: big.NewInt(7), // 111 in binary
+			},
+			nodeIndex:      3,
+			totalNodes:     3,
+			expectedResult: false,
+			expectedError:  "invalid node index: 3",
+		},
+		{
+			name: "Negative node index",
+			sourceChain: SourceChain{
+				ChainSelector:       cciptypes.ChainSelector(1),
+				FObserve:            3,
+				ObserverNodesBitmap: big.NewInt(7), // 111 in binary
+			},
+			nodeIndex:      -1,
+			totalNodes:     3,
+			expectedResult: false,
+			expectedError:  "invalid node index: -1",
+		},
+		{
+			name: "Invalid bitmap (out of bounds)",
+			sourceChain: SourceChain{
+				ChainSelector:       cciptypes.ChainSelector(1),
+				FObserve:            3,
+				ObserverNodesBitmap: big.NewInt(8), // 1000 in binary
+			},
+			nodeIndex:      0,
+			totalNodes:     3,
+			expectedResult: false,
+			expectedError:  "invalid observer nodes bitmap",
+		},
+		{
+			name: "Zero total nodes",
+			sourceChain: SourceChain{
+				ChainSelector:       cciptypes.ChainSelector(1),
+				FObserve:            3,
+				ObserverNodesBitmap: big.NewInt(1),
+			},
+			nodeIndex:      0,
+			totalNodes:     0,
+			expectedResult: false,
+			expectedError:  "invalid total nodes: 0",
+		},
+		{
+			name: "Total nodes exceeds 256",
+			sourceChain: SourceChain{
+				ChainSelector:       cciptypes.ChainSelector(1),
+				FObserve:            3,
+				ObserverNodesBitmap: big.NewInt(1),
+			},
+			nodeIndex:      0,
+			totalNodes:     257,
+			expectedResult: false,
+			expectedError:  "invalid total nodes: 257",
+		},
+		{
+			name: "Last valid node is observer",
+			sourceChain: SourceChain{
+				ChainSelector:       cciptypes.ChainSelector(1),
+				FObserve:            1,
+				ObserverNodesBitmap: new(big.Int).SetBit(big.NewInt(0), 255, 1), // Only the 256th bit is set
+			},
+			nodeIndex:      255,
+			totalNodes:     256,
+			expectedResult: true,
+			expectedError:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := IsNodeObserver(tt.sourceChain, tt.nodeIndex, tt.totalNodes)
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				require.Equal(t, tt.expectedError, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tt.expectedResult, result)
+		})
+	}
+}
+
+func createTestRMNHomeConfigs(
+	primaryEmpty bool,
+	secondaryEmpty bool) (primary, secondary VersionedConfig) {
+	createConfig := func(id byte, isEmpty bool) VersionedConfig {
+		if isEmpty {
+			return VersionedConfig{}
+		}
+		return VersionedConfig{
+			ConfigDigest: cciptypes.Bytes32{id},
+			Version:      uint32(id),
+			DynamicConfig: DynamicConfig{
+				SourceChains: []SourceChain{
+					{
+						ChainSelector:       cciptypes.ChainSelector(id),
+						FObserve:            uint64(id),
+						ObserverNodesBitmap: big.NewInt(int64(id)),
+					},
+				},
+				OffchainConfig: cciptypes.Bytes{30 * id},
+			},
+			StaticConfig: StaticConfig{
+				Nodes: []Node{
+					{
+						PeerID:            cciptypes.Bytes32{10 * id},
+						OffchainPublicKey: cciptypes.Bytes32{20 * id},
+					},
+				},
+				OffchainConfig: cciptypes.Bytes{30 * id},
+			},
+		}
+	}
+
+	primary = createConfig(1, primaryEmpty)
+	secondary = createConfig(2, secondaryEmpty)
+	return primary, secondary
+}
+
+func newRMNHomeForTests(
+	t *testing.T,
+	reader *readermock.MockContractReaderFacade,
+	contract types.BoundContract,
+	duration time.Duration,
+) *rmnHome {
+	poller := newRMNHomePoller(logger.Test(t), reader, contract, duration)
+	return &rmnHome{bgPoller: poller}
+}

--- a/pkg/reader/rmn_home_poller_test.go
+++ b/pkg/reader/rmn_home_poller_test.go
@@ -413,7 +413,7 @@ func TestIsNodeObserver(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := IsNodeObserver(tt.sourceChain, tt.nodeIndex, tt.totalNodes)
+			result, err := isNodeObserver(tt.sourceChain, tt.nodeIndex, tt.totalNodes)
 
 			if tt.expectedError != "" {
 				require.Error(t, err)

--- a/pkg/reader/rmn_home_test.go
+++ b/pkg/reader/rmn_home_test.go
@@ -174,6 +174,10 @@ func newRMNHomeCasted(
 ) *rmnHome {
 	rmn, err := NewRMNHomeChainReader(ctx, lggr, 1*time.Millisecond, selector, address, reader)
 	require.NoError(t, err)
+
+	err = rmn.Start(ctx)
+	require.NoError(t, err)
+
 	casted, ok := rmn.(*rmnHome)
 	require.True(t, ok)
 	return casted

--- a/pkg/reader/rmn_home_test.go
+++ b/pkg/reader/rmn_home_test.go
@@ -3,6 +3,7 @@ package reader
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
@@ -165,7 +166,7 @@ func newRMNHomeCasted(
 	address cciptypes.Bytes,
 	reader *readermock.MockContractReaderFacade,
 ) *rmnHome {
-	rmn, err := NewRMNHome(ctx, lggr, selector, address, reader)
+	rmn, err := NewRMNHomeChainReader(ctx, lggr, 1*time.Millisecond, selector, address, reader)
 	require.NoError(t, err)
 	casted, ok := rmn.(*rmnHome)
 	require.True(t, ok)

--- a/pkg/reader/rmn_home_test.go
+++ b/pkg/reader/rmn_home_test.go
@@ -2,475 +2,18 @@ package reader
 
 import (
 	"context"
-	"fmt"
-	"math/big"
 	"testing"
-	"time"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/testhelpers/rand"
-	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
-
 	readermock "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/contractreader"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
-
-var (
-	rmnHomeBoundContract = types.BoundContract{
-		Address: "0xRMNHomeFakeAddress",
-		Name:    consts.ContractNameRMNHome,
-	}
-)
-
-func TestRMNHomeChainConfigPoller_Ready(t *testing.T) {
-	homeChainReader := readermock.NewMockContractReaderFacade(t)
-	configPoller := newRMNHomePoller(
-		homeChainReader,
-		rmnHomeBoundContract,
-		logger.Test(t),
-		1*time.Millisecond,
-	)
-	// Return any result as we are testing the ready method
-	homeChainReader.On(
-		"GetLatestValue",
-		mock.Anything,
-		mock.Anything,
-		mock.Anything,
-		mock.Anything,
-		mock.Anything).Return(fmt.Errorf("error"))
-
-	// Initially it's not ready
-	require.Error(t, configPoller.Ready())
-
-	require.NoError(t, configPoller.Start(context.Background()))
-	// After starting it's ready
-	require.NoError(t, configPoller.Ready())
-
-	require.NoError(t, configPoller.Close())
-}
-
-func TestRMNHomePoller_HealthReport(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name        string
-		failedPolls uint
-		wantErr     bool
-	}{
-		{
-			name:        "Healthy state",
-			failedPolls: 0,
-			wantErr:     false,
-		},
-		{
-			name:        "Unhealthy state",
-			failedPolls: MaxFailedPolls,
-			wantErr:     true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			homeChainReader := readermock.NewMockContractReaderFacade(t)
-
-			homeChainReader.On("GetLatestValue",
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-			).Run(func(args mock.Arguments) {
-				result := args.Get(4).(*GetAllConfigsResponse)
-				*result = GetAllConfigsResponse{
-					ActiveConfig: VersionedConfig{
-						ConfigDigest:  [32]byte{1},
-						Version:       1,
-						StaticConfig:  StaticConfig{Nodes: []Node{}},
-						DynamicConfig: DynamicConfig{SourceChains: []SourceChain{}},
-					},
-				}
-			}).Return(nil)
-
-			poller := newRMNHomePoller(
-				homeChainReader,
-				rmnHomeBoundContract,
-				logger.Test(t),
-				10*time.Millisecond,
-			)
-
-			require.NoError(t, poller.Start(context.Background()))
-
-			// Wait for the initial fetch to complete
-			require.Eventually(t, func() bool {
-				return homeChainReader.AssertCalled(
-					t,
-					"GetLatestValue",
-					mock.Anything,
-					mock.Anything,
-					mock.Anything,
-					mock.Anything,
-					mock.Anything)
-			}, 5*time.Second, 10*time.Millisecond, "GetLatestValue was not called within the expected timeframe")
-
-			poller.mutex.Lock()
-			poller.failedPolls = tt.failedPolls
-			poller.mutex.Unlock()
-
-			report := poller.HealthReport()
-
-			require.Len(t, report, 1)
-			err := report[poller.Name()]
-
-			if tt.wantErr {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), "polling failed")
-			} else {
-				require.NoError(t, err)
-			}
-
-			require.NoError(t, poller.Close())
-		})
-	}
-}
-
-func Test_RMNHomePollingWorking(t *testing.T) {
-	tests := []struct {
-		name              string
-		primaryEmpty      bool
-		secondaryEmpty    bool
-		expectedCallCount int
-	}{
-		{
-			name:              "Both configs non-empty",
-			primaryEmpty:      false,
-			secondaryEmpty:    false,
-			expectedCallCount: 4,
-		},
-		{
-			name:              "Primary config empty",
-			primaryEmpty:      true,
-			secondaryEmpty:    false,
-			expectedCallCount: 4,
-		},
-		{
-			name:              "Secondary config empty",
-			primaryEmpty:      false,
-			secondaryEmpty:    true,
-			expectedCallCount: 4,
-		},
-		{
-			name:              "Both configs empty",
-			primaryEmpty:      true,
-			secondaryEmpty:    true,
-			expectedCallCount: 4,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			primaryConfig, secondaryConfig := createTestRMNHomeConfigs(tt.primaryEmpty, tt.secondaryEmpty)
-			rmnHomeOnChainConfigs := GetAllConfigsResponse{
-				primaryConfig,
-				secondaryConfig,
-			}
-
-			homeChainReader := readermock.NewMockContractReaderFacade(t)
-			homeChainReader.On(
-				"GetLatestValue",
-				mock.Anything,
-				rmnHomeBoundContract.ReadIdentifier(consts.MethodNameGetAllConfigs),
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-			).Run(
-				func(args mock.Arguments) {
-					arg := args.Get(4).(*GetAllConfigsResponse)
-					*arg = rmnHomeOnChainConfigs
-				}).Return(nil)
-
-			defer homeChainReader.AssertExpectations(t)
-
-			var (
-				tickTime       = 2 * time.Millisecond
-				totalSleepTime = tickTime * 20
-			)
-
-			configPoller := newRMNHomePoller(
-				homeChainReader,
-				rmnHomeBoundContract,
-				logger.Test(t),
-				tickTime,
-			)
-
-			require.NoError(t, configPoller.Start(context.Background()))
-			// sleep to allow polling to happen
-			time.Sleep(totalSleepTime)
-			require.NoError(t, configPoller.Close())
-
-			calls := homeChainReader.Calls
-			callCount := 0
-			for _, call := range calls {
-				if call.Method == "GetLatestValue" {
-					callCount++
-				}
-			}
-			require.GreaterOrEqual(t, callCount, tt.expectedCallCount)
-
-			for i, config := range []VersionedConfig{primaryConfig, secondaryConfig} {
-				isEmpty := (i == 0 && tt.primaryEmpty) || (i == 1 && tt.secondaryEmpty)
-
-				rmnNodes, err := configPoller.GetRMNNodesInfo(config.ConfigDigest)
-				if isEmpty {
-					require.Error(t, err)
-					require.Empty(t, rmnNodes)
-				} else {
-					require.NoError(t, err)
-					require.NotEmpty(t, rmnNodes)
-				}
-
-				isValid := configPoller.IsRMNHomeConfigDigestSet(config.ConfigDigest)
-				if isEmpty {
-					require.False(t, isValid)
-				} else {
-					require.True(t, isValid)
-				}
-
-				offchainConfig, err := configPoller.GetOffChainConfig(config.ConfigDigest)
-				if isEmpty {
-					require.Error(t, err)
-					require.Empty(t, offchainConfig)
-				} else {
-					require.NoError(t, err)
-					require.NotEmpty(t, offchainConfig)
-				}
-
-				minObsMap, err := configPoller.GetFObserve(config.ConfigDigest)
-				if isEmpty {
-					require.Error(t, err)
-					require.Empty(t, minObsMap)
-				} else {
-					require.NoError(t, err)
-					require.Len(t, minObsMap, 1)
-					expectedChainSelector := cciptypes.ChainSelector(uint64(i + 1))
-					minObs, exists := minObsMap[expectedChainSelector]
-					require.True(t, exists)
-					require.Equal(t, i+1, minObs)
-				}
-
-				activeConfigDigest, candidateConfigDigest := configPoller.GetAllConfigDigests()
-				require.Equal(t, primaryConfig.ConfigDigest, activeConfigDigest)
-				require.Equal(t, secondaryConfig.ConfigDigest, candidateConfigDigest)
-
-			}
-		})
-	}
-}
-
-func Test_RMNHomePoller_Close(t *testing.T) {
-	homeChainReader := readermock.NewMockContractReaderFacade(t)
-	poller := newRMNHomePoller(
-		homeChainReader,
-		rmnHomeBoundContract,
-		logger.Test(t),
-		10*time.Millisecond,
-	)
-
-	homeChainReader.On("GetLatestValue",
-		mock.Anything,
-		mock.Anything,
-		mock.Anything,
-		mock.Anything,
-		mock.Anything,
-	).Run(func(args mock.Arguments) {
-		result := args.Get(4).(*GetAllConfigsResponse)
-		*result = GetAllConfigsResponse{
-			ActiveConfig: VersionedConfig{
-				ConfigDigest:  [32]byte{1},
-				Version:       1,
-				StaticConfig:  StaticConfig{Nodes: []Node{}},
-				DynamicConfig: DynamicConfig{SourceChains: []SourceChain{}},
-			},
-		}
-	}).Return(nil)
-
-	ctx := tests.Context(t)
-	require.NoError(t, poller.Start(ctx))
-
-	err1 := poller.Close()
-	require.NoError(t, err1)
-	err2 := poller.Close()
-	require.NoError(t, err2)
-	err3 := poller.Close()
-	require.NoError(t, err3)
-}
-
-func TestIsNodeObserver(t *testing.T) {
-	tests := []struct {
-		name           string
-		sourceChain    SourceChain
-		nodeIndex      int
-		totalNodes     int
-		expectedResult bool
-		expectedError  string
-	}{
-		{
-			name: "Node is observer",
-			sourceChain: SourceChain{
-				ChainSelector:       cciptypes.ChainSelector(1),
-				FObserve:            3,
-				ObserverNodesBitmap: big.NewInt(7), // 111 in binary
-			},
-			nodeIndex:      1,
-			totalNodes:     3,
-			expectedResult: true,
-			expectedError:  "",
-		},
-		{
-			name: "Node is not observer",
-			sourceChain: SourceChain{
-				ChainSelector:       cciptypes.ChainSelector(1),
-				FObserve:            3,
-				ObserverNodesBitmap: big.NewInt(5), // 101 in binary
-			},
-			nodeIndex:      1,
-			totalNodes:     3,
-			expectedResult: false,
-			expectedError:  "",
-		},
-		{
-			name: "Node index out of range (high)",
-			sourceChain: SourceChain{
-				ChainSelector:       cciptypes.ChainSelector(1),
-				FObserve:            3,
-				ObserverNodesBitmap: big.NewInt(7), // 111 in binary
-			},
-			nodeIndex:      3,
-			totalNodes:     3,
-			expectedResult: false,
-			expectedError:  "invalid node index: 3",
-		},
-		{
-			name: "Negative node index",
-			sourceChain: SourceChain{
-				ChainSelector:       cciptypes.ChainSelector(1),
-				FObserve:            3,
-				ObserverNodesBitmap: big.NewInt(7), // 111 in binary
-			},
-			nodeIndex:      -1,
-			totalNodes:     3,
-			expectedResult: false,
-			expectedError:  "invalid node index: -1",
-		},
-		{
-			name: "Invalid bitmap (out of bounds)",
-			sourceChain: SourceChain{
-				ChainSelector:       cciptypes.ChainSelector(1),
-				FObserve:            3,
-				ObserverNodesBitmap: big.NewInt(8), // 1000 in binary
-			},
-			nodeIndex:      0,
-			totalNodes:     3,
-			expectedResult: false,
-			expectedError:  "invalid observer nodes bitmap",
-		},
-		{
-			name: "Zero total nodes",
-			sourceChain: SourceChain{
-				ChainSelector:       cciptypes.ChainSelector(1),
-				FObserve:            3,
-				ObserverNodesBitmap: big.NewInt(1),
-			},
-			nodeIndex:      0,
-			totalNodes:     0,
-			expectedResult: false,
-			expectedError:  "invalid total nodes: 0",
-		},
-		{
-			name: "Total nodes exceeds 256",
-			sourceChain: SourceChain{
-				ChainSelector:       cciptypes.ChainSelector(1),
-				FObserve:            3,
-				ObserverNodesBitmap: big.NewInt(1),
-			},
-			nodeIndex:      0,
-			totalNodes:     257,
-			expectedResult: false,
-			expectedError:  "invalid total nodes: 257",
-		},
-		{
-			name: "Last valid node is observer",
-			sourceChain: SourceChain{
-				ChainSelector:       cciptypes.ChainSelector(1),
-				FObserve:            1,
-				ObserverNodesBitmap: new(big.Int).SetBit(big.NewInt(0), 255, 1), // Only the 256th bit is set
-			},
-			nodeIndex:      255,
-			totalNodes:     256,
-			expectedResult: true,
-			expectedError:  "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := IsNodeObserver(tt.sourceChain, tt.nodeIndex, tt.totalNodes)
-
-			if tt.expectedError != "" {
-				require.Error(t, err)
-				require.Equal(t, tt.expectedError, err.Error())
-			} else {
-				require.NoError(t, err)
-			}
-
-			require.Equal(t, tt.expectedResult, result)
-		})
-	}
-}
-
-func createTestRMNHomeConfigs(
-	primaryEmpty bool,
-	secondaryEmpty bool) (primary, secondary VersionedConfig) {
-	createConfig := func(id byte, isEmpty bool) VersionedConfig {
-		if isEmpty {
-			return VersionedConfig{}
-		}
-		return VersionedConfig{
-			ConfigDigest: cciptypes.Bytes32{id},
-			Version:      uint32(id),
-			DynamicConfig: DynamicConfig{
-				SourceChains: []SourceChain{
-					{
-						ChainSelector:       cciptypes.ChainSelector(id),
-						FObserve:            uint64(id),
-						ObserverNodesBitmap: big.NewInt(int64(id)),
-					},
-				},
-				OffchainConfig: cciptypes.Bytes{30 * id},
-			},
-			StaticConfig: StaticConfig{
-				Nodes: []Node{
-					{
-						PeerID:            cciptypes.Bytes32{10 * id},
-						OffchainPublicKey: cciptypes.Bytes32{20 * id},
-					},
-				},
-				OffchainConfig: cciptypes.Bytes{30 * id},
-			},
-		}
-	}
-
-	primary = createConfig(1, primaryEmpty)
-	secondary = createConfig(2, secondaryEmpty)
-	return primary, secondary
-}
 
 func Test_CachingInstances(t *testing.T) {
 	ctx := tests.Context(t)
@@ -487,21 +30,18 @@ func Test_CachingInstances(t *testing.T) {
 	t.Run("reusing instance for the same chain and address", func(t *testing.T) {
 		chainSelector := cciptypes.ChainSelector(rand.RandomInt64())
 		address := rand.RandomAddressBytes()
-		poller1, err := GetRMNHomePoller(ctx, lggr, chainSelector, address, chain1, HomeChainPollingInterval)
-		require.NoError(t, err)
+		poller1 := newRMNHomeCasted(t, ctx, lggr, chainSelector, address, chain1)
+		poller2 := newRMNHomeCasted(t, ctx, lggr, chainSelector, address, chain1)
+		poller3 := newRMNHomeCasted(t, ctx, lggr, chainSelector, address, chain1)
 
-		poller2, err := GetRMNHomePoller(ctx, lggr, chainSelector, address, chain1, HomeChainPollingInterval)
-		require.NoError(t, err)
-
-		poller3, err := GetRMNHomePoller(ctx, lggr, chainSelector, address, chain1, HomeChainPollingInterval)
-		require.NoError(t, err)
-
-		require.True(t, poller1 == poller2)
-		require.True(t, poller2 == poller3)
+		require.True(t, poller1.bgPoller == poller2.bgPoller)
+		require.True(t, poller2.bgPoller == poller3.bgPoller)
 
 		require.NoError(t, poller1.Close())
 		require.NoError(t, poller2.Close())
 		require.NoError(t, poller3.Close())
+
+		require.Error(t, poller1.bgPoller.sync.Ready())
 	})
 
 	t.Run("creating new instance for different addresses on a single chain", func(t *testing.T) {
@@ -509,15 +49,13 @@ func Test_CachingInstances(t *testing.T) {
 		address1 := rand.RandomAddressBytes()
 		address2 := rand.RandomAddressBytes()
 
-		poller1, err := GetRMNHomePoller(ctx, lggr, chainSelector, address1, chain1, HomeChainPollingInterval)
-		require.NoError(t, err)
+		poller1 := newRMNHomeCasted(t, ctx, lggr, chainSelector, address1, chain1)
+		poller2 := newRMNHomeCasted(t, ctx, lggr, chainSelector, address2, chain1)
 
-		poller2, err := GetRMNHomePoller(ctx, lggr, chainSelector, address2, chain1, HomeChainPollingInterval)
-		require.NoError(t, err)
-
-		require.False(t, poller1 == poller2)
+		require.False(t, poller1.bgPoller == poller2.bgPoller)
 		require.NoError(t, poller1.Close())
 		require.NoError(t, poller2.Close())
+		require.Error(t, poller1.bgPoller.Ready())
 	})
 
 	t.Run("creating new instance for different chains but same addresses", func(t *testing.T) {
@@ -525,15 +63,14 @@ func Test_CachingInstances(t *testing.T) {
 		chainSelector2 := cciptypes.ChainSelector(rand.RandomInt64())
 		address := rand.RandomAddressBytes()
 
-		poller1, err := GetRMNHomePoller(ctx, lggr, chainSelector1, address, chain1, HomeChainPollingInterval)
-		require.NoError(t, err)
+		poller1 := newRMNHomeCasted(t, ctx, lggr, chainSelector1, address, chain1)
+		poller2 := newRMNHomeCasted(t, ctx, lggr, chainSelector2, address, chain2)
 
-		poller2, err := GetRMNHomePoller(ctx, lggr, chainSelector2, address, chain2, HomeChainPollingInterval)
-		require.NoError(t, err)
-
-		require.False(t, poller1 == poller2)
+		require.False(t, poller1.bgPoller == poller2.bgPoller)
 		require.NoError(t, poller1.Close())
 		require.NoError(t, poller2.Close())
+		require.Error(t, poller1.bgPoller.Ready())
+		require.Error(t, poller2.bgPoller.Ready())
 	})
 
 	t.Run("parallel creation of instances doesn't cause any failures", func(t *testing.T) {
@@ -544,39 +81,57 @@ func Test_CachingInstances(t *testing.T) {
 		chainSelector := cciptypes.ChainSelector(rand.RandomInt64())
 		address := rand.RandomAddressBytes()
 
+		pollers := make([]*rmnHome, 1000)
+
 		eg := new(errgroup.Group)
 		for i := 0; i < 1000; i++ {
+			i := i
 			eg.Go(func() error {
-				poller, err := GetRMNHomePoller(ctx, lggr, chainSelector, address, chain1, HomeChainPollingInterval)
-				require.NotNil(t, poller)
-				require.NoError(t, err)
+				pollers[i] = newRMNHomeCasted(t, ctx, lggr, chainSelector, address, chain1)
 				return nil
 			})
 		}
 		require.NoError(t, eg.Wait())
 		require.Len(t, instances, 1)
+		require.NoError(t, pollers[0].bgPoller.Ready())
 
-		poller, err := GetRMNHomePoller(ctx, lggr, chainSelector, address, chain1, HomeChainPollingInterval)
-		require.NoError(t, err)
-		require.NoError(t, poller.Close())
+		// 999 closed, but still one reference remains therefore bgPoller is running
+		for i := 0; i < 999; i++ {
+			require.NoError(t, pollers[i].Close())
+		}
+		require.NoError(t, pollers[0].bgPoller.Ready())
+
+		// All closed, bgPoller should be stopped
+		require.NoError(t, pollers[999].Close())
+		require.Error(t, pollers[0].bgPoller.Ready())
 	})
 
 	t.Run("create new instance when old one is already stopped", func(t *testing.T) {
 		chainSelector := cciptypes.ChainSelector(rand.RandomInt64())
 		address := rand.RandomAddressBytes()
 
-		poller1, err := GetRMNHomePoller(ctx, lggr, chainSelector, address, chain1, HomeChainPollingInterval)
-		require.NoError(t, err)
+		poller1 := newRMNHomeCasted(t, ctx, lggr, chainSelector, address, chain1)
 		require.NoError(t, poller1.Close())
 		require.Error(t, poller1.Start(ctx))
 
-		poller2, err := GetRMNHomePoller(ctx, lggr, chainSelector, address, chain1, HomeChainPollingInterval)
-		require.NoError(t, err)
-
-		castedPoller, ok := poller2.(*rmnHomePoller)
-		require.True(t, ok)
-		require.NoError(t, castedPoller.Ready())
+		poller2 := newRMNHomeCasted(t, ctx, lggr, chainSelector, address, chain1)
+		require.NoError(t, poller2.Ready())
 
 		require.NoError(t, poller2.Close())
 	})
+}
+
+func newRMNHomeCasted(
+	t *testing.T,
+	ctx context.Context,
+	lggr logger.Logger,
+	selector cciptypes.ChainSelector,
+	address cciptypes.Bytes,
+	reader *readermock.MockContractReaderFacade,
+) *rmnHome {
+	rmn, err := NewRMNHome(ctx, lggr, selector, address, reader)
+	require.NoError(t, err)
+	casted, ok := rmn.(*rmnHome)
+	require.True(t, ok)
+	return casted
 }

--- a/pkg/reader/rmn_home_test.go
+++ b/pkg/reader/rmn_home_test.go
@@ -24,15 +24,17 @@ func Test_CachingInstances(t *testing.T) {
 
 	for _, chain := range []*readermock.MockContractReaderFacade{chain1, chain2} {
 		chain.EXPECT().Bind(mock.Anything, mock.Anything).Return(nil).Maybe()
-		chain.EXPECT().GetLatestValue(mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+		chain.EXPECT().GetLatestValue(
+			mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		).Return(nil).Maybe()
 	}
 
 	t.Run("reusing instance for the same chain and address", func(t *testing.T) {
 		chainSelector := cciptypes.ChainSelector(rand.RandomInt64())
 		address := rand.RandomAddressBytes()
-		poller1 := newRMNHomeCasted(t, ctx, lggr, chainSelector, address, chain1)
-		poller2 := newRMNHomeCasted(t, ctx, lggr, chainSelector, address, chain1)
-		poller3 := newRMNHomeCasted(t, ctx, lggr, chainSelector, address, chain1)
+		poller1 := newRMNHomeCasted(ctx, t, lggr, chainSelector, address, chain1)
+		poller2 := newRMNHomeCasted(ctx, t, lggr, chainSelector, address, chain1)
+		poller3 := newRMNHomeCasted(ctx, t, lggr, chainSelector, address, chain1)
 
 		require.True(t, poller1.bgPoller == poller2.bgPoller)
 		require.True(t, poller2.bgPoller == poller3.bgPoller)
@@ -41,7 +43,7 @@ func Test_CachingInstances(t *testing.T) {
 		require.NoError(t, poller2.Close())
 		require.NoError(t, poller3.Close())
 
-		require.Error(t, poller1.bgPoller.sync.Ready())
+		requirePollerStopped(t, poller1)
 	})
 
 	t.Run("creating new instance for different addresses on a single chain", func(t *testing.T) {
@@ -49,13 +51,13 @@ func Test_CachingInstances(t *testing.T) {
 		address1 := rand.RandomAddressBytes()
 		address2 := rand.RandomAddressBytes()
 
-		poller1 := newRMNHomeCasted(t, ctx, lggr, chainSelector, address1, chain1)
-		poller2 := newRMNHomeCasted(t, ctx, lggr, chainSelector, address2, chain1)
+		poller1 := newRMNHomeCasted(ctx, t, lggr, chainSelector, address1, chain1)
+		poller2 := newRMNHomeCasted(ctx, t, lggr, chainSelector, address2, chain1)
 
 		require.False(t, poller1.bgPoller == poller2.bgPoller)
 		require.NoError(t, poller1.Close())
 		require.NoError(t, poller2.Close())
-		require.Error(t, poller1.bgPoller.Ready())
+		requirePollerStopped(t, poller1)
 	})
 
 	t.Run("creating new instance for different chains but same addresses", func(t *testing.T) {
@@ -63,14 +65,35 @@ func Test_CachingInstances(t *testing.T) {
 		chainSelector2 := cciptypes.ChainSelector(rand.RandomInt64())
 		address := rand.RandomAddressBytes()
 
-		poller1 := newRMNHomeCasted(t, ctx, lggr, chainSelector1, address, chain1)
-		poller2 := newRMNHomeCasted(t, ctx, lggr, chainSelector2, address, chain2)
+		poller1 := newRMNHomeCasted(ctx, t, lggr, chainSelector1, address, chain1)
+		poller2 := newRMNHomeCasted(ctx, t, lggr, chainSelector2, address, chain2)
 
 		require.False(t, poller1.bgPoller == poller2.bgPoller)
 		require.NoError(t, poller1.Close())
 		require.NoError(t, poller2.Close())
-		require.Error(t, poller1.bgPoller.Ready())
-		require.Error(t, poller2.bgPoller.Ready())
+		requirePollerStopped(t, poller1)
+		requirePollerStopped(t, poller2)
+	})
+
+	t.Run("poller is not closed when there is remaining parent reference", func(t *testing.T) {
+		chainSelector := cciptypes.ChainSelector(rand.RandomInt64())
+		address := rand.RandomAddressBytes()
+		poller1 := newRMNHomeCasted(ctx, t, lggr, chainSelector, address, chain1)
+		poller2 := newRMNHomeCasted(ctx, t, lggr, chainSelector, address, chain1)
+		poller3 := newRMNHomeCasted(ctx, t, lggr, chainSelector, address, chain1)
+
+		require.NoError(t, poller1.Close())
+		requirePollerStarted(t, poller1)
+
+		require.NoError(t, poller2.Close())
+		require.NoError(t, poller2.Close())
+		requirePollerStarted(t, poller1)
+
+		require.NoError(t, poller3.Close())
+		requirePollerStopped(t, poller1)
+
+		require.NoError(t, poller3.Close())
+		requirePollerStopped(t, poller1)
 	})
 
 	t.Run("parallel creation of instances doesn't cause any failures", func(t *testing.T) {
@@ -85,45 +108,58 @@ func Test_CachingInstances(t *testing.T) {
 
 		eg := new(errgroup.Group)
 		for i := 0; i < 1000; i++ {
-			i := i
+			j := i
 			eg.Go(func() error {
-				pollers[i] = newRMNHomeCasted(t, ctx, lggr, chainSelector, address, chain1)
+				pollers[j] = newRMNHomeCasted(ctx, t, lggr, chainSelector, address, chain1)
 				return nil
 			})
 		}
 		require.NoError(t, eg.Wait())
 		require.Len(t, instances, 1)
-		require.NoError(t, pollers[0].bgPoller.Ready())
+		requirePollerStarted(t, pollers[0])
 
 		// 999 closed, but still one reference remains therefore bgPoller is running
 		for i := 0; i < 999; i++ {
 			require.NoError(t, pollers[i].Close())
 		}
-		require.NoError(t, pollers[0].bgPoller.Ready())
+		requirePollerStarted(t, pollers[0])
 
 		// All closed, bgPoller should be stopped
 		require.NoError(t, pollers[999].Close())
-		require.Error(t, pollers[0].bgPoller.Ready())
+		requirePollerStopped(t, pollers[0])
 	})
 
 	t.Run("create new instance when old one is already stopped", func(t *testing.T) {
 		chainSelector := cciptypes.ChainSelector(rand.RandomInt64())
 		address := rand.RandomAddressBytes()
 
-		poller1 := newRMNHomeCasted(t, ctx, lggr, chainSelector, address, chain1)
+		poller1 := newRMNHomeCasted(ctx, t, lggr, chainSelector, address, chain1)
 		require.NoError(t, poller1.Close())
 		require.Error(t, poller1.Start(ctx))
+		requirePollerStopped(t, poller1)
 
-		poller2 := newRMNHomeCasted(t, ctx, lggr, chainSelector, address, chain1)
+		poller2 := newRMNHomeCasted(ctx, t, lggr, chainSelector, address, chain1)
 		require.NoError(t, poller2.Ready())
+		requirePollerStarted(t, poller2)
 
 		require.NoError(t, poller2.Close())
+		requirePollerStopped(t, poller2)
 	})
 }
 
+func requirePollerStarted(t *testing.T, home *rmnHome) {
+	require.NoError(t, home.bgPoller.Ready())
+	require.Equal(t, "Started", home.bgPoller.sync.State())
+}
+
+func requirePollerStopped(t *testing.T, home *rmnHome) {
+	require.Error(t, home.bgPoller.Ready())
+	require.Equal(t, "Stopped", home.bgPoller.sync.State())
+}
+
 func newRMNHomeCasted(
-	t *testing.T,
 	ctx context.Context,
+	t *testing.T,
 	lggr logger.Logger,
 	selector cciptypes.ChainSelector,
 	address cciptypes.Bytes,


### PR DESCRIPTION
core ref: 08ed8f5153ffb07bd9b0b7feb2f2a2d23a84ac0a

RMNChainPoller is created on every OCR3 initialization [chainlink-ccip/commit/factory.go](https://github.com/smartcontractkit/chainlink-ccip/blob/23551e14342ad197dcd9aadb3d0c344e8d331891/commit/factory.go#L165) 

Although there is always a single `RMNHome.sol` contract (similar to CCIPHome), we keep spawning background routines for every Commit job, which frequently poll the same contract. Unfortunately, OCR3Config allows defining RMNHomeAddres per chain so we can't follow a similar pattern as CCIPHomeChain.

Therefore, we need to implement our own singleton (per address) to support multiple RMNHomes