### PR TITLE
commit|execute|pkg: fix "msg" in log fields

### DIFF
--- a/commit/merkleroot/observation.go
+++ b/commit/merkleroot/observation.go
@@ -695,7 +695,7 @@ func (o observerImpl) computeMerkleRoot(
 
 			msgHash, err := o.msgHasher.Hash(ctx, msg)
 			if err != nil {
-				lggr.Warnw("failed to hash message", "msg", msg, "err", err)
+				lggr.Warnw("failed to hash message", "message", msg, "err", err)
 				return fmt.Errorf("hash message with id %s: %w", msg.Header.MessageID, err)
 			}
 

--- a/execute/report/roots.go
+++ b/execute/report/roots.go
@@ -46,7 +46,7 @@ func ConstructMerkleTree(
 		leaf := report.Hashes[i]
 		lggr.Debugw("Hashed message, adding to tree leaves",
 			"hash", leaf,
-			"msg", msg,
+			"message", msg,
 			"merkleRoot", report.MerkleRoot,
 			"sourceChain", report.SourceChain)
 		treeLeaves = append(treeLeaves, leaf)

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -425,7 +425,7 @@ func (r *ccipChainReader) MsgsBetweenSeqNums(
 		}
 
 		if err := validateSendRequestedEvent(msg, sourceChainSelector, r.destChain, seqNumRange); err != nil {
-			lggr.Errorw("validate send requested event", "err", err, "msg", msg)
+			lggr.Errorw("validate send requested event", "err", err, "message", msg)
 			continue
 		}
 


### PR DESCRIPTION
The "msg" key is used by the logger to log the actual log line.
Overriding it confuses grafana because the same key "msg"
is repeated more than once.