### PR TITLE
solana: timelock operation state management improvement

### DIFF
--- a/chains/solana/contracts/programs/timelock/src/constants.rs
+++ b/chains/solana/contracts/programs/timelock/src/constants.rs
@@ -7,7 +7,6 @@ pub const TIMELOCK_BLOCKED_FUNCITON_SELECTOR_SEED: &[u8] = b"timelock_blocked_fu
 
 /// constants
 pub const ANCHOR_DISCRIMINATOR: usize = 8;
-pub const DONE_TIMESTAMP: u64 = 1;
 pub const EMPTY_PREDECESSOR: [u8; 32] = [0; 32];
 pub const TIMELOCK_ID_PADDED: usize = 32; // fixed size timelock id for distinguishing different timelock states
 pub const MAX_SELECTORS: usize = 128; // max number of function selectors that can be blocked(arrayvec)

--- a/chains/solana/contracts/programs/timelock/src/instructions/execute.rs
+++ b/chains/solana/contracts/programs/timelock/src/instructions/execute.rs
@@ -80,7 +80,7 @@ pub fn execute_batch<'info>(
         });
     }
 
-    // all executed, update the timestamp
+    // all executed, update the operation state
     op.mark_done();
 
     Ok(())
@@ -88,7 +88,7 @@ pub fn execute_batch<'info>(
 
 /// execute operation(instructions) w/o checking predecessors and readiness
 /// bypasser_execute also need the operation to be uploaded formerly
-/// NOTE: operation should be closed after execution
+/// NOTE: operation is closed after execution
 pub fn bypasser_execute_batch<'info>(
     ctx: Context<'_, '_, '_, 'info, BypasserExecuteBatch<'info>>,
     timelock_id: [u8; TIMELOCK_ID_PADDED],
@@ -181,8 +181,8 @@ pub struct BypasserExecuteBatch<'info> {
         mut,
         seeds = [TIMELOCK_BYPASSER_OPERATION_SEED, timelock_id.as_ref(), id.as_ref()],
         bump,
-        constraint = operation.is_finalized @ TimelockError::OperationNotFinalized,
-        close = authority, // close the bypasser operation after execution
+        constraint = operation.is_finalized() @ TimelockError::OperationNotFinalized,
+        close = authority, // close the operation after bypasser execution
     )]
     pub operation: Account<'info, Operation>,
 

--- a/chains/solana/contracts/programs/timelock/src/state/operation.rs
+++ b/chains/solana/contracts/programs/timelock/src/state/operation.rs
@@ -2,40 +2,69 @@ use anchor_lang::prelude::*;
 use anchor_lang::solana_program::instruction::Instruction;
 use anchor_lang::solana_program::keccak::{hashv, HASH_BYTES};
 
-use crate::constants::DONE_TIMESTAMP;
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug, PartialEq, PartialOrd)]
+pub enum OperationState {
+    /// Operation is created but not yet finalized.
+    Initialized,
+    /// Operation is finalized (instructions are locked in) but not yet scheduled.
+    Finalized,
+    /// Operation is scheduled (ready to be executed when its time comes).
+    Scheduled,
+    /// Operation has been executed and is complete.
+    Done,
+}
 
 #[account]
 pub struct Operation {
+    pub state: OperationState,
     pub timestamp: u64,                     // scheduled timestamp in unix time
     pub id: [u8; 32],                       // hashed operation id
     pub predecessor: [u8; 32],              // hash of the previous operation
     pub salt: [u8; 32],                     // random salt for the operation
-    pub is_finalized: bool,                 // flag to indicate if the operation is finalized
     pub total_instructions: u32,            // total number of instructions in the operation
     pub instructions: Vec<InstructionData>, // list of instructions
+}
+
+impl Space for Operation {
+    // state(u8) + timestamp + id + predecessor + salt + total_ixs + vec prefix for instructions
+    const INIT_SPACE: usize = 1 + 8 + 32 + 32 + 32 + 4 + 4;
 }
 
 impl Operation {
     // before scheduling, timestamp should be 0
     pub fn is_scheduled(&self) -> bool {
-        self.timestamp > 0
+        self.state >= OperationState::Scheduled
     }
 
-    // scheduled but not executed
+    pub fn is_finalized(&self) -> bool {
+        self.state == OperationState::Finalized
+    }
+
     pub fn is_pending(&self) -> bool {
-        self.timestamp > DONE_TIMESTAMP
+        // scheduled but not executed
+        self.state == OperationState::Scheduled
     }
 
     pub fn is_ready(&self, current_timestamp: u64) -> bool {
-        self.timestamp > DONE_TIMESTAMP && self.timestamp <= current_timestamp
+        // scheduled and timestamp is in the past
+        self.state == OperationState::Scheduled && self.timestamp <= current_timestamp
     }
 
     pub fn is_done(&self) -> bool {
-        self.timestamp == DONE_TIMESTAMP
+        self.state == OperationState::Done
+    }
+
+    pub fn finalize(&mut self) {
+        self.state = OperationState::Finalized;
+    }
+
+    pub fn schedule(&mut self, scheduled_time: u64) {
+        self.timestamp = scheduled_time;
+        self.state = OperationState::Scheduled;
     }
 
     pub fn mark_done(&mut self) {
-        self.timestamp = DONE_TIMESTAMP;
+        self.state = OperationState::Done;
     }
 
     pub fn hash_instructions(&self, salt: [u8; HASH_BYTES]) -> [u8; HASH_BYTES] {
@@ -78,11 +107,6 @@ impl Operation {
     pub fn verify_id(&self) -> bool {
         self.hash_instructions(self.salt) == self.id
     }
-}
-
-impl Space for Operation {
-    // timestamp + id + predecessor + salt + total_ixs + is_finalized + vec prefix for instructions
-    const INIT_SPACE: usize = 8 + 32 + 32 + 32 + 4 + 1 + 4;
 }
 
 // The native SVM's Instruction type from solana_program doesn't implement the AnchorSerialize trait.
@@ -148,11 +172,11 @@ mod tests {
         predecessor: [u8; HASH_BYTES],
     ) -> Operation {
         Operation {
+            state: OperationState::Initialized,
             timestamp: 0,
             id: [0u8; 32],
             predecessor,
             salt: [0u8; 32],
-            is_finalized: false,
             total_instructions: instructions.len() as u32,
             instructions,
         }

--- a/chains/solana/contracts/target/idl/timelock.json
+++ b/chains/solana/contracts/target/idl/timelock.json
@@ -1327,6 +1327,12 @@
         "kind": "struct",
         "fields": [
           {
+            "name": "state",
+            "type": {
+              "defined": "OperationState"
+            }
+          },
+          {
             "name": "timestamp",
             "type": "u64"
           },
@@ -1356,10 +1362,6 @@
                 32
               ]
             }
-          },
-          {
-            "name": "isFinalized",
-            "type": "bool"
           },
           {
             "name": "totalInstructions",
@@ -1526,6 +1528,26 @@
           },
           {
             "name": "Bypasser"
+          }
+        ]
+      }
+    },
+    {
+      "name": "OperationState",
+      "type": {
+        "kind": "enum",
+        "variants": [
+          {
+            "name": "Initialized"
+          },
+          {
+            "name": "Finalized"
+          },
+          {
+            "name": "Scheduled"
+          },
+          {
+            "name": "Done"
           }
         ]
       }

--- a/chains/solana/contracts/tests/config/timelock_config.go
+++ b/chains/solana/contracts/tests/config/timelock_config.go
@@ -14,7 +14,6 @@ var (
 	BatchAddAccessChunkSize = 24
 	MinDelay                = uint64(1)
 	TimelockEmptyOpID       = [32]byte{}
-	TimelockOpDoneTimestamp = uint64(1)
 	MaxFunctionSelectorLen  = 128
 
 	// operational constraints

--- a/chains/solana/contracts/tests/mcms/mcm_timelock_test.go
+++ b/chains/solana/contracts/tests/mcms/mcm_timelock_test.go
@@ -765,8 +765,8 @@ func TestMcmWithTimelock(t *testing.T) {
 						}
 
 						require.Equal(t,
-							config.TimelockOpDoneTimestamp,
-							opAccount.Timestamp,
+							timelock.Done_OperationState,
+							opAccount.State,
 							"Executed operation's time should be 1(DONE_TIMESTAMP)",
 						)
 
@@ -1483,7 +1483,7 @@ func TestMcmWithTimelock(t *testing.T) {
 				var opAccount timelock.Operation
 				err = common.GetAccountDataBorshInto(ctx, solanaGoClient, op1.OperationPDA(), config.DefaultCommitment, &opAccount)
 				require.NoError(t, err)
-				require.Equal(t, config.TimelockOpDoneTimestamp, opAccount.Timestamp, "Op1 should be marked as executed")
+				require.Equal(t, timelock.Done_OperationState, opAccount.State, "Op1 should be marked as done")
 
 				// Verify treasury balance
 				_, treasuryBalance, tberr := tokens.TokenBalance(ctx, solanaGoClient, treasuryATA, config.DefaultCommitment)
@@ -1583,7 +1583,7 @@ func TestMcmWithTimelock(t *testing.T) {
 				var opAccount timelock.Operation
 				err = common.GetAccountDataBorshInto(ctx, solanaGoClient, op2.OperationPDA(), config.DefaultCommitment, &opAccount)
 				require.NoError(t, err)
-				require.Equal(t, config.TimelockOpDoneTimestamp, opAccount.Timestamp, "Op2 should be marked as executed")
+				require.Equal(t, timelock.Done_OperationState, opAccount.State, "Op2 should be marked as done")
 			})
 		})
 
@@ -2432,7 +2432,7 @@ func TestMcmWithTimelock(t *testing.T) {
 						require.NoError(t, err, "failed to get account info")
 					}
 					require.Equal(t, timelockOp.OperationID(), opAccount.Id, "Operation ID does not match")
-					require.Equal(t, true, opAccount.IsFinalized, "Operation state is invalid")
+					require.Equal(t, timelock.Scheduled_OperationState, opAccount.State, "Operation state is invalid")
 
 					werr := timelockutil.WaitForOperationToBeReady(ctx, solanaGoClient, timelockOp.OperationPDA(), config.DefaultCommitment)
 					require.NoError(t, werr)
@@ -2478,9 +2478,9 @@ func TestMcmWithTimelock(t *testing.T) {
 						}
 
 						require.Equal(t,
-							config.TimelockOpDoneTimestamp,
-							opAccount.Timestamp,
-							"Executed operation's time should be 1(DONE_TIMESTAMP)",
+							timelock.Done_OperationState,
+							opAccount.State,
+							"Executed operation should be marked as done",
 						)
 					}
 				})

--- a/chains/solana/contracts/tests/mcms/timelock_bypasser_execute_test.go
+++ b/chains/solana/contracts/tests/mcms/timelock_bypasser_execute_test.go
@@ -260,8 +260,8 @@ func TestTimelockBypasserExecute(t *testing.T) {
 			}
 
 			require.Equal(t,
-				true,
-				opAccount.IsFinalized,
+				timelock.Finalized_OperationState,
+				opAccount.State,
 				"operation is not finalized",
 			)
 

--- a/chains/solana/contracts/tests/mcms/timelock_schedule_execute_test.go
+++ b/chains/solana/contracts/tests/mcms/timelock_schedule_execute_test.go
@@ -463,9 +463,9 @@ func TestTimelockScheduleAndExecute(t *testing.T) {
 					}
 
 					require.Equal(t,
-						config.TimelockOpDoneTimestamp,
-						opAccount.Timestamp,
-						"Executed operation's time should be 1(DONE_TIMESTAMP)",
+						timelock.Done_OperationState,
+						opAccount.State,
+						"Executed operation should be marked as done",
 					)
 				})
 
@@ -510,9 +510,9 @@ func TestTimelockScheduleAndExecute(t *testing.T) {
 					}
 
 					require.Equal(t,
-						config.TimelockOpDoneTimestamp,
-						opAccount.Timestamp,
-						"Executed operation's time should be 1(DONE_TIMESTAMP)",
+						timelock.Done_OperationState,
+						opAccount.State,
+						"Executed operation should be marked as done",
 					)
 
 					recipientWsolBalance, err := solanaGoClient.GetTokenAccountBalance(

--- a/chains/solana/gobindings/timelock/accounts.go
+++ b/chains/solana/gobindings/timelock/accounts.go
@@ -139,11 +139,11 @@ func (obj *Config) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) 
 }
 
 type Operation struct {
+	State             OperationState
 	Timestamp         uint64
 	Id                [32]uint8
 	Predecessor       [32]uint8
 	Salt              [32]uint8
-	IsFinalized       bool
 	TotalInstructions uint32
 	Instructions      []InstructionData
 }
@@ -153,6 +153,11 @@ var OperationDiscriminator = [8]byte{171, 150, 196, 17, 229, 166, 58, 44}
 func (obj Operation) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
 	// Write account discriminator:
 	err = encoder.WriteBytes(OperationDiscriminator[:], false)
+	if err != nil {
+		return err
+	}
+	// Serialize `State` param:
+	err = encoder.Encode(obj.State)
 	if err != nil {
 		return err
 	}
@@ -173,11 +178,6 @@ func (obj Operation) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) 
 	}
 	// Serialize `Salt` param:
 	err = encoder.Encode(obj.Salt)
-	if err != nil {
-		return err
-	}
-	// Serialize `IsFinalized` param:
-	err = encoder.Encode(obj.IsFinalized)
 	if err != nil {
 		return err
 	}
@@ -208,6 +208,11 @@ func (obj *Operation) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err erro
 				fmt.Sprint(discriminator[:]))
 		}
 	}
+	// Deserialize `State`:
+	err = decoder.Decode(&obj.State)
+	if err != nil {
+		return err
+	}
 	// Deserialize `Timestamp`:
 	err = decoder.Decode(&obj.Timestamp)
 	if err != nil {
@@ -225,11 +230,6 @@ func (obj *Operation) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err erro
 	}
 	// Deserialize `Salt`:
 	err = decoder.Decode(&obj.Salt)
-	if err != nil {
-		return err
-	}
-	// Deserialize `IsFinalized`:
-	err = decoder.Decode(&obj.IsFinalized)
 	if err != nil {
 		return err
 	}

--- a/chains/solana/gobindings/timelock/types.go
+++ b/chains/solana/gobindings/timelock/types.go
@@ -217,3 +217,27 @@ func (value Role) String() string {
 		return ""
 	}
 }
+
+type OperationState ag_binary.BorshEnum
+
+const (
+	Initialized_OperationState OperationState = iota
+	Finalized_OperationState
+	Scheduled_OperationState
+	Done_OperationState
+)
+
+func (value OperationState) String() string {
+	switch value {
+	case Initialized_OperationState:
+		return "Initialized"
+	case Finalized_OperationState:
+		return "Finalized"
+	case Scheduled_OperationState:
+		return "Scheduled"
+	case Done_OperationState:
+		return "Done"
+	default:
+		return ""
+	}
+}

--- a/chains/solana/utils/timelock/timelock.go
+++ b/chains/solana/utils/timelock/timelock.go
@@ -364,7 +364,8 @@ func WaitForOperationToBeReady(ctx context.Context, client *rpc.Client, opPDA so
 		return fmt.Errorf("failed to get account info: %w", err)
 	}
 
-	if opAccount.Timestamp == config.TimelockOpDoneTimestamp {
+	if opAccount.State == timelock.Done_OperationState {
+		// skip waiting if operation is already done
 		return nil
 	}
 


### PR DESCRIPTION
This PR improves operation state management for Solana timelock program [NONEVM-1289]

## Primary Changes
- Introduced OperationState enum (Initialized, Finalized, Scheduled, Done) to replace boolean flags and timestamp-based state tracking
- Updated operation state transitions to be more explicit and deterministic
- Added state-based validation for timelock operations across initialize/schedule/execute flows

## Others
- Removed DONE_TIMESTAMP constant in favor of state-based tracking
- Updated test assertions to validate operation states
- Refactored operation account constraints to better handle state transitions

- [ ] to be merged after https://github.com/smartcontractkit/chainlink-ccip/pull/528

[NONEVM-1289]: https://smartcontract-it.atlassian.net/browse/NONEVM-1289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ