### PR TITLE
[Solana][NONEVM-1034] Error improvements, ccip_router edition.

### DIFF
--- a/chains/solana/contracts/programs/ccip-router/src/context.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/context.rs
@@ -46,7 +46,7 @@ pub mod seed {
 #[derive(Accounts)]
 pub struct WithdrawBilledFunds<'info> {
     #[account(
-        owner = token_program.key() @ CcipRouterError::InvalidInputs,
+        owner = token_program.key() @ CcipRouterError::InvalidInputsMint,
     )]
     pub fee_token_mint: InterfaceAccount<'info, Mint>,
 
@@ -62,7 +62,7 @@ pub struct WithdrawBilledFunds<'info> {
         mut,
         constraint = recipient.key() == get_associated_token_address_with_program_id(
             &config.load()?.fee_aggregator.key(), &fee_token_mint.key(), &token_program.key()
-        ) @ CcipRouterError::InvalidInputs,
+        ) @ CcipRouterError::InvalidInputsAtaAddress,
     )]
     pub recipient: InterfaceAccount<'info, TokenAccount>,
 
@@ -78,7 +78,7 @@ pub struct WithdrawBilledFunds<'info> {
     #[account(
         seeds = [seed::CONFIG],
         bump,
-        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidVersion,
     )]
     pub config: AccountLoader<'info, Config>,
 
@@ -124,7 +124,7 @@ pub struct TransferOwnership<'info> {
         mut,
         seeds = [seed::CONFIG],
         bump,
-        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidVersion,
     )]
     pub config: AccountLoader<'info, Config>,
 
@@ -138,7 +138,7 @@ pub struct AcceptOwnership<'info> {
         mut,
         seeds = [seed::CONFIG],
         bump,
-        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidVersion,
     )]
     pub config: AccountLoader<'info, Config>,
 
@@ -162,7 +162,7 @@ pub struct AddChainSelector<'info> {
     #[account(
         seeds = [seed::CONFIG],
         bump,
-        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidVersion,
     )]
     pub config: AccountLoader<'info, Config>,
 
@@ -178,7 +178,7 @@ pub struct UpdateDestChainSelectorConfig<'info> {
         mut,
         seeds = [seed::DEST_CHAIN_STATE, new_chain_selector.to_le_bytes().as_ref()],
         bump,
-        constraint = valid_version(dest_chain_state.version, MAX_CHAINSTATE_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(dest_chain_state.version, MAX_CHAINSTATE_V) @ CcipRouterError::InvalidVersion,
         realloc = ANCHOR_DISCRIMINATOR + DestChain::INIT_SPACE + dest_chain_config.dynamic_space(),
         realloc::payer = authority,
         // `realloc::zero = true` is only necessary in cases where an instruction is capable of reallocating
@@ -191,7 +191,7 @@ pub struct UpdateDestChainSelectorConfig<'info> {
     #[account(
         seeds = [seed::CONFIG],
         bump,
-        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidVersion,
     )]
     pub config: AccountLoader<'info, Config>,
 
@@ -206,7 +206,7 @@ pub struct UpdateConfigCCIPRouter<'info> {
         mut,
         seeds = [seed::CONFIG],
         bump,
-        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidVersion,
     )]
     pub config: AccountLoader<'info, Config>,
 
@@ -230,7 +230,7 @@ pub struct AddOfframp<'info> {
     #[account(
         seeds = [seed::CONFIG],
         bump,
-        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidVersion,
     )]
     pub config: AccountLoader<'info, Config>,
 
@@ -254,7 +254,7 @@ pub struct RemoveOfframp<'info> {
     #[account(
         seeds = [seed::CONFIG],
         bump,
-        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidVersion,
     )]
     pub config: AccountLoader<'info, Config>,
 
@@ -274,7 +274,7 @@ pub struct CcipSend<'info> {
     #[account(
         seeds = [seed::CONFIG],
         bump,
-        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidVersion,
     )]
     pub config: AccountLoader<'info, Config>,
 
@@ -282,7 +282,7 @@ pub struct CcipSend<'info> {
         mut,
         seeds = [seed::DEST_CHAIN_STATE, destination_chain_selector.to_le_bytes().as_ref()],
         bump,
-        constraint = valid_version(dest_chain_state.version, MAX_CHAINSTATE_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(dest_chain_state.version, MAX_CHAINSTATE_V) @ CcipRouterError::InvalidVersion,
     )]
     pub dest_chain_state: Account<'info, DestChain>,
 
@@ -292,7 +292,7 @@ pub struct CcipSend<'info> {
         bump,
         payer = authority,
         space = ANCHOR_DISCRIMINATOR + Nonce::INIT_SPACE,
-        constraint = uninitialized(nonce.version) || valid_version(nonce.version, MAX_NONCE_V) @ CcipRouterError::InvalidInputs,
+        constraint = uninitialized(nonce.version) || valid_version(nonce.version, MAX_NONCE_V) @ CcipRouterError::InvalidVersion,
     )]
     pub nonce: Account<'info, Nonce>,
 
@@ -306,9 +306,9 @@ pub struct CcipSend<'info> {
     pub fee_token_program: Interface<'info, TokenInterface>,
 
     #[account(
-        owner = fee_token_program.key() @ CcipRouterError::InvalidInputs,
+        owner = fee_token_program.key() @ CcipRouterError::InvalidInputsMint,
         constraint = (message.fee_token == Pubkey::default() && fee_token_mint.key() == native_mint::ID)
-            || message.fee_token.key() == fee_token_mint.key() @ CcipRouterError::InvalidInputs,
+            || message.fee_token.key() == fee_token_mint.key() @ CcipRouterError::InvalidInputsMint,
     )]
     pub fee_token_mint: InterfaceAccount<'info, Mint>, // pass pre-2022 wSOL if using native SOL
 
@@ -349,7 +349,7 @@ pub struct CcipSend<'info> {
     ////////////////////
     /// CHECK: This is the account for the Fee Quoter program
     #[account(
-        address = config.load()?.fee_quoter @ CcipRouterError::InvalidInputs,
+        address = config.load()?.fee_quoter @ CcipRouterError::InvalidVersion,
     )]
     pub fee_quoter: UncheckedAccount<'info>,
 

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/fees.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/fees.rs
@@ -108,8 +108,8 @@ pub fn transfer_fee<'info>(
 ) -> Result<()> {
     require!(
         fee.token == transfer.mint.key(),
-        CcipRouterError::InvalidInputs
-    ); // TODO use more specific error
+        CcipRouterError::FeeTokenMismatch
+    );
 
     do_billing_transfer(token_program, transfer, fee.amount, decimals, signer_bump)
 }

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/onramp.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/onramp.rs
@@ -123,7 +123,7 @@ pub fn ccip_send<'info>(
     let token_count = message.token_amounts.len();
     require!(
         token_indexes.len() == token_count,
-        CcipRouterError::InvalidInputs,
+        CcipRouterError::InvalidInputsTokenIndices,
     );
 
     let mut new_message: SVM2AnyRampMessage = SVM2AnyRampMessage {

--- a/chains/solana/contracts/programs/ccip-router/src/lib.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/lib.rs
@@ -374,9 +374,9 @@ pub enum AnchorErrorHack {
 pub enum CcipRouterError {
     #[msg("The signer is unauthorized")]
     Unauthorized,
-    #[msg("Invalid version of the onchain state")]
-    InvalidInputsMint,
     #[msg("Mint account input is invalid")]
+    InvalidInputsMint,
+    #[msg("Invalid version of the onchain state")]
     InvalidVersion,
     #[msg("Fee token doesn't match transfer token")]
     FeeTokenMismatch,

--- a/chains/solana/contracts/programs/ccip-router/src/lib.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/lib.rs
@@ -61,7 +61,7 @@ pub mod ccip_router {
         link_token_mint: Pubkey,
     ) -> Result<()> {
         let mut config = ctx.accounts.config.load_init()?;
-        require!(config.version == 0, CcipRouterError::InvalidInputs); // assert uninitialized state - AccountLoader doesn't work with constraint
+        require!(config.version == 0, CcipRouterError::InvalidVersion); // assert uninitialized state - AccountLoader doesn't work with constraint
         config.version = 1;
         config.svm_chain_selector = svm_chain_selector;
         config.link_token_mint = link_token_mint;
@@ -374,8 +374,14 @@ pub enum AnchorErrorHack {
 pub enum CcipRouterError {
     #[msg("The signer is unauthorized")]
     Unauthorized,
-    #[msg("Invalid inputs")]
-    InvalidInputs,
+    #[msg("Invalid version of the onchain state")]
+    InvalidInputsMint,
+    #[msg("Mint account input is invalid")]
+    InvalidVersion,
+    #[msg("Fee token doesn't match transfer token")]
+    FeeTokenMismatch,
+    #[msg("Proposed owner is the current owner")]
+    RedundantOwnerProposal,
     #[msg("Reached max sequence number")]
     ReachedMaxSequenceNumber,
     #[msg("Invalid pool account account indices")]
@@ -394,10 +400,14 @@ pub enum CcipRouterError {
     InvalidInputsLookupTableAccountWritable,
     #[msg("Cannot send zero tokens")]
     InvalidInputsTokenAmount,
+    #[msg("Must specify zero amount to send alongside transfer_all")]
+    InvalidInputsTransferAllAmount,
     #[msg("Invalid Associated Token Account address")]
     InvalidInputsAtaAddress,
     #[msg("Invalid Associated Token Account writable flag")]
     InvalidInputsAtaWritable,
+    #[msg("Chain selector is invalid")]
+    InvalidInputsChainSelector,
     #[msg("Insufficient lamports")]
     InsufficientLamports,
     #[msg("Insufficient funds")]

--- a/chains/solana/contracts/programs/ccip-router/src/lib.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/lib.rs
@@ -372,28 +372,12 @@ pub enum AnchorErrorHack {
 
 #[error_code]
 pub enum CcipRouterError {
-    #[msg("The given sequence interval is invalid")]
-    InvalidSequenceInterval,
-    #[msg("The given Merkle Root is missing")]
-    RootNotCommitted,
-    #[msg("The given Merkle Root is already committed")]
-    ExistingMerkleRoot,
     #[msg("The signer is unauthorized")]
     Unauthorized,
     #[msg("Invalid inputs")]
     InvalidInputs,
-    #[msg("Source chain selector not supported")]
-    UnsupportedSourceChainSelector,
-    #[msg("Destination chain selector not supported")]
-    UnsupportedDestinationChainSelector,
-    #[msg("Invalid Proof for Merkle Root")]
-    InvalidProof,
-    #[msg("Invalid message format")]
-    InvalidMessage,
     #[msg("Reached max sequence number")]
     ReachedMaxSequenceNumber,
-    #[msg("Manual execution not allowed")]
-    ManualExecutionNotAllowed,
     #[msg("Invalid pool account account indices")]
     InvalidInputsTokenIndices,
     #[msg("Invalid pool accounts")]
@@ -410,64 +394,20 @@ pub enum CcipRouterError {
     InvalidInputsLookupTableAccountWritable,
     #[msg("Cannot send zero tokens")]
     InvalidInputsTokenAmount,
-    #[msg("Release or mint balance mismatch")]
-    OfframpReleaseMintBalanceMismatch,
-    #[msg("Invalid data length")]
-    OfframpInvalidDataLength,
-    #[msg("Stale commit report")]
-    StaleCommitReport,
-    #[msg("Destination chain disabled")]
-    DestinationChainDisabled,
-    #[msg("Fee token disabled")]
-    FeeTokenDisabled,
-    #[msg("Message exceeds maximum data size")]
-    MessageTooLarge,
-    #[msg("Message contains an unsupported number of tokens")]
-    UnsupportedNumberOfTokens,
-    #[msg("Chain family selector not supported")]
-    UnsupportedChainFamilySelector,
-    #[msg("Invalid EVM address")]
-    InvalidEVMAddress,
-    #[msg("Invalid encoding")]
-    InvalidEncoding,
     #[msg("Invalid Associated Token Account address")]
     InvalidInputsAtaAddress,
     #[msg("Invalid Associated Token Account writable flag")]
     InvalidInputsAtaWritable,
-    #[msg("Invalid token price")]
-    InvalidTokenPrice,
-    #[msg("Stale gas price")]
-    StaleGasPrice,
     #[msg("Insufficient lamports")]
     InsufficientLamports,
     #[msg("Insufficient funds")]
     InsufficientFunds,
-    #[msg("Unsupported token")]
-    UnsupportedToken,
-    #[msg("Inputs are missing token configuration")]
-    InvalidInputsMissingTokenConfig,
-    #[msg("Message fee is too high")]
-    MessageFeeTooHigh,
     #[msg("Source token data is too large")]
     SourceTokenDataTooLarge,
-    #[msg("Message gas limit too high")]
-    MessageGasLimitTooHigh,
-    #[msg("Extra arg out of order execution must be true")]
-    ExtraArgOutOfOrderExecutionMustBeTrue,
     #[msg("New Admin can not be zero address")]
     InvalidTokenAdminRegistryInputsZeroAddress,
     #[msg("An already owned registry can not be proposed")]
     InvalidTokenAdminRegistryProposedAdmin,
-    #[msg("Invalid writability bitmap")]
-    InvalidWritabilityBitmap,
-    #[msg("Invalid extra args tag")]
-    InvalidExtraArgsTag,
-    #[msg("Invalid chain family selector")]
-    InvalidChainFamilySelector,
-    #[msg("Invalid token receiver")]
-    InvalidTokenReceiver,
-    #[msg("Invalid SVM address")]
-    InvalidSVMAddress,
     #[msg("Sender not allowed for that destination chain")]
     SenderNotAllowed,
 }

--- a/chains/solana/contracts/programs/ccip-router/src/token_context.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/token_context.rs
@@ -27,7 +27,7 @@ pub struct RegisterTokenAdminRegistryByCCIPAdmin<'info> {
     #[account(
         seeds = [seed::CONFIG],
         bump,
-        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidVersion,
     )]
     pub config: AccountLoader<'info, Config>,
     #[account(
@@ -51,7 +51,7 @@ pub struct OverridePendingTokenAdminRegistryByCCIPAdmin<'info> {
     #[account(
         seeds = [seed::CONFIG],
         bump,
-        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidVersion,
     )]
     pub config: AccountLoader<'info, Config>,
     #[account(
@@ -73,7 +73,7 @@ pub struct RegisterTokenAdminRegistryByOwner<'info> {
     #[account(
         seeds = [seed::CONFIG],
         bump,
-        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidVersion,
     )]
     pub config: AccountLoader<'info, Config>,
     #[account(
@@ -82,7 +82,7 @@ pub struct RegisterTokenAdminRegistryByOwner<'info> {
         bump,
         payer = authority,
         space = ANCHOR_DISCRIMINATOR + TokenAdminRegistry::INIT_SPACE,
-        constraint = uninitialized(token_admin_registry.version) @ CcipRouterError::InvalidInputs,
+        constraint = uninitialized(token_admin_registry.version) @ CcipRouterError::InvalidVersion,
     )]
     pub token_admin_registry: Account<'info, TokenAdminRegistry>,
     pub mint: InterfaceAccount<'info, Mint>, // underlying token that the pool wraps
@@ -101,7 +101,7 @@ pub struct OverridePendingTokenAdminRegistryByOwner<'info> {
     #[account(
         seeds = [seed::CONFIG],
         bump,
-        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidVersion,
     )]
     pub config: AccountLoader<'info, Config>,
     #[account(
@@ -125,14 +125,14 @@ pub struct ModifyTokenAdminRegistry<'info> {
     #[account(
         seeds = [seed::CONFIG],
         bump,
-        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidVersion,
     )]
     pub config: AccountLoader<'info, Config>,
     #[account(
         mut,
         seeds = [seed::TOKEN_ADMIN_REGISTRY, mint.key().as_ref()],
         bump,
-        constraint = valid_version(token_admin_registry.version, MAX_TOKEN_REGISTRY_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(token_admin_registry.version, MAX_TOKEN_REGISTRY_V) @ CcipRouterError::InvalidVersion,
     )]
     pub token_admin_registry: Account<'info, TokenAdminRegistry>,
     pub mint: InterfaceAccount<'info, Mint>, // underlying token that the pool wraps
@@ -145,14 +145,14 @@ pub struct SetPoolTokenAdminRegistry<'info> {
     #[account(
         seeds = [seed::CONFIG],
         bump,
-        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidVersion,
     )]
     pub config: AccountLoader<'info, Config>,
     #[account(
         mut,
         seeds = [seed::TOKEN_ADMIN_REGISTRY, mint.key().as_ref()],
         bump,
-        constraint = valid_version(token_admin_registry.version, MAX_TOKEN_REGISTRY_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(token_admin_registry.version, MAX_TOKEN_REGISTRY_V) @ CcipRouterError::InvalidVersion,
     )]
     pub token_admin_registry: Account<'info, TokenAdminRegistry>,
     pub mint: InterfaceAccount<'info, Mint>, // underlying token that the pool wraps
@@ -167,14 +167,14 @@ pub struct AcceptAdminRoleTokenAdminRegistry<'info> {
     #[account(
         seeds = [seed::CONFIG],
         bump,
-        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(config.load()?.version, MAX_CONFIG_V) @ CcipRouterError::InvalidVersion,
     )]
     pub config: AccountLoader<'info, Config>,
     #[account(
         mut,
         seeds = [seed::TOKEN_ADMIN_REGISTRY, mint.key().as_ref()],
         bump,
-        constraint = valid_version(token_admin_registry.version, MAX_TOKEN_REGISTRY_V) @ CcipRouterError::InvalidInputs,
+        constraint = valid_version(token_admin_registry.version, MAX_TOKEN_REGISTRY_V) @ CcipRouterError::InvalidVersion,
     )]
     pub token_admin_registry: Account<'info, TokenAdminRegistry>,
     pub mint: InterfaceAccount<'info, Mint>, // underlying token that the pool wraps

--- a/chains/solana/contracts/target/idl/ccip_router.json
+++ b/chains/solana/contracts/target/idl/ccip_router.json
@@ -1270,37 +1270,22 @@
         "kind": "enum",
         "variants": [
           {
-            "name": "InvalidSequenceInterval"
-          },
-          {
-            "name": "RootNotCommitted"
-          },
-          {
-            "name": "ExistingMerkleRoot"
-          },
-          {
             "name": "Unauthorized"
           },
           {
-            "name": "InvalidInputs"
+            "name": "InvalidInputsMint"
           },
           {
-            "name": "UnsupportedSourceChainSelector"
+            "name": "InvalidVersion"
           },
           {
-            "name": "UnsupportedDestinationChainSelector"
+            "name": "FeeTokenMismatch"
           },
           {
-            "name": "InvalidProof"
-          },
-          {
-            "name": "InvalidMessage"
+            "name": "RedundantOwnerProposal"
           },
           {
             "name": "ReachedMaxSequenceNumber"
-          },
-          {
-            "name": "ManualExecutionNotAllowed"
           },
           {
             "name": "InvalidInputsTokenIndices"
@@ -1327,34 +1312,7 @@
             "name": "InvalidInputsTokenAmount"
           },
           {
-            "name": "OfframpReleaseMintBalanceMismatch"
-          },
-          {
-            "name": "OfframpInvalidDataLength"
-          },
-          {
-            "name": "StaleCommitReport"
-          },
-          {
-            "name": "DestinationChainDisabled"
-          },
-          {
-            "name": "FeeTokenDisabled"
-          },
-          {
-            "name": "MessageTooLarge"
-          },
-          {
-            "name": "UnsupportedNumberOfTokens"
-          },
-          {
-            "name": "UnsupportedChainFamilySelector"
-          },
-          {
-            "name": "InvalidEVMAddress"
-          },
-          {
-            "name": "InvalidEncoding"
+            "name": "InvalidInputsTransferAllAmount"
           },
           {
             "name": "InvalidInputsAtaAddress"
@@ -1363,10 +1321,7 @@
             "name": "InvalidInputsAtaWritable"
           },
           {
-            "name": "InvalidTokenPrice"
-          },
-          {
-            "name": "StaleGasPrice"
+            "name": "InvalidInputsChainSelector"
           },
           {
             "name": "InsufficientLamports"
@@ -1375,43 +1330,13 @@
             "name": "InsufficientFunds"
           },
           {
-            "name": "UnsupportedToken"
-          },
-          {
-            "name": "InvalidInputsMissingTokenConfig"
-          },
-          {
-            "name": "MessageFeeTooHigh"
-          },
-          {
             "name": "SourceTokenDataTooLarge"
-          },
-          {
-            "name": "MessageGasLimitTooHigh"
-          },
-          {
-            "name": "ExtraArgOutOfOrderExecutionMustBeTrue"
           },
           {
             "name": "InvalidTokenAdminRegistryInputsZeroAddress"
           },
           {
             "name": "InvalidTokenAdminRegistryProposedAdmin"
-          },
-          {
-            "name": "InvalidWritabilityBitmap"
-          },
-          {
-            "name": "InvalidExtraArgsTag"
-          },
-          {
-            "name": "InvalidChainFamilySelector"
-          },
-          {
-            "name": "InvalidTokenReceiver"
-          },
-          {
-            "name": "InvalidSVMAddress"
           },
           {
             "name": "SenderNotAllowed"

--- a/chains/solana/contracts/tests/ccip/ccip_router_test.go
+++ b/chains/solana/contracts/tests/ccip/ccip_router_test.go
@@ -952,7 +952,7 @@ func TestCCIPRouter(t *testing.T) {
 						legacyAdmin.PublicKey(),
 					).ValidateAndBuild()
 					require.NoError(t, err)
-					result := testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, legacyAdmin, config.DefaultCommitment, []string{"Error Code: " + ccip_router.InvalidInputs_CcipRouterError.String()})
+					result := testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, legacyAdmin, config.DefaultCommitment, []string{"Error Code: " + fee_quoter.InvalidInputs_FeeQuoterError.String()})
 					require.NotNil(t, result)
 				})
 			}
@@ -1129,7 +1129,7 @@ func TestCCIPRouter(t *testing.T) {
 				ccipAdmin.PublicKey(),
 			).ValidateAndBuild()
 			require.NoError(t, err)
-			result = testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, ccipAdmin, config.DefaultCommitment, []string{"Error Code: " + ccip_router.InvalidInputs_CcipRouterError.String()})
+			result = testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, ccipAdmin, config.DefaultCommitment, []string{"Error Code: " + ccip_router.RedundantOwnerProposal_CcipRouterError.String()})
 			require.NotNil(t, result)
 
 			// Validate proposed set to 0-address
@@ -1632,7 +1632,7 @@ func TestCCIPRouter(t *testing.T) {
 				).ValidateAndBuild()
 				require.NoError(t, err)
 
-				testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, ccipAdmin, config.DefaultCommitment, []string{"Error Code: " + ccip_router.InvalidInputs_CcipRouterError.String()})
+				testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, ccipAdmin, config.DefaultCommitment, []string{"Error Code: " + ccip_offramp.InvalidInputs_CcipOfframpError.String()})
 			})
 
 			t.Run("It rejects F = 0", func(t *testing.T) {
@@ -3248,7 +3248,7 @@ func TestCCIPRouter(t *testing.T) {
 			raw.GetFeeTokenUserAssociatedAccountAccount().WRITE()
 			instruction, err := raw.ValidateAndBuild()
 			require.NoError(t, err)
-			testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, anotherUser, config.DefaultCommitment, []string{ccip_router.InvalidInputs_CcipRouterError.String()})
+			testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, anotherUser, config.DefaultCommitment, []string{ccip_router.InvalidInputsAtaAddress_CcipRouterError.String()})
 		})
 
 		t.Run("When another user sending a Valid CCIP Message Emits CCIPMessageSent", func(t *testing.T) {
@@ -4187,7 +4187,7 @@ func TestCCIPRouter(t *testing.T) {
 			).ValidateAndBuild()
 			require.NoError(t, err)
 
-			testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{ix}, ccipAdmin, config.DefaultCommitment, []string{ccip_router.InvalidInputs_CcipRouterError.String()})
+			testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{ix}, ccipAdmin, config.DefaultCommitment, []string{ccip_router.InvalidInputsAtaAddress_CcipRouterError.String()})
 		})
 
 		t.Run("When withdrawing funds from a token account that does not belong to billing, it fails", func(t *testing.T) {
@@ -4221,7 +4221,7 @@ func TestCCIPRouter(t *testing.T) {
 			).ValidateAndBuild()
 			require.NoError(t, err)
 
-			testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{ix}, ccipAdmin, config.DefaultCommitment, []string{ccip_router.InvalidInputs_CcipRouterError.String()})
+			testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{ix}, ccipAdmin, config.DefaultCommitment, []string{ccip_router.InvalidInputsAtaAddress_CcipRouterError.String()})
 		})
 
 		t.Run("When trying to withdraw more funds than what's available, it fails", func(t *testing.T) {
@@ -4891,7 +4891,7 @@ func TestCCIPRouter(t *testing.T) {
 						config.FqConfigPDA,
 					).ValidateAndBuild()
 					require.NoError(t, err)
-					testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, transmitter, config.DefaultCommitment, []string{"Error Code: " + ccip_router.InvalidSequenceInterval_CcipRouterError.String()})
+					testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, transmitter, config.DefaultCommitment, []string{"Error Code: " + ccip_offramp.InvalidSequenceInterval_CcipOfframpError.String()})
 				})
 
 				t.Run("When committing a report with an interval size bigger than supported it fails", func(t *testing.T) {
@@ -4935,7 +4935,7 @@ func TestCCIPRouter(t *testing.T) {
 						config.FqConfigPDA,
 					).ValidateAndBuild()
 					require.NoError(t, err)
-					testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, transmitter, config.DefaultCommitment, []string{"Error Code: " + ccip_router.InvalidSequenceInterval_CcipRouterError.String()})
+					testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, transmitter, config.DefaultCommitment, []string{"Error Code: " + ccip_offramp.InvalidSequenceInterval_CcipOfframpError.String()})
 				})
 
 				t.Run("When committing a report with a zero merkle root it fails", func(t *testing.T) {
@@ -4979,7 +4979,7 @@ func TestCCIPRouter(t *testing.T) {
 						config.FqConfigPDA,
 					).ValidateAndBuild()
 					require.NoError(t, err)
-					testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, transmitter, config.DefaultCommitment, []string{"Error Code: " + ccip_router.InvalidProof_CcipRouterError.String()})
+					testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, transmitter, config.DefaultCommitment, []string{"Error Code: " + ccip_offramp.InvalidProof_CcipOfframpError.String()})
 				})
 
 				t.Run("When committing a report with a repeated merkle root, it fails", func(t *testing.T) {
@@ -5070,7 +5070,7 @@ func TestCCIPRouter(t *testing.T) {
 						config.FqConfigPDA,
 					).ValidateAndBuild()
 					require.NoError(t, err)
-					testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, transmitter, config.DefaultCommitment, []string{"Error Code: " + ccip_router.InvalidSequenceInterval_CcipRouterError.String()})
+					testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, transmitter, config.DefaultCommitment, []string{"Error Code: " + ccip_offramp.InvalidSequenceInterval_CcipOfframpError.String()})
 				})
 
 				t.Run("Invalid price updates", func(t *testing.T) {
@@ -5103,7 +5103,7 @@ func TestCCIPRouter(t *testing.T) {
 							Name:             "with a non-writable billing token config account",
 							Tokens:           []solana.PublicKey{wsol.mint},
 							AccountMetaSlice: solana.AccountMetaSlice{solana.Meta(wsol.fqBillingConfigPDA)}, // not writable
-							ExpectedError:    ccip_router.InvalidInputs_CcipRouterError.String(),
+							ExpectedError:    ccip_offramp.InvalidInputs_CcipOfframpError.String(),
 						},
 						{
 							// when the message source chain is the same as the chain whose gas is updated, then the same chain state is passed
@@ -5112,26 +5112,26 @@ func TestCCIPRouter(t *testing.T) {
 							Name:              "with a non-writable chain state account (different from the message source chain)",
 							GasChainSelectors: []uint64{config.SvmChainSelector},                                 // the message source chain is EVM
 							AccountMetaSlice:  solana.AccountMetaSlice{solana.Meta(config.SvmDestChainStatePDA)}, // not writable
-							ExpectedError:     ccip_router.InvalidInputs_CcipRouterError.String(),
+							ExpectedError:     ccip_offramp.InvalidInputs_CcipOfframpError.String(),
 						},
 						{
 							Name:             "with the wrong billing token config account for a valid token",
 							Tokens:           []solana.PublicKey{wsol.mint},
 							AccountMetaSlice: solana.AccountMetaSlice{solana.Meta(link22.fqBillingConfigPDA).WRITE()}, // mismatch token
-							ExpectedError:    ccip_router.InvalidInputs_CcipRouterError.String(),
+							ExpectedError:    ccip_offramp.InvalidInputs_CcipOfframpError.String(),
 						},
 						{
 							Name:              "with the wrong chain state account for a valid gas update",
 							GasChainSelectors: []uint64{config.SvmChainSelector},
 							AccountMetaSlice:  solana.AccountMetaSlice{solana.Meta(config.EvmDestChainStatePDA).WRITE()}, // mismatch chain
-							ExpectedError:     ccip_router.InvalidInputs_CcipRouterError.String(),
+							ExpectedError:     ccip_offramp.InvalidInputs_CcipOfframpError.String(),
 						},
 						{
 							Name:              "with too few accounts",
 							Tokens:            []solana.PublicKey{wsol.mint},
 							GasChainSelectors: []uint64{config.EvmChainSelector},
 							AccountMetaSlice:  solana.AccountMetaSlice{solana.Meta(wsol.fqBillingConfigPDA).WRITE()}, // missing chain state account
-							ExpectedError:     ccip_router.InvalidInputs_CcipRouterError.String(),
+							ExpectedError:     ccip_offramp.InvalidInputs_CcipOfframpError.String(),
 						},
 						// TODO right now I'm allowing sending too many remaining_accounts, but if we want to be restrictive with that we can add a test here
 					}
@@ -5935,7 +5935,7 @@ func TestCCIPRouter(t *testing.T) {
 				instruction, err = raw.ValidateAndBuild()
 				require.NoError(t, err)
 
-				testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, transmitter, config.DefaultCommitment, []string{"Error Code: " + ccip_router.UnsupportedDestinationChainSelector_CcipRouterError.String()})
+				testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, transmitter, config.DefaultCommitment, []string{"Error Code: " + ccip_offramp.UnsupportedDestinationChainSelector_CcipOfframpError.String()})
 			})
 
 			t.Run("When executing a report with nonexisting PDA for the Merkle Root, it fails", func(t *testing.T) {
@@ -6875,7 +6875,7 @@ func TestCCIPRouter(t *testing.T) {
 						fmt.Printf("User: %s\n", user.PublicKey().String())
 						fmt.Printf("Transmitter: %s\n", transmitter.PublicKey().String())
 
-						testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, user, config.DefaultCommitment, []string{ccip_router.ManualExecutionNotAllowed_CcipRouterError.String()})
+						testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, user, config.DefaultCommitment, []string{ccip_offramp.ManualExecutionNotAllowed_CcipOfframpError.String()})
 					})
 
 					t.Run("When transmitter manually executing before the period of time has passed, it fails", func(t *testing.T) {
@@ -6911,7 +6911,7 @@ func TestCCIPRouter(t *testing.T) {
 						instruction, err = raw.ValidateAndBuild()
 						require.NoError(t, err)
 
-						testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, transmitter, config.DefaultCommitment, []string{ccip_router.ManualExecutionNotAllowed_CcipRouterError.String()})
+						testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{instruction}, transmitter, config.DefaultCommitment, []string{ccip_offramp.ManualExecutionNotAllowed_CcipOfframpError.String()})
 					})
 				})
 

--- a/chains/solana/gobindings/ccip_router/types.go
+++ b/chains/solana/gobindings/ccip_router/types.go
@@ -428,17 +428,12 @@ func (obj *DestChainConfig) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (er
 type CcipRouterError ag_binary.BorshEnum
 
 const (
-	InvalidSequenceInterval_CcipRouterError CcipRouterError = iota
-	RootNotCommitted_CcipRouterError
-	ExistingMerkleRoot_CcipRouterError
-	Unauthorized_CcipRouterError
-	InvalidInputs_CcipRouterError
-	UnsupportedSourceChainSelector_CcipRouterError
-	UnsupportedDestinationChainSelector_CcipRouterError
-	InvalidProof_CcipRouterError
-	InvalidMessage_CcipRouterError
+	Unauthorized_CcipRouterError CcipRouterError = iota
+	InvalidInputsMint_CcipRouterError
+	InvalidVersion_CcipRouterError
+	FeeTokenMismatch_CcipRouterError
+	RedundantOwnerProposal_CcipRouterError
 	ReachedMaxSequenceNumber_CcipRouterError
-	ManualExecutionNotAllowed_CcipRouterError
 	InvalidInputsTokenIndices_CcipRouterError
 	InvalidInputsPoolAccounts_CcipRouterError
 	InvalidInputsTokenAccounts_CcipRouterError
@@ -447,62 +442,32 @@ const (
 	InvalidInputsLookupTableAccounts_CcipRouterError
 	InvalidInputsLookupTableAccountWritable_CcipRouterError
 	InvalidInputsTokenAmount_CcipRouterError
-	OfframpReleaseMintBalanceMismatch_CcipRouterError
-	OfframpInvalidDataLength_CcipRouterError
-	StaleCommitReport_CcipRouterError
-	DestinationChainDisabled_CcipRouterError
-	FeeTokenDisabled_CcipRouterError
-	MessageTooLarge_CcipRouterError
-	UnsupportedNumberOfTokens_CcipRouterError
-	UnsupportedChainFamilySelector_CcipRouterError
-	InvalidEVMAddress_CcipRouterError
-	InvalidEncoding_CcipRouterError
+	InvalidInputsTransferAllAmount_CcipRouterError
 	InvalidInputsAtaAddress_CcipRouterError
 	InvalidInputsAtaWritable_CcipRouterError
-	InvalidTokenPrice_CcipRouterError
-	StaleGasPrice_CcipRouterError
+	InvalidInputsChainSelector_CcipRouterError
 	InsufficientLamports_CcipRouterError
 	InsufficientFunds_CcipRouterError
-	UnsupportedToken_CcipRouterError
-	InvalidInputsMissingTokenConfig_CcipRouterError
-	MessageFeeTooHigh_CcipRouterError
 	SourceTokenDataTooLarge_CcipRouterError
-	MessageGasLimitTooHigh_CcipRouterError
-	ExtraArgOutOfOrderExecutionMustBeTrue_CcipRouterError
 	InvalidTokenAdminRegistryInputsZeroAddress_CcipRouterError
 	InvalidTokenAdminRegistryProposedAdmin_CcipRouterError
-	InvalidWritabilityBitmap_CcipRouterError
-	InvalidExtraArgsTag_CcipRouterError
-	InvalidChainFamilySelector_CcipRouterError
-	InvalidTokenReceiver_CcipRouterError
-	InvalidSVMAddress_CcipRouterError
 	SenderNotAllowed_CcipRouterError
 )
 
 func (value CcipRouterError) String() string {
 	switch value {
-	case InvalidSequenceInterval_CcipRouterError:
-		return "InvalidSequenceInterval"
-	case RootNotCommitted_CcipRouterError:
-		return "RootNotCommitted"
-	case ExistingMerkleRoot_CcipRouterError:
-		return "ExistingMerkleRoot"
 	case Unauthorized_CcipRouterError:
 		return "Unauthorized"
-	case InvalidInputs_CcipRouterError:
-		return "InvalidInputs"
-	case UnsupportedSourceChainSelector_CcipRouterError:
-		return "UnsupportedSourceChainSelector"
-	case UnsupportedDestinationChainSelector_CcipRouterError:
-		return "UnsupportedDestinationChainSelector"
-	case InvalidProof_CcipRouterError:
-		return "InvalidProof"
-	case InvalidMessage_CcipRouterError:
-		return "InvalidMessage"
+	case InvalidInputsMint_CcipRouterError:
+		return "InvalidInputsMint"
+	case InvalidVersion_CcipRouterError:
+		return "InvalidVersion"
+	case FeeTokenMismatch_CcipRouterError:
+		return "FeeTokenMismatch"
+	case RedundantOwnerProposal_CcipRouterError:
+		return "RedundantOwnerProposal"
 	case ReachedMaxSequenceNumber_CcipRouterError:
 		return "ReachedMaxSequenceNumber"
-	case ManualExecutionNotAllowed_CcipRouterError:
-		return "ManualExecutionNotAllowed"
 	case InvalidInputsTokenIndices_CcipRouterError:
 		return "InvalidInputsTokenIndices"
 	case InvalidInputsPoolAccounts_CcipRouterError:
@@ -519,64 +484,24 @@ func (value CcipRouterError) String() string {
 		return "InvalidInputsLookupTableAccountWritable"
 	case InvalidInputsTokenAmount_CcipRouterError:
 		return "InvalidInputsTokenAmount"
-	case OfframpReleaseMintBalanceMismatch_CcipRouterError:
-		return "OfframpReleaseMintBalanceMismatch"
-	case OfframpInvalidDataLength_CcipRouterError:
-		return "OfframpInvalidDataLength"
-	case StaleCommitReport_CcipRouterError:
-		return "StaleCommitReport"
-	case DestinationChainDisabled_CcipRouterError:
-		return "DestinationChainDisabled"
-	case FeeTokenDisabled_CcipRouterError:
-		return "FeeTokenDisabled"
-	case MessageTooLarge_CcipRouterError:
-		return "MessageTooLarge"
-	case UnsupportedNumberOfTokens_CcipRouterError:
-		return "UnsupportedNumberOfTokens"
-	case UnsupportedChainFamilySelector_CcipRouterError:
-		return "UnsupportedChainFamilySelector"
-	case InvalidEVMAddress_CcipRouterError:
-		return "InvalidEVMAddress"
-	case InvalidEncoding_CcipRouterError:
-		return "InvalidEncoding"
+	case InvalidInputsTransferAllAmount_CcipRouterError:
+		return "InvalidInputsTransferAllAmount"
 	case InvalidInputsAtaAddress_CcipRouterError:
 		return "InvalidInputsAtaAddress"
 	case InvalidInputsAtaWritable_CcipRouterError:
 		return "InvalidInputsAtaWritable"
-	case InvalidTokenPrice_CcipRouterError:
-		return "InvalidTokenPrice"
-	case StaleGasPrice_CcipRouterError:
-		return "StaleGasPrice"
+	case InvalidInputsChainSelector_CcipRouterError:
+		return "InvalidInputsChainSelector"
 	case InsufficientLamports_CcipRouterError:
 		return "InsufficientLamports"
 	case InsufficientFunds_CcipRouterError:
 		return "InsufficientFunds"
-	case UnsupportedToken_CcipRouterError:
-		return "UnsupportedToken"
-	case InvalidInputsMissingTokenConfig_CcipRouterError:
-		return "InvalidInputsMissingTokenConfig"
-	case MessageFeeTooHigh_CcipRouterError:
-		return "MessageFeeTooHigh"
 	case SourceTokenDataTooLarge_CcipRouterError:
 		return "SourceTokenDataTooLarge"
-	case MessageGasLimitTooHigh_CcipRouterError:
-		return "MessageGasLimitTooHigh"
-	case ExtraArgOutOfOrderExecutionMustBeTrue_CcipRouterError:
-		return "ExtraArgOutOfOrderExecutionMustBeTrue"
 	case InvalidTokenAdminRegistryInputsZeroAddress_CcipRouterError:
 		return "InvalidTokenAdminRegistryInputsZeroAddress"
 	case InvalidTokenAdminRegistryProposedAdmin_CcipRouterError:
 		return "InvalidTokenAdminRegistryProposedAdmin"
-	case InvalidWritabilityBitmap_CcipRouterError:
-		return "InvalidWritabilityBitmap"
-	case InvalidExtraArgsTag_CcipRouterError:
-		return "InvalidExtraArgsTag"
-	case InvalidChainFamilySelector_CcipRouterError:
-		return "InvalidChainFamilySelector"
-	case InvalidTokenReceiver_CcipRouterError:
-		return "InvalidTokenReceiver"
-	case InvalidSVMAddress_CcipRouterError:
-		return "InvalidSVMAddress"
 	case SenderNotAllowed_CcipRouterError:
 		return "SenderNotAllowed"
 	default:


### PR DESCRIPTION
`core ref: e7be26ff7ee0cc4630fc471b4240fbad6812ca0e`

This turned out fairly large so I'm breaking it up by module.

Turns out a significant number of integration tests were referencing the wrong strings (i.e. offramp tests referencing `ccip_router` errors) so this was a good way to prevent potentially subtle test mishaps.