### PR TITLE
Revert "Source chain specific RMN blessings enable/disable"

### DIFF
--- a/commit/factory.go
+++ b/commit/factory.go
@@ -49,15 +49,15 @@ const (
 
 	// maxObservationLength is set to the maximum size of an observation
 	// check factory_test for the calculation
-	maxObservationLength = 1_047_206
+	maxObservationLength = 1_047_202
 
 	// maxOutcomeLength is set to the maximum size of an outcome
 	// check factory_test for the calculation
-	maxOutcomeLength = 1_167_845
+	maxOutcomeLength = 1_167_836
 
 	// maxReportLength is set to an estimate of a maximum report size
 	// check factory_test for the calculation
-	maxReportLength = 128_2933
+	maxReportLength = 128_2900
 
 	// maxReportCount is set to 1 because the commit plugin only generates one report per round.
 	maxReportCount = 1

--- a/commit/factory_test.go
+++ b/commit/factory_test.go
@@ -251,7 +251,7 @@ func Test_maxOutcomeLength(t *testing.T) {
 
 func Test_maxReportLength(t *testing.T) {
 	rep := ccipocr3.CommitPluginReport{
-		BlessedMerkleRoots: make([]ccipocr3.MerkleRootChain, estimatedMaxNumberOfSourceChains),
+		MerkleRoots: make([]ccipocr3.MerkleRootChain, estimatedMaxNumberOfSourceChains),
 		PriceUpdates: ccipocr3.PriceUpdates{
 			TokenPriceUpdates: make([]ccipocr3.TokenPrice, estimatedMaxNumberOfPricedTokens),
 			GasPriceUpdates:   make([]ccipocr3.GasPriceChain, estimatedMaxNumberOfSourceChains),
@@ -259,8 +259,8 @@ func Test_maxReportLength(t *testing.T) {
 		RMNSignatures: make([]ccipocr3.RMNECDSASignature, estimatedMaxRmnNodesCount),
 	}
 
-	for i := range rep.BlessedMerkleRoots {
-		rep.BlessedMerkleRoots[i] = ccipocr3.MerkleRootChain{
+	for i := range rep.MerkleRoots {
+		rep.MerkleRoots[i] = ccipocr3.MerkleRootChain{
 			ChainSel:      math.MaxUint64,
 			OnRampAddress: make([]byte, 40),
 			SeqNumsRange:  ccipocr3.NewSeqNumRange(math.MaxUint64, math.MaxUint64),

--- a/commit/merkleroot/observation_test.go
+++ b/commit/merkleroot/observation_test.go
@@ -119,8 +119,7 @@ func TestObservation(t *testing.T) {
 						SeqNumsRange: [2]cciptypes.SeqNum{5, 10},
 						MerkleRoot:   [32]byte{1}},
 				},
-				RMNEnabledChains: map[cciptypes.ChainSelector]bool{1: true},
-				FChain:           map[cciptypes.ChainSelector]int{1: 3},
+				FChain: map[cciptypes.ChainSelector]int{1: 3},
 			},
 		},
 		{
@@ -161,11 +160,6 @@ func TestObservation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.setupMocks()
 
-			rmnHomeReader := readerpkg_mock.NewMockRMNHome(t)
-			rmnHomeReader.EXPECT().GetRMNEnabledSourceChains(tc.prevOutcome.RMNRemoteCfg.ConfigDigest).
-				Return(map[cciptypes.ChainSelector]bool{1: true}, nil).Maybe()
-
-			p.rmnHomeReader = rmnHomeReader
 			p.rmnControllerCfgDigest = tc.prevOutcome.RMNRemoteCfg.ConfigDigest // skip rmn controller setup
 			obs, err := p.Observation(ctx, tc.prevOutcome, tc.query)
 

--- a/commit/merkleroot/outcome.go
+++ b/commit/merkleroot/outcome.go
@@ -12,10 +12,9 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
-	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn"
-	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn/rmnpb"
 	typconv "github.com/smartcontractkit/chainlink-ccip/internal/libs/typeconv"
 
+	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn"
 	rmntypes "github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn/types"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon/consensus"
@@ -178,109 +177,75 @@ func buildMerkleRootsOutcome(
 		outcomeType = ReportEmpty
 	}
 
-	lggr.Debugw("building merkle roots outcome",
-		"rmnEnabled", rmnEnabled,
-		"rmnEnabledChains", consensusObservation.RMNEnabledChains,
-		"roots", roots,
-		"rmnSignatures", q.RMNSignatures)
+	if len(roots) > 0 && rmnEnabled && q.RMNSignatures == nil {
+		return Outcome{}, fmt.Errorf("RMN signatures are nil while RMN is enabled")
+	}
 
 	sort.Slice(roots, func(i, j int) bool { return roots[i].ChainSel < roots[j].ChainSel })
 
 	sigs := make([]cciptypes.RMNECDSASignature, 0)
-	var err error
-
-	if len(roots) > 0 && rmnEnabled {
-		if q.RMNSignatures == nil {
-			return Outcome{}, fmt.Errorf("RMN signatures are nil while RMN is enabled")
-		}
-
-		sigs, err = rmn.NewECDSASigsFromPB(q.RMNSignatures.Signatures)
+	if rmnEnabled && q.RMNSignatures != nil {
+		parsedSigs, err := rmn.NewECDSASigsFromPB(q.RMNSignatures.Signatures)
 		if err != nil {
 			return Outcome{}, fmt.Errorf("failed to parse RMN signatures: %w", err)
 		}
+		sigs = parsedSigs
 
-		roots = filterRootsBasedOnRmnSigs(
-			lggr, q.RMNSignatures.LaneUpdates, roots, consensusObservation.RMNEnabledChains)
+		type rootKey struct {
+			ChainSel      cciptypes.ChainSelector
+			SeqNumsRange  cciptypes.SeqNumRange
+			MerkleRoot    cciptypes.Bytes32
+			OnRampAddress string
+		}
+
+		signedRoots := mapset.NewSet[rootKey]()
+		for _, laneUpdate := range q.RMNSignatures.LaneUpdates {
+			rk := rootKey{
+				ChainSel: cciptypes.ChainSelector(laneUpdate.LaneSource.SourceChainSelector),
+				SeqNumsRange: cciptypes.NewSeqNumRange(
+					cciptypes.SeqNum(laneUpdate.ClosedInterval.MinMsgNr),
+					cciptypes.SeqNum(laneUpdate.ClosedInterval.MaxMsgNr),
+				),
+				MerkleRoot: cciptypes.Bytes32(laneUpdate.Root),
+				// NOTE: convert address into a comparable value for mapset.
+				OnRampAddress: typconv.AddressBytesToString(
+					laneUpdate.LaneSource.OnrampAddress,
+					laneUpdate.LaneSource.SourceChainSelector),
+			}
+
+			lggr.Infow("Found signed root", "root", rk)
+			signedRoots.Add(rk)
+		}
+
+		// Only report roots that are present in RMN signatures.
+		rootsToReport := make([]cciptypes.MerkleRootChain, 0)
+		for _, root := range roots {
+			rk := rootKey{
+				ChainSel:      root.ChainSel,
+				SeqNumsRange:  root.SeqNumsRange,
+				MerkleRoot:    root.MerkleRoot,
+				OnRampAddress: typconv.AddressBytesToString(root.OnRampAddress, uint64(root.ChainSel)),
+			}
+
+			if signedRoots.Contains(rk) {
+				lggr.Infow("Root is signed, appending to the report", "root", rk)
+				rootsToReport = append(rootsToReport, root)
+			} else {
+				lggr.Infow("Root not signed by RMN, skipping from the report", "root", rk)
+			}
+		}
+		roots = rootsToReport
 	}
 
 	outcome := Outcome{
 		OutcomeType:         outcomeType,
 		RootsToReport:       roots,
-		RMNEnabledChains:    consensusObservation.RMNEnabledChains,
 		OffRampNextSeqNums:  prevOutcome.OffRampNextSeqNums,
 		RMNReportSignatures: sigs,
 		RMNRemoteCfg:        prevOutcome.RMNRemoteCfg,
 	}
 
 	return outcome, nil
-}
-
-// filterRootsBasedOnRmnSigs filters the roots to only include the ones that are either:
-// 1) RMN-enabled and have RMN signatures
-// 2) RMN-disabled and do not have RMN signatures
-func filterRootsBasedOnRmnSigs(
-	lggr logger.Logger,
-	signedLaneUpdates []*rmnpb.FixedDestLaneUpdate,
-	roots []cciptypes.MerkleRootChain,
-	rmnEnabledChains map[cciptypes.ChainSelector]bool,
-) []cciptypes.MerkleRootChain {
-	// Create a set of signed roots for quick lookup.
-	signedRoots := mapset.NewSet[rootKey]()
-	for _, laneUpdate := range signedLaneUpdates {
-		rk := rootKey{
-			ChainSel: cciptypes.ChainSelector(laneUpdate.LaneSource.SourceChainSelector),
-			SeqNumsRange: cciptypes.NewSeqNumRange(
-				cciptypes.SeqNum(laneUpdate.ClosedInterval.MinMsgNr),
-				cciptypes.SeqNum(laneUpdate.ClosedInterval.MaxMsgNr),
-			),
-			MerkleRoot: cciptypes.Bytes32(laneUpdate.Root),
-			// NOTE: convert address into a comparable value for mapset.
-			OnRampAddress: typconv.AddressBytesToString(
-				laneUpdate.LaneSource.OnrampAddress,
-				laneUpdate.LaneSource.SourceChainSelector),
-		}
-		lggr.Infow("Found signed root", "root", rk)
-		signedRoots.Add(rk)
-	}
-
-	validRoots := make([]cciptypes.MerkleRootChain, 0)
-	for _, root := range roots {
-		rk := rootKey{
-			ChainSel:      root.ChainSel,
-			SeqNumsRange:  root.SeqNumsRange,
-			MerkleRoot:    root.MerkleRoot,
-			OnRampAddress: typconv.AddressBytesToString(root.OnRampAddress, uint64(root.ChainSel)),
-		}
-
-		rootIsSignedAndRmnEnabled := signedRoots.Contains(rk) &&
-			rmnEnabledChains[root.ChainSel]
-
-		rootNotSignedButRmnDisabled := !signedRoots.Contains(rk) &&
-			!rmnEnabledChains[root.ChainSel]
-
-		if rootIsSignedAndRmnEnabled || rootNotSignedButRmnDisabled {
-			lggr.Infow("Adding root to the report",
-				"root", rk,
-				"rootIsSignedAndRmnEnabled", rootIsSignedAndRmnEnabled,
-				"rootNotSignedButRmnDisabled", rootNotSignedButRmnDisabled)
-			validRoots = append(validRoots, root)
-		} else {
-			lggr.Infow("Root invalid, skipping from the report",
-				"root", rk,
-				"rootIsSignedAndRmnEnabled", rootIsSignedAndRmnEnabled,
-				"rootNotSignedButRmnDisabled", rootNotSignedButRmnDisabled,
-			)
-		}
-	}
-
-	return validRoots
-}
-
-type rootKey struct {
-	ChainSel      cciptypes.ChainSelector
-	SeqNumsRange  cciptypes.SeqNumRange
-	MerkleRoot    cciptypes.Bytes32
-	OnRampAddress string
 }
 
 // checkForReportTransmission checks if the OffRamp has an updated set of max seq nums compared to the seq nums that
@@ -364,7 +329,6 @@ func getConsensusObservation(
 	twoFChainPlus1 := consensus.MakeMultiThreshold(fChains, consensus.TwoFPlus1)
 	consensusObs := consensusObservation{
 		MerkleRoots:      consensus.GetConsensusMap(lggr, "Merkle Root", aggObs.MerkleRoots, twoFChainPlus1),
-		RMNEnabledChains: consensus.GetConsensusMap(lggr, "RMNEnabledChains", aggObs.RMNEnabledChains, twoFChainPlus1),
 		OnRampMaxSeqNums: consensus.GetConsensusMap(lggr, "OnRamp Max Seq Nums", aggObs.OnRampMaxSeqNums, twoFChainPlus1),
 		OffRampNextSeqNums: consensus.GetConsensusMap(
 			lggr,

--- a/commit/merkleroot/outcome_test.go
+++ b/commit/merkleroot/outcome_test.go
@@ -377,14 +377,6 @@ func Test_Processor_Outcome(t *testing.T) {
 								MerkleRoot:    bytes32a,
 							},
 						},
-						RMNEnabledChains: map[cciptypes.ChainSelector]bool{
-							chainA: true,
-							chainB: true,
-							chainC: true,
-							chainD: true,
-							chainE: true,
-							chainF: true,
-						},
 						FChain: map[cciptypes.ChainSelector]int{
 							chainA: 1,
 							chainB: 1,
@@ -423,14 +415,6 @@ func Test_Processor_Outcome(t *testing.T) {
 						SeqNumsRange:  cciptypes.NewSeqNumRange(10, 15),
 						MerkleRoot:    cciptypes.Bytes32{0xa},
 					},
-				},
-				RMNEnabledChains: map[cciptypes.ChainSelector]bool{
-					chainA: true,
-					chainB: true,
-					chainC: true,
-					chainD: true,
-					chainE: true,
-					chainF: true,
 				},
 				RMNReportSignatures: []cciptypes.RMNECDSASignature{
 					{R: bytes32a, S: bytes32b},

--- a/commit/merkleroot/query.go
+++ b/commit/merkleroot/query.go
@@ -12,7 +12,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/pkg/logutil"
 )
 
-//nolint:gocyclo //todo
 func (p *Processor) Query(ctx context.Context, prevOutcome Outcome) (Query, error) {
 	lggr := logutil.WithContextValues(ctx, p.lggr)
 
@@ -42,21 +41,8 @@ func (p *Processor) Query(ctx context.Context, prevOutcome Outcome) (Query, erro
 		OfframpAddress:    offRampAddress,
 	}
 
-	rmnEnabledChains, err := p.rmnHomeReader.GetRMNEnabledSourceChains(prevOutcome.RMNRemoteCfg.ConfigDigest)
-	if err != nil {
-		return Query{}, fmt.Errorf("get RMN enabled chains %s: %w",
-			prevOutcome.RMNRemoteCfg.ConfigDigest.String(), err)
-	}
-	lggr.Debugw("fetched RMN-enabled chains from rmnHome", "rmnEnabledChains", rmnEnabledChains)
-
 	reqUpdates := make([]*rmnpb.FixedDestLaneUpdateRequest, 0, len(prevOutcome.RangesSelectedForReport))
 	for _, sourceChainRange := range prevOutcome.RangesSelectedForReport {
-		if !rmnEnabledChains[sourceChainRange.ChainSel] {
-			lggr.Debugw("chain not RMN-enabled, signatures not requested",
-				"chain", sourceChainRange.ChainSel, "rmnEnabledChains", rmnEnabledChains)
-			continue
-		}
-
 		onRampAddress, err := p.ccipReader.GetContractAddress(consts.ContractNameOnRamp, sourceChainRange.ChainSel)
 		if err != nil {
 			lggr.Warnw("failed to get onRamp address", "chain", sourceChainRange.ChainSel, "err", err)
@@ -76,14 +62,8 @@ func (p *Processor) Query(ctx context.Context, prevOutcome Outcome) (Query, erro
 	}
 
 	if len(reqUpdates) == 0 {
-		lggr.Debugw("no RMN-enabled chains to request signatures, empty query returned",
-			"rmnEnabledChains", rmnEnabledChains)
-		return Query{
-			RMNSignatures: &rmn.ReportSignatures{
-				Signatures:  []*rmnpb.EcdsaSignature{},
-				LaneUpdates: []*rmnpb.FixedDestLaneUpdate{},
-			},
-		}, nil
+		lggr.Debugw("no RMN-enabled chains to request signatures, empty query returned")
+		return Query{}, nil
 	}
 
 	ctxQuery, cancel := context.WithTimeout(ctx, p.offchainCfg.RMNSignaturesTimeout)

--- a/commit/merkleroot/query_test.go
+++ b/commit/merkleroot/query_test.go
@@ -297,18 +297,10 @@ func TestProcessor_Query(t *testing.T) {
 				}
 			}
 
-			rmnHomeReader := reader.NewMockRMNHome(t)
-			rmnHomeReader.EXPECT().GetRMNEnabledSourceChains(
-				tc.prevOutcome.RMNRemoteCfg.ConfigDigest).Return(map[ccipocr3.ChainSelector]bool{
-				srcChain1: true,
-				srcChain2: true,
-			}, nil).Maybe()
-
 			w := Processor{
 				offchainCfg:     tc.cfg,
 				destChain:       tc.destChain,
 				ccipReader:      ccipReader,
-				rmnHomeReader:   rmnHomeReader,
 				rmnController:   tc.rmnClient(t),
 				lggr:            logger.Test(t),
 				metricsReporter: NoopMetrics{},

--- a/commit/merkleroot/rmn/types/config.go
+++ b/commit/merkleroot/rmn/types/config.go
@@ -14,9 +14,7 @@ type NodeID uint32
 
 // HomeConfig contains the configuration fetched from the RMNHome contract.
 type HomeConfig struct {
-	Nodes []HomeNodeInfo
-	// SourceChainF contains the "fObserve" for RMN interactions for each source chain.
-	// If a chain does not appear in this map, it is assumed that it is not RMN-enabled and signatures are not required.
+	Nodes          []HomeNodeInfo
 	SourceChainF   map[cciptypes.ChainSelector]int
 	ConfigDigest   cciptypes.Bytes32
 	OffchainConfig cciptypes.Bytes // The raw offchain config

--- a/commit/merkleroot/transmission_checks_test.go
+++ b/commit/merkleroot/transmission_checks_test.go
@@ -9,17 +9,10 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
 	readermock "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/reader"
-	reader2 "github.com/smartcontractkit/chainlink-ccip/pkg/reader"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
 
 func Test_validateMerkleRootsState(t *testing.T) {
-	sourceChainConfig := map[cciptypes.ChainSelector]reader2.SourceChainConfig{
-		10: {IsRMNVerificationDisabled: false, IsEnabled: true},
-		20: {IsRMNVerificationDisabled: false, IsEnabled: true},
-		30: {IsRMNVerificationDisabled: true, IsEnabled: true},
-	}
-
 	testCases := []struct {
 		name                 string
 		onRampNextSeqNum     []plugintypes.SeqNumChain
@@ -74,16 +67,6 @@ func Test_validateMerkleRootsState(t *testing.T) {
 			readerErr:            fmt.Errorf("reader error"),
 			expErr:               true,
 		},
-		{
-			name: "happy path one root unblessed",
-			onRampNextSeqNum: []plugintypes.SeqNumChain{
-				plugintypes.NewSeqNumChain(10, 100),
-				plugintypes.NewSeqNumChain(20, 200),
-				plugintypes.NewSeqNumChain(30, 300),
-			},
-			offRampExpNextSeqNum: map[cciptypes.ChainSelector]cciptypes.SeqNum{10: 100, 20: 200, 30: 300},
-			expErr:               false,
-		},
 	}
 
 	ctx := tests.Context(t)
@@ -93,24 +76,15 @@ func Test_validateMerkleRootsState(t *testing.T) {
 			rep := cciptypes.CommitPluginReport{}
 			chains := make([]cciptypes.ChainSelector, 0, len(tc.onRampNextSeqNum))
 			for _, snc := range tc.onRampNextSeqNum {
-				if sourceChainConfig[snc.ChainSel].IsRMNVerificationDisabled {
-					rep.UnblessedMerkleRoots = append(rep.UnblessedMerkleRoots, cciptypes.MerkleRootChain{
-						ChainSel:     snc.ChainSel,
-						SeqNumsRange: cciptypes.NewSeqNumRange(snc.SeqNum, snc.SeqNum+10),
-					})
-				} else {
-					rep.BlessedMerkleRoots = append(rep.BlessedMerkleRoots, cciptypes.MerkleRootChain{
-						ChainSel:     snc.ChainSel,
-						SeqNumsRange: cciptypes.NewSeqNumRange(snc.SeqNum, snc.SeqNum+10),
-					})
-				}
+				rep.MerkleRoots = append(rep.MerkleRoots, cciptypes.MerkleRootChain{
+					ChainSel:     snc.ChainSel,
+					SeqNumsRange: cciptypes.NewSeqNumRange(snc.SeqNum, snc.SeqNum+10),
+				})
 				chains = append(chains, snc.ChainSel)
 			}
 			reader.EXPECT().NextSeqNum(ctx, chains).Return(tc.offRampExpNextSeqNum, tc.readerErr)
 
-			reader.EXPECT().GetOffRampSourceChainsConfig(ctx, chains).Return(sourceChainConfig, nil).Maybe()
-
-			err := ValidateMerkleRootsState(ctx, rep.BlessedMerkleRoots, rep.UnblessedMerkleRoots, reader)
+			err := ValidateMerkleRootsState(ctx, rep.MerkleRoots, reader)
 			if tc.expErr {
 				assert.Error(t, err)
 				return

--- a/commit/merkleroot/types.go
+++ b/commit/merkleroot/types.go
@@ -16,12 +16,11 @@ type Query struct {
 }
 
 type Observation struct {
-	MerkleRoots        []cciptypes.MerkleRootChain      `json:"merkleRoots"`
-	RMNEnabledChains   map[cciptypes.ChainSelector]bool `json:"rmnEnabledChains"`
-	OnRampMaxSeqNums   []plugintypes.SeqNumChain        `json:"onRampMaxSeqNums"`
-	OffRampNextSeqNums []plugintypes.SeqNumChain        `json:"offRampNextSeqNums"`
-	RMNRemoteConfig    rmntypes.RemoteConfig            `json:"rmnRemoteConfig"`
-	FChain             map[cciptypes.ChainSelector]int  `json:"fChain"`
+	MerkleRoots        []cciptypes.MerkleRootChain     `json:"merkleRoots"`
+	OnRampMaxSeqNums   []plugintypes.SeqNumChain       `json:"onRampMaxSeqNums"`
+	OffRampNextSeqNums []plugintypes.SeqNumChain       `json:"offRampNextSeqNums"`
+	RMNRemoteConfig    rmntypes.RemoteConfig           `json:"rmnRemoteConfig"`
+	FChain             map[cciptypes.ChainSelector]int `json:"fChain"`
 }
 
 func (o Observation) IsEmpty() bool {
@@ -36,9 +35,6 @@ func (o Observation) IsEmpty() bool {
 type aggregatedObservation struct {
 	// A map from chain selectors to the list of merkle roots observed for each chain
 	MerkleRoots map[cciptypes.ChainSelector][]cciptypes.MerkleRootChain
-
-	// RMNEnabledChains is a map of the RMN-enabled source chains.
-	RMNEnabledChains map[cciptypes.ChainSelector][]bool
 
 	// A map from chain selectors to the list of OnRamp max sequence numbers observed for each chain
 	OnRampMaxSeqNums map[cciptypes.ChainSelector][]cciptypes.SeqNum
@@ -57,7 +53,6 @@ type aggregatedObservation struct {
 func aggregateObservations(aos []plugincommon.AttributedObservation[Observation]) aggregatedObservation {
 	aggObs := aggregatedObservation{
 		MerkleRoots:        make(map[cciptypes.ChainSelector][]cciptypes.MerkleRootChain),
-		RMNEnabledChains:   make(map[cciptypes.ChainSelector][]bool),
 		OnRampMaxSeqNums:   make(map[cciptypes.ChainSelector][]cciptypes.SeqNum),
 		OffRampNextSeqNums: make(map[cciptypes.ChainSelector][]cciptypes.SeqNum),
 		RMNRemoteConfigs:   make([]rmntypes.RemoteConfig, 0),
@@ -70,11 +65,6 @@ func aggregateObservations(aos []plugincommon.AttributedObservation[Observation]
 		for _, merkleRoot := range obs.MerkleRoots {
 			aggObs.MerkleRoots[merkleRoot.ChainSel] =
 				append(aggObs.MerkleRoots[merkleRoot.ChainSel], merkleRoot)
-		}
-
-		// RMNEnabledChains
-		for chainSel, enabled := range obs.RMNEnabledChains {
-			aggObs.RMNEnabledChains[chainSel] = append(aggObs.RMNEnabledChains[chainSel], enabled)
 		}
 
 		// OnRampMaxSeqNums
@@ -109,9 +99,6 @@ type consensusObservation struct {
 	// A map from chain selectors to each chain's consensus merkle root
 	MerkleRoots map[cciptypes.ChainSelector]cciptypes.MerkleRootChain
 
-	// RMNEnabledChains holds the consensus of RMNEnabledChains
-	RMNEnabledChains map[cciptypes.ChainSelector]bool
-
 	// A map from chain selectors to each chain's consensus OnRamp max sequence number
 	OnRampMaxSeqNums map[cciptypes.ChainSelector]cciptypes.SeqNum
 
@@ -137,14 +124,13 @@ const (
 )
 
 type Outcome struct {
-	OutcomeType                     OutcomeType                      `json:"outcomeType"`
-	RangesSelectedForReport         []plugintypes.ChainRange         `json:"rangesSelectedForReport"`
-	RootsToReport                   []cciptypes.MerkleRootChain      `json:"rootsToReport"`
-	RMNEnabledChains                map[cciptypes.ChainSelector]bool `json:"rmnEnabledChains"`
-	OffRampNextSeqNums              []plugintypes.SeqNumChain        `json:"offRampNextSeqNums"`
-	ReportTransmissionCheckAttempts uint                             `json:"reportTransmissionCheckAttempts"`
-	RMNReportSignatures             []cciptypes.RMNECDSASignature    `json:"rmnReportSignatures"`
-	RMNRemoteCfg                    rmntypes.RemoteConfig            `json:"rmnRemoteCfg"`
+	OutcomeType                     OutcomeType                   `json:"outcomeType"`
+	RangesSelectedForReport         []plugintypes.ChainRange      `json:"rangesSelectedForReport"`
+	RootsToReport                   []cciptypes.MerkleRootChain   `json:"rootsToReport"`
+	OffRampNextSeqNums              []plugintypes.SeqNumChain     `json:"offRampNextSeqNums"`
+	ReportTransmissionCheckAttempts uint                          `json:"reportTransmissionCheckAttempts"`
+	RMNReportSignatures             []cciptypes.RMNECDSASignature `json:"rmnReportSignatures"`
+	RMNRemoteCfg                    rmntypes.RemoteConfig         `json:"rmnRemoteCfg"`
 }
 
 // Sort all fields of the given Outcome

--- a/commit/merkleroot/types_test.go
+++ b/commit/merkleroot/types_test.go
@@ -158,7 +158,6 @@ func TestAggregateObservations(t *testing.T) {
 				OffRampNextSeqNums: make(map[cciptypes.ChainSelector][]cciptypes.SeqNum),
 				RMNRemoteConfigs:   make([]rmntypes.RemoteConfig, 0),
 				FChain:             make(map[cciptypes.ChainSelector][]int),
-				RMNEnabledChains:   map[cciptypes.ChainSelector][]bool{},
 			},
 		},
 		{
@@ -180,7 +179,6 @@ func TestAggregateObservations(t *testing.T) {
 				OffRampNextSeqNums: map[cciptypes.ChainSelector][]cciptypes.SeqNum{1: {1}},
 				RMNRemoteConfigs:   []rmntypes.RemoteConfig{{ContractAddress: cciptypes.UnknownAddress("address")}},
 				FChain:             map[cciptypes.ChainSelector][]int{1: {1}},
-				RMNEnabledChains:   map[cciptypes.ChainSelector][]bool{},
 			},
 		},
 		{
@@ -213,8 +211,7 @@ func TestAggregateObservations(t *testing.T) {
 					{ContractAddress: cciptypes.UnknownAddress("address1")},
 					{ContractAddress: cciptypes.UnknownAddress("address2")},
 				},
-				RMNEnabledChains: map[cciptypes.ChainSelector][]bool{},
-				FChain:           map[cciptypes.ChainSelector][]int{1: {1}, 2: {2}},
+				FChain: map[cciptypes.ChainSelector][]int{1: {1}, 2: {2}},
 			},
 		},
 	}

--- a/commit/plugin_e2e_test.go
+++ b/commit/plugin_e2e_test.go
@@ -85,11 +85,6 @@ var (
 		DeviationPPB:      ccipocr3.NewBigInt(big.NewInt(1e5)),
 		Decimals:          decimals18,
 	}
-
-	sourceChainConfigs = map[ccipocr3.ChainSelector]reader2.SourceChainConfig{
-		sourceChain1: {IsEnabled: true, IsRMNVerificationDisabled: true},
-		sourceChain2: {IsEnabled: true, IsRMNVerificationDisabled: true},
-	}
 )
 
 func TestPlugin_E2E_AllNodesAgree_MerkleRoots(t *testing.T) {
@@ -126,7 +121,6 @@ func TestPlugin_E2E_AllNodesAgree_MerkleRoots(t *testing.T) {
 				{ChainSel: sourceChain1, SeqNum: 10},
 				{ChainSel: sourceChain2, SeqNum: 20},
 			},
-			RMNEnabledChains:    map[ccipocr3.ChainSelector]bool{},
 			RMNReportSignatures: []ccipocr3.RMNECDSASignature{},
 			RMNRemoteCfg:        params.rmnReportCfg,
 		},
@@ -163,7 +157,7 @@ func TestPlugin_E2E_AllNodesAgree_MerkleRoots(t *testing.T) {
 			expOutcome:  outcomeReportGenerated,
 			expTransmittedReports: []ccipocr3.CommitPluginReport{
 				{
-					UnblessedMerkleRoots: []ccipocr3.MerkleRootChain{
+					MerkleRoots: []ccipocr3.MerkleRootChain{
 						{
 							ChainSel:      sourceChain1,
 							SeqNumsRange:  ccipocr3.NewSeqNumRange(0xa, 0xa),
@@ -171,9 +165,8 @@ func TestPlugin_E2E_AllNodesAgree_MerkleRoots(t *testing.T) {
 							MerkleRoot:    merkleRoot1,
 						},
 					},
-					BlessedMerkleRoots: make([]ccipocr3.MerkleRootChain, 0),
-					PriceUpdates:       ccipocr3.PriceUpdates{},
-					RMNSignatures:      []ccipocr3.RMNECDSASignature{},
+					PriceUpdates:  ccipocr3.PriceUpdates{},
+					RMNSignatures: []ccipocr3.RMNECDSASignature{},
 				},
 			},
 		},
@@ -320,8 +313,6 @@ func TestPlugin_E2E_AllNodesAgree_TokenPrices(t *testing.T) {
 							},
 						},
 					},
-					BlessedMerkleRoots:   make([]ccipocr3.MerkleRootChain, 0),
-					UnblessedMerkleRoots: make([]ccipocr3.MerkleRootChain, 0),
 				},
 			},
 		},
@@ -421,8 +412,6 @@ func TestPlugin_E2E_AllNodesAgree_TokenPrices(t *testing.T) {
 							},
 						},
 					},
-					BlessedMerkleRoots:   make([]ccipocr3.MerkleRootChain, 0),
-					UnblessedMerkleRoots: make([]ccipocr3.MerkleRootChain, 0),
 				},
 			},
 		},
@@ -738,8 +727,6 @@ func prepareCcipReaderMock(
 		Return(ccipocr3.Bytes{1}, nil).Maybe()
 	ccipReader.EXPECT().GetRmnCurseInfo(mock.Anything, mock.Anything).
 		Return(&reader2.CurseInfo{}, nil).Maybe()
-	ccipReader.EXPECT().GetOffRampSourceChainsConfig(mock.Anything, mock.Anything).
-		Return(sourceChainConfigs, nil).Maybe()
 
 	if mockEmptySeqNrs {
 		ccipReader.EXPECT().NextSeqNum(mock.Anything, mock.Anything).Unset()
@@ -799,11 +786,6 @@ func setupNode(params SetupNodeParams) nodeSetup {
 	msgHasher := mocks.NewMessageHasher()
 	homeChainReader := reader_mock.NewMockHomeChain(params.t)
 	rmnHomeReader := readerpkg_mock.NewMockRMNHome(params.t)
-
-	rmnHomeReader.EXPECT().GetRMNEnabledSourceChains(mock.Anything).Return(map[ccipocr3.ChainSelector]bool{
-		sourceChain1: false,
-		sourceChain2: false,
-	}, nil).Maybe()
 
 	fChain := map[ccipocr3.ChainSelector]int{}
 	supportedChainsForPeer := make(map[libocrtypes.PeerID]mapset.Set[ccipocr3.ChainSelector])
@@ -1021,7 +1003,6 @@ func noReportMerkleOutcome(r rmntypes.RemoteConfig) merkleroot.Outcome {
 		OffRampNextSeqNums:      []plugintypes.SeqNumChain{},
 		RMNReportSignatures:     []ccipocr3.RMNECDSASignature{},
 		RMNRemoteCfg:            r,
-		RMNEnabledChains:        map[ccipocr3.ChainSelector]bool{},
 	}
 }
 

--- a/commit/report_test.go
+++ b/commit/report_test.go
@@ -77,9 +77,7 @@ func TestPluginReports(t *testing.T) {
 							{GasPrice: ccipocr3.NewBigIntFromInt64(3), ChainSel: 123},
 						},
 					},
-					RMNSignatures:        nil,
-					UnblessedMerkleRoots: make([]ccipocr3.MerkleRootChain, 0),
-					BlessedMerkleRoots:   make([]ccipocr3.MerkleRootChain, 0),
+					RMNSignatures: nil,
 				},
 			},
 			expReportInfo: ccipocr3.CommitReportInfo{},
@@ -101,9 +99,7 @@ func TestPluginReports(t *testing.T) {
 							{GasPrice: ccipocr3.NewBigIntFromInt64(3), ChainSel: 123},
 						},
 					},
-					UnblessedMerkleRoots: make([]ccipocr3.MerkleRootChain, 0),
-					BlessedMerkleRoots:   make([]ccipocr3.MerkleRootChain, 0),
-					RMNSignatures:        nil,
+					RMNSignatures: nil,
 				},
 			},
 			expReportInfo: ccipocr3.CommitReportInfo{},
@@ -121,15 +117,8 @@ func TestPluginReports(t *testing.T) {
 							SeqNumsRange:  ccipocr3.NewSeqNumRange(10, 20),
 							MerkleRoot:    ccipocr3.Bytes32{1, 2, 3, 4, 5, 6},
 						},
-						{
-							ChainSel:      2,
-							OnRampAddress: []byte{1, 2, 3},
-							SeqNumsRange:  ccipocr3.NewSeqNumRange(110, 210),
-							MerkleRoot:    ccipocr3.Bytes32{1, 2, 3, 4, 5, 6, 7},
-						},
 					},
-					RMNRemoteCfg:     rmntypes.RemoteConfig{FSign: 123},
-					RMNEnabledChains: map[ccipocr3.ChainSelector]bool{3: true, 2: false},
+					RMNRemoteCfg: rmntypes.RemoteConfig{FSign: 123},
 				},
 				TokenPriceOutcome: tokenprice.Outcome{
 					TokenPrices: ccipocr3.TokenPriceMap{
@@ -144,20 +133,12 @@ func TestPluginReports(t *testing.T) {
 			},
 			expReports: []ccipocr3.CommitPluginReport{
 				{
-					BlessedMerkleRoots: []ccipocr3.MerkleRootChain{
+					MerkleRoots: []ccipocr3.MerkleRootChain{
 						{
 							ChainSel:      3,
 							OnRampAddress: []byte{1, 2, 3},
 							SeqNumsRange:  ccipocr3.NewSeqNumRange(10, 20),
 							MerkleRoot:    ccipocr3.Bytes32{1, 2, 3, 4, 5, 6},
-						},
-					},
-					UnblessedMerkleRoots: []ccipocr3.MerkleRootChain{
-						{
-							ChainSel:      2,
-							OnRampAddress: []byte{1, 2, 3},
-							SeqNumsRange:  ccipocr3.NewSeqNumRange(110, 210),
-							MerkleRoot:    ccipocr3.Bytes32{1, 2, 3, 4, 5, 6, 7},
 						},
 					},
 					PriceUpdates: ccipocr3.PriceUpdates{
@@ -174,12 +155,6 @@ func TestPluginReports(t *testing.T) {
 			expReportInfo: ccipocr3.CommitReportInfo{
 				RemoteF: 123,
 				MerkleRoots: []ccipocr3.MerkleRootChain{
-					{
-						ChainSel:      2,
-						OnRampAddress: []byte{1, 2, 3},
-						SeqNumsRange:  ccipocr3.NewSeqNumRange(110, 210),
-						MerkleRoot:    ccipocr3.Bytes32{1, 2, 3, 4, 5, 6, 7},
-					},
 					{
 						ChainSel:      3,
 						OnRampAddress: []byte{1, 2, 3},
@@ -290,7 +265,7 @@ func Test_Plugin_isStaleReport(t *testing.T) {
 				lggr: logger.Test(t),
 			}
 			report := ccipocr3.CommitPluginReport{
-				BlessedMerkleRoots: make([]ccipocr3.MerkleRootChain, tc.lenMerkleRoots),
+				MerkleRoots: make([]ccipocr3.MerkleRootChain, tc.lenMerkleRoots),
 			}
 			stale := p.isStaleReport(p.lggr, tc.reportSeqNum, tc.onChainSeqNum, report)
 			require.Equal(t, tc.shouldBeStale, stale)

--- a/execute/plugin_functions.go
+++ b/execute/plugin_functions.go
@@ -267,8 +267,7 @@ func groupByChainSelector(
 	reports []plugintypes2.CommitPluginReportWithMeta) exectypes.CommitObservations {
 	commitReportCache := make(map[cciptypes.ChainSelector][]exectypes.CommitData)
 	for _, report := range reports {
-		merkleRoots := append(report.Report.BlessedMerkleRoots, report.Report.UnblessedMerkleRoots...)
-		for _, singleReport := range merkleRoots {
+		for _, singleReport := range report.Report.MerkleRoots {
 			commitReportCache[singleReport.ChainSel] = append(commitReportCache[singleReport.ChainSel],
 				exectypes.CommitData{
 					SourceChain:         singleReport.ChainSel,

--- a/execute/plugin_functions_test.go
+++ b/execute/plugin_functions_test.go
@@ -424,7 +424,7 @@ func Test_groupByChainSelector(t *testing.T) {
 			name: "reports",
 			args: args{reports: []plugintypes2.CommitPluginReportWithMeta{{
 				Report: cciptypes.CommitPluginReport{
-					BlessedMerkleRoots: []cciptypes.MerkleRootChain{
+					MerkleRoots: []cciptypes.MerkleRootChain{
 						{ChainSel: 1, SeqNumsRange: cciptypes.NewSeqNumRange(10, 20), MerkleRoot: cciptypes.Bytes32{1}},
 						{ChainSel: 2, SeqNumsRange: cciptypes.NewSeqNumRange(30, 40), MerkleRoot: cciptypes.Bytes32{2}},
 					}}}}},

--- a/execute/plugin_test.go
+++ b/execute/plugin_test.go
@@ -69,7 +69,7 @@ func Test_getPendingExecutedReports(t *testing.T) {
 					BlockNum:  999,
 					Timestamp: time.UnixMilli(10101010101),
 					Report: cciptypes.CommitPluginReport{
-						BlessedMerkleRoots: []cciptypes.MerkleRootChain{
+						MerkleRoots: []cciptypes.MerkleRootChain{
 							{
 								ChainSel:     1,
 								SeqNumsRange: cciptypes.NewSeqNumRange(1, 10),
@@ -100,7 +100,7 @@ func Test_getPendingExecutedReports(t *testing.T) {
 					BlockNum:  999,
 					Timestamp: time.UnixMilli(10101010101),
 					Report: cciptypes.CommitPluginReport{
-						BlessedMerkleRoots: []cciptypes.MerkleRootChain{
+						MerkleRoots: []cciptypes.MerkleRootChain{
 							{
 								ChainSel:     1,
 								SeqNumsRange: cciptypes.NewSeqNumRange(1, 10),
@@ -150,7 +150,7 @@ func Test_getPendingExecutedReports(t *testing.T) {
 					BlockNum:  999,
 					Timestamp: time.UnixMilli(10101010101),
 					Report: cciptypes.CommitPluginReport{
-						BlessedMerkleRoots: []cciptypes.MerkleRootChain{
+						MerkleRoots: []cciptypes.MerkleRootChain{
 							{
 								ChainSel:     1,
 								SeqNumsRange: cciptypes.NewSeqNumRange(1, 10),
@@ -182,7 +182,7 @@ func Test_getPendingExecutedReports(t *testing.T) {
 					BlockNum:  999,
 					Timestamp: time.UnixMilli(10101010101),
 					Report: cciptypes.CommitPluginReport{
-						BlessedMerkleRoots: []cciptypes.MerkleRootChain{
+						MerkleRoots: []cciptypes.MerkleRootChain{
 							{
 								ChainSel:     1,
 								SeqNumsRange: cciptypes.NewSeqNumRange(1, 10),

--- a/execute/test_utils.go
+++ b/execute/test_utils.go
@@ -131,7 +131,7 @@ func (it *IntTest) WithMessages(
 
 		it.ccipReader.Reports = append(it.ccipReader.Reports, plugintypes2.CommitPluginReportWithMeta{
 			Report: cciptypes.CommitPluginReport{
-				BlessedMerkleRoots: []cciptypes.MerkleRootChain{
+				MerkleRoots: []cciptypes.MerkleRootChain{
 					{
 						ChainSel:     reportData.SourceChain,
 						SeqNumsRange: reportData.SequenceNumberRange,

--- a/internal/mocks/inmem/ccipreader_inmem.go
+++ b/internal/mocks/inmem/ccipreader_inmem.go
@@ -206,10 +206,5 @@ func (r InMemoryCCIPReader) GetOffRampConfigDigest(ctx context.Context, pluginTy
 	return r.ConfigDigest, nil
 }
 
-func (r InMemoryCCIPReader) GetOffRampSourceChainsConfig(ctx context.Context, chains []cciptypes.ChainSelector,
-) (map[cciptypes.ChainSelector]reader.SourceChainConfig, error) {
-	return nil, nil
-}
-
 // Interface compatibility check.
 var _ reader.CCIPReader = InMemoryCCIPReader{}

--- a/mocks/pkg/reader/ccip_reader.go
+++ b/mocks/pkg/reader/ccip_reader.go
@@ -655,65 +655,6 @@ func (_c *MockCCIPReader_GetOffRampConfigDigest_Call) RunAndReturn(run func(cont
 	return _c
 }
 
-// GetOffRampSourceChainsConfig provides a mock function with given fields: ctx, sourceChains
-func (_m *MockCCIPReader) GetOffRampSourceChainsConfig(ctx context.Context, sourceChains []ccipocr3.ChainSelector) (map[ccipocr3.ChainSelector]reader.SourceChainConfig, error) {
-	ret := _m.Called(ctx, sourceChains)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetOffRampSourceChainsConfig")
-	}
-
-	var r0 map[ccipocr3.ChainSelector]reader.SourceChainConfig
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, []ccipocr3.ChainSelector) (map[ccipocr3.ChainSelector]reader.SourceChainConfig, error)); ok {
-		return rf(ctx, sourceChains)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, []ccipocr3.ChainSelector) map[ccipocr3.ChainSelector]reader.SourceChainConfig); ok {
-		r0 = rf(ctx, sourceChains)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[ccipocr3.ChainSelector]reader.SourceChainConfig)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, []ccipocr3.ChainSelector) error); ok {
-		r1 = rf(ctx, sourceChains)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockCCIPReader_GetOffRampSourceChainsConfig_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetOffRampSourceChainsConfig'
-type MockCCIPReader_GetOffRampSourceChainsConfig_Call struct {
-	*mock.Call
-}
-
-// GetOffRampSourceChainsConfig is a helper method to define mock.On call
-//   - ctx context.Context
-//   - sourceChains []ccipocr3.ChainSelector
-func (_e *MockCCIPReader_Expecter) GetOffRampSourceChainsConfig(ctx interface{}, sourceChains interface{}) *MockCCIPReader_GetOffRampSourceChainsConfig_Call {
-	return &MockCCIPReader_GetOffRampSourceChainsConfig_Call{Call: _e.mock.On("GetOffRampSourceChainsConfig", ctx, sourceChains)}
-}
-
-func (_c *MockCCIPReader_GetOffRampSourceChainsConfig_Call) Run(run func(ctx context.Context, sourceChains []ccipocr3.ChainSelector)) *MockCCIPReader_GetOffRampSourceChainsConfig_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].([]ccipocr3.ChainSelector))
-	})
-	return _c
-}
-
-func (_c *MockCCIPReader_GetOffRampSourceChainsConfig_Call) Return(_a0 map[ccipocr3.ChainSelector]reader.SourceChainConfig, _a1 error) *MockCCIPReader_GetOffRampSourceChainsConfig_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockCCIPReader_GetOffRampSourceChainsConfig_Call) RunAndReturn(run func(context.Context, []ccipocr3.ChainSelector) (map[ccipocr3.ChainSelector]reader.SourceChainConfig, error)) *MockCCIPReader_GetOffRampSourceChainsConfig_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetRMNRemoteConfig provides a mock function with given fields: ctx
 func (_m *MockCCIPReader) GetRMNRemoteConfig(ctx context.Context) (rmntypes.RemoteConfig, error) {
 	ret := _m.Called(ctx)

--- a/mocks/pkg/reader/rmn_home.go
+++ b/mocks/pkg/reader/rmn_home.go
@@ -245,64 +245,6 @@ func (_c *MockRMNHome_GetOffChainConfig_Call) RunAndReturn(run func(ccipocr3.Byt
 	return _c
 }
 
-// GetRMNEnabledSourceChains provides a mock function with given fields: configDigest
-func (_m *MockRMNHome) GetRMNEnabledSourceChains(configDigest ccipocr3.Bytes32) (map[ccipocr3.ChainSelector]bool, error) {
-	ret := _m.Called(configDigest)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetRMNEnabledSourceChains")
-	}
-
-	var r0 map[ccipocr3.ChainSelector]bool
-	var r1 error
-	if rf, ok := ret.Get(0).(func(ccipocr3.Bytes32) (map[ccipocr3.ChainSelector]bool, error)); ok {
-		return rf(configDigest)
-	}
-	if rf, ok := ret.Get(0).(func(ccipocr3.Bytes32) map[ccipocr3.ChainSelector]bool); ok {
-		r0 = rf(configDigest)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(map[ccipocr3.ChainSelector]bool)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(ccipocr3.Bytes32) error); ok {
-		r1 = rf(configDigest)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockRMNHome_GetRMNEnabledSourceChains_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetRMNEnabledSourceChains'
-type MockRMNHome_GetRMNEnabledSourceChains_Call struct {
-	*mock.Call
-}
-
-// GetRMNEnabledSourceChains is a helper method to define mock.On call
-//   - configDigest ccipocr3.Bytes32
-func (_e *MockRMNHome_Expecter) GetRMNEnabledSourceChains(configDigest interface{}) *MockRMNHome_GetRMNEnabledSourceChains_Call {
-	return &MockRMNHome_GetRMNEnabledSourceChains_Call{Call: _e.mock.On("GetRMNEnabledSourceChains", configDigest)}
-}
-
-func (_c *MockRMNHome_GetRMNEnabledSourceChains_Call) Run(run func(configDigest ccipocr3.Bytes32)) *MockRMNHome_GetRMNEnabledSourceChains_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(ccipocr3.Bytes32))
-	})
-	return _c
-}
-
-func (_c *MockRMNHome_GetRMNEnabledSourceChains_Call) Return(_a0 map[ccipocr3.ChainSelector]bool, _a1 error) *MockRMNHome_GetRMNEnabledSourceChains_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockRMNHome_GetRMNEnabledSourceChains_Call) RunAndReturn(run func(ccipocr3.Bytes32) (map[ccipocr3.ChainSelector]bool, error)) *MockRMNHome_GetRMNEnabledSourceChains_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetRMNNodesInfo provides a mock function with given fields: configDigest
 func (_m *MockRMNHome) GetRMNNodesInfo(configDigest ccipocr3.Bytes32) ([]types.HomeNodeInfo, error) {
 	ret := _m.Called(configDigest)

--- a/pkg/reader/ccip_interface.go
+++ b/pkg/reader/ccip_interface.go
@@ -175,9 +175,4 @@ type CCIPReader interface {
 
 	// GetOffRampConfigDigest returns the offramp config digest for the provided plugin type.
 	GetOffRampConfigDigest(ctx context.Context, pluginType uint8) ([32]byte, error)
-
-	// GetOffRampSourceChainsConfig returns the sourceChains config for all the provided source chains.
-	// If a config was not found it will be missing from the returned map.
-	GetOffRampSourceChainsConfig(ctx context.Context, sourceChains []cciptypes.ChainSelector,
-	) (map[cciptypes.ChainSelector]SourceChainConfig, error)
 }

--- a/pkg/reader/ccip_test.go
+++ b/pkg/reader/ccip_test.go
@@ -63,7 +63,7 @@ func TestCCIPChainReader_getSourceChainsConfig(t *testing.T) {
 				}
 				params := readReq.Params.(map[string]any)
 				sourceChain := params["sourceChainSelector"].(cciptypes.ChainSelector)
-				v := readReq.ReturnVal.(*SourceChainConfig)
+				v := readReq.ReturnVal.(*sourceChainConfig)
 
 				fromString, err := cciptypes.NewBytesFromString(fmt.Sprintf(
 					"0x%d000000000000000000000000000000000000000", sourceChain),
@@ -100,8 +100,7 @@ func TestCCIPChainReader_getSourceChainsConfig(t *testing.T) {
 			Address: typeconv.AddressBytesToString(offrampAddress, 111_111)}}))
 
 	ctx := context.Background()
-	cfgs, err := ccipReader.getOffRampSourceChainsConfig(
-		ctx, logger.Test(t), []cciptypes.ChainSelector{chainA, chainB}, false)
+	cfgs, err := ccipReader.getOffRampSourceChainsConfig(ctx, logger.Test(t), []cciptypes.ChainSelector{chainA, chainB})
 	assert.NoError(t, err)
 	assert.Len(t, cfgs, 2)
 	assert.Equal(t, "0x1000000000000000000000000000000000000000", cfgs[chainA].OnRamp.String())
@@ -443,9 +442,9 @@ func TestCCIPChainReader_DiscoverContracts_HappyPath_Round1(t *testing.T) {
 	srcRouters := [][]byte{{0x7}, {0x8}}
 	//srcFeeQuoters := [2][]byte{{0x7}, {0x8}}
 
-	sourceChainConfigs := make(map[cciptypes.ChainSelector]SourceChainConfig, len(sourceChain))
+	sourceChainConfigs := make(map[cciptypes.ChainSelector]sourceChainConfig, len(sourceChain))
 	for i, chain := range sourceChain {
-		sourceChainConfigs[chain] = SourceChainConfig{
+		sourceChainConfigs[chain] = sourceChainConfig{
 			Router:    srcRouters[i],
 			IsEnabled: true,
 			MinSeqNr:  0,
@@ -476,11 +475,11 @@ func TestCCIPChainReader_DiscoverContracts_HappyPath_Round1(t *testing.T) {
 		mock.Anything,
 	).RunAndReturn(withBatchGetLatestValuesRetValues(t,
 		"0x1234567890123456789012345678901234567890",
-		[]any{&SourceChainConfig{
+		[]any{&sourceChainConfig{
 			OnRamp:    onramps[0],
 			Router:    destRouter,
 			IsEnabled: true,
-		}, &SourceChainConfig{
+		}, &sourceChainConfig{
 			OnRamp:    onramps[1],
 			Router:    destRouter,
 			IsEnabled: true,
@@ -612,12 +611,12 @@ func TestCCIPChainReader_DiscoverContracts_HappyPath_Round2(t *testing.T) {
 		mock.Anything,
 	).RunAndReturn(withBatchGetLatestValuesRetValues(t,
 		"0x1234567890123456789012345678901234567890",
-		[]any{&SourceChainConfig{
+		[]any{&sourceChainConfig{
 			OnRamp:    onramps[0],
 			Router:    destRouter[0],
 			IsEnabled: true,
 		},
-			&SourceChainConfig{
+			&sourceChainConfig{
 				OnRamp:    onramps[1],
 				Router:    destRouter[1],
 				IsEnabled: true,
@@ -723,7 +722,7 @@ func TestCCIPChainReader_DiscoverContracts_GetOfframpStaticConfig_Errors(t *test
 		mock.Anything,
 	).RunAndReturn(withBatchGetLatestValuesRetValues(t,
 		"0x1234567890123456789012345678901234567890",
-		[]any{&SourceChainConfig{}, &SourceChainConfig{}}))
+		[]any{&sourceChainConfig{}, &sourceChainConfig{}}))
 
 	// mock the call to get the static config - failure
 	getLatestValueErr := errors.New("some error")
@@ -787,7 +786,7 @@ func withBatchGetLatestValuesRetValues(
 		ctx context.Context, req contractreader.ExtendedBatchGetLatestValuesRequest, graceful bool,
 	) (types.BatchGetLatestValuesResult, []string, error) {
 		require.GreaterOrEqual(t, len(retVals), 1)
-		_, ok := retVals[0].(*SourceChainConfig)
+		_, ok := retVals[0].(*sourceChainConfig)
 		require.True(t, ok)
 		require.Len(t, req, 1)
 		contract := maps.Keys(req)[0]

--- a/pkg/reader/rmn_home.go
+++ b/pkg/reader/rmn_home.go
@@ -29,9 +29,6 @@ type RMNHome interface {
 	GetRMNNodesInfo(configDigest cciptypes.Bytes32) ([]rmntypes.HomeNodeInfo, error)
 	// IsRMNHomeConfigDigestSet checks if the configDigest is set in the RMNHome contract
 	IsRMNHomeConfigDigestSet(configDigest cciptypes.Bytes32) bool
-	// GetRMNEnabledSourceChains gets the RMN-enabled source chains for the given configDigest.
-	// If a chain is not RMN-enabled it means that we don't need to do RMN signature related operations for that chain.
-	GetRMNEnabledSourceChains(configDigest cciptypes.Bytes32) (map[cciptypes.ChainSelector]bool, error)
 	// GetFObserve gets the F value for each source chain in the given configDigest.
 	// Maximum number of faulty observers; F+1 observers required to agree on an observation for a source chain.
 	GetFObserve(configDigest cciptypes.Bytes32) (map[cciptypes.ChainSelector]int, error)
@@ -118,24 +115,6 @@ func (r *rmnHome) GetFObserve(configDigest cciptypes.Bytes32) (map[cciptypes.Cha
 		return nil, fmt.Errorf("configDigest %s not found in RMNHomeConfig", configDigest)
 	}
 	return state.rmnHomeConfig[configDigest].SourceChainF, nil
-}
-
-// GetRMNEnabledSourceChains returns the source chains that are RMN-enabled. A chain is considered RMN-enabled if
-// F is present in RMNHome config.
-func (r *rmnHome) GetRMNEnabledSourceChains(configDigest cciptypes.Bytes32) (map[cciptypes.ChainSelector]bool, error) {
-	state := r.bgPoller.getRMNHomeState()
-	homeCfg, ok := state.rmnHomeConfig[configDigest]
-	if !ok {
-		return map[cciptypes.ChainSelector]bool{},
-			fmt.Errorf("configDigest %s not found in RMNHomeConfig", configDigest)
-	}
-
-	enabledChains := make(map[cciptypes.ChainSelector]bool, len(homeCfg.SourceChainF))
-	for chain := range homeCfg.SourceChainF {
-		enabledChains[chain] = true
-	}
-
-	return enabledChains, nil
 }
 
 func (r *rmnHome) GetOffChainConfig(configDigest cciptypes.Bytes32) (cciptypes.Bytes, error) {

--- a/pkg/reader/rmn_home_poller.go
+++ b/pkg/reader/rmn_home_poller.go
@@ -317,15 +317,15 @@ func convertOnChainConfigToRMNHomeChainConfig(
 	}
 
 	rmnHomeConfigs := make(map[cciptypes.Bytes32]rmntypes.HomeConfig)
-	for _, cfg := range versionedConfigWithDigests {
-		err := validate(cfg)
+	for _, versionedConfig := range versionedConfigWithDigests {
+		err := validate(versionedConfig)
 		if err != nil {
 			lggr.Warnw("invalid on chain RMNHomeConfig", "err", err)
 			continue
 		}
 
-		nodes := make([]rmntypes.HomeNodeInfo, len(cfg.StaticConfig.Nodes))
-		for i, node := range cfg.StaticConfig.Nodes {
+		nodes := make([]rmntypes.HomeNodeInfo, len(versionedConfig.StaticConfig.Nodes))
+		for i, node := range versionedConfig.StaticConfig.Nodes {
 			pubKey := ed25519.PublicKey(node.OffchainPublicKey[:])
 
 			nodes[i] = rmntypes.HomeNodeInfo{
@@ -337,9 +337,9 @@ func convertOnChainConfigToRMNHomeChainConfig(
 			}
 		}
 
-		homeFMap := make(map[cciptypes.ChainSelector]int, len(cfg.DynamicConfig.SourceChains))
+		homeFMap := make(map[cciptypes.ChainSelector]int)
 
-		for _, chain := range cfg.DynamicConfig.SourceChains {
+		for _, chain := range versionedConfig.DynamicConfig.SourceChains {
 			homeFMap[chain.ChainSelector] = int(chain.FObserve)
 			for j := 0; j < len(nodes); j++ {
 				isObserver, err := isNodeObserver(chain, j, len(nodes))
@@ -353,11 +353,11 @@ func convertOnChainConfigToRMNHomeChainConfig(
 			}
 		}
 
-		rmnHomeConfigs[cfg.ConfigDigest] = rmntypes.HomeConfig{
+		rmnHomeConfigs[versionedConfig.ConfigDigest] = rmntypes.HomeConfig{
 			Nodes:          nodes,
 			SourceChainF:   homeFMap,
-			ConfigDigest:   cfg.ConfigDigest,
-			OffchainConfig: cfg.DynamicConfig.OffchainConfig,
+			ConfigDigest:   versionedConfig.ConfigDigest,
+			OffchainConfig: versionedConfig.DynamicConfig.OffchainConfig,
 		}
 	}
 	return rmnHomeConfigs

--- a/pkg/types/ccipocr3/plugin_commit_types.go
+++ b/pkg/types/ccipocr3/plugin_commit_types.go
@@ -21,9 +21,8 @@ import (
 // RMNSignatures, if RMN is configured for some lanes involved in the commitment.
 // A report with RMN signatures but without merkle roots is invalid.
 type CommitPluginReport struct {
-	PriceUpdates         PriceUpdates      `json:"priceUpdates"`
-	BlessedMerkleRoots   []MerkleRootChain `json:"blessedMerkleRoots"`
-	UnblessedMerkleRoots []MerkleRootChain `json:"unblessedMerkleRoots"`
+	PriceUpdates PriceUpdates      `json:"priceUpdates"`
+	MerkleRoots  []MerkleRootChain `json:"merkleRoots"`
 
 	// RMNSignatures are the ECDSA signatures from the RMN signing nodes on the RMNReport structure.
 	// For more details see the contract here: https://github.com/smartcontractkit/chainlink/blob/7ba0f37134a618375542079ff1805fe2224d7916/contracts/src/v0.8/ccip/interfaces/IRMNV2.sol#L8-L12
@@ -34,8 +33,7 @@ type CommitPluginReport struct {
 // IsEmpty returns true if the CommitPluginReport is empty.
 // NOTE: A report is considered empty when core fields are missing (MerkleRoots, TokenPrices, GasPriceUpdates).
 func (r CommitPluginReport) IsEmpty() bool {
-	return len(r.BlessedMerkleRoots) == 0 &&
-		len(r.UnblessedMerkleRoots) == 0 &&
+	return len(r.MerkleRoots) == 0 &&
 		len(r.PriceUpdates.TokenPriceUpdates) == 0 &&
 		len(r.PriceUpdates.GasPriceUpdates) == 0
 }
@@ -68,7 +66,7 @@ type PriceUpdates struct {
 	GasPriceUpdates   []GasPriceChain `json:"gasPriceUpdates"`
 }
 
-// CommitReportInfo is the info data that will be sent with the along with the report
+// ReportInfo is the info data that will be sent with the along with the report
 // It will be used to determine if the report should be accepted or not
 type CommitReportInfo struct {
 	// RemoteF Max number of faulty RMN nodes; f+1 signers are required to verify a report.

--- a/pkg/types/ccipocr3/plugin_commit_types_test.go
+++ b/pkg/types/ccipocr3/plugin_commit_types_test.go
@@ -23,7 +23,7 @@ func TestCommitPluginReport(t *testing.T) {
 
 	t.Run("is not empty", func(t *testing.T) {
 		r := CommitPluginReport{
-			BlessedMerkleRoots: make([]MerkleRootChain, 1),
+			MerkleRoots: make([]MerkleRootChain, 1),
 		}
 		assert.False(t, r.IsEmpty())
 
@@ -36,7 +36,7 @@ func TestCommitPluginReport(t *testing.T) {
 		assert.False(t, r.IsEmpty())
 
 		r = CommitPluginReport{
-			BlessedMerkleRoots: make([]MerkleRootChain, 1),
+			MerkleRoots: make([]MerkleRootChain, 1),
 			PriceUpdates: PriceUpdates{
 				TokenPriceUpdates: make([]TokenPrice, 1),
 				GasPriceUpdates:   make([]GasPriceChain, 1),


### PR DESCRIPTION
Reverts smartcontractkit/chainlink-ccip#550

I think the original PR might have broken CI, this draft PR is just testing if reverting it fixes CI

---

Confirmed, this fixes CI. Looks like the problem is that #550 expects the roots to be split between `blessed` and `unblessed`. But, as in Solana each report has a single root, there's no such split. https://github.com/smartcontractkit/chainlink/pull/15974 expects the un-split types to be present (which reflects the onchain behaviour correctly), so #550 ends up breaking CI. 