### PR TITLE
Add observation duration related logs

### DIFF
--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -238,7 +238,10 @@ func (p *Plugin) Observation(
 	var err error
 
 	if p.discoveryProcessor != nil {
+		tStart := time.Now()
 		discoveryObs, err = p.discoveryProcessor.Observation(ctx, dt.Outcome{}, dt.Query{})
+		lggr.Debugw("commit discovery observation finished",
+			"duration", time.Since(tStart), "err", err)
 		if err != nil {
 			lggr.Errorw("failed to discover contracts", "err", err)
 		}
@@ -342,13 +345,17 @@ func (p *Plugin) getPriceRelatedObservations(
 	var chainFeeObs chainfee.Observation
 	var err error
 
+	tStart := time.Now()
 	tokenPriceObs, err = p.tokenPriceProcessor.Observation(ctx, prevOutcome.TokenPriceOutcome, decodedQ.TokenPriceQuery)
+	lggr.Debugw("token price observation finished", "duration", time.Since(tStart), "err", err)
 	if err != nil {
 		lggr.Errorw("get token price processor observation", "err", err,
 			"prevTokenPriceOutcome", prevOutcome.TokenPriceOutcome)
 	}
 
+	tStart = time.Now()
 	chainFeeObs, err = p.chainFeeProcessor.Observation(ctx, prevOutcome.ChainFeeOutcome, decodedQ.ChainFeeQuery)
+	lggr.Debugw("chain fee observation finished", "duration", time.Since(tStart), "err", err)
 	if err != nil {
 		lggr.Errorw("get gas prices processor observation",
 			"err", err, "prevChainFeeOutcome", prevOutcome.ChainFeeOutcome)

--- a/execute/observation.go
+++ b/execute/observation.go
@@ -67,10 +67,13 @@ func (p *Plugin) Observation(
 	var discoveryObs dt.Observation
 	// discovery processor disabled by setting it to nil.
 	if p.discovery != nil {
+		tStart := time.Now()
 		discoveryObs, err = p.discovery.Observation(ctx, dt.Outcome{}, dt.Query{})
 		if err != nil {
 			lggr.Errorw("failed to discover contracts", "err", err)
 		}
+		lggr.Debugw("finished exec discovery observation",
+			"discoveryObs", discoveryObs, "duration", time.Since(tStart))
 
 		if !p.contractsInitialized {
 			lggr.Infow("contracts not initialized, only making discovery observations",
@@ -84,6 +87,7 @@ func (p *Plugin) Observation(
 		FChain:    fChain,
 	}
 
+	tStart := time.Now()
 	state := previousOutcome.State.Next()
 	lggr.Debugw("Execute plugin performing observation", "state", state)
 	switch state {
@@ -111,7 +115,8 @@ func (p *Plugin) Observation(
 	}
 
 	p.observer.TrackObservation(observation, state)
-	lggr.Infow("execute plugin got observation", "observation", observation)
+	lggr.Infow("execute plugin got observation", "observation", observation,
+		"duration", time.Since(tStart), "state", state)
 
 	return p.ocrTypeCodec.EncodeObservation(observation)
 }


### PR DESCRIPTION
`core ref: e7be26ff7ee0cc4630fc471b4240fbad6812ca0e`