### PR TITLE
[Solana] Remove redundant constraints

### DIFF
--- a/chains/solana/contracts/programs/ccip-router/src/context.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/context.rs
@@ -265,7 +265,6 @@ pub struct AddChainSelector<'info> {
         bump,
         payer = authority,
         space = ANCHOR_DISCRIMINATOR + SourceChain::INIT_SPACE,
-        constraint = uninitialized(source_chain_state.version) @ CcipRouterError::InvalidInputs,
     )]
     pub source_chain_state: Account<'info, SourceChain>,
 
@@ -275,7 +274,6 @@ pub struct AddChainSelector<'info> {
         bump,
         payer = authority,
         space = ANCHOR_DISCRIMINATOR + DestChain::INIT_SPACE,
-        constraint = uninitialized(dest_chain_state.version) @ CcipRouterError::InvalidInputs, // validate uninitialized
     )]
     pub dest_chain_state: Account<'info, DestChain>,
 
@@ -649,7 +647,6 @@ pub struct CommitReportContext<'info> {
         bump,
         payer = authority,
         space = ANCHOR_DISCRIMINATOR + CommitReport::INIT_SPACE,
-        constraint = uninitialized(commit_report.version) @ CcipRouterError::InvalidInputs, // validate uninitialized
     )]
     pub commit_report: Account<'info, CommitReport>,
 

--- a/chains/solana/contracts/programs/ccip-router/src/token_context.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/token_context.rs
@@ -37,7 +37,6 @@ pub struct RegisterTokenAdminRegistryViaGetCCIPAdmin<'info> {
         bump,
         payer = authority,
         space = ANCHOR_DISCRIMINATOR + TokenAdminRegistry::INIT_SPACE,
-        constraint = uninitialized(token_admin_registry.version) @ CcipRouterError::InvalidInputs,
     )]
     pub token_admin_registry: Account<'info, TokenAdminRegistry>,
     #[account(mut, address = config.load()?.owner @ CcipRouterError::Unauthorized)]
@@ -59,7 +58,6 @@ pub struct RegisterTokenAdminRegistryViaOwner<'info> {
         bump,
         payer = authority,
         space = ANCHOR_DISCRIMINATOR + TokenAdminRegistry::INIT_SPACE,
-        constraint = uninitialized(token_admin_registry.version) @ CcipRouterError::InvalidInputs,
     )]
     pub token_admin_registry: Account<'info, TokenAdminRegistry>,
     #[account(mut)]

--- a/chains/solana/contracts/tests/ccip/ccip_router_test.go
+++ b/chains/solana/contracts/tests/ccip/ccip_router_test.go
@@ -4799,7 +4799,7 @@ func TestCCIPRouter(t *testing.T) {
 					solana.SysVarInstructionsPubkey,
 				).ValidateAndBuild()
 				require.NoError(t, err)
-				tx := testutils.SendAndConfirm(ctx, t, solanaGoClient, []solana.Instruction{instruction}, transmitter, config.DefaultCommitment)
+				tx := testutils.SendAndConfirm(ctx, t, solanaGoClient, []solana.Instruction{instruction}, transmitter, config.DefaultCommitment, common.AddComputeUnitLimit(300_000))
 				event := ccip.EventCommitReportAccepted{}
 				require.NoError(t, common.ParseEvent(tx.Meta.LogMessages, "CommitReportAccepted", &event, config.PrintEvents))
 


### PR DESCRIPTION
Please sanity check this is correct CC @toblich.

Each of these accounts is `init` (not `init_if_needed`) and it's not zero_copy. This means the uninitialized constraint is redundant with the fact we're stating the account is uninitialized.