### PR TITLE
Parallelize price observations

### DIFF
--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -373,7 +373,6 @@ func (p *Plugin) getPriceRelatedObservations(
 	}()
 
 	wg.Wait()
-
 	return tokenPriceObs, chainFeeObs
 }
 


### PR DESCRIPTION
A quick solution to speed up price observations of commit plugin.
There will be a follow up with a solution similar to the merkle roots processor.