### PR TITLE
fix: Token price only reports were missing data in report info

### DIFF
--- a/commit/report.go
+++ b/commit/report.go
@@ -85,6 +85,7 @@ func (p *Plugin) Reports(
 	// OutcomeType == ReportGenerated is only true when roots are present, but
 	// reports can also only contain token price updates
 	repInfo.TokenPrices = rep.PriceUpdates.TokenPriceUpdates
+	repInfo.GasPrices = rep.PriceUpdates.GasPriceUpdates
 
 	if rep.IsEmpty() {
 		lggr.Infow("empty report", "report", rep)

--- a/commit/report.go
+++ b/commit/report.go
@@ -79,9 +79,12 @@ func (p *Plugin) Reports(
 		repInfo = cciptypes.CommitReportInfo{
 			RemoteF:     outcome.MerkleRootOutcome.RMNRemoteCfg.FSign,
 			MerkleRoots: allRoots,
-			TokenPrices: rep.PriceUpdates.TokenPriceUpdates,
 		}
 	}
+
+	// OutcomeType == ReportGenerated is only true when roots are present, but
+	// reports can also only contain token price updates
+	repInfo.TokenPrices = rep.PriceUpdates.TokenPriceUpdates
 
 	if rep.IsEmpty() {
 		lggr.Infow("empty report", "report", rep)

--- a/pkg/types/ccipocr3/plugin_commit_types.go
+++ b/pkg/types/ccipocr3/plugin_commit_types.go
@@ -75,6 +75,7 @@ type CommitReportInfo struct {
 	RemoteF     uint64            `json:"remoteF"`
 	MerkleRoots []MerkleRootChain `json:"merkleRoots"`
 	TokenPrices []TokenPrice      `json:"tokenPrices"`
+	GasPrices   []GasPriceChain   `json:"gasPrices"`
 }
 
 func (cri CommitReportInfo) Encode() ([]byte, error) {


### PR DESCRIPTION
Fixes a mistake from https://github.com/smartcontractkit/chainlink-ccip/pull/505, without this change price update reports would contain empty report info.