### PR TITLE
execute: checkAlreadyExecuted checks if all are exec'd

### DIFF
--- a/commit/report.go
+++ b/commit/report.go
@@ -440,7 +440,7 @@ func (p *Plugin) ShouldAcceptAttestedReport(
 
 	decodedReport, err := p.validateReport(ctx, lggr, seqNr, r)
 	if errors.Is(err, plugincommon.ErrInvalidReport) {
-		lggr.Infow("report not valid, not accepting: %w", err)
+		lggr.Infow("report not valid, not accepting", "err", err)
 		return false, nil
 	}
 	if err != nil {
@@ -516,7 +516,7 @@ func (p *Plugin) ShouldTransmitAcceptedReport(
 
 	decodedReport, err := p.validateReport(ctx, lggr, seqNr, r)
 	if errors.Is(err, plugincommon.ErrInvalidReport) {
-		lggr.Infow("report not valid, transmitting: %w", err)
+		lggr.Infow("report not valid, transmitting", "err", err)
 		return false, nil
 	}
 	if err != nil {

--- a/execute/observation.go
+++ b/execute/observation.go
@@ -17,7 +17,6 @@ import (
 	dt "github.com/smartcontractkit/chainlink-ccip/internal/plugincommon/discovery/discoverytypes"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/logutil"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/reader"
-	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
 
@@ -246,10 +245,10 @@ func (p *Plugin) getCommitReportsObservation(
 
 // buildCombinedReports creates a combined map for updating the earliest unexecuted root
 func buildCombinedReports(
-	groupedCommits map[ccipocr3.ChainSelector][]exectypes.CommitData,
+	groupedCommits map[cciptypes.ChainSelector][]exectypes.CommitData,
 	fullyExecutedUnfinalized []exectypes.CommitData,
-) map[ccipocr3.ChainSelector][]exectypes.CommitData {
-	combinedReports := make(map[ccipocr3.ChainSelector][]exectypes.CommitData)
+) map[cciptypes.ChainSelector][]exectypes.CommitData {
+	combinedReports := make(map[cciptypes.ChainSelector][]exectypes.CommitData)
 
 	// Add all unexecuted commits
 	for chain, commits := range groupedCommits {

--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -585,8 +585,7 @@ func (p *Plugin) validateReport(
 
 	// check that the messages in the report are not already executed onchain.
 	// note that this involves a set of DB queries, hence why its last in the checks.
-	seqNrRangesBySource := getSnRangeSetPairsBySource(decodedReport.ChainReports)
-	err = p.checkAlreadyExecuted(ctx, lggr, seqNrRangesBySource)
+	err = p.checkAlreadyExecuted(ctx, lggr, decodedReport.ChainReports)
 	if errors.Is(err, errAlreadyExecuted) {
 		// Some messages in the report have already
 		// been executed, so we don't want to re-execute them.
@@ -603,55 +602,66 @@ func (p *Plugin) validateReport(
 	return decodedReport, nil
 }
 
-// checkAlreadyExecuted checks if the messages in the report have already been executed
+// checkAlreadyExecuted checks if all the messages from all source chains in the report have already been executed
 // on the destination chain. It queries the DB for executed messages in the given sequence
 // number range for each source chain in the report.
+//
+// The reasoning behind the "all or nothing" approach is that if some messages have already been executed
+// and some have not, its possible that messages with skipped nonces have been executed. This could happen
+// due to out of order transmissions. Giving the transmission another shot would mean we won't have
+// extended delays due to skipped nonces.
+//
+// However, if all messages in the report are already executed, which is the usual case, we can safely skip
+// transmitting the report.
 func (p *Plugin) checkAlreadyExecuted(
 	ctx context.Context,
 	lggr logger.Logger,
-	seqNrRangesBySource map[cciptypes.ChainSelector]snRangeSetPair,
+	reports []cciptypes.ExecutePluginReportSingleChain,
 ) error {
+	seqNrRangesBySource := getSeqNrRangesBySource(reports)
+
 	// TODO: batch these queries? these are all DB reads.
 	// maybe some alternative queries exist.
 	for sourceChainSelector, seqNrRange := range seqNrRangesBySource {
-		executed, err := p.ccipReader.ExecutedMessages(ctx, sourceChainSelector, seqNrRange.snRange, primitives.Unconfirmed)
+		executed, err := p.ccipReader.ExecutedMessages(ctx, sourceChainSelector, seqNrRange, primitives.Unconfirmed)
 		if err != nil {
 			return fmt.Errorf("couldn't check if messages already executed: %w", err)
 		}
 
-		if intersection := mapset.NewSet(executed...).Intersect(seqNrRange.set); !intersection.IsEmpty() {
-			// Some messages in the report have been executed, don't accept it.
-			reportSeqNrsSlice := seqNrRange.set.ToSlice()
-			lggr.Warnw("some messages in report already executed",
-				"alreadyExecuted", executed,
-				"reportSeqNrs", reportSeqNrsSlice,
+		executedSet := mapset.NewSet(executed...)
+		snRangeSet := mapset.NewSet(seqNrRange.ToSlice()...)
+		intersection := executedSet.Intersect(snRangeSet)
+		if intersection.Cardinality() != seqNrRange.Length() {
+			// Some messages have not been executed, return early to accept/transmit the report.
+			notYetExecuted := snRangeSet.Difference(executedSet)
+			lggr.Debugw("some messages from source not yet executed",
+				"sourceChain", sourceChainSelector,
+				"seqNrRange", seqNrRange,
+				"executed", executed,
+				"notYetExecuted", notYetExecuted,
 			)
-			return fmt.Errorf("%w: already executed messages %+v report seq nrs %+v",
-				errAlreadyExecuted, executed, reportSeqNrsSlice)
+			return nil
 		}
+
+		// All messages from this source have been executed, check the next source chain.
+		lggr.Debugw("all messages from source already executed, checking next source",
+			"sourceChain", sourceChainSelector,
+			"seqNrRange", seqNrRange,
+			"executed", executed,
+		)
 	}
 
-	return nil
+	return fmt.Errorf(
+		"%w: all messages from all sources in provided reports already executed, not accepting/transmitting",
+		errAlreadyExecuted)
 }
 
-// snRangeSetPair is an internal data structure used to store a sequence number range
-// and a set of sequence numbers simultaneously.
-type snRangeSetPair struct {
-	// snRange is a range of [min, max] sequence numbers of the messages in the report for a particular source chain.
-	// it is used to query the CCIPReader for executed messages.
-	snRange cciptypes.SeqNumRange
-	// set is the sequence numbers of the messages in the report for a particular source chain.
-	// it is used to check whether the returned array from CCIPReader has a non-empty intersection
-	// with the set of sequence numbers in the report.
-	set mapset.Set[cciptypes.SeqNum]
-}
-
-// getSnRangeSetPairsBySource returns a map of source chain selector to
+// getSeqNrRangesBySource returns a map of source chain selector to
 // the sequence number range of the messages in the report.
-func getSnRangeSetPairsBySource(
+func getSeqNrRangesBySource(
 	chainReports []cciptypes.ExecutePluginReportSingleChain,
-) map[cciptypes.ChainSelector]snRangeSetPair {
-	seqNrRangesBySource := make(map[cciptypes.ChainSelector]snRangeSetPair)
+) map[cciptypes.ChainSelector]cciptypes.SeqNumRange {
+	seqNrRangesBySource := make(map[cciptypes.ChainSelector]cciptypes.SeqNumRange)
 	for _, chainReport := range chainReports {
 		// This should never happen, indicates a bug in the report building and accepting process.
 		// But we sanity check since slices.Min/Max will panic on empty slices.
@@ -664,20 +674,9 @@ func getSnRangeSetPairsBySource(
 		}
 		minMsg := slices.MinFunc(chainReport.Messages, cmpr)
 		maxMsg := slices.MaxFunc(chainReport.Messages, cmpr)
-		seqNrSet := mapset.NewSet(
-			slicelib.Map(
-				chainReport.Messages,
-				func(msg cciptypes.Message) cciptypes.SeqNum {
-					return msg.Header.SequenceNumber
-				},
-			)...,
-		)
-		seqNrRangesBySource[chainReport.SourceChainSelector] = snRangeSetPair{
-			snRange: cciptypes.NewSeqNumRange(
-				minMsg.Header.SequenceNumber,
-				maxMsg.Header.SequenceNumber),
-			set: seqNrSet,
-		}
+		seqNrRangesBySource[chainReport.SourceChainSelector] = cciptypes.NewSeqNumRange(
+			minMsg.Header.SequenceNumber,
+			maxMsg.Header.SequenceNumber)
 	}
 	return seqNrRangesBySource
 }
@@ -689,7 +688,7 @@ func (p *Plugin) ShouldAcceptAttestedReport(
 
 	decodedReport, err := p.validateReport(ctx, lggr, r)
 	if errors.Is(err, plugincommon.ErrInvalidReport) {
-		lggr.Infow("report not valid, not accepting: %w", err)
+		lggr.Infow("report not valid, not accepting", "err", err)
 		return false, nil
 	}
 	if err != nil {

--- a/execute/plugin_functions.go
+++ b/execute/plugin_functions.go
@@ -538,7 +538,7 @@ func initResultsAndValidators(
 			messageTokenID := reader.NewMessageTokenID(seqNr, tokenIndex)
 			if _, ok := validators[selector][messageTokenID]; !ok {
 				validators[selector][messageTokenID] =
-					consensus.NewOracleMinObservation[exectypes.TokenData](consensus.TwoFPlus1(f), exectypes.TokenDataHash)
+					consensus.NewOracleMinObservation(consensus.TwoFPlus1(f), exectypes.TokenDataHash)
 			}
 			validators[selector][messageTokenID].Add(tokenData, oracleID)
 		}

--- a/execute/plugin_test.go
+++ b/execute/plugin_test.go
@@ -129,17 +129,17 @@ func Test_checkAlreadyExecuted(t *testing.T) {
 				// rest are not.
 				midPoint := len(snRangeSetPairBySource) / 2
 				i := 0
-				for sourceSel, seqNrRangePair := range snRangeSetPairBySource {
+				for sourceSel, seqNrRange := range snRangeSetPairBySource {
 					if i == midPoint {
 						ccipReaderMock.
 							EXPECT().
 							ExecutedMessages(
 								mock.Anything,
 								sourceSel,
-								seqNrRangePair,
+								seqNrRange,
 								primitives.Unconfirmed,
 							).Return(
-							seqNrRangePair.ToSlice(),
+							seqNrRange.ToSlice(),
 							nil,
 						).Maybe()
 					} else {
@@ -148,7 +148,7 @@ func Test_checkAlreadyExecuted(t *testing.T) {
 							ExecutedMessages(
 								mock.Anything,
 								sourceSel,
-								seqNrRangePair,
+								seqNrRange,
 								primitives.Unconfirmed,
 							).Return(nil, nil). // not executed
 							Maybe()
@@ -171,15 +171,15 @@ func Test_checkAlreadyExecuted(t *testing.T) {
 				// rest are not.
 				midPoint := len(snRangeSetPairBySource) / 2
 				i := 0
-				for sourceSel, seqNrRangePair := range snRangeSetPairBySource {
+				for sourceSel, seqNrRange := range snRangeSetPairBySource {
 					if i == midPoint {
-						fullRange := seqNrRangePair.ToSlice()
+						fullRange := seqNrRange.ToSlice()
 						ccipReaderMock.
 							EXPECT().
 							ExecutedMessages(
 								mock.Anything,
 								sourceSel,
-								seqNrRangePair,
+								seqNrRange,
 								primitives.Unconfirmed,
 							).Return(
 							fullRange[:len(fullRange)/2],
@@ -191,7 +191,7 @@ func Test_checkAlreadyExecuted(t *testing.T) {
 							ExecutedMessages(
 								mock.Anything,
 								sourceSel,
-								seqNrRangePair,
+								seqNrRange,
 								primitives.Unconfirmed,
 							).Return(nil, nil).Maybe() // not executed
 					}
@@ -207,13 +207,13 @@ func Test_checkAlreadyExecuted(t *testing.T) {
 				t *testing.T,
 				snRangeSetPairBySource map[cciptypes.ChainSelector]cciptypes.SeqNumRange) *readerpkg_mock.MockCCIPReader {
 				ccipReaderMock := readerpkg_mock.NewMockCCIPReader(t)
-				for sourceSel, seqNrRangePair := range snRangeSetPairBySource {
+				for sourceSel, seqNrRange := range snRangeSetPairBySource {
 					ccipReaderMock.
 						EXPECT().
 						ExecutedMessages(
 							mock.Anything,
 							sourceSel,
-							seqNrRangePair,
+							seqNrRange,
 							primitives.Unconfirmed,
 						).Return(nil, nil).Maybe()
 				}
@@ -227,15 +227,15 @@ func Test_checkAlreadyExecuted(t *testing.T) {
 				t *testing.T,
 				snRangeSetPairBySource map[cciptypes.ChainSelector]cciptypes.SeqNumRange) *readerpkg_mock.MockCCIPReader {
 				ccipReaderMock := readerpkg_mock.NewMockCCIPReader(t)
-				for sourceSel, seqNrRangePair := range snRangeSetPairBySource {
+				for sourceSel, seqNrRange := range snRangeSetPairBySource {
 					ccipReaderMock.
 						EXPECT().
 						ExecutedMessages(
 							mock.Anything,
 							sourceSel,
-							seqNrRangePair,
+							seqNrRange,
 							primitives.Unconfirmed,
-						).Return(seqNrRangePair.ToSlice(), nil)
+						).Return(seqNrRange.ToSlice(), nil)
 				}
 				return ccipReaderMock
 			},

--- a/execute/plugin_test.go
+++ b/execute/plugin_test.go
@@ -42,7 +42,6 @@ import (
 	codec_mocks "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 	reader2 "github.com/smartcontractkit/chainlink-ccip/pkg/reader"
-	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	plugintypes2 "github.com/smartcontractkit/chainlink-ccip/plugintypes"
 )
@@ -73,13 +72,13 @@ func genRandomChainReports(numReports, numMsgsPerReport int) []cciptypes.Execute
 
 func Test_getMinMaxSeqNrRangesBySource_emptyMsgs(t *testing.T) {
 	chainReports := genRandomChainReports(1, 0)
-	minMaxSeqNrRanges := getSnRangeSetPairsBySource(chainReports)
+	minMaxSeqNrRanges := getSeqNrRangesBySource(chainReports)
 	require.Len(t, minMaxSeqNrRanges, 0)
 }
 
-func Test_getMinMaxSeqNrRangesBySource(t *testing.T) {
+func Test_getSeqNrRangesBySource(t *testing.T) {
 	chainReports := genRandomChainReports(10, 15)
-	minMaxSeqNrRanges := getSnRangeSetPairsBySource(chainReports)
+	minMaxSeqNrRanges := getSeqNrRangesBySource(chainReports)
 	require.Len(t, minMaxSeqNrRanges, len(chainReports))
 	for _, chainReport := range chainReports {
 		seqNrRange, ok := minMaxSeqNrRanges[chainReport.SourceChainSelector]
@@ -89,8 +88,8 @@ func Test_getMinMaxSeqNrRangesBySource(t *testing.T) {
 		// check the range.
 		expectedMin := chainReport.Messages[0].Header.SequenceNumber
 		expectedMax := chainReport.Messages[len(chainReport.Messages)-1].Header.SequenceNumber
-		require.Equal(t, expectedMin, seqNrRange.snRange.Start())
-		require.Equal(t, expectedMax, seqNrRange.snRange.End())
+		require.Equal(t, expectedMin, seqNrRange.Start())
+		require.Equal(t, expectedMax, seqNrRange.End())
 
 		// check the set.
 		expectedSet := make(map[cciptypes.SeqNum]struct{})
@@ -98,7 +97,7 @@ func Test_getMinMaxSeqNrRangesBySource(t *testing.T) {
 			expectedSet[msg.Header.SequenceNumber] = struct{}{}
 		}
 		expectedSetSlice := maps.Keys(expectedSet)
-		actualSetSlice := seqNrRange.set.ToSlice()
+		actualSetSlice := seqNrRange.ToSlice()
 		sort.Slice(expectedSetSlice, func(i, j int) bool {
 			return expectedSetSlice[i] < expectedSetSlice[j]
 		})
@@ -114,15 +113,15 @@ func Test_checkAlreadyExecuted(t *testing.T) {
 		name           string
 		mockReaderFunc func(
 			t *testing.T,
-			snRangeSetPairBySource map[cciptypes.ChainSelector]snRangeSetPair,
+			snRangeSetPairBySource map[cciptypes.ChainSelector]cciptypes.SeqNumRange,
 		) *readerpkg_mock.MockCCIPReader
 		shouldErr bool
 	}{
 		{
-			name: "full range executed",
+			name: "full range executed, rest unexecuted, should not error",
 			mockReaderFunc: func(
 				t *testing.T,
-				snRangeSetPairBySource map[cciptypes.ChainSelector]snRangeSetPair) *readerpkg_mock.MockCCIPReader {
+				snRangeSetPairBySource map[cciptypes.ChainSelector]cciptypes.SeqNumRange) *readerpkg_mock.MockCCIPReader {
 				ccipReaderMock := readerpkg_mock.NewMockCCIPReader(t)
 				// need to setup assertions like this because map iteration
 				// order is undefined.
@@ -137,19 +136,19 @@ func Test_checkAlreadyExecuted(t *testing.T) {
 							ExecutedMessages(
 								mock.Anything,
 								sourceSel,
-								seqNrRangePair.snRange,
+								seqNrRangePair,
 								primitives.Unconfirmed,
 							).Return(
-							seqNrRangePair.snRange.ToSlice(),
+							seqNrRangePair.ToSlice(),
 							nil,
-						)
+						).Maybe()
 					} else {
 						ccipReaderMock.
 							EXPECT().
 							ExecutedMessages(
 								mock.Anything,
 								sourceSel,
-								seqNrRangePair.snRange,
+								seqNrRangePair,
 								primitives.Unconfirmed,
 							).Return(nil, nil). // not executed
 							Maybe()
@@ -158,13 +157,13 @@ func Test_checkAlreadyExecuted(t *testing.T) {
 				}
 				return ccipReaderMock
 			},
-			shouldErr: true,
+			shouldErr: false,
 		},
 		{
-			name: "subset of range executed",
+			name: "subset of range executed, rest unexecuted, should not error",
 			mockReaderFunc: func(
 				t *testing.T,
-				snRangeSetPairBySource map[cciptypes.ChainSelector]snRangeSetPair) *readerpkg_mock.MockCCIPReader {
+				snRangeSetPairBySource map[cciptypes.ChainSelector]cciptypes.SeqNumRange) *readerpkg_mock.MockCCIPReader {
 				ccipReaderMock := readerpkg_mock.NewMockCCIPReader(t)
 				// need to setup assertions like this because map iteration
 				// order is undefined.
@@ -174,25 +173,25 @@ func Test_checkAlreadyExecuted(t *testing.T) {
 				i := 0
 				for sourceSel, seqNrRangePair := range snRangeSetPairBySource {
 					if i == midPoint {
-						fullRange := seqNrRangePair.snRange.ToSlice()
+						fullRange := seqNrRangePair.ToSlice()
 						ccipReaderMock.
 							EXPECT().
 							ExecutedMessages(
 								mock.Anything,
 								sourceSel,
-								seqNrRangePair.snRange,
+								seqNrRangePair,
 								primitives.Unconfirmed,
 							).Return(
 							fullRange[:len(fullRange)/2],
 							nil,
-						)
+						).Maybe()
 					} else {
 						ccipReaderMock.
 							EXPECT().
 							ExecutedMessages(
 								mock.Anything,
 								sourceSel,
-								seqNrRangePair.snRange,
+								seqNrRangePair,
 								primitives.Unconfirmed,
 							).Return(nil, nil).Maybe() // not executed
 					}
@@ -200,13 +199,13 @@ func Test_checkAlreadyExecuted(t *testing.T) {
 				}
 				return ccipReaderMock
 			},
-			shouldErr: true,
+			shouldErr: false,
 		},
 		{
-			name: "none executed",
+			name: "none executed, should not error",
 			mockReaderFunc: func(
 				t *testing.T,
-				snRangeSetPairBySource map[cciptypes.ChainSelector]snRangeSetPair) *readerpkg_mock.MockCCIPReader {
+				snRangeSetPairBySource map[cciptypes.ChainSelector]cciptypes.SeqNumRange) *readerpkg_mock.MockCCIPReader {
 				ccipReaderMock := readerpkg_mock.NewMockCCIPReader(t)
 				for sourceSel, seqNrRangePair := range snRangeSetPairBySource {
 					ccipReaderMock.
@@ -214,26 +213,46 @@ func Test_checkAlreadyExecuted(t *testing.T) {
 						ExecutedMessages(
 							mock.Anything,
 							sourceSel,
-							seqNrRangePair.snRange,
+							seqNrRangePair,
 							primitives.Unconfirmed,
-						).Return(nil, nil)
+						).Return(nil, nil).Maybe()
 				}
 				return ccipReaderMock
 			},
 			shouldErr: false,
+		},
+		{
+			name: "all executed, should error",
+			mockReaderFunc: func(
+				t *testing.T,
+				snRangeSetPairBySource map[cciptypes.ChainSelector]cciptypes.SeqNumRange) *readerpkg_mock.MockCCIPReader {
+				ccipReaderMock := readerpkg_mock.NewMockCCIPReader(t)
+				for sourceSel, seqNrRangePair := range snRangeSetPairBySource {
+					ccipReaderMock.
+						EXPECT().
+						ExecutedMessages(
+							mock.Anything,
+							sourceSel,
+							seqNrRangePair,
+							primitives.Unconfirmed,
+						).Return(seqNrRangePair.ToSlice(), nil)
+				}
+				return ccipReaderMock
+			},
+			shouldErr: true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			chainReports := genRandomChainReports(10, 15)
-			snRangeSetPairs := getSnRangeSetPairsBySource(chainReports)
+			snRangeSetPairs := getSeqNrRangesBySource(chainReports)
 			ccipReaderMock := tc.mockReaderFunc(t, snRangeSetPairs)
 			p := &Plugin{
 				lggr:       logger.Test(t),
 				ccipReader: ccipReaderMock,
 			}
-			err := p.checkAlreadyExecuted(tests.Context(t), p.lggr, snRangeSetPairs)
+			err := p.checkAlreadyExecuted(tests.Context(t), p.lggr, chainReports)
 			if tc.shouldErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "already executed")
@@ -1105,6 +1124,7 @@ func TestPlugin_ShouldAcceptAttestedReport_ShouldAccept(t *testing.T) {
 			configDigest,
 			nil,
 		)
+		// by default, the message is not executed.
 		ccipReaderMock.
 			EXPECT().
 			ExecutedMessages(
@@ -1262,7 +1282,7 @@ func TestPlugin_ShouldAcceptAttestedReport_ShouldAccept(t *testing.T) {
 				require.NoError(t, err) // error is logged, but not returned
 				require.False(t, b)
 			},
-			logsContain: []string{"some messages in report already executed"},
+			logsContain: []string{"all messages from source already executed, checking next source"},
 		},
 	}
 	for _, tc := range testcases {
@@ -1802,9 +1822,9 @@ func TestCommitRootsCache_CoreOptimizationBehavior(t *testing.T) {
 	afterTimestamp := expectedVisibilityWindow.Add(30 * time.Minute)
 
 	// Create chain selector and roots
-	selector := ccipocr3.ChainSelector(1)
-	beforeRoot := ccipocr3.Bytes32{1}
-	afterRoot := ccipocr3.Bytes32{2}
+	selector := cciptypes.ChainSelector(1)
+	beforeRoot := cciptypes.Bytes32{1}
+	afterRoot := cciptypes.Bytes32{2}
 
 	// Create commit data objects
 	beforeReport := createCommitData(beforeTimestamp, selector, beforeRoot)
@@ -1882,8 +1902,8 @@ func (p *customTimeProvider) Now() time.Time {
 }
 
 // Helper function to create commit reports
-func createCommitReports(reports ...exectypes.CommitData) map[ccipocr3.ChainSelector][]exectypes.CommitData {
-	result := make(map[ccipocr3.ChainSelector][]exectypes.CommitData)
+func createCommitReports(reports ...exectypes.CommitData) map[cciptypes.ChainSelector][]exectypes.CommitData {
+	result := make(map[cciptypes.ChainSelector][]exectypes.CommitData)
 	for _, report := range reports {
 		selector := report.SourceChain
 		result[selector] = append(result[selector], report)
@@ -1894,12 +1914,12 @@ func createCommitReports(reports ...exectypes.CommitData) map[ccipocr3.ChainSele
 // Helper function to create commit data
 func createCommitData(
 	timestamp time.Time,
-	selector ccipocr3.ChainSelector,
-	merkleRoot ccipocr3.Bytes32) exectypes.CommitData {
+	selector cciptypes.ChainSelector,
+	merkleRoot cciptypes.Bytes32) exectypes.CommitData {
 	return exectypes.CommitData{
 		SourceChain:         selector,
 		MerkleRoot:          merkleRoot,
-		SequenceNumberRange: ccipocr3.NewSeqNumRange(1, 10),
+		SequenceNumberRange: cciptypes.NewSeqNumRange(1, 10),
 		Timestamp:           timestamp,
 	}
 }

--- a/execute/test_utils.go
+++ b/execute/test_utils.go
@@ -35,8 +35,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/internal/mocks/inmem"
 	"github.com/smartcontractkit/chainlink-ccip/internal/reader"
 	readermock "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/contractreader"
-	gasmock "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/types/ccipocr3"
-	typepkgmock "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/types/ccipocr3"
+	cciptypesmocks "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
 	readerpkg "github.com/smartcontractkit/chainlink-ccip/pkg/reader"
@@ -236,7 +235,7 @@ func (it *IntTest) Start() *testhelpers.OCR3Runner[[]byte] {
 	)
 	require.NoError(it.t, err)
 
-	ep := gasmock.NewMockEstimateProvider(it.t)
+	ep := cciptypesmocks.NewMockEstimateProvider(it.t)
 	ep.EXPECT().CalculateMessageMaxGas(mock.Anything).Return(uint64(0)).Maybe()
 	ep.EXPECT().CalculateMerkleTreeGas(mock.Anything).Return(uint64(0)).Maybe()
 
@@ -277,7 +276,7 @@ func (it *IntTest) newNode(
 	id int,
 	N int,
 	configDigest [32]byte,
-	mockCodec *typepkgmock.MockAddressCodec,
+	mockCodec *cciptypesmocks.MockAddressCodec,
 ) nodeSetup {
 	reportCodec := mocks.NewExecutePluginJSONReportCodec()
 	rCfg := ocr3types.ReportingPluginConfig{


### PR DESCRIPTION
Previous behavior of this function was that it would prevent a report
from being transmitted if it detected that a single message in the
report was executed. The logic behind this was to prevent re-executions
that would just waste gas onchain.

However, an edge case has been uncovered that involves out of order
transmissions. Since the transmission protocol is async and could take
longer than a round duration, we could have transmissions that get
fumbled and only some of the messages executed while others are skipped
due to incorrect nonces.

In order to address this, checkAlreadyExecuted will only return an error
and prevent report acceptance / transmission if _all_ the messages in
the report are already executed, making it a completely redundant
transmission. However, if some have not yet been executed, it will try
again and the hope is that eventually we'd get rid of the nonce errors
in the transmission schedule.