### PR TITLE
Add ChainFeeDeviationDisabled check to outcome

### DIFF
--- a/commit/chainfee/outcome.go
+++ b/commit/chainfee/outcome.go
@@ -249,6 +249,11 @@ func (p *processor) getGasPricesToUpdate(
 			continue
 		}
 
+		if ci.ChainFeeDeviationDisabled {
+			lggr.Debugw("chain fee deviation disabled", "chain", chain)
+			continue
+		}
+
 		executionFeeDeviates := mathslib.Deviates(
 			currentChainFee.ExecutionFeePriceUSD,
 			lastUpdate.ChainFee.ExecutionFeePriceUSD,

--- a/pluginconfig/commit.go
+++ b/pluginconfig/commit.go
@@ -32,8 +32,17 @@ const (
 )
 
 type FeeInfo struct {
-	ExecDeviationPPB             cciptypes.BigInt `json:"execDeviationPPB"`
+	// ExecDeviationPPB is the deviation threshold in parts per billion that determines whether or not
+	// the exec portion of the gas price has deviated and needs to be reported on chain.
+	ExecDeviationPPB cciptypes.BigInt `json:"execDeviationPPB"`
+
+	// DataAvailabilityDeviationPPB is the deviation threshold in parts per billion that determines whether or not
+	// the data availability portion of the gas price has deviated and needs to be reported on chain.
 	DataAvailabilityDeviationPPB cciptypes.BigInt `json:"dataAvailabilityDeviationPPB"`
+
+	// ChainFeeDeviationDisabled is a flag to disable deviation-based reporting. If true, we will only report
+	// prices based on the heartbeat.
+	ChainFeeDeviationDisabled bool `json:"chainFeeDeviationDisabled"`
 }
 
 type TokenInfo struct {


### PR DESCRIPTION
- Follow-up to: https://github.com/smartcontractkit/chainlink-ccip/pull/526
- We decided to only add the new `ChainFeeDeviationDisabled` param instead of the full curve based deviation logic for now to avoid adding potentially unnecessary complexity in the short term