### PR TITLE
commit/merkleroot: observe fchain on rmn retry

### DIFF
--- a/commit/merkleroot/observation.go
+++ b/commit/merkleroot/observation.go
@@ -268,8 +268,13 @@ func (p *Processor) getObservation(
 	case buildingReport:
 		if q.RetryRMNSignatures {
 			// RMN signature computation failed, we only want to retry getting the RMN signatures in the next round.
-			// So there's nothing to observe, i.e. we don't want to build the report yet.
-			return Observation{}, nextState, nil
+			// So there's nothing to observe except for fChain, i.e. we don't want to build the report yet.
+			return Observation{
+				// We observe fChain to avoid errors in the outcome phase.
+				// We check q.RetryRMNSignatures there and return the appropriate state and outcome
+				// in order to retry.
+				FChain: p.observer.ObserveFChain(ctx),
+			}, nextState, nil
 		}
 		return Observation{
 			MerkleRoots: p.observer.ObserveMerkleRoots(ctx, previousOutcome.RangesSelectedForReport),

--- a/commit/merkleroot/observation_test.go
+++ b/commit/merkleroot/observation_test.go
@@ -148,9 +148,11 @@ func TestObservation(t *testing.T) {
 				RetryRMNSignatures: true,
 			},
 			setupMocks: func() {
-				// No mocks needed for this case
+				mockObserver.EXPECT().ObserveFChain(mock.Anything).Return(map[cciptypes.ChainSelector]int{1: 3})
 			},
-			expectedObs: Observation{},
+			expectedObs: Observation{
+				FChain: map[cciptypes.ChainSelector]int{1: 3},
+			},
 		},
 	}
 

--- a/commit/merkleroot/query.go
+++ b/commit/merkleroot/query.go
@@ -61,6 +61,11 @@ func (p *Processor) Query(ctx context.Context, prevOutcome Outcome) (Query, erro
 		})
 	}
 
+	if len(reqUpdates) == 0 {
+		lggr.Debugw("no RMN-enabled chains to request signatures, empty query returned")
+		return Query{}, nil
+	}
+
 	ctxQuery, cancel := context.WithTimeout(ctx, p.offchainCfg.RMNSignaturesTimeout)
 	defer cancel()
 

--- a/commit/merkleroot/query.go
+++ b/commit/merkleroot/query.go
@@ -71,8 +71,8 @@ func (p *Processor) Query(ctx context.Context, prevOutcome Outcome) (Query, erro
 	if err != nil {
 		p.metricsReporter.TrackRmnReport(float64(time.Since(rmnReportStart).Milliseconds()), false)
 		if errors.Is(err, rmn.ErrTimeout) {
-			lggr.Errorf("RMN timeout while computing signatures for %d updates for chain %v",
-				len(reqUpdates), dstChainInfo)
+			lggr.Errorf("RMN timeout while computing signatures for %d updates for chain %d offramp %x",
+				len(reqUpdates), dstChainInfo.DestChainSelector, dstChainInfo.OfframpAddress)
 			return Query{RetryRMNSignatures: true}, nil
 		}
 

--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -182,6 +182,10 @@ func NewPlugin(
 // Query returns the query for the next round.
 // NOTE: In most cases the Query phase should not return an error based on outCtx to prevent infinite retries.
 func (p *Plugin) Query(ctx context.Context, outCtx ocr3types.OutcomeContext) (types.Query, error) {
+	// Ensure that sequence number is in the context for consumption by all
+	// downstream processors and the ccip reader.
+	ctx, _ = logutil.WithOCRInfo(ctx, p.lggr, outCtx.SeqNr, logutil.PhaseQuery)
+
 	var err error
 	var q committypes.Query
 


### PR DESCRIPTION
Add the missing fChain observation on the RMN retry path.
This should mean less weird errors in the logs since we
already correctly handle the retry scenario in the outcome
phase.

Also add the ocr sequence number and phase to the query
context, it was missed before.