### PR TITLE
execute/tracked: fix logging

### DIFF
--- a/execute/tracked.go
+++ b/execute/tracked.go
@@ -85,7 +85,7 @@ func withTrackedMethod[T any](
 
 	p.reporter.TrackLatency(state, method, latency, err)
 	p.lggr.Debugw("tracking exec latency",
-		"state",
+		"state", state,
 		"method", method,
 		"latency", latency,
 	)


### PR DESCRIPTION
Regression in #632, produces hundreds of:

```
{"L":"ERROR","T":"16:28:28.546783396","N":"CCIPExecPlugin.evm.90000002.0x0eEEe012627fF6860f504830d47e72C2955fB203","C":"zap@v1.27.0/sugar.go:251","M":"Ignored key without a value.","plugin":"Execute","oracleID":2,"donID":2,"configDigest":"000af19ca106634e2ba54f14dc1c80c8ec17d608272e7ceefb815031238035ce","ignored":"29.27407ms"}
```