### PR TITLE
remove extradata encoded map

### DIFF
--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -426,22 +426,7 @@ func (r *ccipChainReader) MsgsBetweenSeqNums(
 			continue
 		}
 
-		msg.Message.ExtraArgsDecoded, err = r.extraDataCodec.DecodeExtraArgs(msg.Message.ExtraArgs, sourceChainSelector)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode the ExtraArgs: %w", err)
-		}
-
 		msg.Message.Header.OnRamp = onRampAddress
-
-		for i, tokenAmount := range msg.Message.TokenAmounts {
-			msg.Message.TokenAmounts[i].DestExecDataDecoded, err = r.extraDataCodec.DecodeTokenAmountDestExecData(
-				tokenAmount.DestExecData,
-				sourceChainSelector,
-			)
-			if err != nil {
-				return nil, fmt.Errorf("failed to decode token amount destExecData (%v): %w", tokenAmount.DestExecData, err)
-			}
-		}
 		msgs = append(msgs, msg.Message)
 	}
 

--- a/pkg/types/ccipocr3/generic_types.go
+++ b/pkg/types/ccipocr3/generic_types.go
@@ -163,10 +163,6 @@ type Message struct {
 	// such as the gasLimit for EVM chains.
 	// This field is encoded in the source chain encoding scheme.
 	ExtraArgs Bytes `json:"extraArgs"`
-	// ExtraArgsDecoded is same as ExtraArgs,
-	// just decoded into a named collection of arguments in a generic format,
-	// which can be read by any destination chain family.
-	ExtraArgsDecoded map[string]any `json:"extraArgsDecoded,omitempty"`
 	// FeeToken is the fee token address.
 	// i.e if the source chain is EVM, len(FeeToken) == 20 (i.e, is not abi-encoded).
 	FeeToken UnknownAddress `json:"feeToken"`
@@ -240,8 +236,4 @@ type RampTokenAmount struct {
 	// NOTE: this must be decoded before providing it as an execution input to the destination chain
 	// or hashing it. See Internal._hash(Any2EVMRampMessage) for more details as an example.
 	DestExecData Bytes `json:"destExecData"`
-	// DestExecDataDecoded is the same as DestExecData
-	// just decoded into a named collection of arguments in a generic format,
-	// which can be read by any destination chain family.
-	DestExecDataDecoded map[string]any `json:"destExecDataDecoded,omitempty"`
 }


### PR DESCRIPTION
Remove decoded map as [discussed](https://chainlink-core.slack.com/archives/C0779R3AH8R/p1739457726431579), follow up with https://github.com/smartcontractkit/chainlink/pull/16402 