### PR TITLE
New factory constructors with stable function signature.

### DIFF
--- a/commit/factory.go
+++ b/commit/factory.go
@@ -88,7 +88,7 @@ type CommitPluginFactoryParams struct {
 	HomeChainReader   reader.HomeChain
 	HomeChainSelector cciptypes.ChainSelector
 	ContractReaders   map[cciptypes.ChainSelector]types.ContractReader
-	ChainWriters      map[cciptypes.ChainSelector]types.ContractWriter
+	ContractWriters   map[cciptypes.ChainSelector]types.ContractWriter
 	RmnPeerClient     rmn.PeerClient
 	RmnCrypto         cciptypes.RMNCrypto
 }
@@ -106,7 +106,7 @@ func NewCommitPluginFactory(params CommitPluginFactoryParams) *PluginFactory {
 		homeChainReader:   params.HomeChainReader,
 		homeChainSelector: params.HomeChainSelector,
 		contractReaders:   params.ContractReaders,
-		chainWriters:      params.ChainWriters,
+		chainWriters:      params.ContractWriters,
 		rmnPeerClient:     params.RmnPeerClient,
 		rmnCrypto:         params.RmnCrypto,
 	}

--- a/commit/factory.go
+++ b/commit/factory.go
@@ -93,8 +93,8 @@ type CommitPluginFactoryParams struct {
 	RmnCrypto         cciptypes.RMNCrypto
 }
 
-// NewCommitPluginFactory creates a new PluginFactory instance. For commit plugin, oracle instances are not managed by the
-// factory. It is safe to assume that a factory instance will create exactly one plugin instance.
+// NewCommitPluginFactory creates a new PluginFactory instance. For commit plugin, oracle instances are not managed by
+// the factory. It is safe to assume that a factory instance will create exactly one plugin instance.
 func NewCommitPluginFactory(params CommitPluginFactoryParams) *PluginFactory {
 	return &PluginFactory{
 		baseLggr:          params.Lggr,

--- a/commit/factory.go
+++ b/commit/factory.go
@@ -78,8 +78,43 @@ type PluginFactory struct {
 	rmnCrypto         cciptypes.RMNCrypto
 }
 
+type CommitPluginFactoryParams struct {
+	Lggr              logger.Logger
+	DonID             plugintypes.DonID
+	OcrConfig         reader.OCR3ConfigWithMeta
+	CommitCodec       cciptypes.CommitPluginCodec
+	MsgHasher         cciptypes.MessageHasher
+	ExtraDataCodec    cciptypes.ExtraDataCodec
+	HomeChainReader   reader.HomeChain
+	HomeChainSelector cciptypes.ChainSelector
+	ContractReaders   map[cciptypes.ChainSelector]types.ContractReader
+	ChainWriters      map[cciptypes.ChainSelector]types.ContractWriter
+	RmnPeerClient     rmn.PeerClient
+	RmnCrypto         cciptypes.RMNCrypto
+}
+
+// NewCommitPluginFactory creates a new PluginFactory instance. For commit plugin, oracle instances are not managed by the
+// factory. It is safe to assume that a factory instance will create exactly one plugin instance.
+func NewCommitPluginFactory(params CommitPluginFactoryParams) *PluginFactory {
+	return &PluginFactory{
+		baseLggr:          params.Lggr,
+		donID:             params.DonID,
+		ocrConfig:         params.OcrConfig,
+		commitCodec:       params.CommitCodec,
+		msgHasher:         params.MsgHasher,
+		extraDataCodec:    params.ExtraDataCodec,
+		homeChainReader:   params.HomeChainReader,
+		homeChainSelector: params.HomeChainSelector,
+		contractReaders:   params.ContractReaders,
+		chainWriters:      params.ChainWriters,
+		rmnPeerClient:     params.RmnPeerClient,
+		rmnCrypto:         params.RmnCrypto,
+	}
+}
+
 // NewPluginFactory creates a new PluginFactory instance. For commit plugin, oracle instances are not managed by the
 // factory. It is safe to assume that a factory instance will create exactly one plugin instance.
+// deprecated: use NewCommitPluginFactory instead
 func NewPluginFactory(
 	lggr logger.Logger,
 	donID plugintypes.DonID,

--- a/execute/factory.go
+++ b/execute/factory.go
@@ -87,7 +87,7 @@ type PluginFactoryParams struct {
 	TokenDataEncoder cciptypes.TokenDataEncoder
 	EstimateProvider cciptypes.EstimateProvider
 	ContractReaders  map[cciptypes.ChainSelector]types.ContractReader
-	ChainWriters     map[cciptypes.ChainSelector]types.ContractWriter
+	ContractWriters  map[cciptypes.ChainSelector]types.ContractWriter
 }
 
 // NewExecutePluginFactory creates a new PluginFactory instance. For execute plugin, oracle instances are not managed by
@@ -104,7 +104,7 @@ func NewExecutePluginFactory(params PluginFactoryParams) *PluginFactory {
 		estimateProvider: params.EstimateProvider,
 		tokenDataEncoder: params.TokenDataEncoder,
 		contractReaders:  params.ContractReaders,
-		chainWriters:     params.ChainWriters,
+		chainWriters:     params.ContractWriters,
 	}
 }
 

--- a/execute/factory.go
+++ b/execute/factory.go
@@ -76,6 +76,39 @@ type PluginFactory struct {
 	chainWriters     map[cciptypes.ChainSelector]types.ContractWriter
 }
 
+type PluginFactoryParams struct {
+	Lggr             logger.Logger
+	DonID            plugintypes.DonID
+	OcrConfig        reader.OCR3ConfigWithMeta
+	ExecCodec        cciptypes.ExecutePluginCodec
+	MsgHasher        cciptypes.MessageHasher
+	ExtraDataCodec   cciptypes.ExtraDataCodec
+	HomeChainReader  reader.HomeChain
+	TokenDataEncoder cciptypes.TokenDataEncoder
+	EstimateProvider cciptypes.EstimateProvider
+	ContractReaders  map[cciptypes.ChainSelector]types.ContractReader
+	ChainWriters     map[cciptypes.ChainSelector]types.ContractWriter
+}
+
+// NewExecutePluginFactory creates a new PluginFactory instance. For execute plugin, oracle instances are not managed by
+// the factory. It is safe to assume that a factory instance will create exactly one plugin instance.
+func NewExecutePluginFactory(params PluginFactoryParams) *PluginFactory {
+	return &PluginFactory{
+		baseLggr:         params.Lggr,
+		donID:            params.DonID,
+		ocrConfig:        params.OcrConfig,
+		execCodec:        params.ExecCodec,
+		msgHasher:        params.MsgHasher,
+		extraDataCodec:   params.ExtraDataCodec,
+		homeChainReader:  params.HomeChainReader,
+		estimateProvider: params.EstimateProvider,
+		tokenDataEncoder: params.TokenDataEncoder,
+		contractReaders:  params.ContractReaders,
+		chainWriters:     params.ChainWriters,
+	}
+}
+
+// deprectated: use NewExececutePluginFactory
 func NewPluginFactory(
 	lggr logger.Logger,
 	donID plugintypes.DonID,


### PR DESCRIPTION
By using a parameter object, we can freely modify the factory inputs without breaking compatibility between chainlink-ccip and chainlink repositories.

core ref: 7ac42f05240ec84385a88cad25f96c9c8d6aaa08