### PR TITLE
[Solana] Increase funding timeout

### DIFF
--- a/chains/solana/contracts/tests/testutils/anchor.go
+++ b/chains/solana/contracts/tests/testutils/anchor.go
@@ -49,7 +49,7 @@ func FundAccounts(ctx context.Context, accounts []solana.PrivateKey, solanaGoCli
 		remaining = unconfirmedTxCount
 
 		time.Sleep(500 * time.Millisecond)
-		if count > 60 {
+		if count > 200 {
 			require.NoError(t, fmt.Errorf("unable to find transaction within timeout"))
 		}
 	}


### PR DESCRIPTION
Several tests are failing intermittently in the funding stage. While this is not a comprehensive solution to the flakiness program, it should help in the short term.