### PR TITLE
CCIP-5262 Improvements to prometheus metrics 

### DIFF
--- a/commit/metrics/prom.go
+++ b/commit/metrics/prom.go
@@ -42,6 +42,7 @@ var (
 				float64(5 * time.Second),
 				float64(7 * time.Second),
 				float64(10 * time.Second),
+				float64(20 * time.Second),
 			},
 		},
 		[]string{"chainID", "processor", "method"},

--- a/commit/metrics/prom_test.go
+++ b/commit/metrics/prom_test.go
@@ -416,18 +416,24 @@ func Test_LatencyAndErrors(t *testing.T) {
 }
 
 func Test_SequenceNumbers(t *testing.T) {
+	chain1 := "2337"
+	selector1 := cciptypes.ChainSelector(12922642891491394802)
+	chain2 := "3337"
+	selector2 := cciptypes.ChainSelector(4793464827907405086)
+	selector3 := cciptypes.ChainSelector(909606746561742123)
+
 	tt := []struct {
 		name   string
 		obs    committypes.Observation
 		out    committypes.Outcome
 		method plugincommon.MethodType
-		exp    map[cciptypes.ChainSelector]cciptypes.SeqNum
+		exp    map[string]cciptypes.SeqNum
 	}{
 		{
 			name:   "empty observation should not report anything",
 			obs:    committypes.Observation{},
 			method: plugincommon.ObservationMethod,
-			exp:    map[cciptypes.ChainSelector]cciptypes.SeqNum{},
+			exp:    map[string]cciptypes.SeqNum{},
 		},
 		{
 			name: "single chain observation with seq nr",
@@ -435,15 +441,15 @@ func Test_SequenceNumbers(t *testing.T) {
 				MerkleRootObs: merkleroot.Observation{
 					MerkleRoots: []cciptypes.MerkleRootChain{
 						{
-							ChainSel:     cciptypes.ChainSelector(123),
+							ChainSel:     selector1,
 							SeqNumsRange: cciptypes.NewSeqNumRange(1, 2),
 						},
 					},
 				},
 			},
 			method: plugincommon.ObservationMethod,
-			exp: map[cciptypes.ChainSelector]cciptypes.SeqNum{
-				123: 2,
+			exp: map[string]cciptypes.SeqNum{
+				chain1: 2,
 			},
 		},
 		{
@@ -452,24 +458,24 @@ func Test_SequenceNumbers(t *testing.T) {
 				MerkleRootObs: merkleroot.Observation{
 					MerkleRoots: []cciptypes.MerkleRootChain{
 						{
-							ChainSel:     cciptypes.ChainSelector(123),
+							ChainSel:     selector1,
 							SeqNumsRange: cciptypes.NewSeqNumRange(1, 2),
 						},
 						{
-							ChainSel:     cciptypes.ChainSelector(456),
+							ChainSel:     selector2,
 							SeqNumsRange: cciptypes.NewSeqNumRange(3, 4),
 						},
 						{
-							ChainSel:     cciptypes.ChainSelector(789),
+							ChainSel:     selector3,
 							SeqNumsRange: cciptypes.NewSeqNumRange(0, 0),
 						},
 					},
 				},
 			},
 			method: plugincommon.ObservationMethod,
-			exp: map[cciptypes.ChainSelector]cciptypes.SeqNum{
-				123: 2,
-				456: 4,
+			exp: map[string]cciptypes.SeqNum{
+				chain1: 2,
+				chain2: 4,
 			},
 		},
 		{
@@ -478,15 +484,15 @@ func Test_SequenceNumbers(t *testing.T) {
 				MerkleRootOutcome: merkleroot.Outcome{
 					RootsToReport: []cciptypes.MerkleRootChain{
 						{
-							ChainSel:     cciptypes.ChainSelector(123),
+							ChainSel:     selector1,
 							SeqNumsRange: cciptypes.NewSeqNumRange(1, 2),
 						},
 					},
 				},
 			},
 			method: plugincommon.OutcomeMethod,
-			exp: map[cciptypes.ChainSelector]cciptypes.SeqNum{
-				123: 2,
+			exp: map[string]cciptypes.SeqNum{
+				chain1: 2,
 			},
 		},
 		{
@@ -495,20 +501,20 @@ func Test_SequenceNumbers(t *testing.T) {
 				MerkleRootOutcome: merkleroot.Outcome{
 					RootsToReport: []cciptypes.MerkleRootChain{
 						{
-							ChainSel:     cciptypes.ChainSelector(123),
+							ChainSel:     selector1,
 							SeqNumsRange: cciptypes.NewSeqNumRange(1, 2),
 						},
 						{
-							ChainSel:     cciptypes.ChainSelector(456),
+							ChainSel:     selector2,
 							SeqNumsRange: cciptypes.NewSeqNumRange(3, 4),
 						},
 					},
 				},
 			},
 			method: plugincommon.OutcomeMethod,
-			exp: map[cciptypes.ChainSelector]cciptypes.SeqNum{
-				123: 2,
-				456: 4,
+			exp: map[string]cciptypes.SeqNum{
+				chain1: 2,
+				chain2: 4,
 			},
 		},
 	}
@@ -527,9 +533,9 @@ func Test_SequenceNumbers(t *testing.T) {
 				reporter.TrackOutcome(tc.out)
 			}
 
-			for sourceChainSelector, maxSeqNr := range tc.exp {
+			for sourceChain, maxSeqNr := range tc.exp {
 				seqNum := testutil.ToFloat64(
-					reporter.sequenceNumbers.WithLabelValues(chainID, sourceChainSelector.String(), tc.method),
+					reporter.sequenceNumbers.WithLabelValues(chainID, sourceChain, tc.method),
 				)
 				require.Equal(t, float64(maxSeqNr), seqNum)
 			}

--- a/execute/metrics/prom.go
+++ b/execute/metrics/prom.go
@@ -39,7 +39,15 @@ var (
 				float64(5 * time.Second),
 				float64(7 * time.Second),
 				float64(10 * time.Second),
+				float64(20 * time.Second),
 			},
+		},
+		[]string{"chainID", "method", "state"},
+	)
+	promExecErrors = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ccip_exec_errors",
+			Help: "This metric tracks the number of errors in the exec plugin",
 		},
 		[]string{"chainID", "method", "state"},
 	)
@@ -74,6 +82,7 @@ func NewPromReporter(lggr logger.Logger, selector cciptypes.ChainSelector) (*Pro
 		chainID: chainID,
 
 		latencyHistogram:     promExecLatencyHistogram,
+		execErrors:           promExecErrors,
 		outputDetailsCounter: promExecOutputCounter,
 		sequenceNumbers:      promSequenceNumbers,
 	}, nil

--- a/execute/metrics/prom.go
+++ b/execute/metrics/prom.go
@@ -17,14 +17,14 @@ import (
 )
 
 var (
-	promExecOutputCounter = promauto.NewCounterVec(
+	PromExecOutputCounter = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "ccip_exec_output_sizes",
 			Help: "This metric tracks the number of different items in the exec plugin",
 		},
 		[]string{"chainID", "method", "state", "type"},
 	)
-	promExecLatencyHistogram = promauto.NewHistogramVec(
+	PromExecLatencyHistogram = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "ccip_exec_latency",
 			Help: "This metric tracks the client-observed latency of a single exec plugin method",
@@ -44,14 +44,14 @@ var (
 		},
 		[]string{"chainID", "method", "state"},
 	)
-	promExecErrors = promauto.NewCounterVec(
+	PromExecErrors = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "ccip_exec_errors",
 			Help: "This metric tracks the number of errors in the exec plugin",
 		},
 		[]string{"chainID", "method", "state"},
 	)
-	promSequenceNumbers = promauto.NewGaugeVec(
+	PromSequenceNumbers = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "ccip_exec_max_sequence_number",
 			Help: "This metric tracks the max sequence number observed by the commit processor",
@@ -81,10 +81,10 @@ func NewPromReporter(lggr logger.Logger, selector cciptypes.ChainSelector) (*Pro
 		lggr:    lggr,
 		chainID: chainID,
 
-		latencyHistogram:     promExecLatencyHistogram,
-		execErrors:           promExecErrors,
-		outputDetailsCounter: promExecOutputCounter,
-		sequenceNumbers:      promSequenceNumbers,
+		latencyHistogram:     PromExecLatencyHistogram,
+		execErrors:           PromExecErrors,
+		outputDetailsCounter: PromExecOutputCounter,
+		sequenceNumbers:      PromSequenceNumbers,
 	}, nil
 }
 

--- a/execute/metrics/prom_test.go
+++ b/execute/metrics/prom_test.go
@@ -283,51 +283,56 @@ func Test_TrackingOutcomes(t *testing.T) {
 }
 
 func Test_SequenceNumbers(t *testing.T) {
+	chain1 := "2337"
+	selector1 := cciptypes.ChainSelector(12922642891491394802)
+	chain2 := "3337"
+	selector2 := cciptypes.ChainSelector(4793464827907405086)
+
 	tt := []struct {
 		name   string
 		obs    exectypes.Observation
 		out    exectypes.Outcome
 		method plugincommon.MethodType
-		exp    map[cciptypes.ChainSelector]cciptypes.SeqNum
+		exp    map[string]cciptypes.SeqNum
 	}{
 		{
 			name:   "empty observation should not report anything",
 			obs:    exectypes.Observation{},
 			method: plugincommon.ObservationMethod,
-			exp:    map[cciptypes.ChainSelector]cciptypes.SeqNum{},
+			exp:    map[string]cciptypes.SeqNum{},
 		},
 		{
 			name: "single chain observation with seq nr",
 			obs: exectypes.Observation{
 				Messages: exectypes.MessageObservations{
-					123: {
+					selector1: {
 						1: {},
 						4: {},
 					},
 				},
 			},
 			method: plugincommon.ObservationMethod,
-			exp: map[cciptypes.ChainSelector]cciptypes.SeqNum{
-				123: 4,
+			exp: map[string]cciptypes.SeqNum{
+				chain1: 4,
 			},
 		},
 		{
 			name: "multiple chain observations with sequence numbers",
 			obs: exectypes.Observation{
 				Messages: exectypes.MessageObservations{
-					123: {
+					selector1: {
 						1: {},
 						2: {},
 					},
-					456: {
+					selector2: {
 						4: {},
 					},
 				},
 			},
 			method: plugincommon.ObservationMethod,
-			exp: map[cciptypes.ChainSelector]cciptypes.SeqNum{
-				123: 2,
-				456: 4,
+			exp: map[string]cciptypes.SeqNum{
+				chain1: 2,
+				chain2: 4,
 			},
 		},
 		{
@@ -335,7 +340,7 @@ func Test_SequenceNumbers(t *testing.T) {
 			out: exectypes.Outcome{
 				CommitReports: []exectypes.CommitData{
 					{
-						SourceChain: 123,
+						SourceChain: selector1,
 						Messages: []cciptypes.Message{
 							{
 								Header: cciptypes.RampMessageHeader{
@@ -347,8 +352,8 @@ func Test_SequenceNumbers(t *testing.T) {
 				},
 			},
 			method: plugincommon.OutcomeMethod,
-			exp: map[cciptypes.ChainSelector]cciptypes.SeqNum{
-				123: 2,
+			exp: map[string]cciptypes.SeqNum{
+				chain1: 2,
 			},
 		},
 		{
@@ -356,7 +361,7 @@ func Test_SequenceNumbers(t *testing.T) {
 			out: exectypes.Outcome{
 				CommitReports: []exectypes.CommitData{
 					{
-						SourceChain: 123,
+						SourceChain: selector1,
 						Messages: []cciptypes.Message{
 							{
 								Header: cciptypes.RampMessageHeader{
@@ -366,7 +371,7 @@ func Test_SequenceNumbers(t *testing.T) {
 						},
 					},
 					{
-						SourceChain: 456,
+						SourceChain: selector2,
 						Messages: []cciptypes.Message{
 							{
 								Header: cciptypes.RampMessageHeader{
@@ -383,9 +388,9 @@ func Test_SequenceNumbers(t *testing.T) {
 				},
 			},
 			method: plugincommon.OutcomeMethod,
-			exp: map[cciptypes.ChainSelector]cciptypes.SeqNum{
-				123: 2,
-				456: 4,
+			exp: map[string]cciptypes.SeqNum{
+				chain1: 2,
+				chain2: 4,
 			},
 		},
 	}
@@ -404,9 +409,9 @@ func Test_SequenceNumbers(t *testing.T) {
 				reporter.TrackOutcome(tc.out, exectypes.GetCommitReports)
 			}
 
-			for sourceChainSelector, maxSeqNr := range tc.exp {
+			for sourceChain, maxSeqNr := range tc.exp {
 				seqNum := testutil.ToFloat64(
-					reporter.sequenceNumbers.WithLabelValues(chainID, sourceChainSelector.String(), tc.method),
+					reporter.sequenceNumbers.WithLabelValues(chainID, sourceChain, tc.method),
 				)
 				require.Equal(t, float64(maxSeqNr), seqNum)
 			}

--- a/execute/metrics/prom_test.go
+++ b/execute/metrics/prom_test.go
@@ -419,9 +419,15 @@ func Test_SequenceNumbers(t *testing.T) {
 	}
 }
 
+func Test_ExecLatency(t *testing.T) {
+
+}
+
 func cleanupMetrics(p *PromReporter) func() {
 	return func() {
 		p.sequenceNumbers.Reset()
 		p.outputDetailsCounter.Reset()
+		p.latencyHistogram.Reset()
+		p.execErrors.Reset()
 	}
 }

--- a/execute/metrics/reporter.go
+++ b/execute/metrics/reporter.go
@@ -1,6 +1,11 @@
 package metrics
 
-import "github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
+import (
+	"time"
+
+	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
+	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
+)
 
 // Reporter is a simple interface used for tracking observations and outcomes of the execution plugin.
 // Default implementation is based on the Prometheus metrics, but it can be extended to support other metrics systems.
@@ -10,6 +15,7 @@ import "github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
 type Reporter interface {
 	TrackObservation(obs exectypes.Observation, state exectypes.PluginState)
 	TrackOutcome(outcome exectypes.Outcome, state exectypes.PluginState)
+	TrackLatency(state exectypes.PluginState, method plugincommon.MethodType, latency time.Duration, err error)
 }
 
 type Noop struct{}
@@ -17,6 +23,8 @@ type Noop struct{}
 func (n *Noop) TrackObservation(exectypes.Observation, exectypes.PluginState) {}
 
 func (n *Noop) TrackOutcome(exectypes.Outcome, exectypes.PluginState) {}
+
+func (n *Noop) TrackLatency(exectypes.PluginState, plugincommon.MethodType, time.Duration, error) {}
 
 var _ Reporter = &Noop{}
 var _ Reporter = &PromReporter{}

--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -101,10 +101,10 @@ func NewPlugin(
 	lggr logger.Logger,
 	costlyMessageObserver costlymessages.Observer,
 	metricsReporter metrics.Reporter,
-) *Plugin {
+) ocr3types.ReportingPlugin[[]byte] {
 	lggr.Infow("creating new plugin instance", "p2pID", oracleIDToP2pID[reportingCfg.OracleID])
 
-	return &Plugin{
+	p := Plugin{
 		donID:                 donID,
 		reportingCfg:          reportingCfg,
 		offchainCfg:           offchainCfg,
@@ -141,6 +141,7 @@ func NewPlugin(
 		inflightMessageCache: cache.NewInflightMessageCache(offchainCfg.InflightCacheExpiry.Duration()),
 		ocrTypeCodec:         ocrtypecodec.NewExecCodecJSON(),
 	}
+	return NewTrackedPlugin(p, metricsReporter)
 }
 
 func (p *Plugin) Query(ctx context.Context, outctx ocr3types.OutcomeContext) (types.Query, error) {

--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -104,7 +104,8 @@ func NewPlugin(
 ) ocr3types.ReportingPlugin[[]byte] {
 	lggr.Infow("creating new plugin instance", "p2pID", oracleIDToP2pID[reportingCfg.OracleID])
 
-	p := Plugin{
+	codec := ocrtypecodec.NewExecCodecJSON()
+	p := &Plugin{
 		donID:                 donID,
 		reportingCfg:          reportingCfg,
 		offchainCfg:           offchainCfg,
@@ -139,9 +140,9 @@ func NewPlugin(
 			offchainCfg.MessageVisibilityInterval.Duration(),
 			time.Minute*5),
 		inflightMessageCache: cache.NewInflightMessageCache(offchainCfg.InflightCacheExpiry.Duration()),
-		ocrTypeCodec:         ocrtypecodec.NewExecCodecJSON(),
+		ocrTypeCodec:         codec,
 	}
-	return NewTrackedPlugin(p, metricsReporter)
+	return NewTrackedPlugin(p, lggr, metricsReporter, codec)
 }
 
 func (p *Plugin) Query(ctx context.Context, outctx ocr3types.OutcomeContext) (types.Query, error) {

--- a/execute/test_utils.go
+++ b/execute/test_utils.go
@@ -345,10 +345,13 @@ func (it *IntTest) newNode(
 		&metrics.Noop{},
 	)
 
+	// FIXME: Test should not rely on the specific type of the plugin but rather than that on
+	// the interface type
 	p := node1.(*TrackedPlugin)
+	pp := p.ReportingPlugin.(*Plugin)
 
 	return nodeSetup{
-		node:        &p.Plugin,
+		node:        pp,
 		reportCodec: reportCodec,
 		msgHasher:   it.msgHasher,
 	}

--- a/execute/test_utils.go
+++ b/execute/test_utils.go
@@ -345,8 +345,10 @@ func (it *IntTest) newNode(
 		&metrics.Noop{},
 	)
 
+	p := node1.(*TrackedPlugin)
+
 	return nodeSetup{
-		node:        node1,
+		node:        &p.Plugin,
 		reportCodec: reportCodec,
 		msgHasher:   it.msgHasher,
 	}

--- a/execute/tracked.go
+++ b/execute/tracked.go
@@ -4,26 +4,37 @@ import (
 	"context"
 	"time"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
 	"github.com/smartcontractkit/chainlink-ccip/execute/metrics"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/ocrtypecodec"
 )
 
+// TrackedPlugin tracks latency of the basic ReportingPlugin's methods. The special ingredient (compared to OCR3)
+// metrics is additional tracking of the state machine state. Please see metrics.Reporter for more details and the
+// exact prometheus metrics that are exposed.
 type TrackedPlugin struct {
-	Plugin
+	ocr3types.ReportingPlugin[[]byte]
+	lggr     logger.Logger
 	reporter metrics.Reporter
+	codec    *ocrtypecodec.ExecCodecJSON
 }
 
 func NewTrackedPlugin(
-	plugin Plugin,
+	plugin ocr3types.ReportingPlugin[[]byte],
+	lggr logger.Logger,
 	reporter metrics.Reporter,
+	codec *ocrtypecodec.ExecCodecJSON,
 ) ocr3types.ReportingPlugin[[]byte] {
 	return &TrackedPlugin{
-		Plugin:   plugin,
-		reporter: reporter,
+		ReportingPlugin: plugin,
+		lggr:            lggr,
+		reporter:        reporter,
+		codec:           codec,
 	}
 }
 
@@ -34,7 +45,7 @@ func (p *TrackedPlugin) Query(
 		p,
 		plugincommon.QueryMethod,
 		outctx,
-		func() (types.Query, error) { return p.Plugin.Query(ctx, outctx) },
+		func() (types.Query, error) { return p.ReportingPlugin.Query(ctx, outctx) },
 	)
 }
 
@@ -45,7 +56,7 @@ func (p *TrackedPlugin) Observation(
 		p,
 		plugincommon.ObservationMethod,
 		outctx,
-		func() (types.Observation, error) { return p.Plugin.Observation(ctx, outctx, query) },
+		func() (types.Observation, error) { return p.ReportingPlugin.Observation(ctx, outctx, query) },
 	)
 }
 
@@ -56,7 +67,7 @@ func (p *TrackedPlugin) Outcome(
 		p,
 		plugincommon.OutcomeMethod,
 		outctx,
-		func() (ocr3types.Outcome, error) { return p.Plugin.Outcome(ctx, outctx, query, aos) },
+		func() (ocr3types.Outcome, error) { return p.ReportingPlugin.Outcome(ctx, outctx, query, aos) },
 	)
 }
 
@@ -85,7 +96,7 @@ func withTrackedMethod[T any](
 func currentState(p *TrackedPlugin, outctx ocr3types.OutcomeContext) exectypes.PluginState {
 	// It's already decoded by the plugin, but we can't easily access it on the interface level.
 	// Assuming for now that CPU consumption for this extra decoding is negligible.
-	out, err := p.ocrTypeCodec.DecodeOutcome(outctx.PreviousOutcome)
+	out, err := p.codec.DecodeOutcome(outctx.PreviousOutcome)
 	if err != nil {
 		p.lggr.Errorw("unable to get state", "error", err)
 		return exectypes.Unknown

--- a/execute/tracked.go
+++ b/execute/tracked.go
@@ -1,0 +1,94 @@
+package execute
+
+import (
+	"context"
+	"time"
+
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
+	"github.com/smartcontractkit/chainlink-ccip/execute/exectypes"
+	"github.com/smartcontractkit/chainlink-ccip/execute/metrics"
+	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
+)
+
+type TrackedPlugin struct {
+	Plugin
+	reporter metrics.Reporter
+}
+
+func NewTrackedPlugin(
+	plugin Plugin,
+	reporter metrics.Reporter,
+) ocr3types.ReportingPlugin[[]byte] {
+	return &TrackedPlugin{
+		Plugin:   plugin,
+		reporter: reporter,
+	}
+}
+
+func (p *TrackedPlugin) Query(
+	ctx context.Context, outctx ocr3types.OutcomeContext,
+) (types.Query, error) {
+	return withTrackedMethod(
+		p,
+		plugincommon.QueryMethod,
+		outctx,
+		func() (types.Query, error) { return p.Plugin.Query(ctx, outctx) },
+	)
+}
+
+func (p *TrackedPlugin) Observation(
+	ctx context.Context, outctx ocr3types.OutcomeContext, query types.Query,
+) (types.Observation, error) {
+	return withTrackedMethod(
+		p,
+		plugincommon.ObservationMethod,
+		outctx,
+		func() (types.Observation, error) { return p.Plugin.Observation(ctx, outctx, query) },
+	)
+}
+
+func (p *TrackedPlugin) Outcome(
+	ctx context.Context, outctx ocr3types.OutcomeContext, query types.Query, aos []types.AttributedObservation,
+) (ocr3types.Outcome, error) {
+	return withTrackedMethod(
+		p,
+		plugincommon.OutcomeMethod,
+		outctx,
+		func() (ocr3types.Outcome, error) { return p.Plugin.Outcome(ctx, outctx, query, aos) },
+	)
+}
+
+func withTrackedMethod[T any](
+	p *TrackedPlugin,
+	method plugincommon.MethodType,
+	outctx ocr3types.OutcomeContext,
+	f func() (T, error),
+) (T, error) {
+	queryStarted := time.Now()
+	resp, err := f()
+
+	latency := time.Since(queryStarted)
+	state := currentState(p, outctx)
+
+	p.reporter.TrackLatency(state, method, latency, err)
+	p.lggr.Debugw("tracking exec latency",
+		"state",
+		"method", method,
+		"latency", latency,
+	)
+
+	return resp, err
+}
+
+func currentState(p *TrackedPlugin, outctx ocr3types.OutcomeContext) exectypes.PluginState {
+	// It's already decoded by the plugin, but we can't easily access it on the interface level.
+	// Assuming for now that CPU consumption for this extra decoding is negligible.
+	out, err := p.ocrTypeCodec.DecodeOutcome(outctx.PreviousOutcome)
+	if err != nil {
+		p.lggr.Errorw("unable to get state", "error", err)
+		return exectypes.Unknown
+	}
+	return out.State.Next()
+}

--- a/execute/tracked_test.go
+++ b/execute/tracked_test.go
@@ -1,0 +1,163 @@
+package execute
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-ccip/execute/metrics"
+	"github.com/smartcontractkit/chainlink-ccip/internal"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/ocrtypecodec"
+	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+)
+
+const (
+	chainID  = "2337"
+	selector = cciptypes.ChainSelector(12922642891491394802)
+)
+
+func Test_LatencyIsTracked(t *testing.T) {
+	t.Cleanup(func() {
+		metrics.PromExecErrors.Reset()
+		metrics.PromExecLatencyHistogram.Reset()
+	})
+
+	query := types.Query([]byte("query"))
+	observation := types.Observation([]byte("observation"))
+	outcome := ocr3types.Outcome([]byte("outcome"))
+	ctx := tests.Context(t)
+	lggr := logger.Test(t)
+	origin := FakePlugin{
+		query:       query,
+		observation: observation,
+		outcome:     outcome,
+	}
+	reporter, err := metrics.NewPromReporter(lggr, selector)
+	require.NoError(t, err)
+	tracked := NewTrackedPlugin(origin, lggr, reporter, ocrtypecodec.NewExecCodecJSON())
+
+	count := 100
+	for i := 0; i < count; i++ {
+		q, err := tracked.Query(ctx, ocr3types.OutcomeContext{})
+		require.Equal(t, query, q)
+		require.NoError(t, err)
+
+		obs, err := tracked.Observation(ctx, ocr3types.OutcomeContext{}, types.Query{})
+		require.Equal(t, observation, obs)
+		require.NoError(t, err)
+
+		out, err := tracked.Outcome(ctx, ocr3types.OutcomeContext{}, types.Query{}, []types.AttributedObservation{})
+		require.Equal(t, outcome, out)
+		require.NoError(t, err)
+	}
+
+	l1 := internal.CounterFromHistogramByLabels(
+		t, metrics.PromExecLatencyHistogram, chainID, "observation", "GetCommitReports",
+	)
+	require.Equal(t, count, l1)
+
+	l2 := internal.CounterFromHistogramByLabels(
+		t, metrics.PromExecLatencyHistogram, chainID, "outcome", "GetCommitReports",
+	)
+	require.Equal(t, count, l2)
+
+	l3 := internal.CounterFromHistogramByLabels(
+		t, metrics.PromExecLatencyHistogram, chainID, "query", "GetCommitReports",
+	)
+	require.Equal(t, count, l3)
+}
+
+func Test_ErrorIsTrackedWhenOriginReturns(t *testing.T) {
+	t.Cleanup(func() {
+		metrics.PromExecErrors.Reset()
+		metrics.PromExecLatencyHistogram.Reset()
+	})
+
+	lggr := logger.Test(t)
+	origin := FakePlugin{err: fmt.Errorf("error")}
+	reporter, err := metrics.NewPromReporter(lggr, selector)
+	require.NoError(t, err)
+	tracked := NewTrackedPlugin(origin, lggr, reporter, ocrtypecodec.NewExecCodecJSON())
+
+	count := 100
+	for i := 0; i < count; i++ {
+		_, err = tracked.Outcome(
+			tests.Context(t), ocr3types.OutcomeContext{}, types.Query{}, []types.AttributedObservation{},
+		)
+		require.Error(t, err)
+	}
+
+	l1 := internal.CounterFromHistogramByLabels(
+		t, metrics.PromExecLatencyHistogram, chainID, "outcome", "GetCommitReports",
+	)
+	require.Equal(t, 0, l1)
+
+	l2 := testutil.ToFloat64(
+		metrics.PromExecErrors.WithLabelValues(chainID, "outcome", "GetCommitReports"),
+	)
+	require.Equal(t, float64(count), l2)
+}
+
+type FakePlugin struct {
+	query       types.Query
+	observation types.Observation
+	outcome     ocr3types.Outcome
+	err         error
+}
+
+func (f FakePlugin) Query(ctx context.Context, outctx ocr3types.OutcomeContext) (types.Query, error) {
+	return f.query, f.err
+}
+
+func (f FakePlugin) Observation(
+	ctx context.Context, outctx ocr3types.OutcomeContext, query types.Query,
+) (types.Observation, error) {
+	return f.observation, f.err
+}
+
+func (f FakePlugin) ValidateObservation(
+	ctx context.Context, outctx ocr3types.OutcomeContext, query types.Query, ao types.AttributedObservation,
+) error {
+	panic("implement me")
+}
+
+func (f FakePlugin) ObservationQuorum(
+	ctx context.Context, outctx ocr3types.OutcomeContext, query types.Query, aos []types.AttributedObservation,
+) (quorumReached bool, err error) {
+	panic("implement me")
+}
+
+func (f FakePlugin) Outcome(
+	ctx context.Context, outctx ocr3types.OutcomeContext, query types.Query, aos []types.AttributedObservation,
+) (ocr3types.Outcome, error) {
+	return f.outcome, f.err
+}
+
+func (f FakePlugin) Reports(
+	ctx context.Context, seqNr uint64, outcome ocr3types.Outcome,
+) ([]ocr3types.ReportPlus[[]byte], error) {
+	panic("implement me")
+}
+
+func (f FakePlugin) ShouldAcceptAttestedReport(
+	ctx context.Context, seqNr uint64, reportWithInfo ocr3types.ReportWithInfo[[]byte],
+) (bool, error) {
+	panic("implement me")
+}
+
+func (f FakePlugin) ShouldTransmitAcceptedReport(
+	ctx context.Context, seqNr uint64, reportWithInfo ocr3types.ReportWithInfo[[]byte],
+) (bool, error) {
+	panic("implement me")
+}
+
+func (f FakePlugin) Close() error {
+	panic("implement me")
+}

--- a/pkg/reader/ccip_interface.go
+++ b/pkg/reader/ccip_interface.go
@@ -93,6 +93,7 @@ func NewCCIPChainReader(
 			destChain,
 			offrampAddress,
 		),
+		lggr,
 		destChain,
 	)
 }

--- a/pkg/reader/observed_ccip.go
+++ b/pkg/reader/observed_ccip.go
@@ -2,7 +2,6 @@ package reader
 
 import (
 	"context"
-	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
 	sel "github.com/smartcontractkit/chain-selectors"
@@ -74,8 +73,8 @@ func (o *observedCCIPReader) trackChainFeeComponents(
 	for k, v := range components {
 		selector, err := sel.GetChainIDFromSelector(uint64(k))
 		if err != nil {
-			selector = strconv.FormatUint(uint64(k), 10)
 			o.lggr.Error("failed to get chainID from selector", "err", err)
+			continue
 		}
 
 		if v.ExecutionFee != nil {

--- a/pkg/reader/observed_ccip_test.go
+++ b/pkg/reader/observed_ccip_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/stretchr/testify/mock"
@@ -35,7 +36,7 @@ func Test_GetChainsFeeComponents(t *testing.T) {
 	}
 
 	origin := mock_reader.NewMockCCIPReader(t)
-	r := reader.NewObservedCCIPReader(origin, cs1)
+	r := reader.NewObservedCCIPReader(origin, logger.Test(t), cs1)
 
 	origin.EXPECT().
 		GetChainsFeeComponents(mock.Anything, mock.Anything).
@@ -118,7 +119,7 @@ func Test_GetDestChainFeeComponents(t *testing.T) {
 			t.Cleanup(func() { reader.PromChainFeeGauge.Reset() })
 
 			origin := mock_reader.NewMockCCIPReader(t)
-			r := reader.NewObservedCCIPReader(origin, chainSelector)
+			r := reader.NewObservedCCIPReader(origin, logger.Test(t), chainSelector)
 
 			origin.EXPECT().
 				GetDestChainFeeComponents(ctx).

--- a/pkg/reader/observed_ccip_test.go
+++ b/pkg/reader/observed_ccip_test.go
@@ -3,7 +3,6 @@ package reader_test
 import (
 	"errors"
 	"math/big"
-	"strconv"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -22,21 +21,24 @@ func Test_GetChainsFeeComponents(t *testing.T) {
 	t.Cleanup(func() { reader.PromChainFeeGauge.Reset() })
 
 	ctx := tests.Context(t)
-	cs1 := cciptypes.ChainSelector(1)
-	cs2 := cciptypes.ChainSelector(2)
+	chain1 := "2337"
+	selector1 := cciptypes.ChainSelector(12922642891491394802)
+	chain2 := "3337"
+	selector2 := cciptypes.ChainSelector(4793464827907405086)
+
 	fees := map[cciptypes.ChainSelector]types.ChainFeeComponents{
-		cs1: {
+		selector1: {
 			ExecutionFee:        big.NewInt(10),
 			DataAvailabilityFee: big.NewInt(15),
 		},
-		cs2: {
+		selector2: {
 			ExecutionFee:        nil,
 			DataAvailabilityFee: big.NewInt(2),
 		},
 	}
 
 	origin := mock_reader.NewMockCCIPReader(t)
-	r := reader.NewObservedCCIPReader(origin, logger.Test(t), cs1)
+	r := reader.NewObservedCCIPReader(origin, logger.Test(t), selector1)
 
 	origin.EXPECT().
 		GetChainsFeeComponents(mock.Anything, mock.Anything).
@@ -47,30 +49,29 @@ func Test_GetChainsFeeComponents(t *testing.T) {
 	require.Equal(
 		t,
 		10.0,
-		testutil.ToFloat64(reader.PromChainFeeGauge.WithLabelValues(strconv.FormatUint(uint64(cs1), 10), "execCost")),
+		testutil.ToFloat64(reader.PromChainFeeGauge.WithLabelValues(chain1, "execCost")),
 	)
 	require.Equal(
 		t,
 		15.0,
-		testutil.ToFloat64(reader.PromChainFeeGauge.WithLabelValues(strconv.FormatUint(uint64(cs1), 10), "daCost")),
+		testutil.ToFloat64(reader.PromChainFeeGauge.WithLabelValues(chain1, "daCost")),
 	)
 	require.Equal(
 		t,
 		0.0,
-		testutil.ToFloat64(reader.PromChainFeeGauge.WithLabelValues(strconv.FormatUint(uint64(cs2), 10), "execCost")),
+		testutil.ToFloat64(reader.PromChainFeeGauge.WithLabelValues(chain2, "execCost")),
 	)
 	require.Equal(
 		t,
 		2.0,
-		testutil.ToFloat64(reader.PromChainFeeGauge.WithLabelValues(strconv.FormatUint(uint64(cs2), 10), "daCost")),
+		testutil.ToFloat64(reader.PromChainFeeGauge.WithLabelValues(chain2, "daCost")),
 	)
-
 }
 
 func Test_GetDestChainFeeComponents(t *testing.T) {
 	ctx := tests.Context(t)
-	chainSelector := cciptypes.ChainSelector(1)
-	stringChainSelector := strconv.Itoa(int(chainSelector))
+	chainID := "2337"
+	chainSelector := cciptypes.ChainSelector(12922642891491394802)
 
 	tt := []struct {
 		name          string
@@ -135,12 +136,12 @@ func Test_GetDestChainFeeComponents(t *testing.T) {
 			require.Equal(
 				t,
 				tc.expExec,
-				testutil.ToFloat64(reader.PromChainFeeGauge.WithLabelValues(stringChainSelector, "execCost")),
+				testutil.ToFloat64(reader.PromChainFeeGauge.WithLabelValues(chainID, "execCost")),
 			)
 			require.Equal(
 				t,
 				tc.expDa,
-				testutil.ToFloat64(reader.PromChainFeeGauge.WithLabelValues(stringChainSelector, "daCost")),
+				testutil.ToFloat64(reader.PromChainFeeGauge.WithLabelValues(chainID, "daCost")),
 			)
 		})
 	}


### PR DESCRIPTION
* exposing source as chainID instead of selector 
* better suited buckets for measuring latencies
* tracking latencies per exec state