### PR TITLE
execute: use lggr with ctx

### DIFF
--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -498,7 +498,7 @@ func (p *Plugin) Reports(
 	}
 
 	reportInfo := extractReportInfo(decodedOutcome)
-	p.lggr.Debugw("report info in Reports()", "reportInfo", reportInfo)
+	lggr.Debugw("report info in Reports()", "reportInfo", reportInfo)
 	encodedInfo, err := reportInfo.Encode()
 	if err != nil {
 		return nil, err

--- a/execute/report/report.go
+++ b/execute/report/report.go
@@ -407,8 +407,8 @@ func verifyReportNonceContinuity(
 			// we've seen this sender before and the msg.Header.Nonce is not the expected value,
 			// it should be latestNonce + 1.
 			return fmt.Errorf(
-				"skipped nonce detected for sender %s: nonce in report %d != last nonce seen %d",
-				sender, msg.Header.Nonce, latestNonce)
+				"skipped nonce detected for sender %s (source chain %d): nonce in report %d != last nonce seen %d",
+				sender, msg.Header.SourceChainSelector, msg.Header.Nonce, latestNonce)
 		}
 
 		// otherwise, the nonce is as expected, continue to the next message.
@@ -426,7 +426,9 @@ func (b *execReportBuilder) verifyReport(
 ) (bool, validationMetadata, error) {
 	err := verifyReportNonceContinuity(b.addressCodec, execReport)
 	if err != nil {
-		b.lggr.Infow("invalid report, skipped nonce detected", "err", err)
+		b.lggr.Infow("invalid report, skipped nonce detected",
+			"err", err,
+			"sourceChain", execReport.SourceChainSelector)
 		return false, validationMetadata{}, nil
 	}
 


### PR DESCRIPTION
And another minor log improvement for the skipped nonce log