### PR TITLE
remove extra data codec and encoded maps

### DIFF
--- a/commit/factory.go
+++ b/commit/factory.go
@@ -69,7 +69,6 @@ type PluginFactory struct {
 	ocrConfig         reader.OCR3ConfigWithMeta
 	commitCodec       cciptypes.CommitPluginCodec
 	msgHasher         cciptypes.MessageHasher
-	extraDataCodec    cciptypes.ExtraDataCodec
 	homeChainReader   reader.HomeChain
 	homeChainSelector cciptypes.ChainSelector
 	contractReaders   map[cciptypes.ChainSelector]types.ContractReader
@@ -84,7 +83,6 @@ type CommitPluginFactoryParams struct {
 	OcrConfig         reader.OCR3ConfigWithMeta
 	CommitCodec       cciptypes.CommitPluginCodec
 	MsgHasher         cciptypes.MessageHasher
-	ExtraDataCodec    cciptypes.ExtraDataCodec
 	HomeChainReader   reader.HomeChain
 	HomeChainSelector cciptypes.ChainSelector
 	ContractReaders   map[cciptypes.ChainSelector]types.ContractReader
@@ -102,7 +100,6 @@ func NewCommitPluginFactory(params CommitPluginFactoryParams) *PluginFactory {
 		ocrConfig:         params.OcrConfig,
 		commitCodec:       params.CommitCodec,
 		msgHasher:         params.MsgHasher,
-		extraDataCodec:    params.ExtraDataCodec,
 		homeChainReader:   params.HomeChainReader,
 		homeChainSelector: params.HomeChainSelector,
 		contractReaders:   params.ContractReaders,
@@ -183,7 +180,6 @@ func (p *PluginFactory) NewReportingPlugin(ctx context.Context, config ocr3types
 		p.chainWriters,
 		p.ocrConfig.Config.ChainSelector,
 		p.ocrConfig.Config.OfframpAddress,
-		p.extraDataCodec,
 	)
 
 	// The node supports the chain that the token prices are on.

--- a/execute/factory.go
+++ b/execute/factory.go
@@ -68,7 +68,6 @@ type PluginFactory struct {
 	ocrConfig        reader.OCR3ConfigWithMeta
 	execCodec        cciptypes.ExecutePluginCodec
 	msgHasher        cciptypes.MessageHasher
-	extraDataCodec   cciptypes.ExtraDataCodec
 	homeChainReader  reader.HomeChain
 	estimateProvider cciptypes.EstimateProvider
 	tokenDataEncoder cciptypes.TokenDataEncoder
@@ -99,7 +98,6 @@ func NewExecutePluginFactory(params PluginFactoryParams) *PluginFactory {
 		ocrConfig:        params.OcrConfig,
 		execCodec:        params.ExecCodec,
 		msgHasher:        params.MsgHasher,
-		extraDataCodec:   params.ExtraDataCodec,
 		homeChainReader:  params.HomeChainReader,
 		estimateProvider: params.EstimateProvider,
 		tokenDataEncoder: params.TokenDataEncoder,

--- a/execute/factory.go
+++ b/execute/factory.go
@@ -147,7 +147,6 @@ func (p PluginFactory) NewReportingPlugin(
 		p.chainWriters,
 		p.ocrConfig.Config.ChainSelector,
 		p.ocrConfig.Config.OfframpAddress,
-		p.extraDataCodec,
 	)
 
 	tokenDataObserver, err := tokendata.NewConfigBasedCompositeObservers(

--- a/pkg/reader/ccip_interface.go
+++ b/pkg/reader/ccip_interface.go
@@ -78,7 +78,6 @@ func NewCCIPChainReader(
 	contractWriters map[cciptypes.ChainSelector]types.ContractWriter,
 	destChain cciptypes.ChainSelector,
 	offrampAddress []byte,
-	extraDataCodec cciptypes.ExtraDataCodec,
 ) CCIPReader {
 	return NewObservedCCIPReader(
 		newCCIPChainReaderInternal(
@@ -88,7 +87,6 @@ func NewCCIPChainReader(
 			contractWriters,
 			destChain,
 			offrampAddress,
-			extraDataCodec,
 		),
 		destChain,
 	)
@@ -102,9 +100,8 @@ func NewCCIPReaderWithExtendedContractReaders(
 	contractWriters map[cciptypes.ChainSelector]types.ContractWriter,
 	destChain cciptypes.ChainSelector,
 	offrampAddress []byte,
-	extraDataCodec cciptypes.ExtraDataCodec,
 ) CCIPReader {
-	cr := newCCIPChainReaderInternal(ctx, lggr, nil, contractWriters, destChain, offrampAddress, extraDataCodec)
+	cr := newCCIPChainReaderInternal(ctx, lggr, nil, contractWriters, destChain, offrampAddress)
 	for ch, extendedCr := range contractReaders {
 		cr.WithExtendedContractReader(ch, extendedCr)
 	}

--- a/pkg/reader/ccip_test.go
+++ b/pkg/reader/ccip_test.go
@@ -16,8 +16,6 @@ import (
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/exp/maps"
 
-	"github.com/smartcontractkit/chainlink-ccip/mocks/pkg/types/ccipocr3"
-
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
@@ -88,7 +86,6 @@ func TestCCIPChainReader_getSourceChainsConfig(t *testing.T) {
 			chainB: sourceCRs[chainB],
 			chainC: destCR,
 		}, nil, chainC, offrampAddress,
-		ccipocr3.NewMockExtraDataCodec(t),
 	)
 
 	require.NoError(t, ccipReader.contractReaders[chainA].Bind(
@@ -826,7 +823,6 @@ func TestCCIPChainReader_getFeeQuoterTokenPriceUSD(t *testing.T) {
 		map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
 			chainC: destCR,
 		}, nil, chainC, offrampAddress,
-		ccipocr3.NewMockExtraDataCodec(t),
 	)
 
 	require.NoError(t, ccipReader.contractReaders[chainC].Bind(
@@ -859,7 +855,6 @@ func TestCCIPFeeComponents_HappyPath(t *testing.T) {
 		contractWriters,
 		chainC,
 		[]byte{0x3},
-		ccipocr3.NewMockExtraDataCodec(t),
 	)
 
 	ctx := context.Background()
@@ -888,7 +883,6 @@ func TestCCIPFeeComponents_NotFoundErrors(t *testing.T) {
 		contractWriters,
 		chainC,
 		[]byte{0x3},
-		ccipocr3.NewMockExtraDataCodec(t),
 	)
 
 	ctx := context.Background()

--- a/pkg/types/ccipocr3/generic_types.go
+++ b/pkg/types/ccipocr3/generic_types.go
@@ -163,10 +163,6 @@ type Message struct {
 	// such as the gasLimit for EVM chains.
 	// This field is encoded in the source chain encoding scheme.
 	ExtraArgs Bytes `json:"extraArgs"`
-	// ExtraArgsDecoded is same as ExtraArgs,
-	// just decoded into a named collection of arguments in a generic format,
-	// which can be read by any destination chain family.
-	ExtraArgsDecoded map[string]any `json:"extraArgsDecoded,omitempty"`
 	// FeeToken is the fee token address.
 	// i.e if the source chain is EVM, len(FeeToken) == 20 (i.e, is not abi-encoded).
 	FeeToken UnknownAddress `json:"feeToken"`
@@ -240,8 +236,4 @@ type RampTokenAmount struct {
 	// NOTE: this must be decoded before providing it as an execution input to the destination chain
 	// or hashing it. See Internal._hash(Any2EVMRampMessage) for more details as an example.
 	DestExecData Bytes `json:"destExecData"`
-	// DestExecDataDecoded is the same as DestExecData
-	// just decoded into a named collection of arguments in a generic format,
-	// which can be read by any destination chain family.
-	DestExecDataDecoded map[string]any `json:"destExecDataDecoded,omitempty"`
 }


### PR DESCRIPTION
Remove decoded map as [discussed](https://chainlink-core.slack.com/archives/C0779R3AH8R/p1739457726431579), follow up with https://github.com/smartcontractkit/chainlink/pull/16402 