### PR TITLE
solana: add rmn placeholders for stable commit struct

### DIFF
--- a/chains/solana/contracts/programs/ccip-router/src/context.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/context.rs
@@ -51,7 +51,7 @@ pub const TOKEN_POOL_CONFIG_SEED: &[u8] = b"ccip_tokenpool_chainconfig";
 pub struct CommitInput {
     pub price_updates: PriceUpdates,
     pub merkle_root: MerkleRoot,
-    // pub rmn_signatures: Vec<[u8; 65]>, // r = 32, s = 32, v = 1; placeholder: RMN not enabled
+    pub rmn_signatures: Vec<[u8; 64]>, // placeholder for stable interface; r = 32, s = 32; https://github.com/smartcontractkit/chainlink/blob/d1a9f8be2f222ea30bdf7182aaa6428bfa605cf7/contracts/src/v0.8/ccip/interfaces/IRMNRemote.sol#L9
 }
 
 // A collection of token price and gas price updates.

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/ocr3impl.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/ocr3impl.rs
@@ -18,6 +18,7 @@ impl Ocr3Report for Ocr3ReportForCommit<'_> {
     fn len(&self) -> usize {
         4 + (32 + 28) * self.0.price_updates.token_price_updates.len() + // token_price_updates
       4 + (8 + 28) * self.0.price_updates.gas_price_updates.len() + // gas_price_updates
+      4 + (32 + 32) * self.0.rmn_signatures.len() + // rmn signatures
       self.0.merkle_root.len()
         // + 4 + 65 * self.rmn_signatures.len()
     }

--- a/chains/solana/contracts/target/idl/ccip_router.json
+++ b/chains/solana/contracts/target/idl/ccip_router.json
@@ -1816,6 +1816,17 @@
             "type": {
               "defined": "MerkleRoot"
             }
+          },
+          {
+            "name": "rmnSignatures",
+            "type": {
+              "vec": {
+                "array": [
+                  "u8",
+                  64
+                ]
+              }
+            }
           }
         ]
       }

--- a/chains/solana/gobindings/ccip_router/types.go
+++ b/chains/solana/gobindings/ccip_router/types.go
@@ -8,8 +8,9 @@ import (
 )
 
 type CommitInput struct {
-	PriceUpdates PriceUpdates
-	MerkleRoot   MerkleRoot
+	PriceUpdates  PriceUpdates
+	MerkleRoot    MerkleRoot
+	RmnSignatures [][64]uint8
 }
 
 func (obj CommitInput) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
@@ -20,6 +21,11 @@ func (obj CommitInput) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error
 	}
 	// Serialize `MerkleRoot` param:
 	err = encoder.Encode(obj.MerkleRoot)
+	if err != nil {
+		return err
+	}
+	// Serialize `RmnSignatures` param:
+	err = encoder.Encode(obj.RmnSignatures)
 	if err != nil {
 		return err
 	}
@@ -34,6 +40,11 @@ func (obj *CommitInput) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err er
 	}
 	// Deserialize `MerkleRoot`:
 	err = decoder.Decode(&obj.MerkleRoot)
+	if err != nil {
+		return err
+	}
+	// Deserialize `RmnSignatures`:
+	err = decoder.Decode(&obj.RmnSignatures)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
add space for RMN signatures for future use to stabilize offchain interfaces