### PR TITLE
[CCIP-4938] Use map instead of slice in token price observations and outcome

### DIFF
--- a/commit/factory.go
+++ b/commit/factory.go
@@ -39,7 +39,7 @@ const (
 	// Estimated maximum number of priced tokens that the Commit DON supports.
 	// This value does not indicate a system limitation but just an estimation to properly tune the OCR parameters.
 	// The value can be adjusted as needed.
-	estimatedMaxNumberOfPricedTokens = 10_000
+	estimatedMaxNumberOfPricedTokens = 14_445
 
 	// maxQueryLength is set to twice the maximum size of a theoretical merkle root processor query
 	// that assumes estimatedMaxNumberOfSourceChains source chains and
@@ -57,7 +57,7 @@ const (
 
 	// maxReportLength is set to an estimate of a maximum report size
 	// check factory_test for the calculation
-	maxReportLength = 993_982
+	maxReportLength = 128_2900
 
 	// maxReportCount is set to 1 because the commit plugin only generates one report per round.
 	maxReportCount = 1

--- a/commit/metrics/prom_test.go
+++ b/commit/metrics/prom_test.go
@@ -49,7 +49,6 @@ func Test_TrackingTokenPrices(t *testing.T) {
 			name: "data is properly reported",
 			observation: tokenprice.Observation{
 				FeedTokenPrices: cciptypes.TokenPriceMap{
-					//cciptypes.UnknownEncodedAddress("0x123"): cciptypes.NewBigInt(big.NewInt(1)),
 					cciptypes.UnknownEncodedAddress("0x123"): {},
 					cciptypes.UnknownEncodedAddress("0x456"): {},
 				},

--- a/commit/metrics/prom_test.go
+++ b/commit/metrics/prom_test.go
@@ -39,7 +39,7 @@ func Test_TrackingTokenPrices(t *testing.T) {
 		{
 			name: "empty/missing structs should not report anything",
 			observation: tokenprice.Observation{
-				FeedTokenPrices:       []cciptypes.TokenPrice{},
+				FeedTokenPrices:       nil,
 				FeeQuoterTokenUpdates: nil,
 			},
 			expectedFeedToken:      0,
@@ -48,13 +48,10 @@ func Test_TrackingTokenPrices(t *testing.T) {
 		{
 			name: "data is properly reported",
 			observation: tokenprice.Observation{
-				FeedTokenPrices: []cciptypes.TokenPrice{
-					{
-						TokenID: cciptypes.UnknownEncodedAddress("0x123"),
-					},
-					{
-						TokenID: cciptypes.UnknownEncodedAddress("0x456"),
-					},
+				FeedTokenPrices: cciptypes.TokenPriceMap{
+					//cciptypes.UnknownEncodedAddress("0x123"): cciptypes.NewBigInt(big.NewInt(1)),
+					cciptypes.UnknownEncodedAddress("0x123"): {},
+					cciptypes.UnknownEncodedAddress("0x456"): {},
 				},
 				FeeQuoterTokenUpdates: map[cciptypes.UnknownEncodedAddress]plugintypes.TimestampedBig{
 					cciptypes.UnknownEncodedAddress("0x123"): {},
@@ -90,7 +87,7 @@ func Test_TrackingTokenPrices(t *testing.T) {
 		{
 			name: "empty/missing structs should not report anything",
 			outcome: tokenprice.Outcome{
-				TokenPrices: []cciptypes.TokenPrice{},
+				TokenPrices: cciptypes.TokenPriceMap{},
 			},
 			expectedTokenPrices: 0,
 		},
@@ -104,10 +101,10 @@ func Test_TrackingTokenPrices(t *testing.T) {
 		{
 			name: "data is properly reported",
 			outcome: tokenprice.Outcome{
-				TokenPrices: []cciptypes.TokenPrice{
-					cciptypes.NewTokenPrice("0x123", big.NewInt(1)),
-					cciptypes.NewTokenPrice("0x234", big.NewInt(2)),
-					cciptypes.NewTokenPrice("0x123", big.NewInt(3)),
+				TokenPrices: cciptypes.TokenPriceMap{
+					cciptypes.UnknownEncodedAddress("0x123"): cciptypes.NewBigIntFromInt64(1),
+					cciptypes.UnknownEncodedAddress("0x234"): cciptypes.NewBigIntFromInt64(2),
+					cciptypes.UnknownEncodedAddress("0x125"): cciptypes.NewBigIntFromInt64(3),
 				},
 			},
 			expectedTokenPrices: 3,

--- a/commit/plugin_e2e_test.go
+++ b/commit/plugin_e2e_test.go
@@ -274,8 +274,11 @@ func TestPlugin_E2E_AllNodesAgree_TokenPrices(t *testing.T) {
 			prevOutcome: committypes.Outcome{},
 			mockPriceReader: func(m *readerpkg_mock.MockPriceReader) {
 				m.EXPECT().
-					// tokens need to be ordered, plugin checks all tokens from commit offchain config
-					GetFeedPricesUSD(mock.Anything, []ccipocr3.UnknownEncodedAddress{arbAddr, ethAddr}).
+					GetFeedPricesUSD(mock.Anything, mock.MatchedBy(func(tokens []ccipocr3.UnknownEncodedAddress) bool {
+						expectedTokens := mapset.NewSet(arbAddr, ethAddr)
+						actualTokens := mapset.NewSet(tokens...)
+						return expectedTokens.Equal(actualTokens)
+					})).
 					Return(ccipocr3.TokenPriceMap{
 						arbAddr: ccipocr3.NewBigInt(arbPrice),
 						ethAddr: ccipocr3.NewBigInt(ethPrice),
@@ -330,8 +333,11 @@ func TestPlugin_E2E_AllNodesAgree_TokenPrices(t *testing.T) {
 			prevOutcome: committypes.Outcome{},
 			mockPriceReader: func(m *readerpkg_mock.MockPriceReader) {
 				m.EXPECT().
-					// tokens need to be ordered, plugin checks all tokens from commit offchain config
-					GetFeedPricesUSD(mock.Anything, []ccipocr3.UnknownEncodedAddress{arbAddr, ethAddr}).
+					GetFeedPricesUSD(mock.Anything, mock.MatchedBy(func(tokens []ccipocr3.UnknownEncodedAddress) bool {
+						expectedTokens := mapset.NewSet(arbAddr, ethAddr)
+						actualTokens := mapset.NewSet(tokens...)
+						return expectedTokens.Equal(actualTokens)
+					})).
 					Return(ccipocr3.TokenPriceMap{
 						arbAddr: ccipocr3.NewBigInt(arbPrice),
 						ethAddr: ccipocr3.NewBigInt(ethPrice),
@@ -360,7 +366,11 @@ func TestPlugin_E2E_AllNodesAgree_TokenPrices(t *testing.T) {
 			mockPriceReader: func(m *readerpkg_mock.MockPriceReader) {
 				m.EXPECT().
 					// tokens need to be ordered, plugin checks all tokens from commit offchain config
-					GetFeedPricesUSD(mock.Anything, []ccipocr3.UnknownEncodedAddress{arbAddr, ethAddr}).
+					GetFeedPricesUSD(mock.Anything, mock.MatchedBy(func(tokens []ccipocr3.UnknownEncodedAddress) bool {
+						expectedTokens := mapset.NewSet(arbAddr, ethAddr)
+						actualTokens := mapset.NewSet(tokens...)
+						return expectedTokens.Equal(actualTokens)
+					})).
 					Return(ccipocr3.TokenPriceMap{
 						arbAddr: ccipocr3.NewBigInt(arbPrice),
 						ethAddr: ccipocr3.NewBigInt(ethPrice),

--- a/commit/plugin_e2e_test.go
+++ b/commit/plugin_e2e_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/mathslib"
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/testhelpers/rand"
 
-	"golang.org/x/exp/maps"
-
 	mapset "github.com/deckarep/golang-set/v2"
 
 	"github.com/stretchr/testify/assert"
@@ -258,13 +256,6 @@ func TestPlugin_E2E_AllNodesAgree_MerkleRoots(t *testing.T) {
 
 func TestPlugin_E2E_AllNodesAgree_TokenPrices(t *testing.T) {
 	params := defaultNodeParams(t)
-
-	tokensToQuery := maps.Keys(params.offchainCfg.TokenInfo)
-	sort.Slice(tokensToQuery, func(i, j int) bool { return tokensToQuery[i] < tokensToQuery[j] })
-	//orderedTokenPrices := make([]ccipocr3.TokenPrice, 0, len(tokensToQuery))
-	//for _, token := range tokensToQuery {
-	//	orderedTokenPrices = append(orderedTokenPrices, tokenPriceMap[token])
-	//}
 
 	nodes := make([]ocr3types.ReportingPlugin[[]byte], len(oracleIDs))
 

--- a/commit/report.go
+++ b/commit/report.go
@@ -66,7 +66,7 @@ func (p *Plugin) Reports(
 	rep = cciptypes.CommitPluginReport{
 		MerkleRoots: outcome.MerkleRootOutcome.RootsToReport,
 		PriceUpdates: cciptypes.PriceUpdates{
-			TokenPriceUpdates: outcome.TokenPriceOutcome.TokenPrices,
+			TokenPriceUpdates: outcome.TokenPriceOutcome.TokenPrices.ToSortedSlice(),
 			GasPriceUpdates:   outcome.ChainFeeOutcome.GasPrices,
 		},
 		RMNSignatures: outcome.MerkleRootOutcome.RMNReportSignatures,

--- a/commit/report_test.go
+++ b/commit/report_test.go
@@ -56,8 +56,8 @@ func TestPluginReports(t *testing.T) {
 					OutcomeType: merkleroot.ReportTransmissionFailed,
 				},
 				TokenPriceOutcome: tokenprice.Outcome{
-					TokenPrices: []ccipocr3.TokenPrice{
-						{TokenID: "a", Price: ccipocr3.NewBigIntFromInt64(123)},
+					TokenPrices: ccipocr3.TokenPriceMap{
+						"a": ccipocr3.NewBigIntFromInt64(123),
 					},
 				},
 				ChainFeeOutcome: chainfee.Outcome{
@@ -120,8 +120,8 @@ func TestPluginReports(t *testing.T) {
 					RMNRemoteCfg: rmntypes.RemoteConfig{FSign: 123},
 				},
 				TokenPriceOutcome: tokenprice.Outcome{
-					TokenPrices: []ccipocr3.TokenPrice{
-						{TokenID: "a", Price: ccipocr3.NewBigIntFromInt64(123)},
+					TokenPrices: ccipocr3.TokenPriceMap{
+						"a": ccipocr3.NewBigIntFromInt64(123),
 					},
 				},
 				ChainFeeOutcome: chainfee.Outcome{

--- a/commit/tokenprice/observation.go
+++ b/commit/tokenprice/observation.go
@@ -55,22 +55,21 @@ func (p *processor) ObserveFChain(lggr logger.Logger) map[cciptypes.ChainSelecto
 	return fChain
 }
 
-func (p *processor) ObserveFeedTokenPrices(ctx context.Context, lggr logger.Logger) []cciptypes.TokenPrice {
+func (p *processor) ObserveFeedTokenPrices(ctx context.Context, lggr logger.Logger) cciptypes.TokenPriceMap {
 	if p.tokenPriceReader == nil {
 		lggr.Debugw("no token price reader available")
-		return []cciptypes.TokenPrice{}
+		return cciptypes.TokenPriceMap{}
 	}
 
 	supportedChains, err := p.chainSupport.SupportedChains(p.oracleID)
 	if err != nil {
 		lggr.Warnw("call to SupportedChains failed", "err", err)
-		return []cciptypes.TokenPrice{}
+		return cciptypes.TokenPriceMap{}
 	}
 
 	if !supportedChains.Contains(p.offChainCfg.PriceFeedChainSelector) {
 		lggr.Debugf("oracle does not support feed chain %d", p.offChainCfg.PriceFeedChainSelector)
-		return []cciptypes.TokenPrice{}
-
+		return cciptypes.TokenPriceMap{}
 	}
 
 	tokensToQuery := maps.Keys(p.offChainCfg.TokenInfo)
@@ -81,17 +80,10 @@ func (p *processor) ObserveFeedTokenPrices(ctx context.Context, lggr logger.Logg
 	if err != nil {
 		lggr.Errorw("call to GetFeedPricesUSD failed",
 			"err", err)
-		return []cciptypes.TokenPrice{}
+		return cciptypes.TokenPriceMap{}
 	}
 
-	tokenPricesUSD := make([]cciptypes.TokenPrice, 0, len(tokenPrices))
-	for _, token := range tokensToQuery {
-		if tokenPrices[token] != nil {
-			tokenPricesUSD = append(tokenPricesUSD, cciptypes.NewTokenPrice(token, tokenPrices[token]))
-		}
-	}
-
-	return tokenPricesUSD
+	return tokenPrices
 }
 
 func (p *processor) ObserveFeeQuoterTokenUpdates(

--- a/commit/tokenprice/observation.go
+++ b/commit/tokenprice/observation.go
@@ -73,8 +73,6 @@ func (p *processor) ObserveFeedTokenPrices(ctx context.Context, lggr logger.Logg
 	}
 
 	tokensToQuery := maps.Keys(p.offChainCfg.TokenInfo)
-	// sort tokens to query to ensure deterministic order
-	sort.Slice(tokensToQuery, func(i, j int) bool { return tokensToQuery[i] < tokensToQuery[j] })
 	lggr.Infow("observing feed token prices", "tokens", tokensToQuery)
 	tokenPrices, err := p.tokenPriceReader.GetFeedPricesUSD(ctx, tokensToQuery)
 	if err != nil {

--- a/commit/tokenprice/observation_test.go
+++ b/commit/tokenprice/observation_test.go
@@ -50,10 +50,14 @@ func Test_Observation(t *testing.T) {
 				chainSupport.EXPECT().SupportedChains(mock.Anything).Return(
 					mapset.NewSet[cciptypes.ChainSelector](feedChainSel, destChainSel), nil,
 				)
-				chainSupport.EXPECT().SupportsDestChain(mock.Anything).Return(true, nil)
+				chainSupport.EXPECT().SupportsDestChain(mock.Anything).Return(true, nil).Maybe()
 
 				tokenPriceReader := readerpkg_mock.NewMockPriceReader(t)
-				tokenPriceReader.EXPECT().GetFeedPricesUSD(mock.Anything, []cciptypes.UnknownEncodedAddress{tokenA, tokenB}).
+				tokenPriceReader.EXPECT().GetFeedPricesUSD(mock.Anything, mock.MatchedBy(func(tokens []cciptypes.UnknownEncodedAddress) bool {
+					expectedTokens := mapset.NewSet(tokenA, tokenB)
+					actualTokens := mapset.NewSet(tokens...)
+					return expectedTokens.Equal(actualTokens)
+				})).
 					Return(cciptypes.TokenPriceMap{
 						tokenA: cciptypes.NewBigInt(bi100),
 						tokenB: cciptypes.NewBigInt(bi200)}, nil)

--- a/commit/tokenprice/observation_test.go
+++ b/commit/tokenprice/observation_test.go
@@ -53,11 +53,12 @@ func Test_Observation(t *testing.T) {
 				chainSupport.EXPECT().SupportsDestChain(mock.Anything).Return(true, nil).Maybe()
 
 				tokenPriceReader := readerpkg_mock.NewMockPriceReader(t)
-				tokenPriceReader.EXPECT().GetFeedPricesUSD(mock.Anything, mock.MatchedBy(func(tokens []cciptypes.UnknownEncodedAddress) bool {
-					expectedTokens := mapset.NewSet(tokenA, tokenB)
-					actualTokens := mapset.NewSet(tokens...)
-					return expectedTokens.Equal(actualTokens)
-				})).
+				tokenPriceReader.EXPECT().GetFeedPricesUSD(mock.Anything, mock.MatchedBy(
+					func(tokens []cciptypes.UnknownEncodedAddress) bool {
+						expectedTokens := mapset.NewSet(tokenA, tokenB)
+						actualTokens := mapset.NewSet(tokens...)
+						return expectedTokens.Equal(actualTokens)
+					})).
 					Return(cciptypes.TokenPriceMap{
 						tokenA: cciptypes.NewBigInt(bi100),
 						tokenB: cciptypes.NewBigInt(bi200)}, nil)

--- a/commit/tokenprice/observation_test.go
+++ b/commit/tokenprice/observation_test.go
@@ -28,9 +28,9 @@ func Test_Observation(t *testing.T) {
 		destChainSel: f,
 	}
 	timestamp := time.Now().UTC()
-	feedTokenPrices := []cciptypes.TokenPrice{
-		cciptypes.NewTokenPrice(tokenA, bi100),
-		cciptypes.NewTokenPrice(tokenB, bi200),
+	feedTokenPrices := cciptypes.TokenPriceMap{
+		tokenA: cciptypes.NewBigInt(bi100),
+		tokenB: cciptypes.NewBigInt(bi200),
 	}
 	feeQuoterTokenUpdates := map[cciptypes.UnknownEncodedAddress]plugintypes.TimestampedBig{
 		tokenA: plugintypes.NewTimestampedBig(bi100.Int64(), timestamp),
@@ -54,9 +54,9 @@ func Test_Observation(t *testing.T) {
 
 				tokenPriceReader := readerpkg_mock.NewMockPriceReader(t)
 				tokenPriceReader.EXPECT().GetFeedPricesUSD(mock.Anything, []cciptypes.UnknownEncodedAddress{tokenA, tokenB}).
-					Return(map[cciptypes.UnknownEncodedAddress]*big.Int{
-						tokenA: bi100,
-						tokenB: bi200}, nil)
+					Return(cciptypes.TokenPriceMap{
+						tokenA: cciptypes.NewBigInt(bi100),
+						tokenB: cciptypes.NewBigInt(bi200)}, nil)
 
 				tokenPriceReader.EXPECT().GetFeeQuoterTokenUpdates(mock.Anything, mock.Anything, mock.Anything).Return(
 					map[cciptypes.UnknownEncodedAddress]plugintypes.TimestampedBig{

--- a/commit/tokenprice/outcome.go
+++ b/commit/tokenprice/outcome.go
@@ -32,6 +32,13 @@ func (p *processor) getConsensusObservation(
 			fmt.Errorf("no consensus value for fDestChain, destChain: %d", p.destChain)
 	}
 
+	if consensus.LtTwoFPlusOne(fDestChain, len(aggObs.Timestamps)) {
+		return ConsensusObservation{},
+			fmt.Errorf("not enough observations for timestamps to reach consensus, have %d, need %d",
+				len(aggObs.Timestamps), consensus.TwoFPlus1(fDestChain))
+	}
+	timestamp := consensus.Median(aggObs.Timestamps, consensus.TimestampComparator)
+
 	fFeedChain, exists := fChains[p.offChainCfg.PriceFeedChainSelector]
 	if !exists {
 		return ConsensusObservation{},
@@ -60,7 +67,7 @@ func (p *processor) getConsensusObservation(
 
 	consensusObs := ConsensusObservation{
 		FChain:                fChains,
-		Timestamp:             consensus.Median(aggObs.Timestamps, consensus.TimestampComparator),
+		Timestamp:             timestamp,
 		FeedTokenPrices:       feedPricesConsensus,
 		FeeQuoterTokenUpdates: feeQuoterUpdatesConsensus,
 	}

--- a/commit/tokenprice/outcome.go
+++ b/commit/tokenprice/outcome.go
@@ -130,7 +130,10 @@ func aggregateObservations(aos []plugincommon.AttributedObservation[Observation]
 		obs := ao.Observation
 		// FeedTokenPrices
 		for tokenID, price := range obs.FeedTokenPrices {
-			aggObs.FeedTokenPrices[tokenID] = append(aggObs.FeedTokenPrices[tokenID], cciptypes.NewTokenPrice(tokenID, price.Int))
+			aggObs.FeedTokenPrices[tokenID] = append(
+				aggObs.FeedTokenPrices[tokenID],
+				cciptypes.NewTokenPrice(tokenID, price.Int),
+			)
 		}
 
 		// FeeQuoterTokenUpdates

--- a/commit/tokenprice/outcome.go
+++ b/commit/tokenprice/outcome.go
@@ -2,7 +2,6 @@ package tokenprice
 
 import (
 	"fmt"
-	"sort"
 	"time"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -83,8 +82,8 @@ func (p *processor) getConsensusObservation(
 func (p *processor) selectTokensForUpdate(
 	lggr logger.Logger,
 	obs ConsensusObservation,
-) []cciptypes.TokenPrice {
-	var tokenPrices []cciptypes.TokenPrice
+) cciptypes.TokenPriceMap {
+	tokenPrices := make(cciptypes.TokenPriceMap)
 	cfg := p.offChainCfg
 	tokenInfo := cfg.TokenInfo
 
@@ -92,10 +91,7 @@ func (p *processor) selectTokensForUpdate(
 		lastUpdate, exists := obs.FeeQuoterTokenUpdates[token]
 		if !exists {
 			// if the token is not in the fee quoter updates, then we should update it
-			tokenPrices = append(tokenPrices, cciptypes.TokenPrice{
-				TokenID: token,
-				Price:   cciptypes.NewBigInt(feedPrice.Price.Int),
-			})
+			tokenPrices[token] = cciptypes.NewBigInt(feedPrice.Price.Int)
 			continue
 		}
 
@@ -110,17 +106,14 @@ func (p *processor) selectTokensForUpdate(
 			obs.Timestamp.After(nextUpdateTime) ||
 				mathslib.Deviates(feedPrice.Price.Int, lastUpdate.Value.Int, ti.DeviationPPB.Int64())
 		if shouldUpdate {
-			tokenPrices = append(tokenPrices, cciptypes.TokenPrice{
-				TokenID: token,
-				Price:   cciptypes.NewBigInt(feedPrice.Price.Int),
-			})
+			tokenPrices[token] = cciptypes.NewBigInt(feedPrice.Price.Int)
 		}
 	}
 
 	// sort the token prices by tokenID
-	sort.Slice(tokenPrices, func(i, j int) bool {
-		return tokenPrices[i].TokenID < tokenPrices[j].TokenID
-	})
+	//sort.Slice(tokenPrices, func(i, j int) bool {
+	//	return tokenPrices[i].TokenID < tokenPrices[j].TokenID
+	//})
 	return tokenPrices
 }
 
@@ -136,8 +129,8 @@ func aggregateObservations(aos []plugincommon.AttributedObservation[Observation]
 	for _, ao := range aos {
 		obs := ao.Observation
 		// FeedTokenPrices
-		for _, tokenPrice := range obs.FeedTokenPrices {
-			aggObs.FeedTokenPrices[tokenPrice.TokenID] = append(aggObs.FeedTokenPrices[tokenPrice.TokenID], tokenPrice)
+		for tokenID, price := range obs.FeedTokenPrices {
+			aggObs.FeedTokenPrices[tokenID] = append(aggObs.FeedTokenPrices[tokenID], cciptypes.NewTokenPrice(tokenID, price.Int))
 		}
 
 		// FeeQuoterTokenUpdates

--- a/commit/tokenprice/outcome.go
+++ b/commit/tokenprice/outcome.go
@@ -110,10 +110,6 @@ func (p *processor) selectTokensForUpdate(
 		}
 	}
 
-	// sort the token prices by tokenID
-	//sort.Slice(tokenPrices, func(i, j int) bool {
-	//	return tokenPrices[i].TokenID < tokenPrices[j].TokenID
-	//})
 	return tokenPrices
 }
 

--- a/commit/tokenprice/outcome_test.go
+++ b/commit/tokenprice/outcome_test.go
@@ -25,11 +25,11 @@ var feedTokenPricesMap = map[cciptypes.UnknownEncodedAddress]cciptypes.TokenPric
 	tokenD: {TokenID: tokenD, Price: cbi200},
 }
 
-var feedTokenPrices = []cciptypes.TokenPrice{
-	feedTokenPricesMap[tokenA],
-	feedTokenPricesMap[tokenB],
-	feedTokenPricesMap[tokenC],
-	feedTokenPricesMap[tokenD],
+var feedTokenPrices = cciptypes.TokenPriceMap{
+	tokenA: feedTokenPricesMap[tokenA].Price,
+	tokenB: feedTokenPricesMap[tokenB].Price,
+	tokenC: feedTokenPricesMap[tokenC].Price,
+	tokenD: feedTokenPricesMap[tokenD].Price,
 }
 
 var feeQuoterUpdates = map[cciptypes.UnknownEncodedAddress]plugintypes.TimestampedBig{
@@ -127,9 +127,9 @@ func TestSelectTokensForUpdate(t *testing.T) {
 	// tokenD will not be updated because it's same price and time is not passed
 	tokenPrices := p.selectTokensForUpdate(lggr, conObs)
 	assert.Len(t, tokenPrices, 3)
-	assert.Equal(t, conObs.FeedTokenPrices[tokenA], tokenPrices[0])
-	assert.Equal(t, conObs.FeedTokenPrices[tokenB], tokenPrices[1])
-	assert.Equal(t, conObs.FeedTokenPrices[tokenC], tokenPrices[2])
+	assert.Equal(t, conObs.FeedTokenPrices[tokenA].Price, tokenPrices[tokenA])
+	assert.Equal(t, conObs.FeedTokenPrices[tokenB].Price, tokenPrices[tokenB])
+	assert.Equal(t, conObs.FeedTokenPrices[tokenC].Price, tokenPrices[tokenC])
 }
 
 // Test Plugin Outcome method returns the correct token prices
@@ -152,10 +152,10 @@ func TestOutcome(t *testing.T) {
 		{OracleID: 5, Observation: obs},
 	})
 
-	expectedOutcome := []cciptypes.TokenPrice{
-		feedTokenPricesMap[tokenA],
-		feedTokenPricesMap[tokenB],
-		feedTokenPricesMap[tokenC],
+	expectedOutcome := cciptypes.TokenPriceMap{
+		tokenA: feedTokenPricesMap[tokenA].Price,
+		tokenB: feedTokenPricesMap[tokenB].Price,
+		tokenC: feedTokenPricesMap[tokenC].Price,
 		// tokenD is not updated because it's the same price and time is not passed
 	}
 

--- a/commit/tokenprice/processor.go
+++ b/commit/tokenprice/processor.go
@@ -81,6 +81,11 @@ func (p *processor) Outcome(
 		"tokenPrices", tokenPriceOutcome,
 	)
 
+	if len(tokenPriceOutcome) == 0 {
+		lggr.Debugw("No token prices to report")
+		return Outcome{}, nil
+	}
+
 	out := Outcome{TokenPrices: tokenPriceOutcome}
 	p.metricsReporter.TrackTokenPricesOutcome(out)
 	return out, nil

--- a/commit/tokenprice/types.go
+++ b/commit/tokenprice/types.go
@@ -13,11 +13,11 @@ type Query struct {
 }
 
 type Outcome struct {
-	TokenPrices []cciptypes.TokenPrice `json:"tokenPrices"`
+	TokenPrices cciptypes.TokenPriceMap `json:"tokenPrices"`
 }
 
 type Observation struct {
-	FeedTokenPrices       []cciptypes.TokenPrice                                         `json:"feedTokenPrices"`
+	FeedTokenPrices       cciptypes.TokenPriceMap                                        `json:"feedTokenPrices"`
 	FeeQuoterTokenUpdates map[cciptypes.UnknownEncodedAddress]plugintypes.TimestampedBig `json:"feeQuoterTokenUpdates"`
 	FChain                map[cciptypes.ChainSelector]int                                `json:"fChain"`
 	Timestamp             time.Time                                                      `json:"timestamp"`

--- a/commit/tokenprice/validate_observation.go
+++ b/commit/tokenprice/validate_observation.go
@@ -22,6 +22,8 @@ func (p *processor) ValidateObservation(
 		return fmt.Errorf("failed to validate observed token prices: %w", err)
 	}
 
+	//TODO: validate supported feed chain if any token prices were updated
+	//TODO: validate supported destChain if any fee quoter token updates were observed
 	//TODO: validate observed fee quoter token updates
 	//TODO: validate observed timestamp
 

--- a/commit/tokenprice/validate_observation.go
+++ b/commit/tokenprice/validate_observation.go
@@ -18,11 +18,6 @@ func (p *processor) ValidateObservation(
 		return fmt.Errorf("failed to validate FChain: %w", err)
 	}
 
-	//observerSupportedChains, err := p.chainSupport.SupportedChains(ao.OracleID)
-	//if err != nil {
-	//	return fmt.Errorf("failed to get supported chains: %w", err)
-	//}
-
 	if err := validateObservedTokenPrices(obs.FeedTokenPrices); err != nil {
 		return fmt.Errorf("failed to validate observed token prices: %w", err)
 	}

--- a/commit/tokenprice/validate_observation.go
+++ b/commit/tokenprice/validate_observation.go
@@ -3,8 +3,6 @@ package tokenprice
 import (
 	"fmt"
 
-	mapset "github.com/deckarep/golang-set/v2"
-
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
@@ -20,34 +18,26 @@ func (p *processor) ValidateObservation(
 		return fmt.Errorf("failed to validate FChain: %w", err)
 	}
 
-	observerSupportedChains, err := p.chainSupport.SupportedChains(ao.OracleID)
-	if err != nil {
-		return fmt.Errorf("failed to get supported chains: %w", err)
-	}
-
-	for chain := range obs.FChain {
-		if !observerSupportedChains.Contains(chain) {
-			return fmt.Errorf("chain %d is not supported by observer", chain)
-		}
-	}
+	//observerSupportedChains, err := p.chainSupport.SupportedChains(ao.OracleID)
+	//if err != nil {
+	//	return fmt.Errorf("failed to get supported chains: %w", err)
+	//}
 
 	if err := validateObservedTokenPrices(obs.FeedTokenPrices); err != nil {
 		return fmt.Errorf("failed to validate observed token prices: %w", err)
 	}
 
+	//TODO: validate observed fee quoter token updates
+	//TODO: validate observed timestamp
+
 	return nil
 }
 
-func validateObservedTokenPrices(tokenPrices []cciptypes.TokenPrice) error {
-	tokensWithPrice := mapset.NewSet[cciptypes.UnknownEncodedAddress]()
-	for _, t := range tokenPrices {
-		if tokensWithPrice.Contains(t.TokenID) {
-			return fmt.Errorf("duplicate token price for token: %s", t.TokenID)
-		}
-		tokensWithPrice.Add(t.TokenID)
-
-		if t.Price.IsEmpty() {
-			return fmt.Errorf("token price of token %v must not be empty", t.TokenID)
+func validateObservedTokenPrices(tokenPrices cciptypes.TokenPriceMap) error {
+	// TODO: cross check that only tokens from tokensToQuery are present
+	for tokenID, price := range tokenPrices {
+		if price.IsEmpty() {
+			return fmt.Errorf("token price of token %v must not be empty", tokenID)
 		}
 	}
 	return nil

--- a/commit/tokenprice/validate_observation_test.go
+++ b/commit/tokenprice/validate_observation_test.go
@@ -31,16 +31,6 @@ func Test_validateObservedTokenPrices(t *testing.T) {
 			expErr: false,
 		},
 		{
-			name: "dup price",
-			tokenPrices: []cciptypes.TokenPrice{
-				cciptypes.NewTokenPrice("0x1", big.NewInt(1)),
-				cciptypes.NewTokenPrice("0x2", big.NewInt(1)),
-				cciptypes.NewTokenPrice("0x1", big.NewInt(1)), // dup
-				cciptypes.NewTokenPrice("0xa", big.NewInt(1)),
-			},
-			expErr: true,
-		},
-		{
 			name: "nil price",
 			tokenPrices: []cciptypes.TokenPrice{
 				cciptypes.NewTokenPrice("0x1", big.NewInt(1)),
@@ -54,7 +44,11 @@ func Test_validateObservedTokenPrices(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateObservedTokenPrices(tc.tokenPrices)
+			tokenPrices := make(cciptypes.TokenPriceMap)
+			for _, tp := range tc.tokenPrices {
+				tokenPrices[tp.TokenID] = tp.Price
+			}
+			err := validateObservedTokenPrices(tokenPrices)
 			if tc.expErr {
 				assert.Error(t, err)
 				return

--- a/mocks/pkg/reader/price_reader.go
+++ b/mocks/pkg/reader/price_reader.go
@@ -4,7 +4,6 @@ package reader
 
 import (
 	context "context"
-	big "math/big"
 
 	ccipocr3 "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 
@@ -87,23 +86,23 @@ func (_c *MockPriceReader_GetFeeQuoterTokenUpdates_Call) RunAndReturn(run func(c
 }
 
 // GetFeedPricesUSD provides a mock function with given fields: ctx, tokens
-func (_m *MockPriceReader) GetFeedPricesUSD(ctx context.Context, tokens []ccipocr3.UnknownEncodedAddress) (map[ccipocr3.UnknownEncodedAddress]*big.Int, error) {
+func (_m *MockPriceReader) GetFeedPricesUSD(ctx context.Context, tokens []ccipocr3.UnknownEncodedAddress) (ccipocr3.TokenPriceMap, error) {
 	ret := _m.Called(ctx, tokens)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetFeedPricesUSD")
 	}
 
-	var r0 map[ccipocr3.UnknownEncodedAddress]*big.Int
+	var r0 ccipocr3.TokenPriceMap
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, []ccipocr3.UnknownEncodedAddress) (map[ccipocr3.UnknownEncodedAddress]*big.Int, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []ccipocr3.UnknownEncodedAddress) (ccipocr3.TokenPriceMap, error)); ok {
 		return rf(ctx, tokens)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, []ccipocr3.UnknownEncodedAddress) map[ccipocr3.UnknownEncodedAddress]*big.Int); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, []ccipocr3.UnknownEncodedAddress) ccipocr3.TokenPriceMap); ok {
 		r0 = rf(ctx, tokens)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[ccipocr3.UnknownEncodedAddress]*big.Int)
+			r0 = ret.Get(0).(ccipocr3.TokenPriceMap)
 		}
 	}
 
@@ -135,12 +134,12 @@ func (_c *MockPriceReader_GetFeedPricesUSD_Call) Run(run func(ctx context.Contex
 	return _c
 }
 
-func (_c *MockPriceReader_GetFeedPricesUSD_Call) Return(_a0 map[ccipocr3.UnknownEncodedAddress]*big.Int, _a1 error) *MockPriceReader_GetFeedPricesUSD_Call {
+func (_c *MockPriceReader_GetFeedPricesUSD_Call) Return(_a0 ccipocr3.TokenPriceMap, _a1 error) *MockPriceReader_GetFeedPricesUSD_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockPriceReader_GetFeedPricesUSD_Call) RunAndReturn(run func(context.Context, []ccipocr3.UnknownEncodedAddress) (map[ccipocr3.UnknownEncodedAddress]*big.Int, error)) *MockPriceReader_GetFeedPricesUSD_Call {
+func (_c *MockPriceReader_GetFeedPricesUSD_Call) RunAndReturn(run func(context.Context, []ccipocr3.UnknownEncodedAddress) (ccipocr3.TokenPriceMap, error)) *MockPriceReader_GetFeedPricesUSD_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/reader/price_reader.go
+++ b/pkg/reader/price_reader.go
@@ -25,7 +25,7 @@ type PriceReader interface {
 	//	1 LINK = 5.00 USD per full token, each full token is 1e18 units -> 5 * 1e18 * 1e18 / 1e18 = 5e18
 	// The order of the returned prices corresponds to the order of the provided tokens.
 	GetFeedPricesUSD(ctx context.Context,
-		tokens []ccipocr3.UnknownEncodedAddress) (map[ccipocr3.UnknownEncodedAddress]*big.Int, error)
+		tokens []ccipocr3.UnknownEncodedAddress) (ccipocr3.TokenPriceMap, error)
 
 	// GetFeeQuoterTokenUpdates returns the latest token prices from the FeeQuoter on the specified chain
 	GetFeeQuoterTokenUpdates(
@@ -153,9 +153,9 @@ func (pr *priceReader) GetFeeQuoterTokenUpdates(
 func (pr *priceReader) GetFeedPricesUSD(
 	ctx context.Context,
 	tokens []ccipocr3.UnknownEncodedAddress,
-) (map[ccipocr3.UnknownEncodedAddress]*big.Int, error) {
+) (ccipocr3.TokenPriceMap, error) {
 	lggr := logutil.WithContextValues(ctx, pr.lggr)
-	prices := make(map[ccipocr3.UnknownEncodedAddress]*big.Int, len(tokens))
+	prices := make(ccipocr3.TokenPriceMap)
 	if pr.feedChainReader() == nil {
 		lggr.Debug("node does not support feed chain")
 		return prices, nil
@@ -206,7 +206,7 @@ func (pr *priceReader) GetFeedPricesUSD(
 				lggr.Errorw("failed to calculate price", "token", token)
 				continue
 			}
-			prices[token] = price
+			prices[token] = ccipocr3.BigInt{Int: price}
 		}
 	}
 

--- a/pkg/reader/price_reader_test.go
+++ b/pkg/reader/price_reader_test.go
@@ -61,7 +61,7 @@ func TestOnchainTokenPricesReader_GetTokenPricesUSD(t *testing.T) {
 		inputTokens   []cciptypes.UnknownEncodedAddress
 		tokenInfo     map[cciptypes.UnknownEncodedAddress]pluginconfig.TokenInfo
 		mockPrices    map[cciptypes.UnknownEncodedAddress]*big.Int
-		want          map[cciptypes.UnknownEncodedAddress]*big.Int
+		want          cciptypes.TokenPriceMap
 		errorAccounts []cciptypes.UnknownEncodedAddress
 		wantErr       bool
 	}{
@@ -72,7 +72,7 @@ func TestOnchainTokenPricesReader_GetTokenPricesUSD(t *testing.T) {
 			},
 			inputTokens: []cciptypes.UnknownEncodedAddress{ArbAddr},
 			mockPrices:  map[cciptypes.UnknownEncodedAddress]*big.Int{ArbAddr: ArbPrice},
-			want:        map[cciptypes.UnknownEncodedAddress]*big.Int{ArbAddr: ArbPrice},
+			want:        cciptypes.TokenPriceMap{ArbAddr: cciptypes.NewBigInt(ArbPrice)},
 		},
 		{
 			name: "On-chain multiple prices",
@@ -82,7 +82,7 @@ func TestOnchainTokenPricesReader_GetTokenPricesUSD(t *testing.T) {
 			},
 			inputTokens: []cciptypes.UnknownEncodedAddress{ArbAddr, EthAddr},
 			mockPrices:  map[cciptypes.UnknownEncodedAddress]*big.Int{ArbAddr: ArbPrice, EthAddr: EthPrice},
-			want:        map[cciptypes.UnknownEncodedAddress]*big.Int{ArbAddr: ArbPrice, EthAddr: EthPrice},
+			want:        cciptypes.TokenPriceMap{ArbAddr: cciptypes.NewBigInt(ArbPrice), EthAddr: cciptypes.NewBigInt(EthPrice)},
 		},
 		{
 			name: "Missing price doesn't fail, return available prices",
@@ -93,7 +93,7 @@ func TestOnchainTokenPricesReader_GetTokenPricesUSD(t *testing.T) {
 			inputTokens:   []cciptypes.UnknownEncodedAddress{ArbAddr, EthAddr},
 			mockPrices:    map[cciptypes.UnknownEncodedAddress]*big.Int{ArbAddr: ArbPrice},
 			errorAccounts: []cciptypes.UnknownEncodedAddress{EthAddr},
-			want:          map[cciptypes.UnknownEncodedAddress]*big.Int{ArbAddr: ArbPrice},
+			want:          cciptypes.TokenPriceMap{ArbAddr: cciptypes.NewBigInt(ArbPrice)},
 		},
 		{
 			name: "Empty input tokens list",
@@ -102,7 +102,7 @@ func TestOnchainTokenPricesReader_GetTokenPricesUSD(t *testing.T) {
 			},
 			inputTokens: []cciptypes.UnknownEncodedAddress{},
 			mockPrices:  map[cciptypes.UnknownEncodedAddress]*big.Int{},
-			want:        map[cciptypes.UnknownEncodedAddress]*big.Int{},
+			want:        cciptypes.TokenPriceMap{},
 		},
 		{
 			name: "Repeated token in input",
@@ -111,7 +111,7 @@ func TestOnchainTokenPricesReader_GetTokenPricesUSD(t *testing.T) {
 			},
 			inputTokens: []cciptypes.UnknownEncodedAddress{ArbAddr, ArbAddr},
 			mockPrices:  map[cciptypes.UnknownEncodedAddress]*big.Int{ArbAddr: ArbPrice},
-			want:        map[cciptypes.UnknownEncodedAddress]*big.Int{ArbAddr: ArbPrice},
+			want:        cciptypes.TokenPriceMap{ArbAddr: cciptypes.NewBigInt(ArbPrice)},
 		},
 		{
 			name: "Zero price should succeed",
@@ -120,7 +120,7 @@ func TestOnchainTokenPricesReader_GetTokenPricesUSD(t *testing.T) {
 			},
 			inputTokens: []cciptypes.UnknownEncodedAddress{ArbAddr},
 			mockPrices:  map[cciptypes.UnknownEncodedAddress]*big.Int{ArbAddr: big.NewInt(0)},
-			want:        map[cciptypes.UnknownEncodedAddress]*big.Int{ArbAddr: big.NewInt(0)},
+			want:        cciptypes.TokenPriceMap{ArbAddr: cciptypes.NewBigInt(big.NewInt(0))},
 		},
 		{
 			name: "Multiple error accounts",
@@ -132,7 +132,7 @@ func TestOnchainTokenPricesReader_GetTokenPricesUSD(t *testing.T) {
 			inputTokens:   []cciptypes.UnknownEncodedAddress{ArbAddr, EthAddr, BtcAddr},
 			mockPrices:    map[cciptypes.UnknownEncodedAddress]*big.Int{ArbAddr: ArbPrice},
 			errorAccounts: []cciptypes.UnknownEncodedAddress{EthAddr, BtcAddr},
-			want:          map[cciptypes.UnknownEncodedAddress]*big.Int{ArbAddr: ArbPrice},
+			want:          cciptypes.TokenPriceMap{ArbAddr: cciptypes.NewBigInt(ArbPrice)},
 		},
 	}
 

--- a/pkg/types/ccipocr3/generic_types.go
+++ b/pkg/types/ccipocr3/generic_types.go
@@ -4,12 +4,29 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"sort"
 	"strconv"
 )
 
 type TokenPrice struct {
 	TokenID UnknownEncodedAddress `json:"tokenID"`
 	Price   BigInt                `json:"price"`
+}
+
+type TokenPriceMap map[UnknownEncodedAddress]BigInt
+
+func (t TokenPriceMap) ToSortedSlice() []TokenPrice {
+	var res []TokenPrice
+	for tokenID, price := range t {
+		res = append(res, TokenPrice{tokenID, price})
+	}
+
+	// sort the token prices by tokenID
+	sort.Slice(res, func(i, j int) bool {
+		return res[i].TokenID < res[j].TokenID
+	})
+
+	return res
 }
 
 func NewTokenPrice(tokenID UnknownEncodedAddress, price *big.Int) TokenPrice {


### PR DESCRIPTION
Use map instead of slice in token price observations and outcome

This is to make by design duplicate resistent so that we don't have issues in consensus later.

Fixed TokenPrice outcome timestamp consensus as it wasn't checking that it has enough observations before.