### PR TITLE
Exec: commit root caching

### DIFF
--- a/execute/internal/cache/commit_root_cache.go
+++ b/execute/internal/cache/commit_root_cache.go
@@ -1,0 +1,122 @@
+package cache
+
+import (
+	"sync"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+)
+
+const (
+	// EvictionGracePeriod defines how long after the messageVisibilityInterval a root is still kept in the cache
+	EvictionGracePeriod = 1 * time.Hour
+	// CleanupInterval defines how often roots cache is scanned to evict stale roots
+	CleanupInterval = 30 * time.Minute
+)
+
+// CommitsRootsCache keeps track of commit roots (and messages?) that are eligible for execution.
+//
+// This cache is used when:
+//   - a commit root is fully executed and we want to skip it in the future. This would be called
+//     in the GetCommitReports phase after checking if each SeqNr is executed (or if the Txm state is finalized).
+//   - remember the oldest pending commit root to limit the database scan to only the unfinalized part of the chain.
+type CommitsRootsCache interface {
+	CanExecute(source ccipocr3.ChainSelector, merkleRoot ccipocr3.Bytes32) bool
+	MarkAsExecuted(source ccipocr3.ChainSelector, merkleRoot ccipocr3.Bytes32)
+	Snooze(source ccipocr3.ChainSelector, merkleRoot ccipocr3.Bytes32)
+}
+
+func NewCommitRootsCache(
+	lggr logger.Logger,
+	messageVisibilityInterval time.Duration,
+	rootSnoozeTime time.Duration,
+) CommitsRootsCache {
+	return internalNewCommitRootsCache(
+		lggr,
+		messageVisibilityInterval,
+		rootSnoozeTime,
+		CleanupInterval,
+		EvictionGracePeriod,
+	)
+}
+
+func internalNewCommitRootsCache(
+	lggr logger.Logger,
+	messageVisibilityInterval time.Duration,
+	rootSnoozeTime time.Duration,
+	cleanupInterval time.Duration,
+	evictionGracePeriod time.Duration,
+) *commitRootsCache {
+	snoozedRoots := cache.New(rootSnoozeTime, cleanupInterval)
+	executedRoots := cache.New(messageVisibilityInterval+evictionGracePeriod, cleanupInterval)
+
+	return &commitRootsCache{
+		lggr:                      lggr,
+		rootSnoozeTime:            rootSnoozeTime,
+		executedRoots:             executedRoots,
+		snoozedRoots:              snoozedRoots,
+		messageVisibilityInterval: messageVisibilityInterval,
+		cacheMu:                   sync.RWMutex{},
+	}
+}
+
+type commitRootsCache struct {
+	lggr                      logger.Logger
+	messageVisibilityInterval time.Duration
+	rootSnoozeTime            time.Duration
+
+	cacheMu sync.RWMutex
+
+	// snoozedRoots used only for temporary snoozing roots. It's a cache with TTL (usually around 5 minutes,
+	// but this configuration is set up on chain using rootSnoozeTime)
+	snoozedRoots *cache.Cache
+	// executedRoots is a cache with TTL (usually around 8 hours, but this configuration is set up on chain using
+	// messageVisibilityInterval). We keep executed roots there to make sure we don't accidentally try to reprocess
+	// already executed CommitReport
+	executedRoots *cache.Cache
+}
+
+func getKey(source ccipocr3.ChainSelector, merkleRoot ccipocr3.Bytes32) string {
+	return source.String() + "_" + merkleRoot.String()
+}
+
+// MarkAsExecuted marks the root as executed. It means that all the messages from the root were executed and the
+// ExecutionStateChange event was finalized.
+func (r *commitRootsCache) MarkAsExecuted(sel ccipocr3.ChainSelector, merkleRoot ccipocr3.Bytes32) {
+	prettyMerkleRoot := getKey(sel, merkleRoot)
+	r.lggr.Infow("Marking root as executed and removing entirely from cache", "merkleRoot", prettyMerkleRoot)
+
+	r.cacheMu.Lock()
+	defer r.cacheMu.Unlock()
+	r.executedRoots.SetDefault(prettyMerkleRoot, struct{}{})
+}
+
+// Snooze temporarily snoozes the root. It means that the root is not eligible for execution for a certain period of
+// time.
+func (r *commitRootsCache) Snooze(sel ccipocr3.ChainSelector, merkleRoot ccipocr3.Bytes32) {
+	prettyMerkleRoot := getKey(sel, merkleRoot)
+	r.lggr.Infow("Snoozing root temporarily", "merkleRoot", prettyMerkleRoot, "rootSnoozeTime", r.rootSnoozeTime)
+	r.snoozedRoots.SetDefault(prettyMerkleRoot, struct{}{})
+}
+
+// CanExecute returns true if the root is not snoozed and not executed.
+func (r *commitRootsCache) CanExecute(sel ccipocr3.ChainSelector, merkleRoot ccipocr3.Bytes32) bool {
+	prettyMerkleRoot := getKey(sel, merkleRoot)
+	return !r.isSnoozed(prettyMerkleRoot) && !r.isExecuted(prettyMerkleRoot)
+}
+
+// IsSnoozed returns true if the root is snoozed.
+func (r *commitRootsCache) isSnoozed(key string) bool {
+	_, snoozed := r.snoozedRoots.Get(key)
+	return snoozed
+}
+
+// isExecuted returns true if the root is executed.
+func (r *commitRootsCache) isExecuted(key string) bool {
+	_, executed := r.executedRoots.Get(key)
+	return executed
+}

--- a/execute/observation.go
+++ b/execute/observation.go
@@ -5,14 +5,15 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/logger"
-
 	"golang.org/x/exp/maps"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
+	"github.com/smartcontractkit/chainlink-ccip/execute/optimizers"
 	typeconv "github.com/smartcontractkit/chainlink-ccip/internal/libs/typeconv"
 	dt "github.com/smartcontractkit/chainlink-ccip/internal/plugincommon/discovery/discoverytypes"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/logutil"
@@ -310,8 +311,10 @@ func (p *Plugin) getMessagesObservation(
 	observation.TokenData = tkData
 
 	// Make sure encoded observation fits within the maximum observation size.
-	//observation, err = truncateObservation(observation, maxObservationLength, p.emptyEncodedSizes)
-	observation, err = p.observationOptimizer.TruncateObservation(observation)
+	observationOptimizer := optimizers.NewObservationOptimizer(
+		lggr,
+		maxObservationLength)
+	observation, err = observationOptimizer.TruncateObservation(observation)
 	if err != nil {
 		return exectypes.Observation{}, fmt.Errorf("unable to truncate observation: %w", err)
 	}

--- a/execute/observation.go
+++ b/execute/observation.go
@@ -131,6 +131,8 @@ func (p *Plugin) getCommitReportsObservation(
 	lggr logger.Logger,
 	observation exectypes.Observation,
 ) (exectypes.Observation, error) {
+	// TODO: set fetchFrom to the oldest pending commit report.
+	// TODO: or, cache commit reports so that we don't need to fetch them again.
 	fetchFrom := time.Now().Add(-p.offchainCfg.MessageVisibilityInterval.Duration()).UTC()
 
 	// Phase 1: Gather commit reports from the destination chain and determine which messages are required to build
@@ -159,14 +161,30 @@ func (p *Plugin) getCommitReportsObservation(
 	}
 
 	// Get pending exec reports.
-	groupedCommits, err := getPendingExecutedReports(ctx, p.ccipReader, fetchFrom, lggr)
+	groupedCommits, fullyExecutedCommits, err := getPendingExecutedReports(
+		ctx,
+		p.ccipReader,
+		p.commitRootsCache.CanExecute,
+		fetchFrom,
+		lggr,
+	)
 	if err != nil {
 		return exectypes.Observation{}, err
 	}
 
-	// Remove cursed observations.
+	// If fully executed reports are detected, mark them in the cache.
+	// This cache will be re-initialized on each plugin restart.
+	for _, fullyExecutedCommit := range fullyExecutedCommits {
+		p.commitRootsCache.MarkAsExecuted(fullyExecutedCommit.SourceChain, fullyExecutedCommit.MerkleRoot)
+	}
+
+	// Remove and snooze commit reports from cursed chains.
 	for chainSelector, isCursed := range ci.CursedSourceChains {
 		if isCursed {
+			// Snooze everything on a cursed chain.
+			for _, commit := range groupedCommits[chainSelector] {
+				p.commitRootsCache.Snooze(chainSelector, commit.MerkleRoot)
+			}
 			delete(groupedCommits, chainSelector)
 		}
 	}

--- a/execute/observation_test.go
+++ b/execute/observation_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/execute/costlymessages"
 	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
-	"github.com/smartcontractkit/chainlink-ccip/execute/optimizers"
 	"github.com/smartcontractkit/chainlink-ccip/execute/tokendata"
 	"github.com/smartcontractkit/chainlink-ccip/internal/mocks"
 	readerpkg_mock "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/reader"
@@ -25,7 +24,6 @@ func Test_getMessagesObservation(t *testing.T) {
 	msgHasher := mocks.NewMessageHasher()
 	tokenDataObserver := tokendata.NoopTokenDataObserver{}
 	costlyMessageObserver := costlymessages.NoopObserver{}
-	observationOptimizer := optimizers.NewObservationOptimizer(maxObservationLength)
 
 	//emptyMsgHash, err := msgHasher.Hash(ctx, cciptypes.Message{})
 	//require.NoError(t, err)
@@ -36,7 +34,6 @@ func Test_getMessagesObservation(t *testing.T) {
 		msgHasher:             msgHasher,
 		tokenDataObserver:     &tokenDataObserver,
 		costlyMessageObserver: &costlyMessageObserver,
-		observationOptimizer:  observationOptimizer,
 	}
 
 	tests := []struct {

--- a/execute/optimizers/type_optimizer.go
+++ b/execute/optimizers/type_optimizer.go
@@ -3,13 +3,13 @@ package optimizers
 import (
 	"sort"
 
+	"golang.org/x/exp/maps"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
 	"github.com/smartcontractkit/chainlink-ccip/execute/internal"
-
-	"golang.org/x/exp/maps"
-
+	"github.com/smartcontractkit/chainlink-ccip/pkg/logutil"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
 
@@ -19,8 +19,9 @@ type ObservationOptimizer struct {
 	lggr              logger.Logger
 }
 
-func NewObservationOptimizer(maxEncodedSize int) ObservationOptimizer {
+func NewObservationOptimizer(lggr logger.Logger, maxEncodedSize int) ObservationOptimizer {
 	return ObservationOptimizer{
+		lggr:              logutil.WithComponent(lggr, "ObservationOptimizer"),
 		maxEncodedSize:    maxEncodedSize,
 		emptyEncodedSizes: NewEmptyEncodeSizes(),
 	}

--- a/execute/optimizers/type_optimizer_test.go
+++ b/execute/optimizers/type_optimizer_test.go
@@ -3,10 +3,11 @@ package optimizers
 import (
 	"testing"
 
-	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
-
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/testhelpers/rand"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
@@ -79,7 +80,8 @@ func Test_truncateLastCommit(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			op := NewObservationOptimizer(10000)
+			lggr := logger.Test(t)
+			op := NewObservationOptimizer(lggr, 10000)
 			truncated, _ := op.truncateLastCommit(tt.observation, tt.chain)
 			require.Equal(t, tt.expected, truncated)
 		})
@@ -166,7 +168,8 @@ func Test_truncateChain(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			op := NewObservationOptimizer(10000) // size not important here
+			lggr := logger.Test(t)
+			op := NewObservationOptimizer(lggr, 10000) // size not important here
 			truncated := op.truncateChain(tt.observation, tt.chain)
 			require.Equal(t, tt.expected, truncated)
 		})
@@ -325,7 +328,8 @@ func Test_truncateObservation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.observation.TokenData = makeNoopTokenDataObservations(tt.observation.Messages)
 			tt.expected.TokenData = tt.observation.TokenData
-			op := NewObservationOptimizer(tt.maxSize)
+			lggr := logger.Test(t)
+			op := NewObservationOptimizer(lggr, tt.maxSize)
 			obs, err := op.TruncateObservation(tt.observation)
 			if tt.wantErr {
 				require.Error(t, err)

--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -23,7 +23,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
 	"github.com/smartcontractkit/chainlink-ccip/execute/internal/cache"
 	"github.com/smartcontractkit/chainlink-ccip/execute/metrics"
-	"github.com/smartcontractkit/chainlink-ccip/execute/optimizers"
 	"github.com/smartcontractkit/chainlink-ccip/execute/report"
 	"github.com/smartcontractkit/chainlink-ccip/execute/tokendata"
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/slicelib"
@@ -67,9 +66,6 @@ type Plugin struct {
 	contractsInitialized bool
 	// this cache remembers commit root details to optimize DB lookups.
 	commitRootsCache cache.CommitsRootsCache
-
-	// TODO: remove this, it can be transient. Also its logger is never initialized.
-	observationOptimizer optimizers.ObservationOptimizer
 }
 
 func NewPlugin(
@@ -119,8 +115,7 @@ func NewPlugin(
 			reportingCfg.OracleID,
 			destChain,
 		),
-		observer:             metricsReporter,
-		observationOptimizer: optimizers.NewObservationOptimizer(maxObservationLength),
+		observer: metricsReporter,
 		commitRootsCache: cache.NewCommitRootsCache(
 			logutil.WithComponent(lggr, "CommitRootsCache"),
 			offchainCfg.MessageVisibilityInterval.Duration(),

--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -153,14 +153,18 @@ func getPendingExecutedReports(
 			continue
 		}
 
-		// Filter out reports that cannot be executed (snoozed).
-		// TODO: filter func instead of 'canExecute'?
+		// Filter out reports that cannot be executed (executed or snoozed).
 		var filtered []exectypes.CommitData
-		for _, commitReport := range reports {
-			if !canExecute(commitReport.SourceChain, commitReport.MerkleRoot) {
-				continue
+		{
+			var skippedCommitRoots []string
+			for _, commitReport := range reports {
+				if !canExecute(commitReport.SourceChain, commitReport.MerkleRoot) {
+					skippedCommitRoots = append(skippedCommitRoots, commitReport.MerkleRoot.String())
+					continue
+				}
+				filtered = append(filtered, commitReport)
 			}
-			filtered = append(filtered, commitReport)
+			lggr.Infow("skipping reports marked as executed or snoozed", "selector", selector, "skippedCommitRoots", skippedCommitRoots)
 		}
 		reports = filtered
 

--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -164,7 +164,11 @@ func getPendingExecutedReports(
 				}
 				filtered = append(filtered, commitReport)
 			}
-			lggr.Infow("skipping reports marked as executed or snoozed", "selector", selector, "skippedCommitRoots", skippedCommitRoots)
+			lggr.Infow(
+				"skipping reports marked as executed or snoozed",
+				"selector", selector,
+				"skippedCommitRoots", skippedCommitRoots,
+			)
 		}
 		reports = filtered
 

--- a/execute/plugin_functions.go
+++ b/execute/plugin_functions.go
@@ -279,11 +279,10 @@ func groupByChainSelector(
 	return commitReportCache
 }
 
-// filterOutExecutedMessages returns a new reports slice with fully executed messages removed.
+// combineReportsAndMessages returns a new reports slice with fully executed messages removed.
 // Reports that have all of their messages executed are not included in the result.
 // The provided reports must be sorted by sequence number range starting sequence number.
-// TODO: rename to filterMessages or combineReportsAndMessages?
-func filterOutExecutedMessages(
+func combineReportsAndMessages(
 	reports []exectypes.CommitData, executedMessages []cciptypes.SeqNum,
 ) ( /* pending */ []exectypes.CommitData /* executed */, []exectypes.CommitData) {
 	if len(executedMessages) == 0 {

--- a/execute/plugin_functions_test.go
+++ b/execute/plugin_functions_test.go
@@ -460,9 +460,10 @@ func Test_filterOutFullyExecutedMessages(t *testing.T) {
 		executedMessages []cciptypes.SeqNum
 	}
 	tests := []struct {
-		name string
-		args args
-		want []exectypes.CommitData
+		name         string
+		args         args
+		wantPending  []exectypes.CommitData
+		wantExecuted []exectypes.CommitData
 	}{
 		{
 			name: "empty",
@@ -470,7 +471,7 @@ func Test_filterOutFullyExecutedMessages(t *testing.T) {
 				reports:          nil,
 				executedMessages: nil,
 			},
-			want: nil,
+			wantPending: nil,
 		},
 		{
 			name: "empty2",
@@ -478,7 +479,7 @@ func Test_filterOutFullyExecutedMessages(t *testing.T) {
 				reports:          []exectypes.CommitData{},
 				executedMessages: nil,
 			},
-			want: []exectypes.CommitData{},
+			wantPending: []exectypes.CommitData{},
 		},
 		{
 			name: "no executed messages",
@@ -490,7 +491,7 @@ func Test_filterOutFullyExecutedMessages(t *testing.T) {
 				},
 				executedMessages: nil,
 			},
-			want: []exectypes.CommitData{
+			wantPending: []exectypes.CommitData{
 				{SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20)},
 				{SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40)},
 				{SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60)},
@@ -506,7 +507,12 @@ func Test_filterOutFullyExecutedMessages(t *testing.T) {
 				},
 				executedMessages: cciptypes.NewSeqNumRange(0, 100).ToSlice(),
 			},
-			want: nil,
+			wantPending: nil,
+			wantExecuted: []exectypes.CommitData{
+				{SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20)},
+				{SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40)},
+				{SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60)},
+			},
 		},
 		{
 			name: "2 partially executed",
@@ -518,7 +524,7 @@ func Test_filterOutFullyExecutedMessages(t *testing.T) {
 				},
 				executedMessages: cciptypes.NewSeqNumRange(15, 35).ToSlice(),
 			},
-			want: []exectypes.CommitData{
+			wantPending: []exectypes.CommitData{
 				{
 					SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
 					ExecutedMessages:    []cciptypes.SeqNum{15, 16, 17, 18, 19, 20},
@@ -542,7 +548,7 @@ func Test_filterOutFullyExecutedMessages(t *testing.T) {
 				},
 				executedMessages: cciptypes.NewSeqNumRange(15, 55).ToSlice(),
 			},
-			want: []exectypes.CommitData{
+			wantPending: []exectypes.CommitData{
 				{
 					SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
 					ExecutedMessages:    []cciptypes.SeqNum{15, 16, 17, 18, 19, 20},
@@ -551,6 +557,9 @@ func Test_filterOutFullyExecutedMessages(t *testing.T) {
 					SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60),
 					ExecutedMessages:    []cciptypes.SeqNum{50, 51, 52, 53, 54, 55},
 				},
+			},
+			wantExecuted: []exectypes.CommitData{
+				{SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40)},
 			},
 		},
 		{
@@ -563,9 +572,12 @@ func Test_filterOutFullyExecutedMessages(t *testing.T) {
 				},
 				executedMessages: cciptypes.NewSeqNumRange(10, 20).ToSlice(),
 			},
-			want: []exectypes.CommitData{
+			wantPending: []exectypes.CommitData{
 				{SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40)},
 				{SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60)},
+			},
+			wantExecuted: []exectypes.CommitData{
+				{SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20)},
 			},
 		},
 		{
@@ -578,63 +590,38 @@ func Test_filterOutFullyExecutedMessages(t *testing.T) {
 				},
 				executedMessages: cciptypes.NewSeqNumRange(50, 60).ToSlice(),
 			},
-			want: []exectypes.CommitData{
+			wantPending: []exectypes.CommitData{
 				{SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20)},
 				{SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40)},
 			},
-		},
-		{
-			name: "sort-report",
-			args: args{
-				reports: []exectypes.CommitData{
-					{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
-					},
-					{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40),
-					},
-					{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60),
-					},
-				},
-				executedMessages: nil,
-			},
-			want: []exectypes.CommitData{
-				{
-					SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
-				},
-				{
-					SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40),
-				},
-				{
-					SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60),
-				},
+			wantExecuted: []exectypes.CommitData{
+				{SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60)},
 			},
 		},
 		{
 			name: "sort-executed",
 			args: args{
 				reports: []exectypes.CommitData{
-					{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20),
-					},
-					{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40),
-					},
-					{
-						SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60),
-					},
+					{SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20)},
+					{SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40)},
+					{SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60)},
 				},
 				executedMessages: cciptypes.NewSeqNumRange(10, 60).ToSlice(),
 			},
-			want: nil,
+			wantPending: nil,
+			wantExecuted: []exectypes.CommitData{
+				{SequenceNumberRange: cciptypes.NewSeqNumRange(10, 20)},
+				{SequenceNumberRange: cciptypes.NewSeqNumRange(30, 40)},
+				{SequenceNumberRange: cciptypes.NewSeqNumRange(50, 60)},
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := filterOutExecutedMessages(tt.args.reports, tt.args.executedMessages)
-			assert.Equalf(t, tt.want, got, "filterOutExecutedMessages(%v, %v)", tt.args.reports, tt.args.executedMessages)
+			got, got2 := filterOutExecutedMessages(tt.args.reports, tt.args.executedMessages)
+			assert.Equal(t, tt.wantPending, got)
+			assert.Equal(t, tt.wantExecuted, got2)
 		})
 	}
 }
@@ -1401,7 +1388,7 @@ func Test_allSeqNrsObserved(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := msgsConformToSeqRange(tt.msgs, tt.numberRange); got != tt.want {
-				t.Errorf("msgsConformToSeqRange() = %v, want %v", got, tt.want)
+				t.Errorf("msgsConformToSeqRange() = %v, wantPending %v", got, tt.want)
 			}
 		})
 	}

--- a/execute/plugin_functions_test.go
+++ b/execute/plugin_functions_test.go
@@ -454,7 +454,7 @@ func Test_groupByChainSelector(t *testing.T) {
 	}
 }
 
-func Test_filterOutFullyExecutedMessages(t *testing.T) {
+func Test_combineReportsAndMessages(t *testing.T) {
 	type args struct {
 		reports          []exectypes.CommitData
 		executedMessages []cciptypes.SeqNum
@@ -619,7 +619,7 @@ func Test_filterOutFullyExecutedMessages(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got2 := filterOutExecutedMessages(tt.args.reports, tt.args.executedMessages)
+			got, got2 := combineReportsAndMessages(tt.args.reports, tt.args.executedMessages)
 			assert.Equal(t, tt.wantPending, got)
 			assert.Equal(t, tt.wantExecuted, got2)
 		})

--- a/execute/plugin_test.go
+++ b/execute/plugin_test.go
@@ -39,18 +39,24 @@ import (
 )
 
 func Test_getPendingExecutedReports(t *testing.T) {
+	canExecute := func(ret bool) CanExecuteHandle {
+		return func(cciptypes.ChainSelector, cciptypes.Bytes32) bool { return ret }
+	}
+
 	tests := []struct {
-		name    string
-		reports []plugintypes2.CommitPluginReportWithMeta
-		ranges  map[cciptypes.ChainSelector][]cciptypes.SeqNum
-		want    exectypes.CommitObservations
-		wantErr assert.ErrorAssertionFunc
+		name         string
+		reports      []plugintypes2.CommitPluginReportWithMeta
+		ranges       map[cciptypes.ChainSelector][]cciptypes.SeqNum
+		canExec      CanExecuteHandle
+		wantObs      exectypes.CommitObservations
+		wantExecuted []exectypes.CommitData
+		wantErr      assert.ErrorAssertionFunc
 	}{
 		{
 			name:    "empty",
 			reports: nil,
 			ranges:  nil,
-			want:    exectypes.CommitObservations{},
+			wantObs: exectypes.CommitObservations{},
 			wantErr: assert.NoError,
 		},
 		{
@@ -72,7 +78,7 @@ func Test_getPendingExecutedReports(t *testing.T) {
 			ranges: map[cciptypes.ChainSelector][]cciptypes.SeqNum{
 				1: nil,
 			},
-			want: exectypes.CommitObservations{
+			wantObs: exectypes.CommitObservations{
 				1: []exectypes.CommitData{
 					{
 						SourceChain:         1,
@@ -103,7 +109,7 @@ func Test_getPendingExecutedReports(t *testing.T) {
 			ranges: map[cciptypes.ChainSelector][]cciptypes.SeqNum{
 				1: {1, 2, 3, 7, 8},
 			},
-			want: exectypes.CommitObservations{
+			wantObs: exectypes.CommitObservations{
 				1: []exectypes.CommitData{
 					{
 						SourceChain:         1,
@@ -131,14 +137,73 @@ func Test_getPendingExecutedReports(t *testing.T) {
 				},
 			},
 			ranges:  map[cciptypes.ChainSelector][]cciptypes.SeqNum{},
-			want:    exectypes.CommitObservations{},
+			wantObs: exectypes.CommitObservations{},
 			wantErr: assert.NoError,
+		},
+		{
+			name: "single fully-executed report",
+			reports: []plugintypes2.CommitPluginReportWithMeta{
+				{
+					BlockNum:  999,
+					Timestamp: time.UnixMilli(10101010101),
+					Report: cciptypes.CommitPluginReport{
+						MerkleRoots: []cciptypes.MerkleRootChain{
+							{
+								ChainSel:     1,
+								SeqNumsRange: cciptypes.NewSeqNumRange(1, 10),
+							},
+						},
+					},
+				},
+			},
+			ranges: map[cciptypes.ChainSelector][]cciptypes.SeqNum{
+				1: cciptypes.NewSeqNumRange(1, 10).ToSlice(),
+			},
+			wantObs: exectypes.CommitObservations{
+				1: nil,
+			},
+			wantExecuted: []exectypes.CommitData{
+				{
+					SourceChain:         1,
+					SequenceNumberRange: cciptypes.NewSeqNumRange(1, 10),
+					Timestamp:           time.UnixMilli(10101010101),
+					BlockNum:            999,
+				},
+			},
+			wantErr: assert.NoError,
+		},
+		{
+			name: "single known-executed report",
+			reports: []plugintypes2.CommitPluginReportWithMeta{
+				{
+					BlockNum:  999,
+					Timestamp: time.UnixMilli(10101010101),
+					Report: cciptypes.CommitPluginReport{
+						MerkleRoots: []cciptypes.MerkleRootChain{
+							{
+								ChainSel:     1,
+								SeqNumsRange: cciptypes.NewSeqNumRange(1, 10),
+							},
+						},
+					},
+				},
+			},
+			canExec: canExecute(false),
+			ranges:  nil,
+			wantObs: exectypes.CommitObservations{
+				1: nil,
+			},
+			wantExecuted: nil, // the executed message is not returned.
+			wantErr:      assert.NoError,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			if tt.canExec == nil {
+				tt.canExec = canExecute(true)
+			}
 			mockReader := readerpkg_mock.NewMockCCIPReader(t)
 			mockReader.On(
 				"CommitReportsGTETimestamp", mock.Anything, mock.Anything, mock.Anything, mock.Anything,
@@ -152,16 +217,18 @@ func Test_getPendingExecutedReports(t *testing.T) {
 			//      CommitReportsGTETimestamp(ctx, dest, ts, 1000) -> ([]cciptypes.CommitPluginReportWithMeta, error)
 			// for each chain selector:
 			//      ExecutedMessages(ctx, selector, dest, seqRange) -> ([]cciptypes.SeqNum, error)
-			got, err := getPendingExecutedReports(
+			got, got2, err := getPendingExecutedReports(
 				context.Background(),
 				mockReader,
+				tt.canExec,
 				time.Now(),
 				logger.Test(t),
 			)
 			if !tt.wantErr(t, err, "getPendingExecutedReports(...)") {
 				return
 			}
-			assert.Equalf(t, tt.want, got, "getPendingExecutedReports(...)")
+			assert.Equalf(t, tt.wantObs, got, "getPendingExecutedReports(...)")
+			assert.Equalf(t, tt.wantExecuted, got2, "getPendingExecutedReports(...)")
 		})
 	}
 }


### PR DESCRIPTION
Add a `CommitsRootCache` which allows the execute plugin to remember what has already been executed. This enables it to skip RPC calls associated with known-executed commit roots.

In addition, a snooze button was added which allows us to snooze commit roots associated with cursed chains.