### PR TITLE
chore: pin actions/* to major version

### DIFF
--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -12,7 +12,7 @@ jobs:
       # We explicitly have this env var not be "CL_DATABASE_URL" to avoid having it be used by core related tests
       # when they should not be using it, while still allowing us to DRY up the setup
       DB_URL: postgresql://postgres:postgres@localhost:5432/chainlink_test?sslmode=disable
-    
+
     strategy:
       fail-fast: false
       matrix:
@@ -33,12 +33,12 @@ jobs:
             name: "Batching Test"
           - cmd: cd integration-tests/smoke/ccip && go test ccip_reader_test.go -timeout 5m -test.parallel=1 -count=1 -json
             name: "CCIPReader Test"
-    
+
     name: Integration Tests (${{ matrix.type.name }})
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the chainlink-ccip repo
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4
       - name: Determine Go version
         id: go_version
         run: echo "GO_VERSION=$(cat go.mod |grep "^go"|cut -d' ' -f 2)" >> $GITHUB_ENV
@@ -83,7 +83,7 @@ jobs:
             echo "::set-output name=ref::$default"
           fi
       - name: Clone Chainlink repo
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4
         with:
           repository: smartcontractkit/chainlink
           ref: ${{ steps.get_chainlink_sha.outputs.ref }}

--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -43,7 +43,7 @@ jobs:
         id: go_version
         run: echo "GO_VERSION=$(cat go.mod |grep "^go"|cut -d' ' -f 2)" >> $GITHUB_ENV
       - name: Setup Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Display Go version

--- a/.github/workflows/ccip-ocr3-build-lint-test.yml
+++ b/.github/workflows/ccip-ocr3-build-lint-test.yml
@@ -18,7 +18,7 @@ jobs:
         id: go_version
         run: echo "GO_VERSION=$(cat go.mod |grep "^go"|cut -d' ' -f 2)" >> $GITHUB_ENV
       - name: Setup Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Display Go version

--- a/.github/workflows/ccip-ocr3-build-lint-test.yml
+++ b/.github/workflows/ccip-ocr3-build-lint-test.yml
@@ -13,7 +13,7 @@ jobs:
       run:
         working-directory: .
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      - uses: actions/checkout@v4
       - name: Determine Go version
         id: go_version
         run: echo "GO_VERSION=$(cat go.mod |grep "^go"|cut -d' ' -f 2)" >> $GITHUB_ENV

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -14,7 +14,7 @@ jobs:
       run:
         working-directory: .
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      - uses: actions/checkout@v4
       - name: Determine Go version
         id: go_version
         run: echo "GO_VERSION=$(cat go.mod |grep "^go"|cut -d' ' -f 2)" >> $GITHUB_ENV

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -19,7 +19,7 @@ jobs:
         id: go_version
         run: echo "GO_VERSION=$(cat go.mod |grep "^go"|cut -d' ' -f 2)" >> $GITHUB_ENV
       - name: Setup Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Display Go version

--- a/.github/workflows/solana.yml
+++ b/.github/workflows/solana.yml
@@ -37,14 +37,14 @@ jobs:
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
     - name: cache docker build image
       id: cache-image
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@v4
       with:
         lookup-only: true
         path: chains/solana/contracts/docker-build.tar
         key: ${{ runner.os }}-solana-build-${{ needs.get_anchor_version.outputs.anchor_version }}-${{ hashFiles('**/Cargo.lock') }}
     - name: Cache cargo target dir
       id: cache-target
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@v4
       with:
         lookup-only: true
         path: chains/solana/contracts/target
@@ -73,14 +73,14 @@ jobs:
     steps:
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
     - name: Cache cargo target dir
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@v4
       with:
         fail-on-cache-miss: true
         path: chains/solana/contracts/target
         key: ${{ runner.os }}-solana-contract-artifacts-${{ hashFiles('**/Cargo.lock') }}
     - name: cache docker build image
       id: cache-image
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@v4
       with:
         fail-on-cache-miss: true
         path: chains/solana/contracts/docker-build.tar
@@ -107,14 +107,14 @@ jobs:
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Cache cargo target dir
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        uses: actions/cache@v4
         with:
           fail-on-cache-miss: true
           path: chains/solana/contracts/target
           key: ${{ runner.os }}-solana-contract-artifacts-${{ hashFiles('**/Cargo.lock') }}
       - name: cache docker build image
         id: cache-image
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        uses: actions/cache@v4
         with:
           fail-on-cache-miss: true
           path: chains/solana/contracts/docker-build.tar
@@ -153,14 +153,14 @@ jobs:
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Cache cargo target dir
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        uses: actions/cache@v4
         with:
           fail-on-cache-miss: true
           path: chains/solana/contracts/target
           key: ${{ runner.os }}-solana-contract-artifacts-${{ hashFiles('**/Cargo.lock') }}
       - name: cache docker build image
         id: cache-image
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        uses: actions/cache@v4
         with:
           fail-on-cache-miss: true
           path: chains/solana/contracts/docker-build.tar
@@ -199,5 +199,5 @@ jobs:
         if: failure()
         shell: bash
         run: cat ./golangci-lint-report.xml
-          
+
 

--- a/.github/workflows/solana.yml
+++ b/.github/workflows/solana.yml
@@ -123,7 +123,7 @@ jobs:
         run: |
           docker load --input contracts/docker-build.tar
       - name: Setup go
-        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        uses: actions/setup-go@v5
         with:
           go-version-file: "./chains/solana/go.mod"
           check-latest: true
@@ -169,7 +169,7 @@ jobs:
         run: |
           docker load --input contracts/docker-build.tar
       - name: Setup go
-        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
+        uses: actions/setup-go@v5
         with:
           go-version-file: "./chains/solana/go.mod"
           check-latest: true

--- a/.github/workflows/solana.yml
+++ b/.github/workflows/solana.yml
@@ -22,7 +22,7 @@ jobs:
       anchor_version: ${{ steps.anchorversion.outputs.anchor }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+        uses: actions/checkout@v4
       - name: Get Anchor Version
         id: anchorversion
         run: |
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest-8cores-32GB
     needs: [get_anchor_version]
     steps:
-    - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+    - uses: actions/checkout@v4
     - name: cache docker build image
       id: cache-image
       uses: actions/cache@v4
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [get_anchor_version, build_solana]
     steps:
-    - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+    - uses: actions/checkout@v4
     - name: Cache cargo target dir
       uses: actions/cache@v4
       with:
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest-8cores-32GB
     needs: [get_anchor_version, build_solana]
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      - uses: actions/checkout@v4
       - name: Cache cargo target dir
         uses: actions/cache@v4
         with:
@@ -151,7 +151,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [get_anchor_version, build_solana]
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      - uses: actions/checkout@v4
       - name: Cache cargo target dir
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
### Changes

Pin `actions/*` reusable actions to their major version

### Motivation

Github likes to break things and managing individual patch bumps is not feasible.

---

RE-3330