### PR TITLE
[Solana][NONEVM-1295]Require PDA for both token config accounts

### DIFF
--- a/chains/solana/contracts/programs/fee-quoter/src/instructions/v1/safe_deserialize.rs
+++ b/chains/solana/contracts/programs/fee-quoter/src/instructions/v1/safe_deserialize.rs
@@ -5,11 +5,13 @@ use crate::context::seed::{FEE_BILLING_TOKEN_CONFIG, PER_CHAIN_PER_TOKEN_CONFIG}
 use crate::state::{BillingTokenConfig, BillingTokenConfigWrapper, PerChainPerTokenConfig};
 use crate::FeeQuoterError;
 
+/// Returns Ok(None) when there's no chain-token configuration pair. The user must still
+/// specify the correct PDA, to ensure the configuration isn't ignored in the case it exists.
 pub fn per_chain_per_token_config<'info>(
     account: &'info AccountInfo<'info>,
     token: Pubkey,
     dest_chain_selector: u64,
-) -> Result<PerChainPerTokenConfig> {
+) -> Result<Option<PerChainPerTokenConfig>> {
     let (expected, _) = Pubkey::find_program_address(
         &[
             PER_CHAIN_PER_TOKEN_CONFIG,
@@ -23,25 +25,28 @@ pub fn per_chain_per_token_config<'info>(
         expected,
         FeeQuoterError::InvalidInputsPerChainPerTokenConfig
     );
-    let account = Account::<PerChainPerTokenConfig>::try_from(account)?;
-    require_eq!(
-        account.version,
-        1, // the v1 version of the onramp will always be tied to version 1 of the state
-        FeeQuoterError::InvalidVersion
-    );
-    Ok(account.into_inner())
+    let account = match Account::<PerChainPerTokenConfig>::try_from(account) {
+        Ok(account) => {
+            require_eq!(
+                account.version,
+                1, // the v1 version of the onramp will always be tied to version 1 of the state
+                FeeQuoterError::InvalidVersion
+            );
+            Some(account.into_inner())
+        }
+        Err(e) if e == ErrorCode::AccountNotInitialized.into() => None,
+        Err(e) => return Err(e),
+    };
+
+    Ok(account)
 }
 
-// Returns Ok(None) when parsing the ZERO address, which is a valid input from users
-// specifying a token that has no Billing config.
+/// Returns Ok(None) when there's no token specific billing config. The user must still
+/// specify the correct PDA, to ensure the configuration isn't ignored in the case it exists.
 pub fn billing_token_config<'info>(
     account: &'info AccountInfo<'info>,
     token: Pubkey,
 ) -> Result<Option<BillingTokenConfig>> {
-    if account.key() == Pubkey::default() {
-        return Ok(None);
-    }
-
     let (expected, _) =
         Pubkey::find_program_address(&[FEE_BILLING_TOKEN_CONFIG, token.as_ref()], &crate::ID);
     require_keys_eq!(
@@ -49,11 +54,19 @@ pub fn billing_token_config<'info>(
         expected,
         FeeQuoterError::InvalidInputsBillingTokenConfig
     );
-    let account = Account::<BillingTokenConfigWrapper>::try_from(account)?;
-    require_eq!(
-        account.version,
-        1, // the v1 version of the onramp will always be tied to version 1 of the state
-        FeeQuoterError::InvalidVersion
-    );
-    Ok(Some(account.into_inner().config))
+
+    let config = match Account::<BillingTokenConfigWrapper>::try_from(account) {
+        Ok(account) => {
+            require_eq!(
+                account.version,
+                1, // the v1 version of the onramp will always be tied to version 1 of the state
+                FeeQuoterError::InvalidVersion
+            );
+            Some(account.into_inner().config)
+        }
+        Err(e) if e == ErrorCode::AccountNotInitialized.into() => None,
+        Err(e) => return Err(e),
+    };
+
+    Ok(config)
 }


### PR DESCRIPTION
`core ref: e7be26ff7ee0cc4630fc471b4240fbad6812ca0e`

Requires the user to supply the correctly derived PDA for both accounts, so it's not possible to "ignore" on-chain config by supplying the zero address anymore, and also supporting tokens with default (not configured) PerChainPerTokenConfig.