### PR TITLE
Port curve-based gas deviation logic over from chainlink repo, add DisableChainFeeDeviationCheck

### DIFF
--- a/commit/chainfee/outcome.go
+++ b/commit/chainfee/outcome.go
@@ -253,9 +253,15 @@ func (p *processor) getGasPricesToUpdate(
 		if feeInfo == nil {
 			continue
 		}
+
 		ci, ok := feeInfo[chain]
 		if !ok {
 			lggr.Warnf("could not find fee info for chain %d", chain)
+			continue
+		}
+
+		if ci.DisableChainFeeDeviationCheck {
+			lggr.Debugf("chain fee deviation check disabled, skipping deviation check for chain %d", chain)
 			continue
 		}
 

--- a/commit/chainfee/outcome.go
+++ b/commit/chainfee/outcome.go
@@ -256,7 +256,7 @@ func (p *processor) getGasPricesToUpdate(
 			continue
 		}
 
-		gasDeviates := p.gasComponentsDeviate(currentChainFee, lastUpdate, ci)
+		gasDeviates := p.gasComponentsDeviate(lggr, chain, currentChainFee, lastUpdate, ci)
 		if gasDeviates {
 			gasPrices = append(gasPrices, cciptypes.GasPriceChain{
 				ChainSel: chain,
@@ -269,6 +269,8 @@ func (p *processor) getGasPricesToUpdate(
 }
 
 func (p *processor) gasComponentsDeviate(
+	lggr logger.Logger,
+	chain cciptypes.ChainSelector,
 	currentChainFee ComponentsUSDPrices,
 	lastUpdate Update,
 	ci pluginconfig.FeeInfo,
@@ -284,6 +286,23 @@ func (p *processor) gasComponentsDeviate(
 			currentChainFee.DataAvFeePriceUSD,
 			lastUpdate.ChainFee.DataAvFeePriceUSD,
 			p.cfg.DataAvNoDeviationThresholdUSDWei.Int,
+		)
+		// Log the deviation check info while we potentially still need to fine-tune the curve.
+		lggr.Debugf(
+			"using curve based deviation check for chain %d - "+
+				"executionFeeDeviates: %t, "+
+				"currentChainFee.executionFeePriceUSD: %s, "+
+				"lastUpdate.executionFeePriceUSD: %s, "+
+				"dataAvFeeDeviates: %t, "+
+				"currentChainFee.dataAvFeePriceUSD: %s, "+
+				"lastUpdate.dataAvFeePriceUSD: %s",
+			chain,
+			executionFeeDeviates,
+			currentChainFee.ExecutionFeePriceUSD.String(),
+			lastUpdate.ChainFee.ExecutionFeePriceUSD.String(),
+			dataAvFeeDeviates,
+			currentChainFee.DataAvFeePriceUSD.String(),
+			lastUpdate.ChainFee.DataAvFeePriceUSD.String(),
 		)
 	} else {
 		executionFeeDeviates = mathslib.Deviates(

--- a/commit/chainfee/outcome.go
+++ b/commit/chainfee/outcome.go
@@ -18,6 +18,16 @@ import (
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
 
+const (
+	// ExecNoDeviationThresholdUSD is the lower bound no deviation threshold for exec gas. If the exec gas price is
+	// less than this value, we should never trigger a deviation. This is set to 10 gwei in USD terms.
+	ExecNoDeviationThresholdUSD = 10e9
+
+	// DataAvNoDeviationThresholdUSD is the lower bound no deviation threshold for DA gas. If the DA gas price is less
+	// than this value, we should never trigger a deviation. This is set to 20 gwei in USD terms.
+	DataAvNoDeviationThresholdUSD = 20e9
+)
+
 func (p *processor) Outcome(
 	ctx context.Context,
 	_ Outcome,
@@ -249,15 +259,17 @@ func (p *processor) getGasPricesToUpdate(
 			continue
 		}
 
-		executionFeeDeviates := mathslib.Deviates(
+		executionFeeDeviates := mathslib.DeviatesOnCurve(
 			currentChainFee.ExecutionFeePriceUSD,
 			lastUpdate.ChainFee.ExecutionFeePriceUSD,
+			big.NewInt(ExecNoDeviationThresholdUSD),
 			ci.ExecDeviationPPB.Int64(),
 		)
 
-		dataAvFeeDeviates := mathslib.Deviates(
+		dataAvFeeDeviates := mathslib.DeviatesOnCurve(
 			currentChainFee.DataAvFeePriceUSD,
 			lastUpdate.ChainFee.DataAvFeePriceUSD,
+			big.NewInt(DataAvNoDeviationThresholdUSD),
 			ci.DataAvailabilityDeviationPPB.Int64(),
 		)
 

--- a/internal/libs/mathslib/calc.go
+++ b/internal/libs/mathslib/calc.go
@@ -69,7 +69,3 @@ func calculateCurveThresholdPPB(x float64) int64 {
 	thresholdPPB := int64(threshold * 1e7)
 	return thresholdPPB
 }
-
-func MergeEpochAndRound(epoch uint32, round uint8) uint64 {
-	return uint64(epoch)<<8 + uint64(round)
-}

--- a/internal/libs/mathslib/calc.go
+++ b/internal/libs/mathslib/calc.go
@@ -5,12 +5,6 @@ import (
 	"math/big"
 )
 
-const (
-	// CurveBasedDeviationPPB is the deviation threshold when writing to Ethereum's PriceRegistry and is the trigger for
-	// using curve-based deviation logic.
-	CurveBasedDeviationPPB = 4e9
-)
-
 // Deviates checks if x1 and x2 deviates based on the provided ppb (parts per billion)
 // ppb is calculated based on the smaller value of the two
 // e.g, if x1 > x2, deviation_parts_per_billion = ((x1 - x2) / x2) * 1e9
@@ -40,13 +34,7 @@ func CalculateUsdPerUnitGas(sourceGasPrice *big.Int, usdPerFeeCoin *big.Int) *bi
 // DeviatesOnCurve calculates a deviation threshold on the fly using xNew. For now it's only used for gas price
 // deviation calculation. It's important to make sure the order of xNew and xOld is correct when passed into this
 // function to get an accurate deviation threshold.
-func DeviatesOnCurve(xNew, xOld, noDeviationLowerBound *big.Int, ppb int64) bool {
-	// This is a temporary gating mechanism that ensures we only apply the gas curve deviation logic to eth-bound price
-	// updates. If ppb from config is not equal to 4000000000, do not apply the gas curve.
-	if ppb != CurveBasedDeviationPPB {
-		return Deviates(xOld, xNew, ppb)
-	}
-
+func DeviatesOnCurve(xNew, xOld, noDeviationLowerBound *big.Int) bool {
 	// If xNew < noDeviationLowerBound, Deviates should never be true
 	if xNew.Cmp(noDeviationLowerBound) < 0 {
 		return false

--- a/internal/libs/mathslib/calc.go
+++ b/internal/libs/mathslib/calc.go
@@ -1,7 +1,14 @@
 package mathslib
 
 import (
+	"math"
 	"math/big"
+)
+
+const (
+	// CurveBasedDeviationPPB is the deviation threshold when writing to Ethereum's PriceRegistry and is the trigger for
+	// using curve-based deviation logic.
+	CurveBasedDeviationPPB = 4e9
 )
 
 // Deviates checks if x1 and x2 deviates based on the provided ppb (parts per billion)
@@ -28,4 +35,53 @@ func CalculateUsdPerUnitGas(sourceGasPrice *big.Int, usdPerFeeCoin *big.Int) *bi
 	// (wei / gas) * (usd / eth) * (1 eth / 1e18 wei)  = usd/gas
 	tmp := new(big.Int).Mul(sourceGasPrice, usdPerFeeCoin)
 	return tmp.Div(tmp, big.NewInt(1e18))
+}
+
+// DeviatesOnCurve calculates a deviation threshold on the fly using xNew. For now it's only used for gas price
+// deviation calculation. It's important to make sure the order of xNew and xOld is correct when passed into this
+// function to get an accurate deviation threshold.
+func DeviatesOnCurve(xNew, xOld, noDeviationLowerBound *big.Int, ppb int64) bool {
+	// This is a temporary gating mechanism that ensures we only apply the gas curve deviation logic to eth-bound price
+	// updates. If ppb from config is not equal to 4000000000, do not apply the gas curve.
+	if ppb != CurveBasedDeviationPPB {
+		return Deviates(xOld, xNew, ppb)
+	}
+
+	// If xNew < noDeviationLowerBound, Deviates should never be true
+	if xNew.Cmp(noDeviationLowerBound) < 0 {
+		return false
+	}
+
+	xNewFloat := new(big.Float).SetInt(xNew)
+	xNewFloat64, _ := xNewFloat.Float64()
+
+	// We use xNew to generate the threshold so that when going from cheap --> expensive, xNew generates a smaller
+	// deviation threshold so we are more likely to update the gas price on chain. When going from expensive --> cheap,
+	// xNew generates a larger deviation threshold since it's not as urgent to update the gas price on chain.
+	curveThresholdPPB := calculateCurveThresholdPPB(xNewFloat64)
+	return Deviates(xNew, xOld, curveThresholdPPB)
+}
+
+// calculateCurveThresholdPPB calculates the deviation threshold percentage with x using the formula:
+// y = (10e11) / (x^0.665). This sliding scale curve was created by collecting several thousands of historical
+// PriceRegistry gas price update samples from chains with volatile gas prices like Zircuit and Mode and then using that
+// historical data to define thresholds of gas deviations that were acceptable given their USD value. The gas prices
+// (X coordinates) and these new thresholds (Y coordinates) were used to fit this sliding scale curve that returns large
+// thresholds at low gas prices and smaller thresholds at higher gas prices. Constructing the curve in USD terms allows
+// us to more easily reason about these thresholds and also better translates to non-evm chains. For example, when the
+// per unit gas price is 0.000006 USD, (6e12 USDgwei), the curve will output a threshold of around 3,000%. However, when
+// the per unit gas price is 0.005 USD (5e15 USDgwei), the curve will output a threshold of only ~30%.
+func calculateCurveThresholdPPB(x float64) int64 {
+	const constantFactor = 10e11
+	const exponent = 0.665
+	xPower := math.Pow(x, exponent)
+	threshold := constantFactor / xPower
+
+	// Convert curve output percentage to PPB
+	thresholdPPB := int64(threshold * 1e7)
+	return thresholdPPB
+}
+
+func MergeEpochAndRound(epoch uint32, round uint8) uint64 {
+	return uint64(epoch)<<8 + uint64(round)
 }

--- a/internal/libs/mathslib/calc_test.go
+++ b/internal/libs/mathslib/calc_test.go
@@ -1,6 +1,7 @@
 package mathslib
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -125,6 +126,144 @@ func TestCalculateUsdPerUnitGas(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			res := CalculateUsdPerUnitGas(tc.sourceGasPrice, tc.usdPerFeeCoin)
 			assert.Zero(t, tc.exp.Cmp(res))
+		})
+	}
+}
+
+func TestDeviatesOnCurve(t *testing.T) {
+	type args struct {
+		xNew  *big.Int
+		xOld  *big.Int
+		noDev *big.Int
+		ppb   int64
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "base case deviates from increase",
+			args: args{xNew: big.NewInt(4e14), xOld: big.NewInt(1e13), noDev: big.NewInt(3e13), ppb: CurveBasedDeviationPPB},
+			want: true,
+		},
+		{
+			name: "base case deviates from decrease",
+			args: args{xNew: big.NewInt(1e13), xOld: big.NewInt(4e15), noDev: big.NewInt(1), ppb: CurveBasedDeviationPPB},
+			want: true,
+		},
+		{
+			name: "does not deviate when equal",
+			args: args{xNew: big.NewInt(3e14), xOld: big.NewInt(3e14), noDev: big.NewInt(3e13), ppb: CurveBasedDeviationPPB},
+			want: false,
+		},
+		{
+			name: "does not deviate with small difference when xNew is bigger",
+			args: args{xNew: big.NewInt(3e14 + 1), xOld: big.NewInt(3e14), noDev: big.NewInt(3e13), ppb: CurveBasedDeviationPPB},
+			want: false,
+		},
+		{
+			name: "does not deviate with small difference when xOld is bigger",
+			args: args{xNew: big.NewInt(3e14), xOld: big.NewInt(3e14 + 1), noDev: big.NewInt(3e13), ppb: CurveBasedDeviationPPB},
+			want: false,
+		},
+		{
+			name: "deviates when ppb is not equal to CurveBasedDeviationPPB",
+			args: args{xNew: big.NewInt(1e9), xOld: big.NewInt(2e9), noDev: big.NewInt(1), ppb: 1},
+			want: true,
+		},
+		{
+			name: "does not deviate when xNew is below noDeviationLowerBound",
+			args: args{xNew: big.NewInt(2e13), xOld: big.NewInt(1e13), noDev: big.NewInt(3e13), ppb: CurveBasedDeviationPPB},
+			want: false,
+		},
+		// thresholdPPB = (10e11) / (xNew^0.665) * 1e7
+		// diff = (xNew - xOld) / min(xNew, xOld) * 1e9
+		// Deviates = abs(diff) > thresholdPPB
+		{
+			name: "xNew is just below deviation threshold and does deviate",
+			args: args{xNew: big.NewInt(3e13), xOld: big.NewInt(2.519478222838e12), noDev: big.NewInt(1), ppb: CurveBasedDeviationPPB},
+			want: false,
+		},
+		{
+			name: "xNew is just above deviation threshold and does deviate",
+			args: args{xNew: big.NewInt(3e13), xOld: big.NewInt(2.519478222838e12 - 30), noDev: big.NewInt(1), ppb: CurveBasedDeviationPPB},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(
+				t,
+				tt.want,
+				DeviatesOnCurve(tt.args.xNew, tt.args.xOld, tt.args.noDev, tt.args.ppb),
+				"DeviatesOnCurve(%v, %v, %v, %v)", tt.args.xNew, tt.args.xOld, tt.args.noDev, tt.args.ppb)
+		})
+	}
+}
+
+func TestCalculateCurveThresholdPPB(t *testing.T) {
+	tests := []struct {
+		x             float64
+		ppbLowerBound int64
+		ppbUpperBound int64
+	}{
+		{
+			x:             500_000,
+			ppbLowerBound: 1_000_000_000_000_000, // 100,000,000%
+			ppbUpperBound: 3_000_000_000_000_000, // 300,000,000%
+		},
+		{
+			x:             50_000_000,
+			ppbLowerBound: 70_000_000_000_000, // 7,000,000%
+			ppbUpperBound: 90_000_000_000_000, // 9,000,000%
+		},
+		{
+			x:             350_000_000,
+			ppbLowerBound: 20_000_000_000_000, // 2,000,000%
+			ppbUpperBound: 30_000_000_000_000, // 3,000,000%
+		},
+		{
+			x:             200_000_000_000,
+			ppbLowerBound: 300_000_000_000, // 30,000%
+			ppbUpperBound: 400_000_000_000, // 40,000%
+		},
+		{
+			x:             6_000_000_000_000,
+			ppbLowerBound: 30_000_000_000, // 3,000%
+			ppbUpperBound: 40000000000,    // 4,000%
+		},
+		{
+			x:             50_000_000_000_000,
+			ppbLowerBound: 7_000_000_000, // 700%
+			ppbUpperBound: 8_000_000_000, // 800%
+		},
+		{
+			x:             225_000_000_000_000,
+			ppbLowerBound: 2_000_000_000, // 200%
+			ppbUpperBound: 3_000_000_000, // 300%
+		},
+		{
+			x:             5_000_000_000_000_000,
+			ppbLowerBound: 300_000_000, // 30%
+			ppbUpperBound: 400_000_000, // 40%
+		},
+		{
+			x:             70_000_000_000_000_000,
+			ppbLowerBound: 60_000_000, // 6%
+			ppbUpperBound: 70_000_000, // 7%
+		},
+		{
+			x:             500_000_000_000_000_000,
+			ppbLowerBound: 10_000_000, // 1%
+			ppbUpperBound: 20_000_000, // 2%
+		},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%f", tt.x), func(t *testing.T) {
+			thresholdPPB := calculateCurveThresholdPPB(tt.x)
+			assert.GreaterOrEqual(t, thresholdPPB, tt.ppbLowerBound)
+			assert.LessOrEqual(t, thresholdPPB, tt.ppbUpperBound)
 		})
 	}
 }

--- a/internal/libs/mathslib/calc_test.go
+++ b/internal/libs/mathslib/calc_test.go
@@ -135,7 +135,6 @@ func TestDeviatesOnCurve(t *testing.T) {
 		xNew  *big.Int
 		xOld  *big.Int
 		noDev *big.Int
-		ppb   int64
 	}
 	tests := []struct {
 		name string
@@ -144,37 +143,32 @@ func TestDeviatesOnCurve(t *testing.T) {
 	}{
 		{
 			name: "base case deviates from increase",
-			args: args{xNew: big.NewInt(4e14), xOld: big.NewInt(1e13), noDev: big.NewInt(3e13), ppb: CurveBasedDeviationPPB},
+			args: args{xNew: big.NewInt(4e14), xOld: big.NewInt(1e13), noDev: big.NewInt(3e13)},
 			want: true,
 		},
 		{
 			name: "base case deviates from decrease",
-			args: args{xNew: big.NewInt(1e13), xOld: big.NewInt(4e15), noDev: big.NewInt(1), ppb: CurveBasedDeviationPPB},
+			args: args{xNew: big.NewInt(1e13), xOld: big.NewInt(4e15), noDev: big.NewInt(1)},
 			want: true,
 		},
 		{
 			name: "does not deviate when equal",
-			args: args{xNew: big.NewInt(3e14), xOld: big.NewInt(3e14), noDev: big.NewInt(3e13), ppb: CurveBasedDeviationPPB},
+			args: args{xNew: big.NewInt(3e14), xOld: big.NewInt(3e14), noDev: big.NewInt(3e13)},
 			want: false,
 		},
 		{
 			name: "does not deviate with small difference when xNew is bigger",
-			args: args{xNew: big.NewInt(3e14 + 1), xOld: big.NewInt(3e14), noDev: big.NewInt(3e13), ppb: CurveBasedDeviationPPB},
+			args: args{xNew: big.NewInt(3e14 + 1), xOld: big.NewInt(3e14), noDev: big.NewInt(3e13)},
 			want: false,
 		},
 		{
 			name: "does not deviate with small difference when xOld is bigger",
-			args: args{xNew: big.NewInt(3e14), xOld: big.NewInt(3e14 + 1), noDev: big.NewInt(3e13), ppb: CurveBasedDeviationPPB},
+			args: args{xNew: big.NewInt(3e14), xOld: big.NewInt(3e14 + 1), noDev: big.NewInt(3e13)},
 			want: false,
 		},
 		{
-			name: "deviates when ppb is not equal to CurveBasedDeviationPPB",
-			args: args{xNew: big.NewInt(1e9), xOld: big.NewInt(2e9), noDev: big.NewInt(1), ppb: 1},
-			want: true,
-		},
-		{
 			name: "does not deviate when xNew is below noDeviationLowerBound",
-			args: args{xNew: big.NewInt(2e13), xOld: big.NewInt(1e13), noDev: big.NewInt(3e13), ppb: CurveBasedDeviationPPB},
+			args: args{xNew: big.NewInt(2e13), xOld: big.NewInt(1e13), noDev: big.NewInt(3e13)},
 			want: false,
 		},
 		// thresholdPPB = (10e11) / (xNew^0.665) * 1e7
@@ -186,7 +180,6 @@ func TestDeviatesOnCurve(t *testing.T) {
 				xNew:  big.NewInt(3e13),
 				xOld:  big.NewInt(2.519478222838e12),
 				noDev: big.NewInt(1),
-				ppb:   CurveBasedDeviationPPB,
 			},
 			want: false,
 		},
@@ -196,7 +189,6 @@ func TestDeviatesOnCurve(t *testing.T) {
 				xNew:  big.NewInt(3e13),
 				xOld:  big.NewInt(2.519478222838e12 - 30),
 				noDev: big.NewInt(1),
-				ppb:   CurveBasedDeviationPPB,
 			},
 			want: true,
 		},
@@ -206,8 +198,8 @@ func TestDeviatesOnCurve(t *testing.T) {
 			assert.Equalf(
 				t,
 				tt.want,
-				DeviatesOnCurve(tt.args.xNew, tt.args.xOld, tt.args.noDev, tt.args.ppb),
-				"DeviatesOnCurve(%v, %v, %v, %v)", tt.args.xNew, tt.args.xOld, tt.args.noDev, tt.args.ppb)
+				DeviatesOnCurve(tt.args.xNew, tt.args.xOld, tt.args.noDev),
+				"DeviatesOnCurve(%v, %v, %v)", tt.args.xNew, tt.args.xOld, tt.args.noDev)
 		})
 	}
 }

--- a/internal/libs/mathslib/calc_test.go
+++ b/internal/libs/mathslib/calc_test.go
@@ -182,12 +182,22 @@ func TestDeviatesOnCurve(t *testing.T) {
 		// Deviates = abs(diff) > thresholdPPB
 		{
 			name: "xNew is just below deviation threshold and does deviate",
-			args: args{xNew: big.NewInt(3e13), xOld: big.NewInt(2.519478222838e12), noDev: big.NewInt(1), ppb: CurveBasedDeviationPPB},
+			args: args{
+				xNew:  big.NewInt(3e13),
+				xOld:  big.NewInt(2.519478222838e12),
+				noDev: big.NewInt(1),
+				ppb:   CurveBasedDeviationPPB,
+			},
 			want: false,
 		},
 		{
 			name: "xNew is just above deviation threshold and does deviate",
-			args: args{xNew: big.NewInt(3e13), xOld: big.NewInt(2.519478222838e12 - 30), noDev: big.NewInt(1), ppb: CurveBasedDeviationPPB},
+			args: args{
+				xNew:  big.NewInt(3e13),
+				xOld:  big.NewInt(2.519478222838e12 - 30),
+				noDev: big.NewInt(1),
+				ppb:   CurveBasedDeviationPPB,
+			},
 			want: true,
 		},
 	}

--- a/pluginconfig/commit.go
+++ b/pluginconfig/commit.go
@@ -249,16 +249,11 @@ func (c *CommitOffchainConfig) applyDefaults() {
 		}
 	}
 
-	// Only apply defaults if the curve based deviation is disabled. Otherwise, these values should already be set in
-	// the config.
-	if !c.CurveBasedGasDeviationEnabled {
-		if c.ExecNoDeviationThresholdUSDWei.Int == nil {
-			c.ExecNoDeviationThresholdUSDWei = cciptypes.BigInt{Int: big.NewInt(defaultExecNoDeviationThresholdUSDWei)}
-		}
-
-		if c.DataAvNoDeviationThresholdUSDWei.Int == nil {
-			c.DataAvNoDeviationThresholdUSDWei = cciptypes.BigInt{Int: big.NewInt(defaultDataAvNoDeviationThresholdUSDWei)}
-		}
+	if c.ExecNoDeviationThresholdUSDWei.Int == nil {
+		c.ExecNoDeviationThresholdUSDWei = cciptypes.BigInt{Int: big.NewInt(defaultExecNoDeviationThresholdUSDWei)}
+	}
+	if c.DataAvNoDeviationThresholdUSDWei.Int == nil {
+		c.DataAvNoDeviationThresholdUSDWei = cciptypes.BigInt{Int: big.NewInt(defaultDataAvNoDeviationThresholdUSDWei)}
 	}
 }
 

--- a/pluginconfig/commit.go
+++ b/pluginconfig/commit.go
@@ -171,6 +171,18 @@ type CommitOffchainConfig struct {
 	// in order to avoid delays when there are reports from multiple sources.
 	// NOTE: this can only be used if RMNEnabled == false.
 	MultipleReportsEnabled bool `json:"multipleReports"`
+
+	// ExecNoDeviationThresholdUSDWei is the lower bound *no* deviation threshold for exec gas. If the exec gas price is
+	// less than this value, we should never trigger a deviation. A value of 5e9 would correspond to 0.000000005 USD.
+	ExecNoDeviationThresholdUSDWei cciptypes.BigInt `json:"execNoDeviationThresholdUSDWei"`
+
+	// DataAvNoDeviationThresholdUSDWei is the lower bound *no* deviation threshold for DA gas. If the DA gas price is
+	// less than this value, we should never trigger a deviation. A value of 5e9 would correspond to 0.000000005 USD.
+	DataAvNoDeviationThresholdUSDWei cciptypes.BigInt `json:"dataAvNoDeviationThresholdUSDWei"`
+
+	// CurveBasedGasDeviationEnabled determines whether or not we should use the deviation curve or the fixed PPB values
+	// when determining whether or not the gas price has deviated.
+	CurveBasedGasDeviationEnabled bool `json:"curveBasedGasDeviationEnabled"`
 }
 
 //nolint:gocyclo // it is considered ok since we don't have complicated logic here

--- a/pluginconfig/commit.go
+++ b/pluginconfig/commit.go
@@ -32,8 +32,9 @@ const (
 )
 
 type FeeInfo struct {
-	ExecDeviationPPB             cciptypes.BigInt `json:"execDeviationPPB"`
-	DataAvailabilityDeviationPPB cciptypes.BigInt `json:"dataAvailabilityDeviationPPB"`
+	ExecDeviationPPB              cciptypes.BigInt `json:"execDeviationPPB"`
+	DataAvailabilityDeviationPPB  cciptypes.BigInt `json:"dataAvailabilityDeviationPPB"`
+	DisableChainFeeDeviationCheck bool             `json:"disableChainFeeDeviationCheck"`
 }
 
 type TokenInfo struct {

--- a/pluginconfig/commit.go
+++ b/pluginconfig/commit.go
@@ -327,20 +327,18 @@ func (c *CommitOffchainConfig) Validate() error {
 		}
 	}
 
-	if c.ExecNoDeviationThresholdUSDWei.Int == nil {
-		return fmt.Errorf("execNoDeviationThresholdUSDWei not set")
-	}
-
-	if c.DataAvNoDeviationThresholdUSDWei.Int == nil {
-		return fmt.Errorf("dataAvNoDeviationThresholdUSDWei not set")
-	}
-
 	if c.CurveBasedGasDeviationEnabled {
-		if c.ExecNoDeviationThresholdUSDWei.Int.Cmp(big.NewInt(0)) <= 0 {
-			return fmt.Errorf("execNoDeviationThresholdUSDWei must be greater than 0")
+		if c.ExecNoDeviationThresholdUSDWei.Int == nil {
+			return fmt.Errorf("curveBasedGasDeviationEnabled is true but execNoDeviationThresholdUSDWei not set")
 		}
-		if c.DataAvNoDeviationThresholdUSDWei.Int.Cmp(big.NewInt(0)) <= 0 {
-			return fmt.Errorf("dataAvNoDeviationThresholdUSDWei must be greater than 0")
+		if c.DataAvNoDeviationThresholdUSDWei.Int == nil {
+			return fmt.Errorf("curveBasedGasDeviationEnabled is true but dataAvNoDeviationThresholdUSDWei not set")
+		}
+		if c.ExecNoDeviationThresholdUSDWei.Int.Cmp(big.NewInt(0)) < 0 {
+			return fmt.Errorf("execNoDeviationThresholdUSDWei must be non-negative")
+		}
+		if c.DataAvNoDeviationThresholdUSDWei.Int.Cmp(big.NewInt(0)) < 0 {
+			return fmt.Errorf("dataAvNoDeviationThresholdUSDWei must be non-negative")
 		}
 	}
 

--- a/pluginconfig/commit_test.go
+++ b/pluginconfig/commit_test.go
@@ -316,7 +316,7 @@ func TestCommitOffchainConfig_Validate(t *testing.T) {
 			false,
 		},
 		{
-			"invalid, curve based gas deviation nil",
+			"valid, curve turned off and no deviation values are nil",
 			fields{
 				RemoteGasPriceBatchWriteFrequency:  *commonconfig.MustNewDuration(1),
 				TokenPriceBatchWriteFrequency:      *commonconfig.MustNewDuration(0),
@@ -333,10 +333,10 @@ func TestCommitOffchainConfig_Validate(t *testing.T) {
 				ExecNoDeviationThresholdUSDWei:     cciptypes.BigInt{Int: nil},
 				DataAvNoDeviationThresholdUSDWei:   cciptypes.BigInt{Int: nil},
 			},
-			true,
+			false,
 		},
 		{
-			"invalid, curve based gas deviation turned on but no threshold values are 0",
+			"invalid, curve based gas deviation turned on but no threshold values are negative",
 			fields{
 				RemoteGasPriceBatchWriteFrequency:  *commonconfig.MustNewDuration(1),
 				TokenPriceBatchWriteFrequency:      *commonconfig.MustNewDuration(0),
@@ -350,8 +350,8 @@ func TestCommitOffchainConfig_Validate(t *testing.T) {
 				ChainFeeAsyncObserverSyncFreq:      defaultAsyncObserverSyncFreq,
 				ChainFeeAsyncObserverSyncTimeout:   defaultAsyncObserverSyncTimeout,
 				CurveBasedGasDeviationEnabled:      true,
-				ExecNoDeviationThresholdUSDWei:     cciptypes.BigInt{Int: big.NewInt(0)},
-				DataAvNoDeviationThresholdUSDWei:   cciptypes.BigInt{Int: big.NewInt(0)},
+				ExecNoDeviationThresholdUSDWei:     cciptypes.BigInt{Int: big.NewInt(-1)},
+				DataAvNoDeviationThresholdUSDWei:   cciptypes.BigInt{Int: big.NewInt(-1)},
 			},
 			true,
 		},


### PR DESCRIPTION
- This was added to `chainlink` in https://github.com/smartcontractkit/chainlink/commit/d2fa4bcbbfe783844238dcd33cb0813fac06d4d4
- Port it here as well (CCIP-4813)
- Also add `DisableChainFeeDeviationCheck` to `FeeInfo` so we can disable deviation checks on a lane-specific level. Since this param lives in `FeeInfo`, there is a value for each source chain configured for this dest chain.

core ref: efbc0805fc0920f68b214f7fa06db6b4d7b7965e