### PR TITLE
CCIP-5216 Tracking latencies and simplification in the metrics code

### DIFF
--- a/commit/chainfee/observation.go
+++ b/commit/chainfee/observation.go
@@ -108,8 +108,6 @@ func (p *processor) Observation(
 		ChainFeeUpdates:   chainFeeUpdates,
 		TimestampNow:      now,
 	}
-
-	p.metricsReporter.TrackChainFeeObservation(obs)
 	return obs, nil
 }
 

--- a/commit/chainfee/observation_test.go
+++ b/commit/chainfee/observation_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
+	plugincommon2 "github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
 	"github.com/smartcontractkit/chainlink-ccip/mocks/internal_/plugincommon"
 	reader2 "github.com/smartcontractkit/chainlink-ccip/mocks/internal_/reader"
@@ -122,7 +123,7 @@ func Test_processor_Observation(t *testing.T) {
 				ccipReader:      ccipReader,
 				oracleID:        oracleID,
 				homeChain:       homeChain,
-				metricsReporter: NoopMetrics{},
+				metricsReporter: plugincommon2.NoopReporter{},
 			}
 
 			supportedSet := mapset.NewSet(tc.supportedChains...)
@@ -316,7 +317,7 @@ func Test_unique_chain_filter_in_Observation(t *testing.T) {
 				ccipReader:      ccipReader,
 				oracleID:        oracleID,
 				homeChain:       homeChain,
-				metricsReporter: NoopMetrics{},
+				metricsReporter: plugincommon2.NoopReporter{},
 			}
 
 			supportedSet := mapset.NewSet(tc.supportedChains...)

--- a/commit/chainfee/outcome.go
+++ b/commit/chainfee/outcome.go
@@ -89,7 +89,6 @@ func (p *processor) Outcome(
 
 	lggr.Infow("Gas Prices Outcome", "gasPrices", gasPrices)
 	out := Outcome{GasPrices: gasPrices}
-	p.metricsReporter.TrackChainFeeOutcome(out)
 	return out, nil
 }
 

--- a/commit/chainfee/outcome_test.go
+++ b/commit/chainfee/outcome_test.go
@@ -226,7 +226,7 @@ func TestProcessor_Outcome(t *testing.T) {
 					RemoteGasPriceBatchWriteFrequency: tt.chainFeeWriteFrequency,
 					FeeInfo:                           tt.feeInfo,
 				},
-				metricsReporter: NoopMetrics{},
+				metricsReporter: plugincommon.NoopReporter{},
 			}
 
 			outcome, err := p.Outcome(ctx, Outcome{}, Query{}, tt.aos)

--- a/commit/chainfee/processor.go
+++ b/commit/chainfee/processor.go
@@ -48,7 +48,7 @@ func NewProcessor(
 		cfg:             offChainConfig,
 		metricsReporter: metricsReporter,
 	}
-	return plugincommon.NewObservedProcessor(lggr, p, "chainfee", metricsReporter)
+	return plugincommon.NewTrackedProcessor(lggr, p, "chainfee", metricsReporter)
 }
 
 func (p *processor) Query(ctx context.Context, prevOutcome Outcome) (Query, error) {

--- a/commit/chainfee/processor.go
+++ b/commit/chainfee/processor.go
@@ -48,7 +48,7 @@ func NewProcessor(
 		cfg:             offChainConfig,
 		metricsReporter: metricsReporter,
 	}
-	return plugincommon.NewTrackedProcessor(lggr, p, "chainfee", metricsReporter)
+	return plugincommon.NewTrackedProcessor(lggr, p, processorLabel, metricsReporter)
 }
 
 func (p *processor) Query(ctx context.Context, prevOutcome Outcome) (Query, error) {

--- a/commit/chainfee/processor.go
+++ b/commit/chainfee/processor.go
@@ -37,7 +37,7 @@ func NewProcessor(
 	fRoleDON int,
 	metricsReporter MetricsReporter,
 ) plugincommon.PluginProcessor[Query, Observation, Outcome] {
-	return &processor{
+	p := &processor{
 		lggr:            lggr,
 		oracleID:        oracleID,
 		destChain:       destChain,
@@ -48,6 +48,7 @@ func NewProcessor(
 		cfg:             offChainConfig,
 		metricsReporter: metricsReporter,
 	}
+	return plugincommon.NewObservedProcessor(lggr, p, "chainfee", metricsReporter)
 }
 
 func (p *processor) Query(ctx context.Context, prevOutcome Outcome) (Query, error) {

--- a/commit/chainfee/processor.go
+++ b/commit/chainfee/processor.go
@@ -22,7 +22,7 @@ type processor struct {
 	ccipReader      readerpkg.CCIPReader
 	cfg             pluginconfig.CommitOffchainConfig
 	chainSupport    plugincommon.ChainSupport
-	metricsReporter MetricsReporter
+	metricsReporter plugincommon.MetricsReporter
 	fRoleDON        int
 }
 
@@ -35,7 +35,7 @@ func NewProcessor(
 	offChainConfig pluginconfig.CommitOffchainConfig,
 	chainSupport plugincommon.ChainSupport,
 	fRoleDON int,
-	metricsReporter MetricsReporter,
+	metricsReporter plugincommon.MetricsReporter,
 ) plugincommon.PluginProcessor[Query, Observation, Outcome] {
 	p := &processor{
 		lggr:            lggr,

--- a/commit/chainfee/types.go
+++ b/commit/chainfee/types.go
@@ -71,18 +71,18 @@ type Update struct {
 
 // MetricsReporter exposes only relevant methods for reporting chain fees from metrics.Reporter
 type MetricsReporter interface {
-	TrackProcessorLatency(processor string, method string, latency time.Duration)
-	TrackProcessorObservation(processor string, obs plugintypes.Trackable, err error)
-	TrackProcessorOutcome(processor string, out plugintypes.Trackable, err error)
+	TrackProcessorLatency(processor string, method string, latency time.Duration, err error)
+	TrackProcessorObservation(processor string, obs plugintypes.Trackable)
+	TrackProcessorOutcome(processor string, out plugintypes.Trackable)
 }
 
 type NoopMetrics struct{}
 
-func (n NoopMetrics) TrackProcessorLatency(string, string, time.Duration) {}
+func (n NoopMetrics) TrackProcessorLatency(string, string, time.Duration, error) {}
 
-func (n NoopMetrics) TrackProcessorObservation(string, plugintypes.Trackable, error) {}
+func (n NoopMetrics) TrackProcessorObservation(string, plugintypes.Trackable) {}
 
-func (n NoopMetrics) TrackProcessorOutcome(string, plugintypes.Trackable, error) {}
+func (n NoopMetrics) TrackProcessorOutcome(string, plugintypes.Trackable) {}
 
 func (o Observation) IsEmpty() bool {
 	return len(o.FeeComponents) == 0 && len(o.NativeTokenPrices) == 0 && len(o.ChainFeeUpdates) == 0 &&

--- a/commit/chainfee/types.go
+++ b/commit/chainfee/types.go
@@ -10,6 +10,7 @@ import (
 )
 
 const (
+	processorLabel         = "chainfee"
 	gasPricesLabel         = "gasPrices"
 	feeComponentsLabel     = "feeComponents"
 	nativeTokenPricesLabel = "nativeTokenPrices"

--- a/commit/chainfee/types.go
+++ b/commit/chainfee/types.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 
-	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
 
@@ -50,6 +49,13 @@ func (o Observation) Stats() map[string]int {
 	}
 }
 
+func (o Observation) IsEmpty() bool {
+	return len(o.FeeComponents) == 0 &&
+		len(o.NativeTokenPrices) == 0 &&
+		len(o.ChainFeeUpdates) == 0 &&
+		len(o.FChain) == 0 && o.TimestampNow.IsZero()
+}
+
 // AggregateObservation is the aggregation of a list of observations
 type AggregateObservation struct {
 	FeeComponents     map[cciptypes.ChainSelector][]types.ChainFeeComponents `json:"feeComponents"`
@@ -67,24 +73,4 @@ type ComponentsUSDPrices struct {
 type Update struct {
 	ChainFee  ComponentsUSDPrices `json:"chainFee"`
 	Timestamp time.Time           `json:"timestamp"`
-}
-
-// MetricsReporter exposes only relevant methods for reporting chain fees from metrics.Reporter
-type MetricsReporter interface {
-	TrackProcessorLatency(processor string, method string, latency time.Duration, err error)
-	TrackProcessorObservation(processor string, obs plugintypes.Trackable)
-	TrackProcessorOutcome(processor string, out plugintypes.Trackable)
-}
-
-type NoopMetrics struct{}
-
-func (n NoopMetrics) TrackProcessorLatency(string, string, time.Duration, error) {}
-
-func (n NoopMetrics) TrackProcessorObservation(string, plugintypes.Trackable) {}
-
-func (n NoopMetrics) TrackProcessorOutcome(string, plugintypes.Trackable) {}
-
-func (o Observation) IsEmpty() bool {
-	return len(o.FeeComponents) == 0 && len(o.NativeTokenPrices) == 0 && len(o.ChainFeeUpdates) == 0 &&
-		len(o.FChain) == 0 && o.TimestampNow.IsZero()
 }

--- a/commit/chainfee/types.go
+++ b/commit/chainfee/types.go
@@ -51,6 +51,7 @@ type Update struct {
 type MetricsReporter interface {
 	TrackChainFeeObservation(obs Observation)
 	TrackChainFeeOutcome(outcome Outcome)
+	TrackProcessorLatency(processor string, method string, latency time.Duration)
 }
 
 type NoopMetrics struct{}
@@ -58,6 +59,8 @@ type NoopMetrics struct{}
 func (n NoopMetrics) TrackChainFeeObservation(Observation) {}
 
 func (n NoopMetrics) TrackChainFeeOutcome(Outcome) {}
+
+func (n NoopMetrics) TrackProcessorLatency(string, string, time.Duration) {}
 
 func (o Observation) IsEmpty() bool {
 	return len(o.FeeComponents) == 0 && len(o.NativeTokenPrices) == 0 && len(o.ChainFeeUpdates) == 0 &&

--- a/commit/merkleroot/observation.go
+++ b/commit/merkleroot/observation.go
@@ -80,7 +80,6 @@ func (p *Processor) Observation(
 	}
 	lggr.Infow("sending merkle root processor observation",
 		"observation", observation, "nextState", nextState, "observationDuration", time.Since(tStart))
-	p.metricsReporter.TrackMerkleObservation(observation, nextState.String())
 	return observation, nil
 }
 

--- a/commit/merkleroot/outcome.go
+++ b/commit/merkleroot/outcome.go
@@ -45,7 +45,6 @@ func (p *Processor) Outcome(
 		return Outcome{}, err
 	}
 
-	p.metricsReporter.TrackMerkleOutcome(outcome, nextState.String())
 	lggr.Infow("Sending Outcome",
 		"outcome", outcome, "nextState", nextState, "outcomeDuration", time.Since(tStart))
 	return outcome, nil

--- a/commit/merkleroot/processor.go
+++ b/commit/merkleroot/processor.go
@@ -54,8 +54,8 @@ func NewProcessor(
 	rmnCrypto cciptypes.RMNCrypto,
 	rmnHomeReader readerpkg.RMNHome,
 	metricsReporter MetricsReporter,
-) *Processor {
-	return &Processor{
+) plugincommon.PluginProcessor[Query, Observation, Outcome] {
+	p := &Processor{
 		oracleID:        oracleID,
 		oracleIDToP2pID: oracleIDToP2pID,
 		offchainCfg:     offchainCfg,
@@ -77,6 +77,7 @@ func NewProcessor(
 		rmnHomeReader:   rmnHomeReader,
 		metricsReporter: metricsReporter,
 	}
+	return plugincommon.NewObservedProcessor(lggr, p, "merkleroot", metricsReporter)
 }
 
 var _ plugincommon.PluginProcessor[Query, Observation, Outcome] = &Processor{}

--- a/commit/merkleroot/processor.go
+++ b/commit/merkleroot/processor.go
@@ -90,7 +90,7 @@ func NewProcessor(
 		rmnHomeReader:   rmnHomeReader,
 		metricsReporter: metricsReporter,
 	}
-	return plugincommon.NewTrackedProcessor(lggr, p, "merkleroot", metricsReporter)
+	return plugincommon.NewTrackedProcessor(lggr, p, processorLabel, metricsReporter)
 }
 
 var _ plugincommon.PluginProcessor[Query, Observation, Outcome] = &Processor{}

--- a/commit/merkleroot/processor.go
+++ b/commit/merkleroot/processor.go
@@ -77,7 +77,7 @@ func NewProcessor(
 		rmnHomeReader:   rmnHomeReader,
 		metricsReporter: metricsReporter,
 	}
-	return plugincommon.NewObservedProcessor(lggr, p, "merkleroot", metricsReporter)
+	return plugincommon.NewTrackedProcessor(lggr, p, "merkleroot", metricsReporter)
 }
 
 var _ plugincommon.PluginProcessor[Query, Observation, Outcome] = &Processor{}

--- a/commit/merkleroot/types.go
+++ b/commit/merkleroot/types.go
@@ -242,17 +242,17 @@ func (p processorState) String() string {
 // MetricsReporter exposes only relevant methods for reporting merkle roots from metrics.Reporter
 type MetricsReporter interface {
 	TrackRmnReport(latency float64, success bool)
-	TrackProcessorLatency(processor string, method string, latency time.Duration)
-	TrackProcessorObservation(processor string, obs plugintypes.Trackable, err error)
-	TrackProcessorOutcome(processor string, out plugintypes.Trackable, err error)
+	TrackProcessorLatency(processor string, method string, latency time.Duration, err error)
+	TrackProcessorObservation(processor string, obs plugintypes.Trackable)
+	TrackProcessorOutcome(processor string, out plugintypes.Trackable)
 }
 
 type NoopMetrics struct{}
 
 func (n NoopMetrics) TrackRmnReport(float64, bool) {}
 
-func (n NoopMetrics) TrackProcessorLatency(string, string, time.Duration) {}
+func (n NoopMetrics) TrackProcessorLatency(string, string, time.Duration, error) {}
 
-func (n NoopMetrics) TrackProcessorObservation(string, plugintypes.Trackable, error) {}
+func (n NoopMetrics) TrackProcessorObservation(string, plugintypes.Trackable) {}
 
-func (n NoopMetrics) TrackProcessorOutcome(string, plugintypes.Trackable, error) {}
+func (n NoopMetrics) TrackProcessorOutcome(string, plugintypes.Trackable) {}

--- a/commit/merkleroot/types.go
+++ b/commit/merkleroot/types.go
@@ -243,8 +243,7 @@ func (p processorState) String() string {
 type MetricsReporter interface {
 	TrackRmnReport(latency float64, success bool)
 	TrackProcessorLatency(processor string, method string, latency time.Duration, err error)
-	TrackProcessorObservation(processor string, obs plugintypes.Trackable)
-	TrackProcessorOutcome(processor string, out plugintypes.Trackable)
+	TrackProcessorOutput(processor string, method plugincommon.MethodType, obs plugintypes.Trackable)
 }
 
 type NoopMetrics struct{}
@@ -253,6 +252,4 @@ func (n NoopMetrics) TrackRmnReport(float64, bool) {}
 
 func (n NoopMetrics) TrackProcessorLatency(string, string, time.Duration, error) {}
 
-func (n NoopMetrics) TrackProcessorObservation(string, plugintypes.Trackable) {}
-
-func (n NoopMetrics) TrackProcessorOutcome(string, plugintypes.Trackable) {}
+func (n NoopMetrics) TrackProcessorOutput(string, plugincommon.MethodType, plugintypes.Trackable) {}

--- a/commit/merkleroot/types.go
+++ b/commit/merkleroot/types.go
@@ -2,6 +2,7 @@ package merkleroot
 
 import (
 	"sort"
+	"time"
 
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn"
 	rmntypes "github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn/types"
@@ -213,6 +214,7 @@ type MetricsReporter interface {
 	TrackMerkleObservation(obs Observation, state string)
 	TrackMerkleOutcome(outcome Outcome, state string)
 	TrackRmnReport(latency float64, success bool)
+	TrackProcessorLatency(processor string, method string, latency time.Duration)
 }
 
 type NoopMetrics struct{}
@@ -222,3 +224,5 @@ func (n NoopMetrics) TrackMerkleObservation(Observation, string) {}
 func (n NoopMetrics) TrackMerkleOutcome(Outcome, string) {}
 
 func (n NoopMetrics) TrackRmnReport(float64, bool) {}
+
+func (n NoopMetrics) TrackProcessorLatency(string, string, time.Duration) {}

--- a/commit/merkleroot/types.go
+++ b/commit/merkleroot/types.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	// Prometheus labels for merkle processor
+	processorLabel    = "merkleroot"
 	rootsLabel        = "roots"
 	messagesLabel     = "messages"
 	rmnSignatureLabel = "rmnSignatures"

--- a/commit/metrics/prom.go
+++ b/commit/metrics/prom.go
@@ -1,7 +1,9 @@
 package metrics
 
 import (
+	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -132,9 +134,21 @@ func NewPromReporter(lggr logger.Logger, selector cciptypes.ChainSelector) (*Pro
 }
 
 func (p *PromReporter) TrackObservation(obs committypes.Observation) {
+	for _, root := range obs.MerkleRootObs.MerkleRoots {
+		sourceChainSelector := root.ChainSel
+		maxSeqNr := root.SeqNumsRange.End()
+
+		fmt.Println(sourceChainSelector, maxSeqNr)
+	}
 }
 
 func (p *PromReporter) TrackOutcome(outcome committypes.Outcome) {
+	for _, root := range outcome.MerkleRootOutcome.RootsToReport {
+		sourceChainSelector := root.ChainSel
+		maxSeqNr := root.SeqNumsRange.End()
+
+		fmt.Println(sourceChainSelector, maxSeqNr)
+	}
 }
 
 func (p *PromReporter) TrackChainFeeObservation(obs chainfee.Observation) {
@@ -205,6 +219,10 @@ func (p *PromReporter) TrackTokenPricesOutcome(outcome tokenprice.Outcome) {
 			WithLabelValues(p.chainID, key).
 			Add(float64(count))
 	}
+}
+
+func (p *PromReporter) TrackProcessorLatency(processor string, method string, latency time.Duration) {
+
 }
 
 func merkleRootObservationMetrics(obs merkleroot.Observation) map[string]int {

--- a/commit/metrics/prom.go
+++ b/commit/metrics/prom.go
@@ -104,6 +104,7 @@ func (p *PromReporter) TrackObservation(obs committypes.Observation) {
 		sourceChainSelector := root.ChainSel
 		maxSeqNr := root.SeqNumsRange.End()
 
+		// TODO Implement me in next PR!
 		fmt.Println(sourceChainSelector, maxSeqNr)
 	}
 }
@@ -113,6 +114,7 @@ func (p *PromReporter) TrackOutcome(outcome committypes.Outcome) {
 		sourceChainSelector := root.ChainSel
 		maxSeqNr := root.SeqNumsRange.End()
 
+		// TODO Implement me in next PR!
 		fmt.Println(sourceChainSelector, maxSeqNr)
 	}
 }

--- a/commit/metrics/prom.go
+++ b/commit/metrics/prom.go
@@ -11,46 +11,50 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
-	"github.com/smartcontractkit/chainlink-ccip/commit/chainfee"
 	"github.com/smartcontractkit/chainlink-ccip/commit/committypes"
-	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot"
-	"github.com/smartcontractkit/chainlink-ccip/commit/tokenprice"
+	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
 
-const (
-	// Prometheus labels for merkle processor
-	rootsLabel        = "roots"
-	messagesLabel     = "messages"
-	rmnSignatureLabel = "rmnSignatures"
-
-	// Prometheus labels for token price processor
-	tokenPricesLabel           = "tokenPrices"
-	feedTokenPricesLabel       = "feedTokenPrices"
-	feeQuoterTokenUpdatesLabel = "feeQuoterTokenUpdates"
-
-	// Prometheus labels for chain fee processor
-	gasPricesLabel         = "gasPrices"
-	feeComponentsLabel     = "feeComponents"
-	nativeTokenPricesLabel = "nativeTokenPrices"
-	chainFeeUpdatesLabel   = "chainFeeUpdates"
-)
-
 var (
-	RequestLatencyBucketsMilliseconds     = []float64{5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000}
-	promMerkleProcessorObservationDetails = promauto.NewCounterVec(
+	RequestLatencyBucketsMilliseconds = []float64{
+		5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000,
+	}
+	promProcessorObservationCounter = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "ccip_commit_merkle_processor_observation_components_sizes",
-			Help: "This metric tracks the number of different items in the merkle observation of the commit plugin",
+			Name: "ccip_commit_processor_observation_sizes",
+			Help: "This metric tracks the number of different items in the commit processor",
 		},
-		[]string{"chainID", "state", "type"},
+		[]string{"chainID", "processor", "type"},
 	)
-	promMerkleOutcomeDetails = promauto.NewCounterVec(
+	promProcessorOutcomeCounter = promauto.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "ccip_commit_merkle_processor_outcome_components_sizes",
-			Help: "This metric tracks the number of different items in the merkle outcome of the commit plugin",
+			Name: "ccip_commit_processor_outcome_sizes",
+			Help: "This metric tracks the number of different items in the commit processor",
 		},
-		[]string{"chainID", "state", "type"},
+		[]string{"chainID", "processor", "type"},
+	)
+	promProcessorLatencyHistogram = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "ccip_commit_processor_latency_ms",
+			Help:    "This metric tracks the client-observed latency of a single processor method",
+			Buckets: RequestLatencyBucketsMilliseconds,
+		},
+		[]string{"chainID", "processor", "method"},
+	)
+	promProcessorObservationErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ccip_commit_processor_observation_errors",
+			Help: "This metric tracks the number of errors in the commit processor observation",
+		},
+		[]string{"chainID", "processor"},
+	)
+	promProcessorOutcomeErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ccip_commit_processor_outcome_errors",
+			Help: "This metric tracks the number of errors in the commit processor outcome",
+		},
+		[]string{"chainID", "processor"},
 	)
 	promMerkleProcessorRmnReportLatency = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -68,48 +72,19 @@ var (
 		},
 		[]string{"method", "nodeID", "error"},
 	)
-	promTokenPriceObservationDetails = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "ccip_commit_token_processor_observation_components_sizes",
-			Help: "This metric tracks the number of different items in the token prices observation of the commit plugin",
-		},
-		[]string{"chainID", "type"},
-	)
-	promTokenPriceOutcomeDetails = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "ccip_commit_token_processor_outcome_components_sizes",
-			Help: "This metric tracks the number of different items in the token prices outcome of the commit plugin",
-		},
-		[]string{"chainID", "type"},
-	)
-	promChainFeeObservationDetails = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "ccip_commit_chain_fee_processor_observation_components_sizes",
-			Help: "This metric tracks the number of different items in the chain fee observation of the commit plugin",
-		},
-		[]string{"chainID", "type"},
-	)
-	promChainFeeOutcomeDetails = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "ccip_commit_chain_fee_processor_outcome_components_sizes",
-			Help: "This metric tracks the number of different items in the chain fee outcome of the commit plugin",
-		},
-		[]string{"chainID", "type"},
-	)
 )
 
 type PromReporter struct {
 	lggr    logger.Logger
 	chainID string
 	// Prometheus components
-	merkleProcessorObservationCounter   *prometheus.CounterVec
-	merkleProcessorOutcomeCounter       *prometheus.CounterVec
-	merkleProcessorRmnReportHistogram   *prometheus.HistogramVec
-	rmnControllerRmnRequestHistogram    *prometheus.HistogramVec
-	tokenProcessorObservationCounter    *prometheus.CounterVec
-	tokenProcessorOutcomeCounter        *prometheus.CounterVec
-	chainFeeProcessorObservationCounter *prometheus.CounterVec
-	chainFeeProcessorOutcomeCounter     *prometheus.CounterVec
+	merkleProcessorRmnReportHistogram *prometheus.HistogramVec
+	rmnControllerRmnRequestHistogram  *prometheus.HistogramVec
+	processorLatencyHistogram         *prometheus.HistogramVec
+	processorObservationCounter       *prometheus.CounterVec
+	processorOutcomeCounter           *prometheus.CounterVec
+	processorObservationErrors        *prometheus.CounterVec
+	processorOutcomeErrors            *prometheus.CounterVec
 }
 
 func NewPromReporter(lggr logger.Logger, selector cciptypes.ChainSelector) (*PromReporter, error) {
@@ -122,14 +97,14 @@ func NewPromReporter(lggr logger.Logger, selector cciptypes.ChainSelector) (*Pro
 		lggr:    lggr,
 		chainID: chainID,
 
-		merkleProcessorObservationCounter:   promMerkleProcessorObservationDetails,
-		merkleProcessorOutcomeCounter:       promMerkleOutcomeDetails,
-		merkleProcessorRmnReportHistogram:   promMerkleProcessorRmnReportLatency,
-		rmnControllerRmnRequestHistogram:    promRmnControllerRmnRequestLatency,
-		tokenProcessorObservationCounter:    promTokenPriceObservationDetails,
-		tokenProcessorOutcomeCounter:        promTokenPriceOutcomeDetails,
-		chainFeeProcessorObservationCounter: promChainFeeObservationDetails,
-		chainFeeProcessorOutcomeCounter:     promChainFeeOutcomeDetails,
+		merkleProcessorRmnReportHistogram: promMerkleProcessorRmnReportLatency,
+		rmnControllerRmnRequestHistogram:  promRmnControllerRmnRequestLatency,
+
+		processorLatencyHistogram:   promProcessorLatencyHistogram,
+		processorObservationCounter: promProcessorObservationCounter,
+		processorOutcomeCounter:     promProcessorOutcomeCounter,
+		processorObservationErrors:  promProcessorObservationErrors,
+		processorOutcomeErrors:      promProcessorOutcomeErrors,
 	}, nil
 }
 
@@ -151,46 +126,6 @@ func (p *PromReporter) TrackOutcome(outcome committypes.Outcome) {
 	}
 }
 
-func (p *PromReporter) TrackChainFeeObservation(obs chainfee.Observation) {
-	counts := chainFeeObservationMetrics(obs)
-
-	for key, count := range counts {
-		p.chainFeeProcessorObservationCounter.
-			WithLabelValues(p.chainID, key).
-			Add(float64(count))
-	}
-}
-
-func (p *PromReporter) TrackChainFeeOutcome(outcome chainfee.Outcome) {
-	counts := chainFeeOutcomeMetrics(outcome)
-
-	for key, count := range counts {
-		p.chainFeeProcessorOutcomeCounter.
-			WithLabelValues(p.chainID, key).
-			Add(float64(count))
-	}
-}
-
-func (p *PromReporter) TrackMerkleObservation(obs merkleroot.Observation, state string) {
-	counts := merkleRootObservationMetrics(obs)
-
-	for key, count := range counts {
-		p.merkleProcessorObservationCounter.
-			WithLabelValues(p.chainID, state, key).
-			Add(float64(count))
-	}
-}
-
-func (p *PromReporter) TrackMerkleOutcome(outcome merkleroot.Outcome, state string) {
-	counts := merkleRootOutcomeMetrics(outcome)
-
-	for key, count := range counts {
-		p.merkleProcessorOutcomeCounter.
-			WithLabelValues(p.chainID, state, key).
-			Add(float64(count))
-	}
-}
-
 func (p *PromReporter) TrackRmnReport(latency float64, success bool) {
 	successStr := strconv.FormatBool(success)
 	p.merkleProcessorRmnReportHistogram.WithLabelValues(p.chainID, successStr).Observe(latency)
@@ -201,76 +136,38 @@ func (p *PromReporter) TrackRmnRequest(method string, latency float64, nodeID ui
 	p.rmnControllerRmnRequestHistogram.WithLabelValues(method, nodeIDStr, err).Observe(latency)
 }
 
-func (p *PromReporter) TrackTokenPricesObservation(obs tokenprice.Observation) {
-	counts := tokenPricesObservationMetrics(obs)
-
-	for key, count := range counts {
-		p.tokenProcessorObservationCounter.
-			WithLabelValues(p.chainID, key).
-			Add(float64(count))
-	}
-}
-
-func (p *PromReporter) TrackTokenPricesOutcome(outcome tokenprice.Outcome) {
-	counts := tokenPricesOutcomeMetrics(outcome)
-
-	for key, count := range counts {
-		p.tokenProcessorOutcomeCounter.
-			WithLabelValues(p.chainID, key).
-			Add(float64(count))
-	}
-}
-
 func (p *PromReporter) TrackProcessorLatency(processor string, method string, latency time.Duration) {
-
+	p.processorLatencyHistogram.
+		WithLabelValues(p.chainID, processor, method).
+		Observe(float64(latency.Milliseconds()))
 }
 
-func merkleRootObservationMetrics(obs merkleroot.Observation) map[string]int {
-	counts := map[string]int{
-		rootsLabel:    len(obs.MerkleRoots),
-		messagesLabel: 0,
+func (p *PromReporter) TrackProcessorObservation(processor string, obs plugintypes.Trackable, err error) {
+	if err != nil {
+		p.processorObservationErrors.
+			WithLabelValues(p.chainID, processor).
+			Inc()
+		return
 	}
-	for _, root := range obs.MerkleRoots {
-		counts[messagesLabel] += root.SeqNumsRange.Length()
-	}
-	return counts
-}
 
-func merkleRootOutcomeMetrics(outcome merkleroot.Outcome) map[string]int {
-	counts := map[string]int{
-		rootsLabel:        len(outcome.RootsToReport),
-		rmnSignatureLabel: len(outcome.RMNReportSignatures),
-		messagesLabel:     0,
-	}
-	for _, root := range outcome.RootsToReport {
-		counts[messagesLabel] += root.SeqNumsRange.Length()
-	}
-	return counts
-}
-
-func tokenPricesObservationMetrics(obs tokenprice.Observation) map[string]int {
-	return map[string]int{
-		feedTokenPricesLabel:       len(obs.FeedTokenPrices),
-		feeQuoterTokenUpdatesLabel: len(obs.FeeQuoterTokenUpdates),
+	for key, val := range obs.Stats() {
+		p.processorObservationCounter.
+			WithLabelValues(p.chainID, processor, key).
+			Add(float64(val))
 	}
 }
 
-func tokenPricesOutcomeMetrics(outcome tokenprice.Outcome) map[string]int {
-	return map[string]int{
-		tokenPricesLabel: len(outcome.TokenPrices),
+func (p *PromReporter) TrackProcessorOutcome(processor string, out plugintypes.Trackable, err error) {
+	if err != nil {
+		p.processorOutcomeErrors.
+			WithLabelValues(p.chainID, processor).
+			Inc()
+		return
 	}
-}
 
-func chainFeeObservationMetrics(obs chainfee.Observation) map[string]int {
-	return map[string]int{
-		feeComponentsLabel:     len(obs.FeeComponents),
-		nativeTokenPricesLabel: len(obs.NativeTokenPrices),
-		chainFeeUpdatesLabel:   len(obs.ChainFeeUpdates),
-	}
-}
-
-func chainFeeOutcomeMetrics(outcome chainfee.Outcome) map[string]int {
-	return map[string]int{
-		gasPricesLabel: len(outcome.GasPrices),
+	for key, val := range out.Stats() {
+		p.processorOutcomeCounter.
+			WithLabelValues(p.chainID, processor, key).
+			Add(float64(val))
 	}
 }

--- a/commit/metrics/prom_test.go
+++ b/commit/metrics/prom_test.go
@@ -66,7 +66,7 @@ func Test_TrackingTokenPrices(t *testing.T) {
 
 	for _, tc := range obsTcs {
 		t.Run(tc.name, func(t *testing.T) {
-			reporter.TrackProcessorObservation(tokenPricesProcessor, tc.observation, nil)
+			reporter.TrackProcessorObservation(tokenPricesProcessor, tc.observation)
 
 			feedTokens := int(testutil.ToFloat64(
 				reporter.processorObservationCounter.WithLabelValues(chainID, tokenPricesProcessor, "feedTokenPrices")),
@@ -113,7 +113,7 @@ func Test_TrackingTokenPrices(t *testing.T) {
 
 	for _, tc := range outTcs {
 		t.Run(tc.name, func(t *testing.T) {
-			reporter.TrackProcessorOutcome(tokenPricesProcessor, tc.outcome, err)
+			reporter.TrackProcessorOutcome(tokenPricesProcessor, tc.outcome)
 
 			tokenPrices := int(testutil.ToFloat64(
 				reporter.processorOutcomeCounter.WithLabelValues(chainID, tokenPricesProcessor, "tokenPrices")),
@@ -170,7 +170,7 @@ func Test_TrackingChainFees(t *testing.T) {
 
 	for _, tc := range obsTcs {
 		t.Run(tc.name, func(t *testing.T) {
-			reporter.TrackProcessorObservation(chainFeeProcessor, tc.observation, nil)
+			reporter.TrackProcessorObservation(chainFeeProcessor, tc.observation)
 
 			feeComponents := int(testutil.ToFloat64(
 				reporter.processorObservationCounter.WithLabelValues(chainID, chainFeeProcessor, "feeComponents")),
@@ -215,7 +215,7 @@ func Test_TrackingChainFees(t *testing.T) {
 
 	for _, tc := range outTcs {
 		t.Run(tc.name, func(t *testing.T) {
-			reporter.TrackProcessorOutcome(chainFeeProcessor, tc.outcome, nil)
+			reporter.TrackProcessorOutcome(chainFeeProcessor, tc.outcome)
 
 			gasPrices := int(testutil.ToFloat64(
 				reporter.processorOutcomeCounter.WithLabelValues(chainID, chainFeeProcessor, "gasPrices")),
@@ -273,7 +273,7 @@ func Test_MerkleRoots(t *testing.T) {
 
 	for _, tc := range obsTcs {
 		t.Run(tc.name, func(t *testing.T) {
-			reporter.TrackProcessorObservation(processor, tc.observation, nil)
+			reporter.TrackProcessorObservation(processor, tc.observation)
 
 			roots := int(testutil.ToFloat64(
 				reporter.processorObservationCounter.WithLabelValues(chainID, processor, "roots")),
@@ -332,7 +332,7 @@ func Test_MerkleRoots(t *testing.T) {
 
 	for _, tc := range outTcs {
 		t.Run(tc.name, func(t *testing.T) {
-			reporter.TrackProcessorOutcome(processor, tc.outcome, nil)
+			reporter.TrackProcessorOutcome(processor, tc.outcome)
 
 			roots := int(testutil.ToFloat64(
 				reporter.processorOutcomeCounter.WithLabelValues(chainID, processor, "roots")),
@@ -352,8 +352,7 @@ func Test_MerkleRoots(t *testing.T) {
 
 func cleanupMetrics(reporter *PromReporter) func() {
 	return func() {
-		reporter.processorOutcomeErrors.Reset()
-		reporter.processorObservationErrors.Reset()
+		reporter.processorErrors.Reset()
 		reporter.processorOutcomeCounter.Reset()
 		reporter.processorObservationCounter.Reset()
 	}

--- a/commit/metrics/prom_test.go
+++ b/commit/metrics/prom_test.go
@@ -25,6 +25,7 @@ const (
 )
 
 func Test_TrackingTokenPrices(t *testing.T) {
+	tokenPricesProcessor := "tokenprices"
 	reporter, err := NewPromReporter(logger.Test(t), selector)
 	require.NoError(t, err)
 
@@ -65,14 +66,14 @@ func Test_TrackingTokenPrices(t *testing.T) {
 
 	for _, tc := range obsTcs {
 		t.Run(tc.name, func(t *testing.T) {
-			reporter.TrackTokenPricesObservation(tc.observation)
+			reporter.TrackProcessorObservation(tokenPricesProcessor, tc.observation, nil)
 
 			feedTokens := int(testutil.ToFloat64(
-				reporter.tokenProcessorObservationCounter.WithLabelValues(chainID, "feedTokenPrices")),
+				reporter.processorObservationCounter.WithLabelValues(chainID, tokenPricesProcessor, "feedTokenPrices")),
 			)
 			require.Equal(t, tc.expectedFeedToken, feedTokens)
 			feeQuoted := int(testutil.ToFloat64(
-				reporter.tokenProcessorObservationCounter.WithLabelValues(chainID, "feeQuoterTokenUpdates")),
+				reporter.processorObservationCounter.WithLabelValues(chainID, tokenPricesProcessor, "feeQuoterTokenUpdates")),
 			)
 			require.Equal(t, tc.expectedFeeQuotedToken, feeQuoted)
 		})
@@ -112,10 +113,10 @@ func Test_TrackingTokenPrices(t *testing.T) {
 
 	for _, tc := range outTcs {
 		t.Run(tc.name, func(t *testing.T) {
-			reporter.TrackTokenPricesOutcome(tc.outcome)
+			reporter.TrackProcessorOutcome(tokenPricesProcessor, tc.outcome, err)
 
 			tokenPrices := int(testutil.ToFloat64(
-				reporter.tokenProcessorOutcomeCounter.WithLabelValues(chainID, "tokenPrices")),
+				reporter.processorOutcomeCounter.WithLabelValues(chainID, tokenPricesProcessor, "tokenPrices")),
 			)
 			require.Equal(t, tc.expectedTokenPrices, tokenPrices)
 		})
@@ -123,6 +124,7 @@ func Test_TrackingTokenPrices(t *testing.T) {
 }
 
 func Test_TrackingChainFees(t *testing.T) {
+	chainFeeProcessor := "chainfee"
 	reporter, err := NewPromReporter(logger.Test(t), selector)
 	require.NoError(t, err)
 
@@ -168,18 +170,18 @@ func Test_TrackingChainFees(t *testing.T) {
 
 	for _, tc := range obsTcs {
 		t.Run(tc.name, func(t *testing.T) {
-			reporter.TrackChainFeeObservation(tc.observation)
+			reporter.TrackProcessorObservation(chainFeeProcessor, tc.observation, nil)
 
 			feeComponents := int(testutil.ToFloat64(
-				reporter.chainFeeProcessorObservationCounter.WithLabelValues(chainID, "feeComponents")),
+				reporter.processorObservationCounter.WithLabelValues(chainID, chainFeeProcessor, "feeComponents")),
 			)
 			require.Equal(t, tc.expectedFeeComponents, feeComponents)
 			nativePrices := int(testutil.ToFloat64(
-				reporter.chainFeeProcessorObservationCounter.WithLabelValues(chainID, "nativeTokenPrices")),
+				reporter.processorObservationCounter.WithLabelValues(chainID, chainFeeProcessor, "nativeTokenPrices")),
 			)
 			require.Equal(t, tc.expectedNativePrices, nativePrices)
 			chainFeeUpdates := int(testutil.ToFloat64(
-				reporter.chainFeeProcessorObservationCounter.WithLabelValues(chainID, "chainFeeUpdates")),
+				reporter.processorObservationCounter.WithLabelValues(chainID, chainFeeProcessor, "chainFeeUpdates")),
 			)
 			require.Equal(t, tc.expectedCHainFeeUpdates, chainFeeUpdates)
 		})
@@ -213,10 +215,10 @@ func Test_TrackingChainFees(t *testing.T) {
 
 	for _, tc := range outTcs {
 		t.Run(tc.name, func(t *testing.T) {
-			reporter.TrackChainFeeOutcome(tc.outcome)
+			reporter.TrackProcessorOutcome(chainFeeProcessor, tc.outcome, nil)
 
 			gasPrices := int(testutil.ToFloat64(
-				reporter.chainFeeProcessorOutcomeCounter.WithLabelValues(chainID, "gasPrices")),
+				reporter.processorOutcomeCounter.WithLabelValues(chainID, chainFeeProcessor, "gasPrices")),
 			)
 			require.Equal(t, tc.expectedGasPrices, gasPrices)
 		})
@@ -224,6 +226,7 @@ func Test_TrackingChainFees(t *testing.T) {
 }
 
 func Test_MerkleRoots(t *testing.T) {
+	processor := "merkleroot"
 	reporter, err := NewPromReporter(logger.Test(t), selector)
 	require.NoError(t, err)
 
@@ -270,14 +273,14 @@ func Test_MerkleRoots(t *testing.T) {
 
 	for _, tc := range obsTcs {
 		t.Run(tc.name, func(t *testing.T) {
-			reporter.TrackMerkleObservation(tc.observation, tc.state)
+			reporter.TrackProcessorObservation(processor, tc.observation, nil)
 
 			roots := int(testutil.ToFloat64(
-				reporter.merkleProcessorObservationCounter.WithLabelValues(chainID, tc.state, "roots")),
+				reporter.processorObservationCounter.WithLabelValues(chainID, processor, "roots")),
 			)
 			require.Equal(t, tc.expectedRoots, roots)
 			messages := int(testutil.ToFloat64(
-				reporter.merkleProcessorObservationCounter.WithLabelValues(chainID, tc.state, "messages")),
+				reporter.processorObservationCounter.WithLabelValues(chainID, processor, "messages")),
 			)
 			require.Equal(t, tc.expectedMessages, messages)
 		})
@@ -329,18 +332,18 @@ func Test_MerkleRoots(t *testing.T) {
 
 	for _, tc := range outTcs {
 		t.Run(tc.name, func(t *testing.T) {
-			reporter.TrackMerkleOutcome(tc.outcome, tc.state)
+			reporter.TrackProcessorOutcome(processor, tc.outcome, nil)
 
 			roots := int(testutil.ToFloat64(
-				reporter.merkleProcessorOutcomeCounter.WithLabelValues(chainID, tc.state, "roots")),
+				reporter.processorOutcomeCounter.WithLabelValues(chainID, processor, "roots")),
 			)
 			require.Equal(t, tc.expectedRoots, roots)
 			messages := int(testutil.ToFloat64(
-				reporter.merkleProcessorOutcomeCounter.WithLabelValues(chainID, tc.state, "messages")),
+				reporter.processorOutcomeCounter.WithLabelValues(chainID, processor, "messages")),
 			)
 			require.Equal(t, tc.expectedMessages, messages)
 			rmns := int(testutil.ToFloat64(
-				reporter.merkleProcessorOutcomeCounter.WithLabelValues(chainID, tc.state, "rmnSignatures")),
+				reporter.processorOutcomeCounter.WithLabelValues(chainID, processor, "rmnSignatures")),
 			)
 			require.Equal(t, tc.expectedRMNSignatures, rmns)
 		})
@@ -349,11 +352,9 @@ func Test_MerkleRoots(t *testing.T) {
 
 func cleanupMetrics(reporter *PromReporter) func() {
 	return func() {
-		reporter.chainFeeProcessorObservationCounter.Reset()
-		reporter.chainFeeProcessorOutcomeCounter.Reset()
-		reporter.merkleProcessorOutcomeCounter.Reset()
-		reporter.merkleProcessorObservationCounter.Reset()
-		reporter.tokenProcessorOutcomeCounter.Reset()
-		reporter.tokenProcessorObservationCounter.Reset()
+		reporter.processorOutcomeErrors.Reset()
+		reporter.processorObservationErrors.Reset()
+		reporter.processorOutcomeCounter.Reset()
+		reporter.processorObservationCounter.Reset()
 	}
 }

--- a/commit/metrics/prom_test.go
+++ b/commit/metrics/prom_test.go
@@ -361,7 +361,7 @@ func Test_LatencyAndErrors(t *testing.T) {
 		method := "query"
 
 		reporter.TrackProcessorLatency(processor, method, time.Second, nil)
-		l1 := internal.CounterFromHistogramByLabels(t, reporter.processorLatencyHistogram, chainID, "merkle", "method")
+		l1 := internal.CounterFromHistogramByLabels(t, reporter.processorLatencyHistogram, chainID, processor, method)
 		require.Equal(t, 1, l1)
 
 		errs := testutil.ToFloat64(

--- a/commit/metrics/prom_test.go
+++ b/commit/metrics/prom_test.go
@@ -350,6 +350,10 @@ func Test_MerkleRoots(t *testing.T) {
 	}
 }
 
+func Test_LatencyAndErrors(t *testing.T) {
+
+}
+
 func cleanupMetrics(reporter *PromReporter) func() {
 	return func() {
 		reporter.processorErrors.Reset()

--- a/commit/metrics/prom_test.go
+++ b/commit/metrics/prom_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/commit/tokenprice"
 	"github.com/smartcontractkit/chainlink-ccip/internal"
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/testhelpers/rand"
+	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
@@ -68,14 +69,18 @@ func Test_TrackingTokenPrices(t *testing.T) {
 
 	for _, tc := range obsTcs {
 		t.Run(tc.name, func(t *testing.T) {
-			reporter.TrackProcessorObservation(tokenPricesProcessor, tc.observation)
+			reporter.TrackProcessorOutput(tokenPricesProcessor, plugincommon.ObservationMethod, tc.observation)
 
 			feedTokens := int(testutil.ToFloat64(
-				reporter.processorObservationCounter.WithLabelValues(chainID, tokenPricesProcessor, "feedTokenPrices")),
+				reporter.processorOutputCounter.WithLabelValues(
+					chainID, tokenPricesProcessor, plugincommon.ObservationMethod, "feedTokenPrices",
+				)),
 			)
 			require.Equal(t, tc.expectedFeedToken, feedTokens)
 			feeQuoted := int(testutil.ToFloat64(
-				reporter.processorObservationCounter.WithLabelValues(chainID, tokenPricesProcessor, "feeQuoterTokenUpdates")),
+				reporter.processorOutputCounter.WithLabelValues(
+					chainID, tokenPricesProcessor, plugincommon.ObservationMethod, "feeQuoterTokenUpdates",
+				)),
 			)
 			require.Equal(t, tc.expectedFeeQuotedToken, feeQuoted)
 		})
@@ -115,10 +120,12 @@ func Test_TrackingTokenPrices(t *testing.T) {
 
 	for _, tc := range outTcs {
 		t.Run(tc.name, func(t *testing.T) {
-			reporter.TrackProcessorOutcome(tokenPricesProcessor, tc.outcome)
+			reporter.TrackProcessorOutput(tokenPricesProcessor, plugincommon.OutcomeMethod, tc.outcome)
 
 			tokenPrices := int(testutil.ToFloat64(
-				reporter.processorOutcomeCounter.WithLabelValues(chainID, tokenPricesProcessor, "tokenPrices")),
+				reporter.processorOutputCounter.WithLabelValues(
+					chainID, tokenPricesProcessor, plugincommon.OutcomeMethod, "tokenPrices",
+				)),
 			)
 			require.Equal(t, tc.expectedTokenPrices, tokenPrices)
 		})
@@ -172,18 +179,26 @@ func Test_TrackingChainFees(t *testing.T) {
 
 	for _, tc := range obsTcs {
 		t.Run(tc.name, func(t *testing.T) {
-			reporter.TrackProcessorObservation(chainFeeProcessor, tc.observation)
+			reporter.TrackProcessorOutput(
+				chainFeeProcessor, plugincommon.ObservationMethod, tc.observation,
+			)
 
 			feeComponents := int(testutil.ToFloat64(
-				reporter.processorObservationCounter.WithLabelValues(chainID, chainFeeProcessor, "feeComponents")),
+				reporter.processorOutputCounter.WithLabelValues(
+					chainID, chainFeeProcessor, plugincommon.ObservationMethod, "feeComponents",
+				)),
 			)
 			require.Equal(t, tc.expectedFeeComponents, feeComponents)
 			nativePrices := int(testutil.ToFloat64(
-				reporter.processorObservationCounter.WithLabelValues(chainID, chainFeeProcessor, "nativeTokenPrices")),
+				reporter.processorOutputCounter.WithLabelValues(
+					chainID, chainFeeProcessor, plugincommon.ObservationMethod, "nativeTokenPrices",
+				)),
 			)
 			require.Equal(t, tc.expectedNativePrices, nativePrices)
 			chainFeeUpdates := int(testutil.ToFloat64(
-				reporter.processorObservationCounter.WithLabelValues(chainID, chainFeeProcessor, "chainFeeUpdates")),
+				reporter.processorOutputCounter.WithLabelValues(
+					chainID, chainFeeProcessor, plugincommon.ObservationMethod, "chainFeeUpdates",
+				)),
 			)
 			require.Equal(t, tc.expectedCHainFeeUpdates, chainFeeUpdates)
 		})
@@ -217,10 +232,12 @@ func Test_TrackingChainFees(t *testing.T) {
 
 	for _, tc := range outTcs {
 		t.Run(tc.name, func(t *testing.T) {
-			reporter.TrackProcessorOutcome(chainFeeProcessor, tc.outcome)
+			reporter.TrackProcessorOutput(chainFeeProcessor, plugincommon.OutcomeMethod, tc.outcome)
 
 			gasPrices := int(testutil.ToFloat64(
-				reporter.processorOutcomeCounter.WithLabelValues(chainID, chainFeeProcessor, "gasPrices")),
+				reporter.processorOutputCounter.WithLabelValues(
+					chainID, chainFeeProcessor, plugincommon.OutcomeMethod, "gasPrices",
+				)),
 			)
 			require.Equal(t, tc.expectedGasPrices, gasPrices)
 		})
@@ -275,14 +292,14 @@ func Test_MerkleRoots(t *testing.T) {
 
 	for _, tc := range obsTcs {
 		t.Run(tc.name, func(t *testing.T) {
-			reporter.TrackProcessorObservation(processor, tc.observation)
+			reporter.TrackProcessorOutput(processor, plugincommon.ObservationMethod, tc.observation)
 
 			roots := int(testutil.ToFloat64(
-				reporter.processorObservationCounter.WithLabelValues(chainID, processor, "roots")),
+				reporter.processorOutputCounter.WithLabelValues(chainID, processor, plugincommon.ObservationMethod, "roots")),
 			)
 			require.Equal(t, tc.expectedRoots, roots)
 			messages := int(testutil.ToFloat64(
-				reporter.processorObservationCounter.WithLabelValues(chainID, processor, "messages")),
+				reporter.processorOutputCounter.WithLabelValues(chainID, processor, plugincommon.ObservationMethod, "messages")),
 			)
 			require.Equal(t, tc.expectedMessages, messages)
 		})
@@ -334,18 +351,18 @@ func Test_MerkleRoots(t *testing.T) {
 
 	for _, tc := range outTcs {
 		t.Run(tc.name, func(t *testing.T) {
-			reporter.TrackProcessorOutcome(processor, tc.outcome)
+			reporter.TrackProcessorOutput(processor, plugincommon.OutcomeMethod, tc.outcome)
 
 			roots := int(testutil.ToFloat64(
-				reporter.processorOutcomeCounter.WithLabelValues(chainID, processor, "roots")),
+				reporter.processorOutputCounter.WithLabelValues(chainID, processor, plugincommon.OutcomeMethod, "roots")),
 			)
 			require.Equal(t, tc.expectedRoots, roots)
 			messages := int(testutil.ToFloat64(
-				reporter.processorOutcomeCounter.WithLabelValues(chainID, processor, "messages")),
+				reporter.processorOutputCounter.WithLabelValues(chainID, processor, plugincommon.OutcomeMethod, "messages")),
 			)
 			require.Equal(t, tc.expectedMessages, messages)
 			rmns := int(testutil.ToFloat64(
-				reporter.processorOutcomeCounter.WithLabelValues(chainID, processor, "rmnSignatures")),
+				reporter.processorOutputCounter.WithLabelValues(chainID, processor, plugincommon.OutcomeMethod, "rmnSignatures")),
 			)
 			require.Equal(t, tc.expectedRMNSignatures, rmns)
 		})
@@ -400,8 +417,7 @@ func Test_LatencyAndErrors(t *testing.T) {
 func cleanupMetrics(reporter *PromReporter) func() {
 	return func() {
 		reporter.processorErrors.Reset()
-		reporter.processorOutcomeCounter.Reset()
-		reporter.processorObservationCounter.Reset()
+		reporter.processorOutputCounter.Reset()
 		reporter.processorLatencyHistogram.Reset()
 	}
 }

--- a/commit/metrics/reporter.go
+++ b/commit/metrics/reporter.go
@@ -28,9 +28,9 @@ type Reporter interface {
 	TrackRmnReport(latency float64, success bool)
 	TrackRmnRequest(method string, latency float64, nodeID uint64, err string)
 
-	TrackProcessorLatency(processor string, method string, latency time.Duration)
-	TrackProcessorObservation(processor string, obs plugintypes.Trackable, err error)
-	TrackProcessorOutcome(processor string, out plugintypes.Trackable, err error)
+	TrackProcessorLatency(processor string, method string, latency time.Duration, err error)
+	TrackProcessorObservation(processor string, obs plugintypes.Trackable)
+	TrackProcessorOutcome(processor string, out plugintypes.Trackable)
 }
 
 type CommitPluginReporter interface {
@@ -56,11 +56,11 @@ func (n *Noop) TrackTokenPricesObservation(tokenprice.Observation) {}
 
 func (n *Noop) TrackTokenPricesOutcome(tokenprice.Outcome) {}
 
-func (n *Noop) TrackProcessorLatency(string, string, time.Duration) {}
+func (n *Noop) TrackProcessorLatency(string, string, time.Duration, error) {}
 
-func (n *Noop) TrackProcessorObservation(string, plugintypes.Trackable, error) {}
+func (n *Noop) TrackProcessorObservation(string, plugintypes.Trackable) {}
 
-func (n *Noop) TrackProcessorOutcome(string, plugintypes.Trackable, error) {}
+func (n *Noop) TrackProcessorOutcome(string, plugintypes.Trackable) {}
 
 var _ Reporter = &PromReporter{}
 var _ CommitPluginReporter = &PromReporter{}

--- a/commit/metrics/reporter.go
+++ b/commit/metrics/reporter.go
@@ -3,7 +3,6 @@ package metrics
 import (
 	"time"
 
-	"github.com/smartcontractkit/chainlink-ccip/commit/chainfee"
 	"github.com/smartcontractkit/chainlink-ccip/commit/committypes"
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot"
 	"github.com/smartcontractkit/chainlink-ccip/commit/tokenprice"
@@ -64,5 +63,4 @@ func (n *Noop) TrackProcessorOutcome(string, plugintypes.Trackable) {}
 
 var _ Reporter = &PromReporter{}
 var _ CommitPluginReporter = &PromReporter{}
-var _ chainfee.MetricsReporter = &PromReporter{}
 var _ merkleroot.MetricsReporter = &PromReporter{}

--- a/commit/metrics/reporter.go
+++ b/commit/metrics/reporter.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/commit/committypes"
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot"
-	"github.com/smartcontractkit/chainlink-ccip/commit/tokenprice"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
 )
 
@@ -43,17 +42,9 @@ func (n *Noop) TrackObservation(committypes.Observation) {}
 
 func (n *Noop) TrackOutcome(committypes.Outcome) {}
 
-func (n *Noop) TrackMerkleObservation(merkleroot.Observation, string) {}
-
-func (n *Noop) TrackMerkleOutcome(merkleroot.Outcome, string) {}
-
 func (n *Noop) TrackRmnReport(float64, bool) {}
 
 func (n *Noop) TrackRmnRequest(string, float64, uint64, string) {}
-
-func (n *Noop) TrackTokenPricesObservation(tokenprice.Observation) {}
-
-func (n *Noop) TrackTokenPricesOutcome(tokenprice.Outcome) {}
 
 func (n *Noop) TrackProcessorLatency(string, string, time.Duration, error) {}
 

--- a/commit/metrics/reporter.go
+++ b/commit/metrics/reporter.go
@@ -7,6 +7,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/commit/committypes"
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot"
 	"github.com/smartcontractkit/chainlink-ccip/commit/tokenprice"
+	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
 )
 
 // Reporter is a simple interface used for tracking observations and outcomes of the commit plugin.
@@ -21,20 +22,15 @@ import (
 // This split is required to define the reporting logic in one place but inject only relevant dependencies to
 // plugins/processors. Also, it solves the problem of cyclic dependencies between the plugins/processors.
 type Reporter interface {
-	TrackProcessorLatency(processor string, method string, latency time.Duration)
 	TrackObservation(obs committypes.Observation)
 	TrackOutcome(outcome committypes.Outcome)
 
-	TrackMerkleObservation(obs merkleroot.Observation, state string)
-	TrackMerkleOutcome(outcome merkleroot.Outcome, state string)
 	TrackRmnReport(latency float64, success bool)
 	TrackRmnRequest(method string, latency float64, nodeID uint64, err string)
 
-	TrackChainFeeObservation(obs chainfee.Observation)
-	TrackChainFeeOutcome(outcome chainfee.Outcome)
-
-	TrackTokenPricesObservation(obs tokenprice.Observation)
-	TrackTokenPricesOutcome(outcome tokenprice.Outcome)
+	TrackProcessorLatency(processor string, method string, latency time.Duration)
+	TrackProcessorObservation(processor string, obs plugintypes.Trackable, err error)
+	TrackProcessorOutcome(processor string, out plugintypes.Trackable, err error)
 }
 
 type CommitPluginReporter interface {
@@ -47,10 +43,6 @@ type Noop struct{}
 func (n *Noop) TrackObservation(committypes.Observation) {}
 
 func (n *Noop) TrackOutcome(committypes.Outcome) {}
-
-func (n *Noop) TrackChainFeeObservation(chainfee.Observation) {}
-
-func (n *Noop) TrackChainFeeOutcome(chainfee.Outcome) {}
 
 func (n *Noop) TrackMerkleObservation(merkleroot.Observation, string) {}
 
@@ -65,6 +57,10 @@ func (n *Noop) TrackTokenPricesObservation(tokenprice.Observation) {}
 func (n *Noop) TrackTokenPricesOutcome(tokenprice.Outcome) {}
 
 func (n *Noop) TrackProcessorLatency(string, string, time.Duration) {}
+
+func (n *Noop) TrackProcessorObservation(string, plugintypes.Trackable, error) {}
+
+func (n *Noop) TrackProcessorOutcome(string, plugintypes.Trackable, error) {}
 
 var _ Reporter = &PromReporter{}
 var _ CommitPluginReporter = &PromReporter{}

--- a/commit/metrics/reporter.go
+++ b/commit/metrics/reporter.go
@@ -1,6 +1,8 @@
 package metrics
 
 import (
+	"time"
+
 	"github.com/smartcontractkit/chainlink-ccip/commit/chainfee"
 	"github.com/smartcontractkit/chainlink-ccip/commit/committypes"
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot"
@@ -19,6 +21,7 @@ import (
 // This split is required to define the reporting logic in one place but inject only relevant dependencies to
 // plugins/processors. Also, it solves the problem of cyclic dependencies between the plugins/processors.
 type Reporter interface {
+	TrackProcessorLatency(processor string, method string, latency time.Duration)
 	TrackObservation(obs committypes.Observation)
 	TrackOutcome(outcome committypes.Outcome)
 
@@ -60,6 +63,8 @@ func (n *Noop) TrackRmnRequest(string, float64, uint64, string) {}
 func (n *Noop) TrackTokenPricesObservation(tokenprice.Observation) {}
 
 func (n *Noop) TrackTokenPricesOutcome(tokenprice.Outcome) {}
+
+func (n *Noop) TrackProcessorLatency(string, string, time.Duration) {}
 
 var _ Reporter = &PromReporter{}
 var _ CommitPluginReporter = &PromReporter{}

--- a/commit/metrics/reporter.go
+++ b/commit/metrics/reporter.go
@@ -66,4 +66,3 @@ var _ Reporter = &PromReporter{}
 var _ CommitPluginReporter = &PromReporter{}
 var _ chainfee.MetricsReporter = &PromReporter{}
 var _ merkleroot.MetricsReporter = &PromReporter{}
-var _ tokenprice.MetricsReporter = &PromReporter{}

--- a/commit/metrics/reporter.go
+++ b/commit/metrics/reporter.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/commit/committypes"
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot"
+	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
 )
 
@@ -13,9 +14,7 @@ import (
 // It allows you to track observation/outcome on the processor level as well as on the individual plugin level.
 // That gives us more flexibility and granularity in tracking the performance of the commit plugin.
 // Processors have a dedicated sub-interfaces covering only the relevant methods for reporting, please see:
-// - chainfee.MetricsReporter
 // - merkleroot.MetricsReporter
-// - tokenprice.MetricsReporter
 // - CommitPluginReporter
 // This split is required to define the reporting logic in one place but inject only relevant dependencies to
 // plugins/processors. Also, it solves the problem of cyclic dependencies between the plugins/processors.
@@ -26,9 +25,8 @@ type Reporter interface {
 	TrackRmnReport(latency float64, success bool)
 	TrackRmnRequest(method string, latency float64, nodeID uint64, err string)
 
-	TrackProcessorLatency(processor string, method string, latency time.Duration, err error)
-	TrackProcessorObservation(processor string, obs plugintypes.Trackable)
-	TrackProcessorOutcome(processor string, out plugintypes.Trackable)
+	TrackProcessorLatency(processor string, method plugincommon.MethodType, latency time.Duration, err error)
+	TrackProcessorOutput(processor string, method plugincommon.MethodType, obs plugintypes.Trackable)
 }
 
 type CommitPluginReporter interface {
@@ -46,11 +44,9 @@ func (n *Noop) TrackRmnReport(float64, bool) {}
 
 func (n *Noop) TrackRmnRequest(string, float64, uint64, string) {}
 
-func (n *Noop) TrackProcessorLatency(string, string, time.Duration, error) {}
+func (n *Noop) TrackProcessorLatency(string, plugincommon.MethodType, time.Duration, error) {}
 
-func (n *Noop) TrackProcessorObservation(string, plugintypes.Trackable) {}
-
-func (n *Noop) TrackProcessorOutcome(string, plugintypes.Trackable) {}
+func (n *Noop) TrackProcessorOutput(string, plugincommon.MethodType, plugintypes.Trackable) {}
 
 var _ Reporter = &PromReporter{}
 var _ CommitPluginReporter = &PromReporter{}

--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -56,7 +56,7 @@ type Plugin struct {
 	merkleRootProcessor plugincommon.PluginProcessor[merkleroot.Query, merkleroot.Observation, merkleroot.Outcome]
 	tokenPriceProcessor plugincommon.PluginProcessor[tokenprice.Query, tokenprice.Observation, tokenprice.Outcome]
 	chainFeeProcessor   plugincommon.PluginProcessor[chainfee.Query, chainfee.Observation, chainfee.Outcome]
-	discoveryProcessor  *discovery.ContractDiscoveryProcessor
+	discoveryProcessor  plugincommon.PluginProcessor[dt.Query, dt.Observation, dt.Outcome]
 	metricsReporter     metrics.CommitPluginReporter
 	ocrTypeCodec        ocrtypecodec.CommitCodec
 

--- a/commit/tokenprice/observation.go
+++ b/commit/tokenprice/observation.go
@@ -42,7 +42,6 @@ func (p *processor) Observation(
 		FChain:                fChain,
 		Timestamp:             now,
 	}
-	p.metricsReporter.TrackTokenPricesObservation(obs)
 	return obs, nil
 }
 

--- a/commit/tokenprice/observation_test.go
+++ b/commit/tokenprice/observation_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
+	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
 	common_mock "github.com/smartcontractkit/chainlink-ccip/mocks/internal_/plugincommon"
 	readermock "github.com/smartcontractkit/chainlink-ccip/mocks/internal_/reader"
@@ -86,7 +87,7 @@ func Test_Observation(t *testing.T) {
 					offChainCfg:      defaultCfg,
 					destChain:        destChainSel,
 					fRoleDON:         f,
-					metricsReporter:  NoopMetrics{},
+					metricsReporter:  plugincommon.NoopReporter{},
 				}
 			},
 			expObs: Observation{
@@ -114,7 +115,7 @@ func Test_Observation(t *testing.T) {
 					destChain:        destChainSel,
 					offChainCfg:      defaultCfg,
 					fRoleDON:         f,
-					metricsReporter:  NoopMetrics{},
+					metricsReporter:  plugincommon.NoopReporter{},
 				}
 			},
 			expObs: Observation{},

--- a/commit/tokenprice/outcome_test.go
+++ b/commit/tokenprice/outcome_test.go
@@ -141,7 +141,7 @@ func TestOutcome(t *testing.T) {
 		destChain:       destChainSel,
 		offChainCfg:     offChainCfg,
 		fRoleDON:        1,
-		metricsReporter: NoopMetrics{},
+		metricsReporter: plugincommon.NoopReporter{},
 	}
 
 	outcome, err := p.Outcome(ctx, Outcome{}, Query{}, []plugincommon.AttributedObservation[Observation]{

--- a/commit/tokenprice/processor.go
+++ b/commit/tokenprice/processor.go
@@ -24,7 +24,7 @@ type processor struct {
 	chainSupport     plugincommon.ChainSupport
 	tokenPriceReader pkgreader.PriceReader
 	homeChain        reader.HomeChain
-	metricsReporter  MetricsReporter
+	metricsReporter  plugincommon.MetricsReporter
 	fRoleDON         int
 }
 
@@ -37,7 +37,7 @@ func NewProcessor(
 	tokenPriceReader pkgreader.PriceReader,
 	homeChain reader.HomeChain,
 	fRoleDON int,
-	metricsReporter MetricsReporter,
+	metricsReporter plugincommon.MetricsReporter,
 ) plugincommon.PluginProcessor[Query, Observation, Outcome] {
 	p := &processor{
 		oracleID:         oracleID,

--- a/commit/tokenprice/processor.go
+++ b/commit/tokenprice/processor.go
@@ -50,7 +50,7 @@ func NewProcessor(
 		fRoleDON:         fRoleDON,
 		metricsReporter:  metricsReporter,
 	}
-	return plugincommon.NewObservedProcessor(lggr, p, "tokenprice", metricsReporter)
+	return plugincommon.NewTrackedProcessor(lggr, p, "tokenprice", metricsReporter)
 }
 
 func (p *processor) Query(ctx context.Context, prevOutcome Outcome) (Query, error) {

--- a/commit/tokenprice/processor.go
+++ b/commit/tokenprice/processor.go
@@ -50,7 +50,7 @@ func NewProcessor(
 		fRoleDON:         fRoleDON,
 		metricsReporter:  metricsReporter,
 	}
-	return plugincommon.NewTrackedProcessor(lggr, p, "tokenprice", metricsReporter)
+	return plugincommon.NewTrackedProcessor(lggr, p, processorsLabel, metricsReporter)
 }
 
 func (p *processor) Query(ctx context.Context, prevOutcome Outcome) (Query, error) {

--- a/commit/tokenprice/processor.go
+++ b/commit/tokenprice/processor.go
@@ -39,7 +39,7 @@ func NewProcessor(
 	fRoleDON int,
 	metricsReporter MetricsReporter,
 ) plugincommon.PluginProcessor[Query, Observation, Outcome] {
-	return &processor{
+	p := &processor{
 		oracleID:         oracleID,
 		lggr:             lggr,
 		offChainCfg:      offChainCfg,
@@ -50,6 +50,7 @@ func NewProcessor(
 		fRoleDON:         fRoleDON,
 		metricsReporter:  metricsReporter,
 	}
+	return plugincommon.NewObservedProcessor(lggr, p, "tokenprice", metricsReporter)
 }
 
 func (p *processor) Query(ctx context.Context, prevOutcome Outcome) (Query, error) {

--- a/commit/tokenprice/processor.go
+++ b/commit/tokenprice/processor.go
@@ -89,7 +89,6 @@ func (p *processor) Outcome(
 	}
 
 	out := Outcome{TokenPrices: tokenPriceOutcome}
-	p.metricsReporter.TrackTokenPricesOutcome(out)
 	return out, nil
 }
 

--- a/commit/tokenprice/types.go
+++ b/commit/tokenprice/types.go
@@ -10,6 +10,7 @@ import (
 )
 
 const (
+	processorsLabel            = "tokenprice"
 	tokenPricesLabel           = "tokenPrices"
 	feedTokenPricesLabel       = "feedTokenPrices"
 	feeQuoterTokenUpdatesLabel = "feeQuoterTokenUpdates"

--- a/commit/tokenprice/types.go
+++ b/commit/tokenprice/types.go
@@ -71,22 +71,3 @@ type Observer interface {
 
 	ObserveFChain() map[cciptypes.ChainSelector]int
 }
-
-// MetricsReporter exposes only relevant methods for reporting token prices from metrics.Reporter
-type MetricsReporter interface {
-	TrackProcessorLatency(processor string, method string, latency time.Duration, err error)
-	TrackProcessorObservation(processor string, obs plugintypes.Trackable)
-	TrackProcessorOutcome(processor string, out plugintypes.Trackable)
-}
-
-type NoopMetrics struct{}
-
-func (n NoopMetrics) TrackTokenPricesObservation(Observation) {}
-
-func (n NoopMetrics) TrackTokenPricesOutcome(Outcome) {}
-
-func (n NoopMetrics) TrackProcessorLatency(string, string, time.Duration, error) {}
-
-func (n NoopMetrics) TrackProcessorObservation(string, plugintypes.Trackable) {}
-
-func (n NoopMetrics) TrackProcessorOutcome(string, plugintypes.Trackable) {}

--- a/commit/tokenprice/types.go
+++ b/commit/tokenprice/types.go
@@ -57,6 +57,7 @@ type Observer interface {
 type MetricsReporter interface {
 	TrackTokenPricesObservation(obs Observation)
 	TrackTokenPricesOutcome(outcome Outcome)
+	TrackProcessorLatency(processor string, method string, latency time.Duration)
 }
 
 type NoopMetrics struct{}
@@ -64,3 +65,5 @@ type NoopMetrics struct{}
 func (n NoopMetrics) TrackTokenPricesObservation(Observation) {}
 
 func (n NoopMetrics) TrackTokenPricesOutcome(Outcome) {}
+
+func (n NoopMetrics) TrackProcessorLatency(string, string, time.Duration) {}

--- a/commit/tokenprice/types.go
+++ b/commit/tokenprice/types.go
@@ -9,11 +9,23 @@ import (
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
 
+const (
+	tokenPricesLabel           = "tokenPrices"
+	feedTokenPricesLabel       = "feedTokenPrices"
+	feeQuoterTokenUpdatesLabel = "feeQuoterTokenUpdates"
+)
+
 type Query struct {
 }
 
 type Outcome struct {
 	TokenPrices cciptypes.TokenPriceMap `json:"tokenPrices"`
+}
+
+func (out Outcome) Stats() map[string]int {
+	return map[string]int{
+		tokenPricesLabel: len(out.TokenPrices),
+	}
 }
 
 type Observation struct {
@@ -25,6 +37,13 @@ type Observation struct {
 
 func (obs Observation) IsEmpty() bool {
 	return len(obs.FeedTokenPrices) == 0 && len(obs.FeeQuoterTokenUpdates) == 0 && len(obs.FChain) == 0
+}
+
+func (obs Observation) Stats() map[string]int {
+	return map[string]int{
+		feedTokenPricesLabel:       len(obs.FeedTokenPrices),
+		feeQuoterTokenUpdatesLabel: len(obs.FeeQuoterTokenUpdates),
+	}
 }
 
 // AggregateObservation is the aggregation of a list of observations
@@ -55,9 +74,9 @@ type Observer interface {
 
 // MetricsReporter exposes only relevant methods for reporting token prices from metrics.Reporter
 type MetricsReporter interface {
-	TrackTokenPricesObservation(obs Observation)
-	TrackTokenPricesOutcome(outcome Outcome)
 	TrackProcessorLatency(processor string, method string, latency time.Duration)
+	TrackProcessorObservation(processor string, obs plugintypes.Trackable, err error)
+	TrackProcessorOutcome(processor string, out plugintypes.Trackable, err error)
 }
 
 type NoopMetrics struct{}
@@ -67,3 +86,7 @@ func (n NoopMetrics) TrackTokenPricesObservation(Observation) {}
 func (n NoopMetrics) TrackTokenPricesOutcome(Outcome) {}
 
 func (n NoopMetrics) TrackProcessorLatency(string, string, time.Duration) {}
+
+func (n NoopMetrics) TrackProcessorObservation(string, plugintypes.Trackable, error) {}
+
+func (n NoopMetrics) TrackProcessorOutcome(string, plugintypes.Trackable, error) {}

--- a/commit/tokenprice/types.go
+++ b/commit/tokenprice/types.go
@@ -74,9 +74,9 @@ type Observer interface {
 
 // MetricsReporter exposes only relevant methods for reporting token prices from metrics.Reporter
 type MetricsReporter interface {
-	TrackProcessorLatency(processor string, method string, latency time.Duration)
-	TrackProcessorObservation(processor string, obs plugintypes.Trackable, err error)
-	TrackProcessorOutcome(processor string, out plugintypes.Trackable, err error)
+	TrackProcessorLatency(processor string, method string, latency time.Duration, err error)
+	TrackProcessorObservation(processor string, obs plugintypes.Trackable)
+	TrackProcessorOutcome(processor string, out plugintypes.Trackable)
 }
 
 type NoopMetrics struct{}
@@ -85,8 +85,8 @@ func (n NoopMetrics) TrackTokenPricesObservation(Observation) {}
 
 func (n NoopMetrics) TrackTokenPricesOutcome(Outcome) {}
 
-func (n NoopMetrics) TrackProcessorLatency(string, string, time.Duration) {}
+func (n NoopMetrics) TrackProcessorLatency(string, string, time.Duration, error) {}
 
-func (n NoopMetrics) TrackProcessorObservation(string, plugintypes.Trackable, error) {}
+func (n NoopMetrics) TrackProcessorObservation(string, plugintypes.Trackable) {}
 
-func (n NoopMetrics) TrackProcessorOutcome(string, plugintypes.Trackable, error) {}
+func (n NoopMetrics) TrackProcessorOutcome(string, plugintypes.Trackable) {}

--- a/internal/plugincommon/discovery/discoverytypes/types.go
+++ b/internal/plugincommon/discovery/discoverytypes/types.go
@@ -11,6 +11,10 @@ type Outcome struct {
 	// Request bool
 }
 
+func (o Outcome) Stats() map[string]int {
+	return map[string]int{}
+}
+
 // Query isn't needed for this processor.
 type Query []byte
 
@@ -23,6 +27,10 @@ type Observation struct {
 
 	// TODO: some sort of request flag to avoid including this every time.
 	// Request bool
+}
+
+func (o Observation) Stats() map[string]int {
+	return map[string]int{}
 }
 
 func (o Observation) IsEmpty() bool {

--- a/internal/plugincommon/discovery/processor.go
+++ b/internal/plugincommon/discovery/processor.go
@@ -48,7 +48,7 @@ func NewContractDiscoveryProcessor(
 		fRoleDON:        fRoleDON,
 		oracleIDToP2PID: oracleIDToP2PID,
 	}
-	return plugincommon.NewObservedProcessor(lggr, p, "discovery", plugincommon.NoopReporter{})
+	return plugincommon.NewTrackedProcessor(lggr, p, "discovery", plugincommon.NoopReporter{})
 }
 
 // Query is not needed for this processor.

--- a/internal/plugincommon/discovery/processor.go
+++ b/internal/plugincommon/discovery/processor.go
@@ -39,8 +39,8 @@ func NewContractDiscoveryProcessor(
 	dest cciptypes.ChainSelector,
 	fRoleDON int,
 	oracleIDToP2PID map[commontypes.OracleID]ragep2ptypes.PeerID,
-) *ContractDiscoveryProcessor {
-	return &ContractDiscoveryProcessor{
+) plugincommon.PluginProcessor[dt.Query, dt.Observation, dt.Outcome] {
+	p := &ContractDiscoveryProcessor{
 		lggr:            lggr,
 		reader:          reader,
 		homechain:       homechain,
@@ -48,6 +48,7 @@ func NewContractDiscoveryProcessor(
 		fRoleDON:        fRoleDON,
 		oracleIDToP2PID: oracleIDToP2PID,
 	}
+	return plugincommon.NewObservedProcessor(lggr, p, "discovery", plugincommon.NoopReporter{})
 }
 
 // Query is not needed for this processor.

--- a/internal/plugincommon/observed_processor.go
+++ b/internal/plugincommon/observed_processor.go
@@ -85,7 +85,6 @@ type NoopReporter struct{}
 
 func (n NoopReporter) TrackProcessorLatency(string, string, time.Duration, error) {}
 
-func (n NoopReporter) TrackProcessorObservation(processor string, obs plugintypes.Trackable) {
-}
+func (n NoopReporter) TrackProcessorObservation(string, plugintypes.Trackable) {}
 
-func (n NoopReporter) TrackProcessorOutcome(processor string, out plugintypes.Trackable) {}
+func (n NoopReporter) TrackProcessorOutcome(string, plugintypes.Trackable) {}

--- a/internal/plugincommon/observed_processor.go
+++ b/internal/plugincommon/observed_processor.go
@@ -1,0 +1,73 @@
+package plugincommon
+
+import (
+	"context"
+	"time"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+type MetricsReporter interface {
+	TrackProcessorLatency(processor string, method string, latency time.Duration)
+}
+
+type ObservedProcessor[Query any, Observation any, Outcome any] struct {
+	PluginProcessor[Query, Observation, Outcome]
+	lggr          logger.Logger
+	processorName string
+	reporter      MetricsReporter
+}
+
+func NewObservedProcessor[Query any, Observation any, Outcome any](
+	lggr logger.Logger,
+	origin PluginProcessor[Query, Observation, Outcome],
+	processorName string,
+	reporter MetricsReporter,
+) *ObservedProcessor[Query, Observation, Outcome] {
+	return &ObservedProcessor[Query, Observation, Outcome]{
+		PluginProcessor: origin,
+		lggr:            lggr,
+		processorName:   processorName,
+		reporter:        reporter,
+	}
+}
+
+func (p *ObservedProcessor[Query, Observation, Outcome]) Query(ctx context.Context, prev Outcome) (Query, error) {
+	return withObservedQuery[Query](p, "query", func() (Query, error) {
+		return p.PluginProcessor.Query(ctx, prev)
+	})
+}
+
+func (p *ObservedProcessor[Query, Observation, Outcome]) Observation(ctx context.Context, prev Outcome, query Query) (Observation, error) {
+	return withObservedQuery[Observation](p, "observation", func() (Observation, error) {
+		return p.PluginProcessor.Observation(ctx, prev, query)
+	})
+}
+
+func (p *ObservedProcessor[Query, Observation, Outcome]) Outcome(ctx context.Context, prev Outcome, query Query, aos []AttributedObservation[Observation]) (Outcome, error) {
+	return withObservedQuery[Outcome](p, "outcome", func() (Outcome, error) {
+		return p.PluginProcessor.Outcome(ctx, prev, query, aos)
+	})
+}
+
+func withObservedQuery[T any, Query any, Observation any, Outcome any](
+	p *ObservedProcessor[Query, Observation, Outcome],
+	method string,
+	f func() (T, error),
+) (T, error) {
+	queryStarted := time.Now()
+	defer func() {
+		latency := time.Since(queryStarted)
+		p.reporter.TrackProcessorLatency(p.processorName, method, latency)
+		p.lggr.Debugw("tracking processor latency",
+			"processor", p.processorName,
+			"method", method,
+			"latency", latency,
+		)
+	}()
+	return f()
+}
+
+type NoopReporter struct{}
+
+func (n NoopReporter) TrackProcessorLatency(string, string, time.Duration) {}

--- a/internal/plugincommon/observed_processor.go
+++ b/internal/plugincommon/observed_processor.go
@@ -5,20 +5,24 @@ import (
 	"time"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
+	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
 )
 
 type MetricsReporter interface {
+	TrackProcessorObservation(processor string, obs plugintypes.Trackable, err error)
+	TrackProcessorOutcome(processor string, out plugintypes.Trackable, err error)
 	TrackProcessorLatency(processor string, method string, latency time.Duration)
 }
 
-type ObservedProcessor[Query any, Observation any, Outcome any] struct {
+type ObservedProcessor[Query any, Observation plugintypes.Trackable, Outcome plugintypes.Trackable] struct {
 	PluginProcessor[Query, Observation, Outcome]
 	lggr          logger.Logger
 	processorName string
 	reporter      MetricsReporter
 }
 
-func NewObservedProcessor[Query any, Observation any, Outcome any](
+func NewObservedProcessor[Query any, Observation plugintypes.Trackable, Outcome plugintypes.Trackable](
 	lggr logger.Logger,
 	origin PluginProcessor[Query, Observation, Outcome],
 	processorName string,
@@ -39,18 +43,22 @@ func (p *ObservedProcessor[Query, Observation, Outcome]) Query(ctx context.Conte
 }
 
 func (p *ObservedProcessor[Query, Observation, Outcome]) Observation(ctx context.Context, prev Outcome, query Query) (Observation, error) {
-	return withObservedQuery[Observation](p, "observation", func() (Observation, error) {
+	obs, err := withObservedQuery[Observation](p, "observation", func() (Observation, error) {
 		return p.PluginProcessor.Observation(ctx, prev, query)
 	})
+	p.reporter.TrackProcessorObservation(p.processorName, obs, err)
+	return obs, err
 }
 
 func (p *ObservedProcessor[Query, Observation, Outcome]) Outcome(ctx context.Context, prev Outcome, query Query, aos []AttributedObservation[Observation]) (Outcome, error) {
-	return withObservedQuery[Outcome](p, "outcome", func() (Outcome, error) {
+	out, err := withObservedQuery[Outcome](p, "outcome", func() (Outcome, error) {
 		return p.PluginProcessor.Outcome(ctx, prev, query, aos)
 	})
+	p.reporter.TrackProcessorOutcome(p.processorName, out, err)
+	return out, err
 }
 
-func withObservedQuery[T any, Query any, Observation any, Outcome any](
+func withObservedQuery[T any, Query any, Observation plugintypes.Trackable, Outcome plugintypes.Trackable](
 	p *ObservedProcessor[Query, Observation, Outcome],
 	method string,
 	f func() (T, error),
@@ -71,3 +79,8 @@ func withObservedQuery[T any, Query any, Observation any, Outcome any](
 type NoopReporter struct{}
 
 func (n NoopReporter) TrackProcessorLatency(string, string, time.Duration) {}
+
+func (n NoopReporter) TrackProcessorObservation(processor string, obs plugintypes.Trackable, err error) {
+}
+
+func (n NoopReporter) TrackProcessorOutcome(processor string, out plugintypes.Trackable, err error) {}

--- a/internal/plugincommon/tracked_processor.go
+++ b/internal/plugincommon/tracked_processor.go
@@ -41,7 +41,7 @@ func NewTrackedProcessor[Query any, Observation plugintypes.Trackable, Outcome p
 }
 
 func (p *TrackedProcessor[Query, Observation, Outcome]) Query(ctx context.Context, prev Outcome) (Query, error) {
-	return withObservedQuery[Query](p, "query", func() (Query, error) {
+	return withTrackedMethod[Query](p, "query", func() (Query, error) {
 		return p.PluginProcessor.Query(ctx, prev)
 	})
 }
@@ -51,7 +51,7 @@ func (p *TrackedProcessor[Query, Observation, Outcome]) Observation(
 	prev Outcome,
 	query Query,
 ) (Observation, error) {
-	obs, err := withObservedQuery[Observation](p, "observation", func() (Observation, error) {
+	obs, err := withTrackedMethod[Observation](p, "observation", func() (Observation, error) {
 		return p.PluginProcessor.Observation(ctx, prev, query)
 	})
 	if err != nil {
@@ -66,7 +66,7 @@ func (p *TrackedProcessor[Query, Observation, Outcome]) Outcome(
 	query Query,
 	aos []AttributedObservation[Observation],
 ) (Outcome, error) {
-	out, err := withObservedQuery[Outcome](p, "outcome", func() (Outcome, error) {
+	out, err := withTrackedMethod[Outcome](p, "outcome", func() (Outcome, error) {
 		return p.PluginProcessor.Outcome(ctx, prev, query, aos)
 	})
 	if err != nil {
@@ -75,7 +75,7 @@ func (p *TrackedProcessor[Query, Observation, Outcome]) Outcome(
 	return out, err
 }
 
-func withObservedQuery[T any, Query any, Observation plugintypes.Trackable, Outcome plugintypes.Trackable](
+func withTrackedMethod[T any, Query any, Observation plugintypes.Trackable, Outcome plugintypes.Trackable](
 	p *TrackedProcessor[Query, Observation, Outcome],
 	method string,
 	f func() (T, error),

--- a/internal/plugincommon/tracked_processor.go
+++ b/internal/plugincommon/tracked_processor.go
@@ -15,20 +15,24 @@ type MetricsReporter interface {
 	TrackProcessorLatency(processor string, method string, latency time.Duration, err error)
 }
 
-type ObservedProcessor[Query any, Observation plugintypes.Trackable, Outcome plugintypes.Trackable] struct {
+// TrackedProcessor wraps a PluginProcessor and tracks
+// * latencies of most of the perf critical methods (Query, Observation, Outcome)
+// * observations and outcomes (and their stats) of the processor
+// * errors in the tracked methods
+type TrackedProcessor[Query any, Observation plugintypes.Trackable, Outcome plugintypes.Trackable] struct {
 	PluginProcessor[Query, Observation, Outcome]
 	lggr          logger.Logger
 	processorName string
 	reporter      MetricsReporter
 }
 
-func NewObservedProcessor[Query any, Observation plugintypes.Trackable, Outcome plugintypes.Trackable](
+func NewTrackedProcessor[Query any, Observation plugintypes.Trackable, Outcome plugintypes.Trackable](
 	lggr logger.Logger,
 	origin PluginProcessor[Query, Observation, Outcome],
 	processorName string,
 	reporter MetricsReporter,
-) *ObservedProcessor[Query, Observation, Outcome] {
-	return &ObservedProcessor[Query, Observation, Outcome]{
+) *TrackedProcessor[Query, Observation, Outcome] {
+	return &TrackedProcessor[Query, Observation, Outcome]{
 		PluginProcessor: origin,
 		lggr:            lggr,
 		processorName:   processorName,
@@ -36,13 +40,17 @@ func NewObservedProcessor[Query any, Observation plugintypes.Trackable, Outcome 
 	}
 }
 
-func (p *ObservedProcessor[Query, Observation, Outcome]) Query(ctx context.Context, prev Outcome) (Query, error) {
+func (p *TrackedProcessor[Query, Observation, Outcome]) Query(ctx context.Context, prev Outcome) (Query, error) {
 	return withObservedQuery[Query](p, "query", func() (Query, error) {
 		return p.PluginProcessor.Query(ctx, prev)
 	})
 }
 
-func (p *ObservedProcessor[Query, Observation, Outcome]) Observation(ctx context.Context, prev Outcome, query Query) (Observation, error) {
+func (p *TrackedProcessor[Query, Observation, Outcome]) Observation(
+	ctx context.Context,
+	prev Outcome,
+	query Query,
+) (Observation, error) {
 	obs, err := withObservedQuery[Observation](p, "observation", func() (Observation, error) {
 		return p.PluginProcessor.Observation(ctx, prev, query)
 	})
@@ -52,7 +60,12 @@ func (p *ObservedProcessor[Query, Observation, Outcome]) Observation(ctx context
 	return obs, err
 }
 
-func (p *ObservedProcessor[Query, Observation, Outcome]) Outcome(ctx context.Context, prev Outcome, query Query, aos []AttributedObservation[Observation]) (Outcome, error) {
+func (p *TrackedProcessor[Query, Observation, Outcome]) Outcome(
+	ctx context.Context,
+	prev Outcome,
+	query Query,
+	aos []AttributedObservation[Observation],
+) (Outcome, error) {
 	out, err := withObservedQuery[Outcome](p, "outcome", func() (Outcome, error) {
 		return p.PluginProcessor.Outcome(ctx, prev, query, aos)
 	})
@@ -63,7 +76,7 @@ func (p *ObservedProcessor[Query, Observation, Outcome]) Outcome(ctx context.Con
 }
 
 func withObservedQuery[T any, Query any, Observation plugintypes.Trackable, Outcome plugintypes.Trackable](
-	p *ObservedProcessor[Query, Observation, Outcome],
+	p *TrackedProcessor[Query, Observation, Outcome],
 	method string,
 	f func() (T, error),
 ) (T, error) {

--- a/internal/plugintypes/common.go
+++ b/internal/plugintypes/common.go
@@ -37,6 +37,10 @@ func NewUSD18(value int64) USD18 {
 	return big.NewInt(value)
 }
 
+// Trackable is an interface for types that can be tracked using Prometheus metrics.
+// That way we are moving responsibility of presenting proper stats and metrics to
+// the underlying types. It's meant to be implemented by Observation and Outcome in
+// the Commit Plugin's processors.
 type Trackable interface {
 	Stats() map[string]int
 }

--- a/internal/plugintypes/common.go
+++ b/internal/plugintypes/common.go
@@ -36,3 +36,7 @@ type USD18 = *big.Int
 func NewUSD18(value int64) USD18 {
 	return big.NewInt(value)
 }
+
+type Trackable interface {
+	Stats() map[string]int
+}


### PR DESCRIPTION
Simplifying tracking metrics for the processors by:
* reducing number of interfaces and moving stats to the struct 
* reducing number of method in the reporter
* tracking metrics is done in the decorator (see `TrackedProcessor`), so plugin is less polluted with the observability stuff 
* any processor can add tracking of their observations and outcomes as long it's wrapped with TrackedProcessor 

Additionally, tracking errors and latencies for the processor methods 