### PR TITLE
execute/report: remove unnecessary len check

### DIFF
--- a/execute/report/report.go
+++ b/execute/report/report.go
@@ -35,11 +35,6 @@ func buildSingleChainReportHelper(
 		}
 	}
 
-	if len(readyMessages) == 0 {
-		lggr.Infow("no messages ready for execution", "sourceChain", report.SourceChain)
-		return ccipocr3.ExecutePluginReportSingleChain{}, nil
-	}
-
 	numMsg := len(report.Messages)
 	if len(report.MessageTokenData) != numMsg {
 		return ccipocr3.ExecutePluginReportSingleChain{},


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/CCIP-4708

The `readyMessages` map always has length > 0, unless `report.Messages` is empty (which is an invariant violation)