### PR TITLE
add new function to get consensus on sequence numbers

### DIFF
--- a/commit/merkleroot/outcome.go
+++ b/commit/merkleroot/outcome.go
@@ -393,7 +393,7 @@ func getConsensusObservation(
 
 	// Get consensus using strict 2fChain+1 threshold.
 	twoFChainPlus1 := consensus.MakeMultiThreshold(fChains, consensus.TwoFPlus1)
-	FChain := consensus.MakeMultiThreshold(fChains, consensus.F)
+	fChain := consensus.MakeMultiThreshold(fChains, consensus.F)
 
 	consensusObs := consensusObservation{
 		MerkleRoots:      consensus.GetConsensusMap(lggr, "Merkle Root", aggObs.MerkleRoots, twoFChainPlus1),
@@ -402,12 +402,12 @@ func getConsensusObservation(
 			lggr,
 			"OnRamp Max Seq Nums",
 			aggObs.OnRampMaxSeqNums,
-			FChain),
+			fChain),
 		OffRampNextSeqNums: consensus.GetOrderedConsensus(
 			lggr,
 			"OffRamp Next Seq Nums",
 			aggObs.OffRampNextSeqNums,
-			FChain),
+			fChain),
 		RMNRemoteConfig: consensus.GetConsensusMap(lggr, "RMNRemote cfg", rmnRemoteConfigs, twoFChainPlus1),
 		FChain:          fChains,
 	}

--- a/commit/merkleroot/outcome.go
+++ b/commit/merkleroot/outcome.go
@@ -398,12 +398,12 @@ func getConsensusObservation(
 	consensusObs := consensusObservation{
 		MerkleRoots:      consensus.GetConsensusMap(lggr, "Merkle Root", aggObs.MerkleRoots, twoFChainPlus1),
 		RMNEnabledChains: consensus.GetConsensusMap(lggr, "RMNEnabledChains", aggObs.RMNEnabledChains, twoFChainPlus1),
-		OnRampMaxSeqNums: consensus.GetConservativelyOrderedConsensus(
+		OnRampMaxSeqNums: consensus.GetOrderedConsensus(
 			lggr,
 			"OnRamp Max Seq Nums",
 			aggObs.OnRampMaxSeqNums,
 			FChain),
-		OffRampNextSeqNums: consensus.GetConservativelyOrderedConsensus(
+		OffRampNextSeqNums: consensus.GetOrderedConsensus(
 			lggr,
 			"OffRamp Next Seq Nums",
 			aggObs.OffRampNextSeqNums,

--- a/commit/merkleroot/outcome.go
+++ b/commit/merkleroot/outcome.go
@@ -393,19 +393,21 @@ func getConsensusObservation(
 
 	// Get consensus using strict 2fChain+1 threshold.
 	twoFChainPlus1 := consensus.MakeMultiThreshold(fChains, consensus.TwoFPlus1)
+	FChain := consensus.MakeMultiThreshold(fChains, consensus.F)
+
 	consensusObs := consensusObservation{
 		MerkleRoots:      consensus.GetConsensusMap(lggr, "Merkle Root", aggObs.MerkleRoots, twoFChainPlus1),
 		RMNEnabledChains: consensus.GetConsensusMap(lggr, "RMNEnabledChains", aggObs.RMNEnabledChains, twoFChainPlus1),
-		OnRampMaxSeqNums: consensus.GetMaxSqNrWithConsensus(
+		OnRampMaxSeqNums: consensus.GetConservativelyOrderedConsensus(
 			lggr,
 			"OnRamp Max Seq Nums",
 			aggObs.OnRampMaxSeqNums,
-			twoFChainPlus1),
-		OffRampNextSeqNums: consensus.GetConsensusMap(
+			FChain),
+		OffRampNextSeqNums: consensus.GetConservativelyOrderedConsensus(
 			lggr,
 			"OffRamp Next Seq Nums",
 			aggObs.OffRampNextSeqNums,
-			twoFChainPlus1),
+			FChain),
 		RMNRemoteConfig: consensus.GetConsensusMap(lggr, "RMNRemote cfg", rmnRemoteConfigs, twoFChainPlus1),
 		FChain:          fChains,
 	}

--- a/commit/merkleroot/outcome.go
+++ b/commit/merkleroot/outcome.go
@@ -396,7 +396,11 @@ func getConsensusObservation(
 	consensusObs := consensusObservation{
 		MerkleRoots:      consensus.GetConsensusMap(lggr, "Merkle Root", aggObs.MerkleRoots, twoFChainPlus1),
 		RMNEnabledChains: consensus.GetConsensusMap(lggr, "RMNEnabledChains", aggObs.RMNEnabledChains, twoFChainPlus1),
-		OnRampMaxSeqNums: GetMaximumSequenceNumberWithConsensus(lggr, "OnRamp Max Seq Nums", aggObs.OnRampMaxSeqNums, twoFChainPlus1),
+		OnRampMaxSeqNums: consensus.GetMaxSqNrWithConsensus(
+			lggr,
+			"OnRamp Max Seq Nums",
+			aggObs.OnRampMaxSeqNums,
+			twoFChainPlus1),
 		OffRampNextSeqNums: consensus.GetConsensusMap(
 			lggr,
 			"OffRamp Next Seq Nums",
@@ -407,33 +411,4 @@ func getConsensusObservation(
 	}
 
 	return consensusObs, nil
-}
-
-func GetMaximumSequenceNumberWithConsensus[K comparable](
-	lggr logger.Logger,
-	objectName string,
-	itemsByKey map[K][]cciptypes.SeqNum,
-	minObs consensus.MultiThreshold[K]) map[K]cciptypes.SeqNum {
-	result := make(map[K]cciptypes.SeqNum)
-
-	for key, items := range itemsByKey {
-		if minThresh, exists := minObs.Get(key); exists {
-			if len(items) < int(minThresh) {
-				lggr.Debugf("failed to reach consensus on a %s's for key %+v "+
-					"because no single item was observed more than the expected min (%d) times, "+
-					"all observed items: %v",
-					objectName, key, minThresh, items)
-				continue
-			}
-
-			sort.Slice(items, func(i, j int) bool {
-				return items[i] > items[j]
-			})
-
-			result[key] = items[int(minThresh)-1]
-		} else {
-			lggr.Warnf("getConsensus(%s): min not found for chain %d", objectName, key)
-		}
-	}
-	return result
 }

--- a/commit/merkleroot/outcome_test.go
+++ b/commit/merkleroot/outcome_test.go
@@ -1,8 +1,9 @@
 package merkleroot
 
 import (
-	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon/consensus"
 	"testing"
+
+	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon/consensus"
 
 	"github.com/stretchr/testify/require"
 

--- a/commit/merkleroot/outcome_test.go
+++ b/commit/merkleroot/outcome_test.go
@@ -1,6 +1,7 @@
 package merkleroot
 
 import (
+	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon/consensus"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -781,6 +782,81 @@ func Test_reportRangesOutcome(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			outcome := reportRangesOutcome(Query{}, lggr, tc.consensusObservation, tc.merkleTreeSizeLimit, destChain)
 			require.Equal(t, tc.expectedOutcome, outcome)
+		})
+	}
+}
+
+func Test_SeqNumConsensus(t *testing.T) {
+	lggr := logger.Test(t)
+
+	testCases := []struct {
+		name           string
+		f              int
+		inputMap       map[cciptypes.ChainSelector][]cciptypes.SeqNum
+		expectedOutput map[cciptypes.ChainSelector]cciptypes.SeqNum
+	}{
+		{
+			name: "single chain with seqNum values",
+			f:    3,
+			inputMap: map[cciptypes.ChainSelector][]cciptypes.SeqNum{
+				cciptypes.ChainSelector(1): {1, 1, 1, 2, 1, 3},
+			},
+			expectedOutput: map[cciptypes.ChainSelector]cciptypes.SeqNum{
+				cciptypes.ChainSelector(1): 1,
+			},
+		},
+		{
+			name: "single chain with minimal seqNum",
+			f:    3,
+			inputMap: map[cciptypes.ChainSelector][]cciptypes.SeqNum{
+				cciptypes.ChainSelector(1): {1, 1, 1, 1, 1, 2, 2, 3, 3},
+			},
+			expectedOutput: map[cciptypes.ChainSelector]cciptypes.SeqNum{
+				cciptypes.ChainSelector(1): 2,
+			},
+		},
+		{
+			name: "unsorted single chain with minimal seqNum",
+			f:    3,
+			inputMap: map[cciptypes.ChainSelector][]cciptypes.SeqNum{
+				cciptypes.ChainSelector(1): {3, 2, 1, 3, 2, 1},
+			},
+			expectedOutput: map[cciptypes.ChainSelector]cciptypes.SeqNum{
+				cciptypes.ChainSelector(1): 2,
+			},
+		},
+		{
+			name: "single chain with max seqNum",
+			f:    3,
+			inputMap: map[cciptypes.ChainSelector][]cciptypes.SeqNum{
+				cciptypes.ChainSelector(1): {1, 2, 2, 3, 3, 3, 3},
+			},
+			expectedOutput: map[cciptypes.ChainSelector]cciptypes.SeqNum{
+				cciptypes.ChainSelector(1): 3,
+			},
+		},
+		{
+			name: "multiple unsorted chains with min seqNum",
+			f:    3,
+			inputMap: map[cciptypes.ChainSelector][]cciptypes.SeqNum{
+				cciptypes.ChainSelector(1): {1, 1, 2, 2, 3, 3},
+				cciptypes.ChainSelector(2): {1, 2, 2, 2, 2, 3},
+				cciptypes.ChainSelector(3): {1, 1}, // not enough observations, should skip
+				cciptypes.ChainSelector(4): {1, 2, 2, 3, 3, 3},
+			},
+			expectedOutput: map[cciptypes.ChainSelector]cciptypes.SeqNum{
+				cciptypes.ChainSelector(1): 2,
+				cciptypes.ChainSelector(2): 2,
+				cciptypes.ChainSelector(4): 3,
+			},
+		},
+	}
+
+	for _, scenario := range testCases {
+		t.Run(scenario.name, func(t *testing.T) {
+			minObs := consensus.MakeConstantThreshold[cciptypes.ChainSelector](consensus.Threshold(scenario.f))
+			result := GetMaximumSequenceNumberWithConsensus(lggr, "fChain", scenario.inputMap, minObs)
+			require.Equal(t, scenario.expectedOutput, result)
 		})
 	}
 }

--- a/commit/merkleroot/outcome_test.go
+++ b/commit/merkleroot/outcome_test.go
@@ -3,8 +3,6 @@ package merkleroot
 import (
 	"testing"
 
-	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon/consensus"
-
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
@@ -783,81 +781,6 @@ func Test_reportRangesOutcome(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			outcome := reportRangesOutcome(Query{}, lggr, tc.consensusObservation, tc.merkleTreeSizeLimit, destChain)
 			require.Equal(t, tc.expectedOutcome, outcome)
-		})
-	}
-}
-
-func Test_SeqNumConsensus(t *testing.T) {
-	lggr := logger.Test(t)
-
-	testCases := []struct {
-		name           string
-		f              int
-		inputMap       map[cciptypes.ChainSelector][]cciptypes.SeqNum
-		expectedOutput map[cciptypes.ChainSelector]cciptypes.SeqNum
-	}{
-		{
-			name: "single chain with seqNum values",
-			f:    3,
-			inputMap: map[cciptypes.ChainSelector][]cciptypes.SeqNum{
-				cciptypes.ChainSelector(1): {1, 1, 1, 2, 1, 3},
-			},
-			expectedOutput: map[cciptypes.ChainSelector]cciptypes.SeqNum{
-				cciptypes.ChainSelector(1): 1,
-			},
-		},
-		{
-			name: "single chain with minimal seqNum",
-			f:    3,
-			inputMap: map[cciptypes.ChainSelector][]cciptypes.SeqNum{
-				cciptypes.ChainSelector(1): {1, 1, 1, 1, 1, 2, 2, 3, 3},
-			},
-			expectedOutput: map[cciptypes.ChainSelector]cciptypes.SeqNum{
-				cciptypes.ChainSelector(1): 2,
-			},
-		},
-		{
-			name: "unsorted single chain with minimal seqNum",
-			f:    3,
-			inputMap: map[cciptypes.ChainSelector][]cciptypes.SeqNum{
-				cciptypes.ChainSelector(1): {3, 2, 1, 3, 2, 1},
-			},
-			expectedOutput: map[cciptypes.ChainSelector]cciptypes.SeqNum{
-				cciptypes.ChainSelector(1): 2,
-			},
-		},
-		{
-			name: "single chain with max seqNum",
-			f:    3,
-			inputMap: map[cciptypes.ChainSelector][]cciptypes.SeqNum{
-				cciptypes.ChainSelector(1): {1, 2, 2, 3, 3, 3, 3},
-			},
-			expectedOutput: map[cciptypes.ChainSelector]cciptypes.SeqNum{
-				cciptypes.ChainSelector(1): 3,
-			},
-		},
-		{
-			name: "multiple unsorted chains with min seqNum",
-			f:    3,
-			inputMap: map[cciptypes.ChainSelector][]cciptypes.SeqNum{
-				cciptypes.ChainSelector(1): {1, 1, 2, 2, 3, 3},
-				cciptypes.ChainSelector(2): {1, 2, 2, 2, 2, 3},
-				cciptypes.ChainSelector(3): {1, 1}, // not enough observations, should skip
-				cciptypes.ChainSelector(4): {1, 2, 2, 3, 3, 3},
-			},
-			expectedOutput: map[cciptypes.ChainSelector]cciptypes.SeqNum{
-				cciptypes.ChainSelector(1): 2,
-				cciptypes.ChainSelector(2): 2,
-				cciptypes.ChainSelector(4): 3,
-			},
-		},
-	}
-
-	for _, scenario := range testCases {
-		t.Run(scenario.name, func(t *testing.T) {
-			minObs := consensus.MakeConstantThreshold[cciptypes.ChainSelector](consensus.Threshold(scenario.f))
-			result := GetMaximumSequenceNumberWithConsensus(lggr, "fChain", scenario.inputMap, minObs)
-			require.Equal(t, scenario.expectedOutput, result)
 		})
 	}
 }

--- a/internal/plugincommon/consensus/consensus.go
+++ b/internal/plugincommon/consensus/consensus.go
@@ -102,7 +102,6 @@ func Median[T any](vals []T, less func(T, T) bool) T {
 // [honest 1, honest 1, honest 2, malicious 2], in this case we pick 2, but it's not enough to be able
 // to build a report since the first 2 honest nodes are unaware of message 2.
 // In an observation of [1, 2, 3, 4], we would pick 1, which is the most conservative choice.
-// https://github.com/smartcontractkit/chainlink/blob/5156cfe5ce0f8e060255b39e6b6ce2160da4a3b5/core/services/ocr2/plugins/ccip/ccipcommit/ocr2.go#L329
 func GetOrderedConsensus[K comparable, T cmp.Ordered](
 	lggr logger.Logger,
 	objectName string,

--- a/internal/plugincommon/consensus/consensus.go
+++ b/internal/plugincommon/consensus/consensus.go
@@ -1,6 +1,7 @@
 package consensus
 
 import (
+	"cmp"
 	"sort"
 	"time"
 
@@ -31,16 +32,17 @@ func GetConsensusMap[K comparable, T any](
 			items = minObservations.GetValid()
 			if len(items) != 1 {
 				// TODO: metrics
-				lggr.Debugf("failed to reach consensus on a %s's for key %+v "+
-					"because no single item was observed more than the expected min (%d) times, "+
-					"all observed items: %v",
-					objectName, key, minThresh, items)
+				lggr.Debugw("could not reach consensus due to not enough observations meeting the minimum threshold",
+					"objectName", objectName,
+					"key", key,
+					"minThreshold", minThresh,
+					"items", items)
 			} else {
 				consensus[key] = items[0]
 			}
 		} else {
 			// TODO: metrics
-			lggr.Warnf("getConsensus(%s): min not found for chain %d", objectName, key)
+			lggr.Warnw("min threshold not found defined", "objectName", objectName, "key", key)
 		}
 	}
 	return consensus
@@ -60,7 +62,9 @@ func GetConsensusMapAggregator[K comparable, T any](
 
 	for key, values := range items {
 		if thresh, ok := f.Get(key); !ok || len(values) < int(thresh) {
-			lggr.Debugf("could not reach consensus on %s for key %v", objectName, key)
+			lggr.Debugw("could not reach consensus in consensusMapAggregator",
+				"objectName", objectName,
+				"key", key)
 			continue
 		}
 		consensus[key] = agg(values)
@@ -83,33 +87,56 @@ func Median[T any](vals []T, less func(T, T) bool) T {
 	return valsCopy[len(valsCopy)/2]
 }
 
-// GetMaxSqNrWithConsensus returns the greatest sequence number for each chain that meets the min obs threshold
-// We do this by sorting the array in ascending order, then returning the value of item[minObs]
-func GetMaxSqNrWithConsensus[K comparable](
+// GetConservativelyOrderedConsensus returns the greatest sequence number for each chain that meets the min obs threshold
+// taking into account f which is the maximum number of faults across the whole DON.
+// OCR itself won't call Report unless there are 2*f+1 observations
+// https://github.com/smartcontractkit/libocr/blob/master/offchainreporting2/internal/protocol/report_generation_follower.go#L415
+// and f of those observations may be either unparseable or adversarially set values. That means
+// we'll either have f+1 parsed honest values here, 2f+1 parsed values with f adversarial values or somewhere
+// in between.
+// We choose the more "conservative" sorted_maxes[f] so:
+// - We are ensured that at least one honest oracle has seen the max, so adversary cannot set it lower and
+// cause the maxSeqNum < minSeqNum errors
+// - If an honest oracle reports sorted_max[f] which happens to be stale i.e. that oracle
+// has a delayed view of the source chain, then we simply lose a little bit of throughput.
+// - If we were to pick sorted_max[-f] i.e. the maximum honest node view (a more "aggressive" setting in terms of throughput),
+// then an adversary can continually send high values e.g. imagine we have observations from all 4 nodes
+// [honest 1, honest 1, honest 2, malicious 2], in this case we pick 2, but it's not enough to be able
+// to build a report since the first 2 honest nodes are unaware of message 2.
+// In an observation of [1, 2, 3, 4], we would pick 1, which is the most conservative choice.
+func GetConservativelyOrderedConsensus[K comparable, T cmp.Ordered](
 	lggr logger.Logger,
 	objectName string,
-	itemsByKey map[K][]cciptypes.SeqNum,
-	minObs MultiThreshold[K]) map[K]cciptypes.SeqNum {
-	result := make(map[K]cciptypes.SeqNum)
+	itemsByKey map[K][]T,
+	minObs MultiThreshold[K]) map[K]T {
+	result := make(map[K]T)
 
 	for key, items := range itemsByKey {
-		if minThresh, exists := minObs.Get(key); exists {
-			if len(items) < int(minThresh) {
-				lggr.Debugf("failed to reach consensus on a %s's for key %+v "+
-					"because no single item was observed more than the expected min (%d) times, "+
-					"all observed items: %v",
-					objectName, key, minThresh, items)
-				continue
-			}
-
-			sort.Slice(items, func(i, j int) bool {
-				return items[i] > items[j]
-			})
-
-			result[key] = items[int(minThresh)-1]
-		} else {
-			lggr.Warnf("getConsensus(%s): min not found for chain %d", objectName, key)
+		if _, exists := minObs.Get(key); !exists {
+			lggr.Warnw("could not find threshold value", "objectName", objectName, "key", key)
+			continue
 		}
+
+		minThresh, _ := minObs.Get(key)
+		if minThresh <= 0 {
+			lggr.Errorw("found a negative or 0 threshold",
+				"objectName", objectName,
+				"key", key,
+				"minThresh", minThresh)
+			continue
+		}
+
+		if len(items) < 2*int(minThresh)+1 {
+			lggr.Errorw("insufficient items to reach consensus",
+				"objectName", objectName,
+				"key", key,
+				"minThresh", minThresh,
+				"items", items)
+			continue
+		}
+
+		sort.Slice(items, func(i, j int) bool { return items[i] < items[j] })
+		result[key] = items[minThresh]
 	}
 	return result
 }

--- a/internal/plugincommon/consensus/consensus.go
+++ b/internal/plugincommon/consensus/consensus.go
@@ -88,18 +88,18 @@ func Median[T any](vals []T, less func(T, T) bool) T {
 }
 
 // GetConservativelyOrderedConsensus returns the greatest sequence number for each chain that meets the min obs threshold
-// taking into account f which is the maximum number of faults across the whole DON.
-// OCR itself won't call Report unless there are 2*f+1 observations
+// taking into account thresholds which is the maximum number of faults across the whole DON.
+// OCR itself won't call Report unless there are 2*thresholds+1 observations
 // https://github.com/smartcontractkit/libocr/blob/master/offchainreporting2/internal/protocol/report_generation_follower.go#L415
-// and f of those observations may be either unparseable or adversarially set values. That means
-// we'll either have f+1 parsed honest values here, 2f+1 parsed values with f adversarial values or somewhere
+// and thresholds of those observations may be either unparseable or adversarially set values. That means
+// we'll either have thresholds+1 parsed honest values here, 2f+1 parsed values with thresholds adversarial values or somewhere
 // in between.
-// We choose the more "conservative" sorted_maxes[f] so:
+// We choose the more "conservative" sorted_maxes[thresholds] so:
 // - We are ensured that at least one honest oracle has seen the max, so adversary cannot set it lower and
 // cause the maxSeqNum < minSeqNum errors
-// - If an honest oracle reports sorted_max[f] which happens to be stale i.e. that oracle
+// - If an honest oracle reports sorted_max[thresholds] which happens to be stale i.e. that oracle
 // has a delayed view of the source chain, then we simply lose a little bit of throughput.
-// - If we were to pick sorted_max[-f] i.e. the maximum honest node view (a more "aggressive" setting in terms of throughput),
+// - If we were to pick sorted_max[-thresholds] i.e. the maximum honest node view (a more "aggressive" setting in terms of throughput),
 // then an adversary can continually send high values e.g. imagine we have observations from all 4 nodes
 // [honest 1, honest 1, honest 2, malicious 2], in this case we pick 2, but it's not enough to be able
 // to build a report since the first 2 honest nodes are unaware of message 2.

--- a/internal/plugincommon/consensus/consensus.go
+++ b/internal/plugincommon/consensus/consensus.go
@@ -87,24 +87,23 @@ func Median[T any](vals []T, less func(T, T) bool) T {
 	return valsCopy[len(valsCopy)/2]
 }
 
-// GetConservativelyOrderedConsensus returns the greatest sequence number for each chain that meets the min obs threshold
+// GetOrderedConsensus returns the max sequence number for each chain that meets the min obs threshold
 // taking into account thresholds which is the maximum number of faults across the whole DON.
-// OCR itself won't call Report unless there are 2*thresholds+1 observations
-// https://github.com/smartcontractkit/libocr/blob/master/offchainreporting2/internal/protocol/report_generation_follower.go#L415
-// and thresholds of those observations may be either unparseable or adversarially set values. That means
-// we'll either have thresholds+1 parsed honest values here, 2f+1 parsed values with thresholds adversarial values or somewhere
-// in between.
-// We choose the more "conservative" sorted_maxes[thresholds] so:
+// Here we'll either have thresholds+1 parsed honest values here,
+// 2f+1 parsed values with thresholds adversarial values or somewhere in between.
+// We choose the more "conservative" seqNum[thresholds] so:
 // - We are ensured that at least one honest oracle has seen the max, so adversary cannot set it lower and
 // cause the maxSeqNum < minSeqNum errors
 // - If an honest oracle reports sorted_max[thresholds] which happens to be stale i.e. that oracle
 // has a delayed view of the source chain, then we simply lose a little bit of throughput.
-// - If we were to pick sorted_max[-thresholds] i.e. the maximum honest node view (a more "aggressive" setting in terms of throughput),
+// - If we were to pick sorted_max[-thresholds]
+// i.e. the maximum honest node view (a more "aggressive" setting in terms of throughput),
 // then an adversary can continually send high values e.g. imagine we have observations from all 4 nodes
 // [honest 1, honest 1, honest 2, malicious 2], in this case we pick 2, but it's not enough to be able
 // to build a report since the first 2 honest nodes are unaware of message 2.
 // In an observation of [1, 2, 3, 4], we would pick 1, which is the most conservative choice.
-func GetConservativelyOrderedConsensus[K comparable, T cmp.Ordered](
+// https://github.com/smartcontractkit/chainlink/blob/5156cfe5ce0f8e060255b39e6b6ce2160da4a3b5/core/services/ocr2/plugins/ccip/ccipcommit/ocr2.go#L329
+func GetOrderedConsensus[K comparable, T cmp.Ordered](
 	lggr logger.Logger,
 	objectName string,
 	itemsByKey map[K][]T,

--- a/internal/plugincommon/consensus/consensus.go
+++ b/internal/plugincommon/consensus/consensus.go
@@ -83,6 +83,8 @@ func Median[T any](vals []T, less func(T, T) bool) T {
 	return valsCopy[len(valsCopy)/2]
 }
 
+// GetMaxSqNrWithConsensus returns the greatest sequence number for each chain that meets the min obs threshold
+// We do this by sorting the array in ascending order, then returning the value of item[minObs]
 func GetMaxSqNrWithConsensus[K comparable](
 	lggr logger.Logger,
 	objectName string,

--- a/internal/plugincommon/consensus/consensus_test.go
+++ b/internal/plugincommon/consensus/consensus_test.go
@@ -80,7 +80,7 @@ func Test_SeqNumConsensus(t *testing.T) {
 			name: "single chain with minimal seqNum",
 			f:    3,
 			inputMap: map[cciptypes.ChainSelector][]cciptypes.SeqNum{
-				cciptypes.ChainSelector(1): {1, 1, 1, 1, 1, 2, 2, 3, 3},
+				cciptypes.ChainSelector(1): {1, 1, 1, 1, 1, 1, 2, 3, 3},
 			},
 			expectedOutput: map[cciptypes.ChainSelector]cciptypes.SeqNum{
 				cciptypes.ChainSelector(1): 2,
@@ -94,6 +94,16 @@ func Test_SeqNumConsensus(t *testing.T) {
 			},
 			expectedOutput: map[cciptypes.ChainSelector]cciptypes.SeqNum{
 				cciptypes.ChainSelector(1): 2,
+			},
+		},
+		{
+			name: "reverse single chain with ascending seqNum",
+			f:    3,
+			inputMap: map[cciptypes.ChainSelector][]cciptypes.SeqNum{
+				cciptypes.ChainSelector(1): {7, 6, 5, 4, 3, 2, 1},
+			},
+			expectedOutput: map[cciptypes.ChainSelector]cciptypes.SeqNum{
+				cciptypes.ChainSelector(1): 5,
 			},
 		},
 		{

--- a/internal/plugincommon/consensus/consensus_test.go
+++ b/internal/plugincommon/consensus/consensus_test.go
@@ -119,7 +119,7 @@ func Test_SeqNumConsensus(t *testing.T) {
 			inputMap: map[cciptypes.ChainSelector][]cciptypes.SeqNum{
 				cciptypes.ChainSelector(1): {1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 				cciptypes.ChainSelector(2): {1, 1, 1, 2, 2, 2, 3, 3, 3, 4},
-				cciptypes.ChainSelector(3): {1, 1}, // not enough observations, should skip
+				cciptypes.ChainSelector(3): {1, 1, 5}, // should skip
 				cciptypes.ChainSelector(4): {4, 3, 2, 1, 4, 3, 2, 1, 4, 3},
 			},
 			expectedOutput: map[cciptypes.ChainSelector]cciptypes.SeqNum{

--- a/internal/plugincommon/consensus/consensus_test.go
+++ b/internal/plugincommon/consensus/consensus_test.go
@@ -29,8 +29,8 @@ func Test_fChainConsensus(t *testing.T) {
 			inputMap: map[cciptypes.ChainSelector][]int{
 				cciptypes.ChainSelector(1): {5, 5, 5, 5, 5},
 				cciptypes.ChainSelector(2): {5, 5, 5, 3, 5},
-				cciptypes.ChainSelector(3): {5, 5},             // not enough observations, must be observed at least thresholds times.
-				cciptypes.ChainSelector(4): {5, 3, 5, 3, 5, 3}, // both values appear at least thresholds times, no consensus
+				cciptypes.ChainSelector(3): {5, 5},             // not enough observations, must be observed at least f times.
+				cciptypes.ChainSelector(4): {5, 3, 5, 3, 5, 3}, // both values appear at least f times, no consensus
 			},
 			expectedOutput: map[cciptypes.ChainSelector]int{
 				cciptypes.ChainSelector(1): 5,
@@ -132,7 +132,7 @@ func Test_SeqNumConsensus(t *testing.T) {
 
 	for _, scenario := range testCases {
 		t.Run(scenario.name, func(t *testing.T) {
-			result := GetConservativelyOrderedConsensus(lggr, "fChain", scenario.inputMap, scenario.thresholds)
+			result := GetOrderedConsensus(lggr, "fChain", scenario.inputMap, scenario.thresholds)
 			require.Equal(t, scenario.expectedOutput, result)
 		})
 	}
@@ -149,7 +149,7 @@ func Test_GetConsensusMapMedianTimestamp(t *testing.T) {
 	timeValues := map[int][]time.Time{
 		1: {ts1, ts1, ts1, ts1, ts1},
 		2: {ts2, ts2, ts1, ts1, ts1},
-		3: {ts1, ts1}, // not enough observations, must be observed at least thresholds times.
+		3: {ts1, ts1}, // not enough observations, must be observed at least f times.
 		4: {ts1, ts2, ts3},
 	}
 
@@ -174,7 +174,7 @@ func Test_GetConsensusMapMedianInt(t *testing.T) {
 	intValues := map[int][]int{
 		1: {5, 5, 5, 5, 5},
 		2: {5, 5, 5, 3, 5},
-		3: {5, 5}, // not enough observations, must be observed at least thresholds times.
+		3: {5, 5}, // not enough observations, must be observed at least f times.
 		4: {1, 2, 3, 4, 5, 6},
 		5: {5, 4, 3, 2, 1},
 	}
@@ -351,7 +351,7 @@ func TestMakeMultiThreshold_GenericKey(t *testing.T) {
 
 func Test_GetConsensusMapAggregator(t *testing.T) {
 	lggr := logger.Test(t)
-	//thresholds := 3
+	//f := 3
 
 	testCases := []struct {
 		name           string

--- a/internal/plugincommon/consensus/threshold.go
+++ b/internal/plugincommon/consensus/threshold.go
@@ -21,6 +21,8 @@ func FPlus1(f int) Threshold {
 	return Threshold(f + 1)
 }
 
+func F(f int) Threshold { return Threshold(f) }
+
 // MakeMultiThreshold constructs a threshold that maps each key to a threshold value.
 func MakeMultiThreshold[K comparable](fChain map[K]int, mapping func(int) Threshold) MultiThreshold[K] {
 	thresh := make(multiThreshold[K])

--- a/internal/plugincommon/consensus/threshold.go
+++ b/internal/plugincommon/consensus/threshold.go
@@ -9,13 +9,13 @@ type MultiThreshold[T any] interface {
 	Get(key T) (Threshold, bool)
 }
 
-// TwoFPlus1 is a common threshold mapping function that returns 2*thresholds + 1.
+// TwoFPlus1 is a common threshold mapping function that returns 2*f + 1.
 // See ocr3types.QuorumTwoFPlusOne - guarantees an honest majority of observations
 func TwoFPlus1(f int) Threshold {
 	return Threshold(2*f + 1)
 }
 
-// FPlus1 is a common threshold mapping function that returns thresholds + 1.
+// FPlus1 is a common threshold mapping function that returns f + 1.
 // See ocr3types.QuorumFPlusOne - Guarantees at least one honest observation
 func FPlus1(f int) Threshold {
 	return Threshold(f + 1)

--- a/internal/plugincommon/consensus/threshold.go
+++ b/internal/plugincommon/consensus/threshold.go
@@ -9,13 +9,13 @@ type MultiThreshold[T any] interface {
 	Get(key T) (Threshold, bool)
 }
 
-// TwoFPlus1 is a common threshold mapping function that returns 2*f + 1.
+// TwoFPlus1 is a common threshold mapping function that returns 2*thresholds + 1.
 // See ocr3types.QuorumTwoFPlusOne - guarantees an honest majority of observations
 func TwoFPlus1(f int) Threshold {
 	return Threshold(2*f + 1)
 }
 
-// FPlus1 is a common threshold mapping function that returns f + 1.
+// FPlus1 is a common threshold mapping function that returns thresholds + 1.
 // See ocr3types.QuorumFPlusOne - Guarantees at least one honest observation
 func FPlus1(f int) Threshold {
 	return Threshold(f + 1)


### PR DESCRIPTION
Updated to use the same approach that we had in 1.5
https://github.com/smartcontractkit/chainlink/blob/5156cfe5ce0f8e060255b39e6b6ce2160da4a3b5/core/services/ocr2/plugins/ccip/ccipcommit/ocr2.go#L329


====
https://chainlink-core.slack.com/archives/C06S76UEBK8/p1739432015202169

SequenceNumbers consensus algorithm
What we currently do for [onRamp seqNums](https://github.com/smartcontractkit/chainlink-ccip/blob/ab5458b5c6a8241f00b2803f3acdc30a2c67ffa5/commit/merkleroot/outcome.go#L368)
```
consensus.GetConsensusMap(lggr, "OnRamp Max Seq Nums", aggObs.OnRampMaxSeqNums, twoFChainPlus1)
// The consensus item for a given chain is the item with the
// most observations that was observed at least fChain times.
```
But imagine that we have a constant stream of seqNums, then it's very unlikely that at least 2f+1 oracles are seeing the same seqNum. e.g.:
```
Oracle1: 13
Oracle2: 15
Oracle3: 16
Oracle4: 15
```



