### PR TITLE
[CCIP-4934] Defense against non-positive results in price reader

### DIFF
--- a/pkg/reader/price_reader.go
+++ b/pkg/reader/price_reader.go
@@ -195,6 +195,11 @@ func (pr *priceReader) GetFeedPricesUSD(
 			continue
 		}
 
+		if latestRoundData.Answer == nil || latestRoundData.Answer.Cmp(big.NewInt(0)) <= 0 {
+			lggr.Errorw("latestRoundData.Answer is nil or non positive", "contract", boundContract.Address)
+			continue
+		}
+
 		// Normalize price for this contract
 		normalizedContractPrice := pr.normalizePrice(latestRoundData.Answer, *decimals)
 

--- a/pkg/reader/price_reader_test.go
+++ b/pkg/reader/price_reader_test.go
@@ -114,13 +114,13 @@ func TestOnchainTokenPricesReader_GetTokenPricesUSD(t *testing.T) {
 			want:        cciptypes.TokenPriceMap{ArbAddr: cciptypes.NewBigInt(ArbPrice)},
 		},
 		{
-			name: "Zero price should succeed",
+			name: "Zero price should be discarded",
 			tokenInfo: map[cciptypes.UnknownEncodedAddress]pluginconfig.TokenInfo{
 				ArbAddr: ArbInfo,
 			},
 			inputTokens: []cciptypes.UnknownEncodedAddress{ArbAddr},
 			mockPrices:  map[cciptypes.UnknownEncodedAddress]*big.Int{ArbAddr: big.NewInt(0)},
-			want:        cciptypes.TokenPriceMap{ArbAddr: cciptypes.NewBigInt(big.NewInt(0))},
+			want:        cciptypes.TokenPriceMap{},
 		},
 		{
 			name: "Multiple error accounts",


### PR DESCRIPTION
core ref: 7d543d6436c3f41653fc399411b445c3983e1c96