### PR TITLE
Fix reader panic cases

### DIFF
--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -639,13 +639,13 @@ func (r *ccipChainReader) GetWrappedNativeTokenPriceUSD(
 //nolint:lll
 func (r *ccipChainReader) GetChainFeePriceUpdate(ctx context.Context, selectors []cciptypes.ChainSelector) map[cciptypes.ChainSelector]plugintypes.TimestampedBig {
 	lggr := logutil.WithContextValues(ctx, r.lggr)
+	if err := validateExtendedReaderExistence(r.contractReaders, r.destChain); err != nil {
+		lggr.Errorw("GetChainFeePriceUpdate dest chain extended reader not exist", "err", err)
+		return nil
+	}
+
 	feeUpdates := make(map[cciptypes.ChainSelector]plugintypes.TimestampedBig, len(selectors))
 	for _, chain := range selectors {
-		if _, ok := r.contractReaders[r.destChain]; !ok {
-			lggr.Errorw("contract reader not found for GetChainFeePriceUpdate", "chain", chain)
-			continue
-		}
-
 		update := plugintypes.TimestampedUnixBig{}
 		// Read from dest chain
 		err := r.contractReaders[r.destChain].ExtendedGetLatestValue(


### PR DESCRIPTION
While working on another reader related issue I discovered the following issues.

- Missing checks for reader existence which will lead to panic
- Path with an uninitialized address type where we call `nil.Append`

`core ref: 8dab162d78d38f5307046eb254b88b233772d130`