### PR TITLE
param all PDA access

### DIFF
--- a/chains/solana/contracts/tests/ccip/ccip_router_test.go
+++ b/chains/solana/contracts/tests/ccip/ccip_router_test.go
@@ -392,9 +392,9 @@ func TestCCIPRouter(t *testing.T) {
 			require.Equal(t, defaultGasLimit, configAccount.DefaultGasLimit)
 			require.Equal(t, uint8(1), configAccount.DefaultAllowOutOfOrderExecution)
 
-			nonceEvmPDA, err = ccip.GetNoncePDA(config.EvmChainSelector, user.PublicKey(), config.CcipRouterProgram)
+			nonceEvmPDA, err = common.GetNoncePDA(config.EvmChainSelector, user.PublicKey(), config.CcipRouterProgram)
 			require.NoError(t, err)
-			nonceSvmPDA, err = ccip.GetNoncePDA(config.SVMChainSelector, user.PublicKey())
+			nonceSvmPDA, err = common.GetNoncePDA(config.SVMChainSelector, user.PublicKey(), config.CcipRouterProgram)
 			require.NoError(t, err)
 		})
 
@@ -502,9 +502,9 @@ func TestCCIPRouter(t *testing.T) {
 		t.Run("When and admin adds a chain selector with invalid dest chain config, it fails", func(t *testing.T) {
 			for _, test := range invalidInputTests {
 				t.Run(test.Name, func(t *testing.T) {
-					sourceChainStatePDA, serr := ccip.GetSourceChainStatePDA(test.Selector, config.CcipRouterProgram)
+					sourceChainStatePDA, serr := common.GetSourceChainStatePDA(test.Selector, config.CcipRouterProgram)
 					require.NoError(t, serr)
-					destChainStatePDA, derr := ccip.GetDestChainStatePDA(test.Selector, config.CcipRouterProgram)
+					destChainStatePDA, derr := common.GetDestChainStatePDA(test.Selector, config.CcipRouterProgram)
 					require.NoError(t, derr)
 					instruction, err := ccip_router.NewAddChainSelectorInstruction(
 						test.Selector,
@@ -691,7 +691,7 @@ func TestCCIPRouter(t *testing.T) {
 					continue
 				}
 				t.Run(test.Name, func(t *testing.T) {
-					destChainStatePDA, derr := ccip.GetDestChainStatePDA(test.Selector, config.CcipRouterProgram)
+					destChainStatePDA, derr := common.GetDestChainStatePDA(test.Selector, config.CcipRouterProgram)
 					require.NoError(t, derr)
 					instruction, err := ccip_router.NewUpdateDestChainConfigInstruction(
 						test.Selector,
@@ -2027,7 +2027,7 @@ func TestCCIPRouter(t *testing.T) {
 	t.Run("OnRamp ccipSend", func(t *testing.T) {
 		t.Run("When sending to an invalid destination chain selector it fails", func(t *testing.T) {
 			destinationChainSelector := uint64(189)
-			destinationChainStatePDA, err := ccip.GetDestChainStatePDA(destinationChainSelector, config.CcipRouterProgram)
+			destinationChainStatePDA, err := common.GetDestChainStatePDA(destinationChainSelector, config.CcipRouterProgram)
 			require.NoError(t, err)
 			message := ccip_router.SVM2AnyMessage{
 				FeeToken: wsol.mint,
@@ -2620,7 +2620,7 @@ func TestCCIPRouter(t *testing.T) {
 				Receiver: validReceiverAddress[:],
 				Data:     []byte{4, 5, 6},
 			}
-			anotherUserNonceEVMPDA, err := ccip.GetNoncePDA(config.EvmChainSelector, anotherUser.PublicKey(), config.CcipRouterProgram)
+			anotherUserNonceEVMPDA, err := common.GetNoncePDA(config.EvmChainSelector, anotherUser.PublicKey(), config.CcipRouterProgram)
 			require.NoError(t, err)
 
 			raw := ccip_router.NewCcipSendInstruction(
@@ -2655,7 +2655,7 @@ func TestCCIPRouter(t *testing.T) {
 				Receiver: validReceiverAddress[:],
 				Data:     []byte{4, 5, 6},
 			}
-			anotherUserNonceEVMPDA, err := ccip.GetNoncePDA(config.EvmChainSelector, anotherUser.PublicKey(), config.CcipRouterProgram)
+			anotherUserNonceEVMPDA, err := common.GetNoncePDA(config.EvmChainSelector, anotherUser.PublicKey(), config.CcipRouterProgram)
 			require.NoError(t, err)
 
 			raw := ccip_router.NewCcipSendInstruction(
@@ -3012,7 +3012,7 @@ func TestCCIPRouter(t *testing.T) {
 				Data:     []byte{4, 5, 6},
 			}
 
-			noncePDA, err := ccip.GetNoncePDA(config.EvmChainSelector, tokenlessUser.PublicKey(), config.CcipRouterProgram)
+			noncePDA, err := common.GetNoncePDA(config.EvmChainSelector, tokenlessUser.PublicKey(), config.CcipRouterProgram)
 			require.NoError(t, err)
 
 			// ccipSend
@@ -3541,7 +3541,7 @@ func TestCCIPRouter(t *testing.T) {
 				for i, testcase := range priceUpdatesCases {
 					t.Run(testcase.Name, func(t *testing.T) {
 						_, root := testutils.MakeAnyToSVMMessage(t, config.CcipTokenReceiver, config.CcipLogicReceiver, config.EvmChainSelector, config.SVMChainSelector, []byte{1, 2, 3, uint8(i)})
-						rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+						rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 						require.NoError(t, err)
 
 						minV := currentMinSeqNr
@@ -3642,10 +3642,10 @@ func TestCCIPRouter(t *testing.T) {
 				t.Run("When committing a report with an invalid source chain selector it fails", func(t *testing.T) {
 					t.Parallel()
 					sourceChainSelector := uint64(34)
-					sourceChainStatePDA, err := ccip.GetSourceChainStatePDA(sourceChainSelector)
+					sourceChainStatePDA, err := common.GetSourceChainStatePDA(sourceChainSelector, config.CcipRouterProgram)
 					require.NoError(t, err)
 					_, root := testutils.MakeAnyToSVMMessage(t, config.CcipTokenReceiver, config.CcipLogicReceiver, sourceChainSelector, config.SVMChainSelector, []byte{4, 5, 6})
-					rootPDA, err := ccip.GetCommitReportPDA(sourceChainSelector, root, config.CcipRouterProgram)
+					rootPDA, err := common.GetCommitReportPDA(sourceChainSelector, root, config.CcipRouterProgram)
 					require.NoError(t, err)
 
 					minV := currentMinSeqNr
@@ -3682,7 +3682,7 @@ func TestCCIPRouter(t *testing.T) {
 				t.Run("When committing a report with an invalid interval it fails", func(t *testing.T) {
 					t.Parallel()
 					_, root := testutils.MakeAnyToSVMMessage(t, config.CcipTokenReceiver, config.CcipLogicReceiver, config.EvmChainSelector, config.SVMChainSelector, []byte{4, 5, 6})
-					rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+					rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 					require.NoError(t, err)
 
 					minV := currentMinSeqNr
@@ -3719,7 +3719,7 @@ func TestCCIPRouter(t *testing.T) {
 				t.Run("When committing a report with an interval size bigger than supported it fails", func(t *testing.T) {
 					t.Parallel()
 					_, root := testutils.MakeAnyToSVMMessage(t, config.CcipTokenReceiver, config.CcipLogicReceiver, config.EvmChainSelector, config.SVMChainSelector, []byte{4, 5, 6})
-					rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+					rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 					require.NoError(t, err)
 
 					minV := currentMinSeqNr
@@ -3756,7 +3756,7 @@ func TestCCIPRouter(t *testing.T) {
 				t.Run("When committing a report with a zero merkle root it fails", func(t *testing.T) {
 					t.Parallel()
 					root := [32]byte{}
-					rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+					rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 					require.NoError(t, err)
 
 					minV := currentMinSeqNr
@@ -3793,7 +3793,7 @@ func TestCCIPRouter(t *testing.T) {
 				t.Run("When committing a report with a repeated merkle root, it fails", func(t *testing.T) {
 					t.Parallel()
 					_, root := testutils.MakeAnyToSVMMessage(t, config.CcipTokenReceiver, config.CcipLogicReceiver, config.EvmChainSelector, config.SVMChainSelector, []byte{1, 2, 3, 1}) // repeated root
-					rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+					rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 					require.NoError(t, err)
 
 					minV := currentMinSeqNr
@@ -3831,7 +3831,7 @@ func TestCCIPRouter(t *testing.T) {
 				t.Run("When committing a report with an invalid min interval, it fails", func(t *testing.T) {
 					t.Parallel()
 					_, root := testutils.MakeAnyToSVMMessage(t, config.CcipTokenReceiver, config.CcipLogicReceiver, config.EvmChainSelector, config.SVMChainSelector, []byte{4, 5, 6})
-					rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+					rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 					require.NoError(t, err)
 
 					minV := uint64(8) // this is lower than expected
@@ -3869,7 +3869,7 @@ func TestCCIPRouter(t *testing.T) {
 					randomToken := solana.MustPublicKeyFromBase58("AGDpGy7auzgKT8zt6qhfHFm1rDwvqQGGTYxuYn7MtydQ") // just some non-existing token
 
 					randomChain := uint64(123456) // just some non-existing chain
-					randomChainPDA, err := ccip.GetDestChainStatePDA(randomChain, config.CcipRouterProgram)
+					randomChainPDA, err := common.GetDestChainStatePDA(randomChain, config.CcipRouterProgram)
 					require.NoError(t, err)
 
 					testcases := []struct {
@@ -3929,7 +3929,7 @@ func TestCCIPRouter(t *testing.T) {
 					}
 
 					_, root := testutils.MakeAnyToSVMMessage(t, config.CcipTokenReceiver, config.CcipLogicReceiver, config.EvmChainSelector, config.SVMChainSelector, []byte{1, 2, 3})
-					rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+					rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 					require.NoError(t, err)
 
 					for _, testcase := range testcases {
@@ -3996,7 +3996,7 @@ func TestCCIPRouter(t *testing.T) {
 
 			t.Run("When committing a report with the exact next interval, it succeeds", func(t *testing.T) {
 				_, root := testutils.MakeAnyToSVMMessage(t, config.CcipTokenReceiver, config.CcipLogicReceiver, config.EvmChainSelector, config.SVMChainSelector, []byte{4, 5, 6})
-				rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+				rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 				require.NoError(t, err)
 
 				minV := currentMinSeqNr
@@ -4062,7 +4062,7 @@ func TestCCIPRouter(t *testing.T) {
 				t.Run("It rejects mismatch config digest", func(t *testing.T) {
 					t.Parallel()
 					msg, root := testutils.CreateNextMessage(ctx, solanaGoClient, t)
-					rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+					rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 					require.NoError(t, err)
 
 					minV := msg.Header.SequenceNumber
@@ -4101,7 +4101,7 @@ func TestCCIPRouter(t *testing.T) {
 				t.Run("It rejects unauthorized transmitter", func(t *testing.T) {
 					t.Parallel()
 					msg, root := testutils.CreateNextMessage(ctx, solanaGoClient, t)
-					rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+					rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 					require.NoError(t, err)
 
 					minV := msg.Header.SequenceNumber
@@ -4138,7 +4138,7 @@ func TestCCIPRouter(t *testing.T) {
 				t.Run("It rejects incorrect signature count", func(t *testing.T) {
 					t.Parallel()
 					msg, root := testutils.CreateNextMessage(ctx, solanaGoClient, t)
-					rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+					rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 					require.NoError(t, err)
 
 					minV := msg.Header.SequenceNumber
@@ -4183,7 +4183,7 @@ func TestCCIPRouter(t *testing.T) {
 				t.Run("It rejects invalid signature", func(t *testing.T) {
 					t.Parallel()
 					msg, root := testutils.CreateNextMessage(ctx, solanaGoClient, t)
-					rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+					rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 					require.NoError(t, err)
 
 					minV := msg.Header.SequenceNumber
@@ -4219,7 +4219,7 @@ func TestCCIPRouter(t *testing.T) {
 				t.Run("It rejects unauthorized signer", func(t *testing.T) {
 					t.Parallel()
 					msg, root := testutils.CreateNextMessage(ctx, solanaGoClient, t)
-					rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+					rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 					require.NoError(t, err)
 
 					minV := msg.Header.SequenceNumber
@@ -4267,7 +4267,7 @@ func TestCCIPRouter(t *testing.T) {
 				t.Run("It rejects duplicate signatures", func(t *testing.T) {
 					t.Parallel()
 					msg, root := testutils.CreateNextMessage(ctx, solanaGoClient, t)
-					rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+					rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 					require.NoError(t, err)
 
 					minV := msg.Header.SequenceNumber
@@ -4334,7 +4334,7 @@ func TestCCIPRouter(t *testing.T) {
 				}
 				sigs, err := ccip.SignCommitReport(reportContext, commitReport, signers)
 				require.NoError(t, err)
-				rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+				rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 				require.NoError(t, err)
 
 				instruction, err := ccip_router.NewCommitInstruction(
@@ -4420,7 +4420,7 @@ func TestCCIPRouter(t *testing.T) {
 				}
 				sigs, err := ccip.SignCommitReport(reportContext, commitReport, signers)
 				require.NoError(t, err)
-				rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+				rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 				require.NoError(t, err)
 
 				instruction, err := ccip_router.NewCommitInstruction(
@@ -4491,7 +4491,7 @@ func TestCCIPRouter(t *testing.T) {
 				}
 				sigs, err := ccip.SignCommitReport(reportContext, commitReport, signers)
 				require.NoError(t, err)
-				rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+				rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 				require.NoError(t, err)
 
 				instruction, err := ccip_router.NewCommitInstruction(
@@ -4510,9 +4510,9 @@ func TestCCIPRouter(t *testing.T) {
 				event := ccip.EventCommitReportAccepted{}
 				require.NoError(t, common.ParseEvent(tx.Meta.LogMessages, "CommitReportAccepted", &event, config.PrintEvents))
 
-				unsupportedSourceChainStatePDA, err := ccip.GetSourceChainStatePDA(unsupportedChainSelector, config.CcipRouterProgram)
+				unsupportedSourceChainStatePDA, err := common.GetSourceChainStatePDA(unsupportedChainSelector, config.CcipRouterProgram)
 				require.NoError(t, err)
-				unsupportedDestChainStatePDA, err := ccip.GetDestChainStatePDA(unsupportedChainSelector, config.CcipRouterProgram)
+				unsupportedDestChainStatePDA, err := common.GetDestChainStatePDA(unsupportedChainSelector, config.CcipRouterProgram)
 				require.NoError(t, err)
 				message.Header.SourceChainSelector = unsupportedChainSelector
 				message.Header.SequenceNumber = 1
@@ -4584,7 +4584,7 @@ func TestCCIPRouter(t *testing.T) {
 				}
 				sigs, err := ccip.SignCommitReport(reportContext, commitReport, signers)
 				require.NoError(t, err)
-				rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+				rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 				require.NoError(t, err)
 
 				instruction, err := ccip_router.NewCommitInstruction(
@@ -4639,7 +4639,7 @@ func TestCCIPRouter(t *testing.T) {
 				transmitter := getTransmitter()
 
 				message, root := testutils.CreateNextMessage(ctx, solanaGoClient, t)
-				rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+				rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 				require.NoError(t, err)
 
 				executionReport := ccip_router.ExecutionReportSingleChain{
@@ -4684,7 +4684,7 @@ func TestCCIPRouter(t *testing.T) {
 				require.NoError(t, err)
 				root := [32]byte(hash)
 
-				rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+				rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 				require.NoError(t, err)
 
 				executionReport := ccip_router.ExecutionReportSingleChain{
@@ -4747,7 +4747,7 @@ func TestCCIPRouter(t *testing.T) {
 				}
 				sigs, err := ccip.SignCommitReport(reportContext, commitReport, signers)
 				require.NoError(t, err)
-				rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+				rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 				require.NoError(t, err)
 
 				instruction, err := ccip_router.NewCommitInstruction(
@@ -4880,7 +4880,7 @@ func TestCCIPRouter(t *testing.T) {
 				}
 				sigs, err := ccip.SignCommitReport(reportContext, commitReport, signers)
 				require.NoError(t, err)
-				rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+				rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 				require.NoError(t, err)
 
 				instruction, err := ccip_router.NewCommitInstruction(
@@ -4957,7 +4957,7 @@ func TestCCIPRouter(t *testing.T) {
 				}
 				sigs, err := ccip.SignCommitReport(reportContext, commitReport, signers)
 				require.NoError(t, err)
-				rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+				rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 				require.NoError(t, err)
 
 				instruction, err := ccip_router.NewCommitInstruction(
@@ -5041,7 +5041,7 @@ func TestCCIPRouter(t *testing.T) {
 				}
 				sigs, err := ccip.SignCommitReport(reportContext, commitReport, signers)
 				require.NoError(t, err)
-				rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+				rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 				require.NoError(t, err)
 
 				instruction, err := ccip_router.NewCommitInstruction(
@@ -5115,7 +5115,7 @@ func TestCCIPRouter(t *testing.T) {
 
 			t.Run("OffRamp Manual Execution: when executing a non-committed report, it fails", func(t *testing.T) {
 				message, root := testutils.CreateNextMessage(ctx, solanaGoClient, t)
-				rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+				rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 				require.NoError(t, err)
 
 				executionReport := ccip_router.ExecutionReportSingleChain{
@@ -5174,7 +5174,7 @@ func TestCCIPRouter(t *testing.T) {
 				}
 				sigs, err := ccip.SignCommitReport(reportContext, commitReport, signers)
 				require.NoError(t, err)
-				rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+				rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 				require.NoError(t, err)
 
 				instruction, err := ccip_router.NewCommitInstruction(
@@ -5382,7 +5382,7 @@ func TestCCIPRouter(t *testing.T) {
 			// note: simple recursion execute -> ccipSend is currently not possible as the router does not implement the ccipReceive method signature
 			t.Run("failed reentrancy A (execute) -> B (ccipReceive) -> A (ccipSend)", func(t *testing.T) {
 				transmitter := getTransmitter()
-				receiverContractEvmPDA, err := ccip.GetNoncePDA(config.EvmChainSelector, config.ReceiverExternalExecutionConfigPDA, config.CcipRouterProgram)
+				receiverContractEvmPDA, err := common.GetNoncePDA(config.EvmChainSelector, config.ReceiverExternalExecutionConfigPDA, config.CcipRouterProgram)
 				require.NoError(t, err)
 
 				message, _ := testutils.CreateNextMessage(ctx, solanaGoClient, t)
@@ -5417,7 +5417,7 @@ func TestCCIPRouter(t *testing.T) {
 				}
 				sigs, err := ccip.SignCommitReport(reportContext, commitReport, signers)
 				require.NoError(t, err)
-				rootPDA, _ := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+				rootPDA, _ := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 
 				instruction, err := ccip_router.NewCommitInstruction(
 					reportContext,
@@ -5511,7 +5511,7 @@ func TestCCIPRouter(t *testing.T) {
 				}
 				sigs, err := ccip.SignCommitReport(reportContext, commitReport, signers)
 				require.NoError(t, err)
-				rootPDA, err := ccip.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
+				rootPDA, err := common.GetCommitReportPDA(config.EvmChainSelector, root, config.CcipRouterProgram)
 				require.NoError(t, err)
 				instruction, err := ccip_router.NewCommitInstruction(
 					reportContext,

--- a/chains/solana/contracts/tests/ccip/ccip_router_test.go
+++ b/chains/solana/contracts/tests/ccip/ccip_router_test.go
@@ -109,12 +109,12 @@ func TestCCIPRouter(t *testing.T) {
 	}
 
 	getTokenConfigPDA := func(mint solana.PublicKey) solana.PublicKey {
-		tokenConfigPda, _, _ := common.FindFeeBillingTokenConfigPDA(config.CcipRouterProgram, mint)
+		tokenConfigPda, _, _ := common.FindFeeBillingTokenConfigPDA(mint, config.CcipRouterProgram)
 		return tokenConfigPda
 	}
 
 	getPerChainPerTokenConfigBillingPDA := func(mint solana.PublicKey) solana.PublicKey {
-		tokenBillingPda, _, _ := common.FindCcipTokenpoolBillingPDA(config.CcipRouterProgram, mint, config.EvmChainSelector)
+		tokenBillingPda, _, _ := common.FindCcipTokenpoolBillingPDA(config.EvmChainSelector, mint, config.CcipRouterProgram)
 		return tokenBillingPda
 	}
 
@@ -237,11 +237,11 @@ func TestCCIPRouter(t *testing.T) {
 			// WSOL //
 			//////////
 
-			wsolPDA, _, aerr := common.FindFeeBillingTokenConfigPDA(ccip_router.ProgramID, solana.SolMint)
+			wsolPDA, _, aerr := common.FindFeeBillingTokenConfigPDA(solana.SolMint, ccip_router.ProgramID)
 			require.NoError(t, aerr)
 			wsolReceiver, _, rerr := tokens.FindAssociatedTokenAddress(solana.TokenProgramID, solana.SolMint, config.BillingSignerPDA)
 			require.NoError(t, rerr)
-			wsolEvmConfigPDA, _, perr := common.FindCcipTokenpoolBillingPDA(config.CcipRouterProgram, solana.SolMint, config.EvmChainSelector)
+			wsolEvmConfigPDA, _, perr := common.FindCcipTokenpoolBillingPDA(config.EvmChainSelector, solana.SolMint, config.CcipRouterProgram)
 			require.NoError(t, perr)
 			wsolUserATA, _, uerr := tokens.FindAssociatedTokenAddress(solana.TokenProgramID, solana.SolMint, user.PublicKey())
 			require.NoError(t, uerr)
@@ -276,9 +276,9 @@ func TestCCIPRouter(t *testing.T) {
 			require.NoError(t, terr)
 			testutils.SendAndConfirm(ctx, t, solanaGoClient, ixToken, admin, config.DefaultCommitment, common.AddSigners(mintPrivK))
 
-			token2022PDA, _, aerr := common.FindFeeBillingTokenConfigPDA(ccip_router.ProgramID, mintPubK)
+			token2022PDA, _, aerr := common.FindFeeBillingTokenConfigPDA(mintPubK, ccip_router.ProgramID)
 			require.NoError(t, aerr)
-			token2022EvmConfigPDA, _, puerr := common.FindCcipTokenpoolBillingPDA(config.CcipRouterProgram, mintPubK, config.EvmChainSelector)
+			token2022EvmConfigPDA, _, puerr := common.FindCcipTokenpoolBillingPDA(config.EvmChainSelector, mintPubK, config.CcipRouterProgram)
 			require.NoError(t, puerr)
 			token2022Receiver, _, rerr := tokens.FindAssociatedTokenAddress(config.Token2022Program, mintPubK, config.BillingSignerPDA)
 			require.NoError(t, rerr)
@@ -5638,7 +5638,7 @@ func TestCCIPRouter(t *testing.T) {
 			require.NoError(t, terr)
 			testutils.SendAndConfirm(ctx, t, solanaGoClient, ixToken, admin, config.DefaultCommitment, common.AddSigners(mintPriv))
 
-			configPDA, _, perr := common.FindFeeBillingTokenConfigPDA(ccip_router.ProgramID, mint)
+			configPDA, _, perr := common.FindFeeBillingTokenConfigPDA(mint, ccip_router.ProgramID)
 			require.NoError(t, perr)
 			receiver, _, terr := tokens.FindAssociatedTokenAddress(solana.TokenProgramID, mint, config.BillingSignerPDA)
 			require.NoError(t, terr)

--- a/chains/solana/contracts/tests/ccip/tokenpool_test.go
+++ b/chains/solana/contracts/tests/ccip/tokenpool_test.go
@@ -86,9 +86,9 @@ func TestTokenPool(t *testing.T) {
 				})
 
 				t.Run("pool:"+poolType.String(), func(t *testing.T) {
-					poolConfig, err := tokens.TokenPoolConfigAddress(config.CcipTokenPoolProgram, mint)
+					poolConfig, err := tokens.TokenPoolConfigAddress(mint, config.CcipTokenPoolProgram)
 					require.NoError(t, err)
-					poolSigner, err := tokens.TokenPoolSignerAddress(config.CcipTokenPoolProgram, mint)
+					poolSigner, err := tokens.TokenPoolSignerAddress(mint, config.CcipTokenPoolProgram)
 					require.NoError(t, err)
 					createI, poolTokenAccount, err := tokens.CreateAssociatedTokenAccount(v.tokenProgram, mint, poolSigner, admin.PublicKey())
 					require.NoError(t, err)
@@ -367,9 +367,9 @@ func TestTokenPool(t *testing.T) {
 
 		t.Run("setup:pool", func(t *testing.T) {
 			var err error
-			p.PoolConfig, err = tokens.TokenPoolConfigAddress(config.CcipTokenPoolProgram, mint)
+			p.PoolConfig, err = tokens.TokenPoolConfigAddress(mint, config.CcipTokenPoolProgram)
 			require.NoError(t, err)
-			p.PoolSigner, err = tokens.TokenPoolSignerAddress(config.CcipTokenPoolProgram, mint)
+			p.PoolSigner, err = tokens.TokenPoolSignerAddress(mint, config.CcipTokenPoolProgram)
 			require.NoError(t, err)
 
 			// create token

--- a/chains/solana/contracts/tests/ccip/tokenpool_test.go
+++ b/chains/solana/contracts/tests/ccip/tokenpool_test.go
@@ -86,9 +86,9 @@ func TestTokenPool(t *testing.T) {
 				})
 
 				t.Run("pool:"+poolType.String(), func(t *testing.T) {
-					poolConfig, err := tokens.TokenPoolConfigAddress(mint)
+					poolConfig, err := tokens.TokenPoolConfigAddress(config.CcipTokenPoolProgram, mint)
 					require.NoError(t, err)
-					poolSigner, err := tokens.TokenPoolSignerAddress(mint)
+					poolSigner, err := tokens.TokenPoolSignerAddress(config.CcipTokenPoolProgram, mint)
 					require.NoError(t, err)
 					createI, poolTokenAccount, err := tokens.CreateAssociatedTokenAccount(v.tokenProgram, mint, poolSigner, admin.PublicKey())
 					require.NoError(t, err)
@@ -367,9 +367,9 @@ func TestTokenPool(t *testing.T) {
 
 		t.Run("setup:pool", func(t *testing.T) {
 			var err error
-			p.PoolConfig, err = tokens.TokenPoolConfigAddress(mint)
+			p.PoolConfig, err = tokens.TokenPoolConfigAddress(config.CcipTokenPoolProgram, mint)
 			require.NoError(t, err)
-			p.PoolSigner, err = tokens.TokenPoolSignerAddress(mint)
+			p.PoolSigner, err = tokens.TokenPoolSignerAddress(config.CcipTokenPoolProgram, mint)
 			require.NoError(t, err)
 
 			// create token

--- a/chains/solana/contracts/tests/config/ccip_config.go
+++ b/chains/solana/contracts/tests/config/ccip_config.go
@@ -4,7 +4,6 @@ import (
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/ccip"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
 )
 
@@ -31,10 +30,10 @@ var (
 	EvmChainSelector uint64 = 21
 	EvmChainLE              = common.Uint64ToLE(EvmChainSelector)
 
-	SVMSourceChainStatePDA, _, _ = ccip.FindSourceChainStatePDA(SVMChainSelector, CcipRouterProgram)
-	SVMDestChainStatePDA, _, _   = ccip.FindDestChainStatePDA(SVMChainSelector, CcipRouterProgram)
-	EvmSourceChainStatePDA, _, _ = ccip.FindSourceChainStatePDA(EvmChainSelector, CcipRouterProgram)
-	EvmDestChainStatePDA, _, _   = ccip.FindDestChainStatePDA(EvmChainSelector, CcipRouterProgram)
+	SVMSourceChainStatePDA, _ = common.GetSourceChainStatePDA(SVMChainSelector, CcipRouterProgram)
+	SVMDestChainStatePDA, _   = common.GetDestChainStatePDA(SVMChainSelector, CcipRouterProgram)
+	EvmSourceChainStatePDA, _ = common.GetSourceChainStatePDA(EvmChainSelector, CcipRouterProgram)
+	EvmDestChainStatePDA, _   = common.GetDestChainStatePDA(EvmChainSelector, CcipRouterProgram)
 
 	OnRampAddress        = []byte{1, 2, 3}
 	OnRampAddressPadded  = [64]byte{1, 2, 3}

--- a/chains/solana/contracts/tests/config/ccip_config.go
+++ b/chains/solana/contracts/tests/config/ccip_config.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gagliardetto/solana-go/rpc"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
 )
 
 var (
@@ -18,22 +19,22 @@ var (
 	CcipTokenPoolProgram       = solana.MustPublicKeyFromBase58("GRvFSLwR7szpjgNEZbGe4HtxfJYXqySXuuRUAJDpu4WH")
 	Token2022Program           = solana.MustPublicKeyFromBase58("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb")
 
-	RouterConfigPDA, _, _                    = common.FindConfigPDA(CcipRouterProgram)
-	RouterStatePDA, _, _                     = common.FindStatePDA(CcipRouterProgram)
-	ExternalExecutionConfigPDA, _, _         = common.FindExternalExecutionConfigPDA(CcipRouterProgram)
-	ExternalTokenPoolsSignerPDA, _, _        = common.FindExternalTokenPoolsSignerPDA(CcipRouterProgram)
-	ReceiverTargetAccountPDA, _, _           = common.FindCounterPDA(CcipLogicReceiver)
-	ReceiverExternalExecutionConfigPDA, _, _ = common.FindExternalExecutionConfigPDA(CcipLogicReceiver)
-	BillingSignerPDA, _, _                   = common.FindFeeBillingSignerPDA(CcipRouterProgram)
+	RouterConfigPDA, _, _                    = state.FindConfigPDA(CcipRouterProgram)
+	RouterStatePDA, _, _                     = state.FindStatePDA(CcipRouterProgram)
+	ExternalExecutionConfigPDA, _, _         = state.FindExternalExecutionConfigPDA(CcipRouterProgram)
+	ExternalTokenPoolsSignerPDA, _, _        = state.FindExternalTokenPoolsSignerPDA(CcipRouterProgram)
+	ReceiverTargetAccountPDA, _, _           = solana.FindProgramAddress([][]byte{[]byte("counter")}, CcipLogicReceiver)
+	ReceiverExternalExecutionConfigPDA, _, _ = state.FindExternalExecutionConfigPDA(CcipLogicReceiver)
+	BillingSignerPDA, _, _                   = state.FindFeeBillingSignerPDA(CcipRouterProgram)
 
 	SVMChainSelector uint64 = 15
 	EvmChainSelector uint64 = 21
 	EvmChainLE              = common.Uint64ToLE(EvmChainSelector)
 
-	SVMSourceChainStatePDA, _ = common.GetSourceChainStatePDA(SVMChainSelector, CcipRouterProgram)
-	SVMDestChainStatePDA, _   = common.GetDestChainStatePDA(SVMChainSelector, CcipRouterProgram)
-	EvmSourceChainStatePDA, _ = common.GetSourceChainStatePDA(EvmChainSelector, CcipRouterProgram)
-	EvmDestChainStatePDA, _   = common.GetDestChainStatePDA(EvmChainSelector, CcipRouterProgram)
+	SVMSourceChainStatePDA, _ = state.FindSourceChainStatePDA(SVMChainSelector, CcipRouterProgram)
+	SVMDestChainStatePDA, _   = state.FindDestChainStatePDA(SVMChainSelector, CcipRouterProgram)
+	EvmSourceChainStatePDA, _ = state.FindSourceChainStatePDA(EvmChainSelector, CcipRouterProgram)
+	EvmDestChainStatePDA, _   = state.FindDestChainStatePDA(EvmChainSelector, CcipRouterProgram)
 
 	OnRampAddress        = []byte{1, 2, 3}
 	OnRampAddressPadded  = [64]byte{1, 2, 3}

--- a/chains/solana/contracts/tests/config/ccip_config.go
+++ b/chains/solana/contracts/tests/config/ccip_config.go
@@ -1,11 +1,10 @@
 package config
 
 import (
-	"encoding/binary"
-
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
 
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/ccip"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
 )
 
@@ -20,25 +19,22 @@ var (
 	CcipTokenPoolProgram       = solana.MustPublicKeyFromBase58("GRvFSLwR7szpjgNEZbGe4HtxfJYXqySXuuRUAJDpu4WH")
 	Token2022Program           = solana.MustPublicKeyFromBase58("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb")
 
-	RouterConfigPDA, _, _                    = solana.FindProgramAddress([][]byte{[]byte("config")}, CcipRouterProgram)
-	RouterStatePDA, _, _                     = solana.FindProgramAddress([][]byte{[]byte("state")}, CcipRouterProgram)
-	ExternalExecutionConfigPDA, _, _         = solana.FindProgramAddress([][]byte{[]byte("external_execution_config")}, CcipRouterProgram)
-	ExternalTokenPoolsSignerPDA, _, _        = solana.FindProgramAddress([][]byte{[]byte("external_token_pools_signer")}, CcipRouterProgram)
-	ReceiverTargetAccountPDA, _, _           = solana.FindProgramAddress([][]byte{[]byte("counter")}, CcipLogicReceiver)
-	ReceiverExternalExecutionConfigPDA, _, _ = solana.FindProgramAddress([][]byte{[]byte("external_execution_config")}, CcipLogicReceiver)
-	BillingSignerPDA, _, _                   = solana.FindProgramAddress([][]byte{[]byte("fee_billing_signer")}, CcipRouterProgram)
-
-	BillingTokenConfigPrefix = []byte("fee_billing_token_config")
-	DestChainConfigPrefix    = []byte("destination_billing_config")
+	RouterConfigPDA, _, _                    = common.FindConfigPDA(CcipRouterProgram)
+	RouterStatePDA, _, _                     = common.FindStatePDA(CcipRouterProgram)
+	ExternalExecutionConfigPDA, _, _         = common.FindExternalExecutionConfigPDA(CcipRouterProgram)
+	ExternalTokenPoolsSignerPDA, _, _        = common.FindExternalTokenPoolsSignerPDA(CcipRouterProgram)
+	ReceiverTargetAccountPDA, _, _           = common.FindCounterPDA(CcipLogicReceiver)
+	ReceiverExternalExecutionConfigPDA, _, _ = common.FindExternalExecutionConfigPDA(CcipLogicReceiver)
+	BillingSignerPDA, _, _                   = common.FindFeeBillingSignerPDA(CcipRouterProgram)
 
 	SVMChainSelector uint64 = 15
 	EvmChainSelector uint64 = 21
 	EvmChainLE              = common.Uint64ToLE(EvmChainSelector)
 
-	SVMSourceChainStatePDA, _, _ = solana.FindProgramAddress([][]byte{[]byte("source_chain_state"), binary.LittleEndian.AppendUint64([]byte{}, SVMChainSelector)}, CcipRouterProgram)
-	SVMDestChainStatePDA, _, _   = solana.FindProgramAddress([][]byte{[]byte("dest_chain_state"), binary.LittleEndian.AppendUint64([]byte{}, SVMChainSelector)}, CcipRouterProgram)
-	EvmSourceChainStatePDA, _, _ = solana.FindProgramAddress([][]byte{[]byte("source_chain_state"), binary.LittleEndian.AppendUint64([]byte{}, EvmChainSelector)}, CcipRouterProgram)
-	EvmDestChainStatePDA, _, _   = solana.FindProgramAddress([][]byte{[]byte("dest_chain_state"), binary.LittleEndian.AppendUint64([]byte{}, EvmChainSelector)}, CcipRouterProgram)
+	SVMSourceChainStatePDA, _, _ = ccip.FindSourceChainStatePDA(SVMChainSelector, CcipRouterProgram)
+	SVMDestChainStatePDA, _, _   = ccip.FindDestChainStatePDA(SVMChainSelector, CcipRouterProgram)
+	EvmSourceChainStatePDA, _, _ = ccip.FindSourceChainStatePDA(EvmChainSelector, CcipRouterProgram)
+	EvmDestChainStatePDA, _, _   = ccip.FindDestChainStatePDA(EvmChainSelector, CcipRouterProgram)
 
 	OnRampAddress        = []byte{1, 2, 3}
 	OnRampAddressPadded  = [64]byte{1, 2, 3}

--- a/chains/solana/utils/ccip/ccip_transactions.go
+++ b/chains/solana/utils/ccip/ccip_transactions.go
@@ -5,11 +5,9 @@ import (
 
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
-	"github.com/gagliardetto/solana-go"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/contracts/tests/config"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_router"
-	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/eth"
 )
 
@@ -34,28 +32,4 @@ func SignCommitReport(ctx [3][32]byte, report ccip_router.CommitInput, baseSigne
 		sigs = append(sigs, [65]byte(baseSig))
 	}
 	return sigs, nil
-}
-
-func GetSourceChainStatePDA(chainSelector uint64, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
-	chainSelectorLE := common.Uint64ToLE(chainSelector)
-	p, _, err := solana.FindProgramAddress([][]byte{[]byte("source_chain_state"), chainSelectorLE}, ccipRouterProgram)
-	return p, err
-}
-
-func GetDestChainStatePDA(chainSelector uint64, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
-	chainSelectorLE := common.Uint64ToLE(chainSelector)
-	p, _, err := solana.FindProgramAddress([][]byte{[]byte("dest_chain_state"), chainSelectorLE}, ccipRouterProgram)
-	return p, err
-}
-
-func GetCommitReportPDA(chainSelector uint64, root [32]byte, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
-	chainSelectorLE := common.Uint64ToLE(chainSelector)
-	p, _, err := solana.FindProgramAddress([][]byte{[]byte("commit_report"), chainSelectorLE, root[:]}, ccipRouterProgram)
-	return p, err
-}
-
-func GetNoncePDA(chainSelector uint64, user solana.PublicKey, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
-	chainSelectorLE := common.Uint64ToLE(chainSelector)
-	p, _, err := solana.FindProgramAddress([][]byte{[]byte("nonce"), chainSelectorLE, user.Bytes()}, ccipRouterProgram)
-	return p, err
 }

--- a/chains/solana/utils/ccip/ccip_transactions.go
+++ b/chains/solana/utils/ccip/ccip_transactions.go
@@ -36,26 +36,26 @@ func SignCommitReport(ctx [3][32]byte, report ccip_router.CommitInput, baseSigne
 	return sigs, nil
 }
 
-func GetSourceChainStatePDA(chainSelector uint64) (solana.PublicKey, error) {
+func GetSourceChainStatePDA(chainSelector uint64, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
 	chainSelectorLE := common.Uint64ToLE(chainSelector)
-	p, _, err := solana.FindProgramAddress([][]byte{[]byte("source_chain_state"), chainSelectorLE}, config.CcipRouterProgram)
+	p, _, err := solana.FindProgramAddress([][]byte{[]byte("source_chain_state"), chainSelectorLE}, ccipRouterProgram)
 	return p, err
 }
 
-func GetDestChainStatePDA(chainSelector uint64) (solana.PublicKey, error) {
+func GetDestChainStatePDA(chainSelector uint64, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
 	chainSelectorLE := common.Uint64ToLE(chainSelector)
-	p, _, err := solana.FindProgramAddress([][]byte{[]byte("dest_chain_state"), chainSelectorLE}, config.CcipRouterProgram)
+	p, _, err := solana.FindProgramAddress([][]byte{[]byte("dest_chain_state"), chainSelectorLE}, ccipRouterProgram)
 	return p, err
 }
 
-func GetCommitReportPDA(chainSelector uint64, root [32]byte) (solana.PublicKey, error) {
+func GetCommitReportPDA(chainSelector uint64, root [32]byte, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
 	chainSelectorLE := common.Uint64ToLE(chainSelector)
-	p, _, err := solana.FindProgramAddress([][]byte{[]byte("commit_report"), chainSelectorLE, root[:]}, config.CcipRouterProgram)
+	p, _, err := solana.FindProgramAddress([][]byte{[]byte("commit_report"), chainSelectorLE, root[:]}, ccipRouterProgram)
 	return p, err
 }
 
-func GetNoncePDA(chainSelector uint64, user solana.PublicKey) (solana.PublicKey, error) {
+func GetNoncePDA(chainSelector uint64, user solana.PublicKey, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
 	chainSelectorLE := common.Uint64ToLE(chainSelector)
-	p, _, err := solana.FindProgramAddress([][]byte{[]byte("nonce"), chainSelectorLE, user.Bytes()}, config.CcipRouterProgram)
+	p, _, err := solana.FindProgramAddress([][]byte{[]byte("nonce"), chainSelectorLE, user.Bytes()}, ccipRouterProgram)
 	return p, err
 }

--- a/chains/solana/utils/common/lookuptable.go
+++ b/chains/solana/utils/common/lookuptable.go
@@ -29,10 +29,7 @@ func NewCreateLookupTableInstruction(
 	funder solana.PublicKey,
 	slot uint64,
 ) (solana.PublicKey, solana.Instruction, error) {
-	// https://github.com/solana-labs/solana-web3.js/blob/c1c98715b0c7900ce37c59bffd2056fa0037213d/src/programs/address-lookup-table/index.ts#L274
-	slotLE := make([]byte, 8)
-	binary.LittleEndian.PutUint64(slotLE, slot)
-	account, bumpSeed, err := solana.FindProgramAddress([][]byte{authority.Bytes(), slotLE}, AddressLookupTableProgram)
+	account, bumpSeed, err := FindLookupTablePDA(authority, slot)
 	if err != nil {
 		return solana.PublicKey{}, nil, err
 	}
@@ -154,4 +151,11 @@ func GetAddressLookupTable(ctx context.Context, client *rpc.Client, lookupTableP
 	}
 
 	return lookupTableState.Addresses, nil
+}
+
+// https://github.com/solana-labs/solana-web3.js/blob/c1c98715b0c7900ce37c59bffd2056fa0037213d/src/programs/address-lookup-table/index.ts#L274
+func FindLookupTablePDA(authority solana.PublicKey, slot uint64) (solana.PublicKey, uint8, error) {
+	slotLE := make([]byte, 8)
+	binary.LittleEndian.PutUint64(slotLE, slot)
+	return solana.FindProgramAddress([][]byte{authority.Bytes(), slotLE}, AddressLookupTableProgram)
 }

--- a/chains/solana/utils/common/pda.go
+++ b/chains/solana/utils/common/pda.go
@@ -1,49 +1,40 @@
 package common
 
 import (
-	"encoding/binary"
-
 	"github.com/gagliardetto/solana-go"
 )
 
-func FindConfigPDA(programID solana.PublicKey) (solana.PublicKey, uint8, error) {
-	return solana.FindProgramAddress([][]byte{[]byte("config")}, programID)
+func FindConfigPDA(ccipRouterProgram solana.PublicKey) (solana.PublicKey, uint8, error) {
+	return solana.FindProgramAddress([][]byte{[]byte("config")}, ccipRouterProgram)
 }
 
-func FindStatePDA(programID solana.PublicKey) (solana.PublicKey, uint8, error) {
-	return solana.FindProgramAddress([][]byte{[]byte("state")}, programID)
+func FindStatePDA(ccipRouterProgram solana.PublicKey) (solana.PublicKey, uint8, error) {
+	return solana.FindProgramAddress([][]byte{[]byte("state")}, ccipRouterProgram)
 }
 
-func FindExternalExecutionConfigPDA(programID solana.PublicKey) (solana.PublicKey, uint8, error) {
-	return solana.FindProgramAddress([][]byte{[]byte("external_execution_config")}, programID)
+func FindExternalExecutionConfigPDA(ccipRouterProgram solana.PublicKey) (solana.PublicKey, uint8, error) {
+	return solana.FindProgramAddress([][]byte{[]byte("external_execution_config")}, ccipRouterProgram)
 }
 
-func FindExternalTokenPoolsSignerPDA(programID solana.PublicKey) (solana.PublicKey, uint8, error) {
-	return solana.FindProgramAddress([][]byte{[]byte("external_token_pools_signer")}, programID)
+func FindExternalTokenPoolsSignerPDA(ccipRouterProgram solana.PublicKey) (solana.PublicKey, uint8, error) {
+	return solana.FindProgramAddress([][]byte{[]byte("external_token_pools_signer")}, ccipRouterProgram)
 }
 
-func FindCounterPDA(programID solana.PublicKey) (solana.PublicKey, uint8, error) {
-	return solana.FindProgramAddress([][]byte{[]byte("counter")}, programID)
+func FindFeeBillingSignerPDA(ccipRouterProgram solana.PublicKey) (solana.PublicKey, uint8, error) {
+	return solana.FindProgramAddress([][]byte{[]byte("fee_billing_signer")}, ccipRouterProgram)
 }
 
-func FindFeeBillingSignerPDA(programID solana.PublicKey) (solana.PublicKey, uint8, error) {
-	return solana.FindProgramAddress([][]byte{[]byte("fee_billing_signer")}, programID)
+func FindTokenAdminRegistryPDA(mint, ccipRouterProgram solana.PublicKey) (solana.PublicKey, uint8, error) {
+	return solana.FindProgramAddress([][]byte{[]byte("token_admin_registry"), mint.Bytes()}, ccipRouterProgram)
 }
 
-func FindTokenAdminRegistryPDA(programID, mint solana.PublicKey) (solana.PublicKey, uint8, error) {
-	return solana.FindProgramAddress([][]byte{[]byte("token_admin_registry"), mint.Bytes()}, programID)
+func FindFeeBillingTokenConfigPDA(mint, ccipRouterProgram solana.PublicKey) (solana.PublicKey, uint8, error) {
+	return solana.FindProgramAddress([][]byte{[]byte("fee_billing_token_config"), mint.Bytes()}, ccipRouterProgram)
 }
 
-func FindFeeBillingTokenConfigPDA(programID, mint solana.PublicKey) (solana.PublicKey, uint8, error) {
-	return solana.FindProgramAddress([][]byte{[]byte("fee_billing_token_config"), mint.Bytes()}, programID)
-}
-
-func FindCcipTokenpoolBillingPDA(programID, mint solana.PublicKey, chainSelector uint64) (solana.PublicKey, uint8, error) {
-	return solana.FindProgramAddress([][]byte{[]byte("ccip_tokenpool_billing"), binary.LittleEndian.AppendUint64([]byte{}, chainSelector), mint.Bytes()}, programID)
-}
-
-func FindCcipTokenpoolChainconfigPDA(programID, mint solana.PublicKey, chainSelector uint64) (solana.PublicKey, uint8, error) {
-	return solana.FindProgramAddress([][]byte{[]byte("ccip_tokenpool_chainconfig"), binary.LittleEndian.AppendUint64([]byte{}, chainSelector), mint.Bytes()}, programID)
+func FindCcipTokenpoolBillingPDA(chainSelector uint64, mint, ccipRouterProgram solana.PublicKey) (solana.PublicKey, uint8, error) {
+	chainSelectorLE := Uint64ToLE(chainSelector)
+	return solana.FindProgramAddress([][]byte{[]byte("ccip_tokenpool_billing"), chainSelectorLE, mint.Bytes()}, ccipRouterProgram)
 }
 
 func GetSourceChainStatePDA(chainSelector uint64, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
@@ -64,8 +55,14 @@ func GetCommitReportPDA(chainSelector uint64, root [32]byte, ccipRouterProgram s
 	return p, err
 }
 
-func GetNoncePDA(chainSelector uint64, user solana.PublicKey, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
+func GetNoncePDA(chainSelector uint64, user, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
 	chainSelectorLE := Uint64ToLE(chainSelector)
 	p, _, err := solana.FindProgramAddress([][]byte{[]byte("nonce"), chainSelectorLE, user.Bytes()}, ccipRouterProgram)
 	return p, err
+}
+
+// Test Code
+
+func FindCounterPDA(ccipReceiverProgram solana.PublicKey) (solana.PublicKey, uint8, error) {
+	return solana.FindProgramAddress([][]byte{[]byte("counter")}, ccipReceiverProgram)
 }

--- a/chains/solana/utils/common/pda.go
+++ b/chains/solana/utils/common/pda.go
@@ -45,3 +45,27 @@ func FindCcipTokenpoolBillingPDA(programID, mint solana.PublicKey, chainSelector
 func FindCcipTokenpoolChainconfigPDA(programID, mint solana.PublicKey, chainSelector uint64) (solana.PublicKey, uint8, error) {
 	return solana.FindProgramAddress([][]byte{[]byte("ccip_tokenpool_chainconfig"), binary.LittleEndian.AppendUint64([]byte{}, chainSelector), mint.Bytes()}, programID)
 }
+
+func GetSourceChainStatePDA(chainSelector uint64, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
+	chainSelectorLE := Uint64ToLE(chainSelector)
+	p, _, err := solana.FindProgramAddress([][]byte{[]byte("source_chain_state"), chainSelectorLE}, ccipRouterProgram)
+	return p, err
+}
+
+func GetDestChainStatePDA(chainSelector uint64, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
+	chainSelectorLE := Uint64ToLE(chainSelector)
+	p, _, err := solana.FindProgramAddress([][]byte{[]byte("dest_chain_state"), chainSelectorLE}, ccipRouterProgram)
+	return p, err
+}
+
+func GetCommitReportPDA(chainSelector uint64, root [32]byte, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
+	chainSelectorLE := Uint64ToLE(chainSelector)
+	p, _, err := solana.FindProgramAddress([][]byte{[]byte("commit_report"), chainSelectorLE, root[:]}, ccipRouterProgram)
+	return p, err
+}
+
+func GetNoncePDA(chainSelector uint64, user solana.PublicKey, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
+	chainSelectorLE := Uint64ToLE(chainSelector)
+	p, _, err := solana.FindProgramAddress([][]byte{[]byte("nonce"), chainSelectorLE, user.Bytes()}, ccipRouterProgram)
+	return p, err
+}

--- a/chains/solana/utils/common/pda.go
+++ b/chains/solana/utils/common/pda.go
@@ -1,0 +1,47 @@
+package common
+
+import (
+	"encoding/binary"
+
+	"github.com/gagliardetto/solana-go"
+)
+
+func FindConfigPDA(programID solana.PublicKey) (solana.PublicKey, uint8, error) {
+	return solana.FindProgramAddress([][]byte{[]byte("config")}, programID)
+}
+
+func FindStatePDA(programID solana.PublicKey) (solana.PublicKey, uint8, error) {
+	return solana.FindProgramAddress([][]byte{[]byte("state")}, programID)
+}
+
+func FindExternalExecutionConfigPDA(programID solana.PublicKey) (solana.PublicKey, uint8, error) {
+	return solana.FindProgramAddress([][]byte{[]byte("external_execution_config")}, programID)
+}
+
+func FindExternalTokenPoolsSignerPDA(programID solana.PublicKey) (solana.PublicKey, uint8, error) {
+	return solana.FindProgramAddress([][]byte{[]byte("external_token_pools_signer")}, programID)
+}
+
+func FindCounterPDA(programID solana.PublicKey) (solana.PublicKey, uint8, error) {
+	return solana.FindProgramAddress([][]byte{[]byte("counter")}, programID)
+}
+
+func FindFeeBillingSignerPDA(programID solana.PublicKey) (solana.PublicKey, uint8, error) {
+	return solana.FindProgramAddress([][]byte{[]byte("fee_billing_signer")}, programID)
+}
+
+func FindTokenAdminRegistryPDA(programID, mint solana.PublicKey) (solana.PublicKey, uint8, error) {
+	return solana.FindProgramAddress([][]byte{[]byte("token_admin_registry"), mint.Bytes()}, programID)
+}
+
+func FindFeeBillingTokenConfigPDA(programID, mint solana.PublicKey) (solana.PublicKey, uint8, error) {
+	return solana.FindProgramAddress([][]byte{[]byte("fee_billing_token_config"), mint.Bytes()}, programID)
+}
+
+func FindCcipTokenpoolBillingPDA(programID, mint solana.PublicKey, chainSelector uint64) (solana.PublicKey, uint8, error) {
+	return solana.FindProgramAddress([][]byte{[]byte("ccip_tokenpool_billing"), binary.LittleEndian.AppendUint64([]byte{}, chainSelector), mint.Bytes()}, programID)
+}
+
+func FindCcipTokenpoolChainconfigPDA(programID, mint solana.PublicKey, chainSelector uint64) (solana.PublicKey, uint8, error) {
+	return solana.FindProgramAddress([][]byte{[]byte("ccip_tokenpool_chainconfig"), binary.LittleEndian.AppendUint64([]byte{}, chainSelector), mint.Bytes()}, programID)
+}

--- a/chains/solana/utils/state/pda.go
+++ b/chains/solana/utils/state/pda.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"github.com/gagliardetto/solana-go"
+
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
 )
 

--- a/chains/solana/utils/state/pda.go
+++ b/chains/solana/utils/state/pda.go
@@ -1,7 +1,8 @@
-package common
+package state
 
 import (
 	"github.com/gagliardetto/solana-go"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
 )
 
 func FindConfigPDA(ccipRouterProgram solana.PublicKey) (solana.PublicKey, uint8, error) {
@@ -24,45 +25,39 @@ func FindFeeBillingSignerPDA(ccipRouterProgram solana.PublicKey) (solana.PublicK
 	return solana.FindProgramAddress([][]byte{[]byte("fee_billing_signer")}, ccipRouterProgram)
 }
 
-func FindTokenAdminRegistryPDA(mint, ccipRouterProgram solana.PublicKey) (solana.PublicKey, uint8, error) {
+func FindTokenAdminRegistryPDA(mint solana.PublicKey, ccipRouterProgram solana.PublicKey) (solana.PublicKey, uint8, error) {
 	return solana.FindProgramAddress([][]byte{[]byte("token_admin_registry"), mint.Bytes()}, ccipRouterProgram)
 }
 
-func FindFeeBillingTokenConfigPDA(mint, ccipRouterProgram solana.PublicKey) (solana.PublicKey, uint8, error) {
+func FindFeeBillingTokenConfigPDA(mint solana.PublicKey, ccipRouterProgram solana.PublicKey) (solana.PublicKey, uint8, error) {
 	return solana.FindProgramAddress([][]byte{[]byte("fee_billing_token_config"), mint.Bytes()}, ccipRouterProgram)
 }
 
-func FindCcipTokenpoolBillingPDA(chainSelector uint64, mint, ccipRouterProgram solana.PublicKey) (solana.PublicKey, uint8, error) {
-	chainSelectorLE := Uint64ToLE(chainSelector)
+func FindCcipTokenpoolBillingPDA(chainSelector uint64, mint solana.PublicKey, ccipRouterProgram solana.PublicKey) (solana.PublicKey, uint8, error) {
+	chainSelectorLE := common.Uint64ToLE(chainSelector)
 	return solana.FindProgramAddress([][]byte{[]byte("ccip_tokenpool_billing"), chainSelectorLE, mint.Bytes()}, ccipRouterProgram)
 }
 
-func GetSourceChainStatePDA(chainSelector uint64, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
-	chainSelectorLE := Uint64ToLE(chainSelector)
+func FindSourceChainStatePDA(chainSelector uint64, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
+	chainSelectorLE := common.Uint64ToLE(chainSelector)
 	p, _, err := solana.FindProgramAddress([][]byte{[]byte("source_chain_state"), chainSelectorLE}, ccipRouterProgram)
 	return p, err
 }
 
-func GetDestChainStatePDA(chainSelector uint64, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
-	chainSelectorLE := Uint64ToLE(chainSelector)
+func FindDestChainStatePDA(chainSelector uint64, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
+	chainSelectorLE := common.Uint64ToLE(chainSelector)
 	p, _, err := solana.FindProgramAddress([][]byte{[]byte("dest_chain_state"), chainSelectorLE}, ccipRouterProgram)
 	return p, err
 }
 
-func GetCommitReportPDA(chainSelector uint64, root [32]byte, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
-	chainSelectorLE := Uint64ToLE(chainSelector)
+func FindCommitReportPDA(chainSelector uint64, root [32]byte, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
+	chainSelectorLE := common.Uint64ToLE(chainSelector)
 	p, _, err := solana.FindProgramAddress([][]byte{[]byte("commit_report"), chainSelectorLE, root[:]}, ccipRouterProgram)
 	return p, err
 }
 
-func GetNoncePDA(chainSelector uint64, user, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
-	chainSelectorLE := Uint64ToLE(chainSelector)
+func FindNoncePDA(chainSelector uint64, user solana.PublicKey, ccipRouterProgram solana.PublicKey) (solana.PublicKey, error) {
+	chainSelectorLE := common.Uint64ToLE(chainSelector)
 	p, _, err := solana.FindProgramAddress([][]byte{[]byte("nonce"), chainSelectorLE, user.Bytes()}, ccipRouterProgram)
 	return p, err
-}
-
-// Test Code
-
-func FindCounterPDA(ccipReceiverProgram solana.PublicKey) (solana.PublicKey, uint8, error) {
-	return solana.FindProgramAddress([][]byte{[]byte("counter")}, ccipReceiverProgram)
 }

--- a/chains/solana/utils/tokens/tokenpool.go
+++ b/chains/solana/utils/tokens/tokenpool.go
@@ -12,6 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/ccip_router"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
 )
 
 type TokenPool struct {
@@ -61,7 +62,7 @@ func NewTokenPool(program solana.PublicKey) (TokenPool, error) {
 	if err != nil {
 		return TokenPool{}, err
 	}
-	tokenAdminRegistryPDA, _, err := common.FindTokenAdminRegistryPDA(mint.PublicKey(), config.CcipRouterProgram)
+	tokenAdminRegistryPDA, _, err := state.FindTokenAdminRegistryPDA(mint.PublicKey(), config.CcipRouterProgram)
 	if err != nil {
 		return TokenPool{}, err
 	}
@@ -71,11 +72,11 @@ func NewTokenPool(program solana.PublicKey) (TokenPool, error) {
 	if err != nil {
 		return TokenPool{}, err
 	}
-	billingPDA, _, err := common.FindCcipTokenpoolBillingPDA(config.EvmChainSelector, mint.PublicKey(), config.CcipRouterProgram)
+	billingPDA, _, err := state.FindCcipTokenpoolBillingPDA(config.EvmChainSelector, mint.PublicKey(), config.CcipRouterProgram)
 	if err != nil {
 		return TokenPool{}, err
 	}
-	tokenConfigPda, _, err := common.FindFeeBillingTokenConfigPDA(mint.PublicKey(), config.CcipRouterProgram)
+	tokenConfigPda, _, err := state.FindFeeBillingTokenConfigPDA(mint.PublicKey(), config.CcipRouterProgram)
 	if err != nil {
 		return TokenPool{}, err
 	}

--- a/chains/solana/utils/tokens/tokenpool.go
+++ b/chains/solana/utils/tokens/tokenpool.go
@@ -67,7 +67,7 @@ func NewTokenPool(program solana.PublicKey) (TokenPool, error) {
 	}
 
 	// preload with defined config.EvmChainSelector
-	chainPDA, _, err := common.FindCcipTokenpoolChainconfigPDA(config.CcipRouterProgram, mint.PublicKey(), config.EvmChainSelector)
+	chainPDA, _, err := common.FindCcipTokenpoolChainconfigPDA(config.CcipTokenPoolProgram, mint.PublicKey(), config.EvmChainSelector)
 	if err != nil {
 		return TokenPool{}, err
 	}


### PR DESCRIPTION
We want to re-use all PDA fetching logic as part of deployments/tooling. If we parameterize the program IDs as part of every fetch, we can import and re-use this elsewhere.