### PR TITLE
[Solana][NONEVM-1416][NONEVM-1402] Fix rate limiter

### DIFF
--- a/chains/solana/contracts/programs/base-token-pool/src/common.rs
+++ b/chains/solana/contracts/programs/base-token-pool/src/common.rs
@@ -6,7 +6,7 @@ use rmn_remote::state::CurseSubject;
 use spl_math::uint::U256;
 use std::ops::Deref;
 
-use crate::rate_limiter::{validate_token_bucket_config, RateLimitConfig, RateLimitTokenBucket};
+use crate::rate_limiter::{RateLimitConfig, RateLimitTokenBucket};
 
 pub const ANCHOR_DISCRIMINATOR: usize = 8; // 8-byte anchor discriminator length
 pub const POOL_CHAINCONFIG_SEED: &[u8] = b"ccip_tokenpool_chainconfig"; // seed used by CCIP to provide correct chain config to pool
@@ -213,11 +213,10 @@ impl BaseChain {
         inbound: RateLimitConfig,
         outbound: RateLimitConfig,
     ) -> Result<()> {
-        validate_token_bucket_config(&inbound)?;
-        validate_token_bucket_config(&outbound)?;
-
-        self.inbound_rate_limit.cfg = inbound.clone();
-        self.outbound_rate_limit.cfg = outbound.clone();
+        self.inbound_rate_limit
+            .set_token_bucket_config(inbound.clone())?;
+        self.outbound_rate_limit
+            .set_token_bucket_config(outbound.clone())?;
 
         emit!(RateLimitConfigured {
             chain_selector: remote_chain_selector,

--- a/chains/solana/contracts/programs/base-token-pool/src/common.rs
+++ b/chains/solana/contracts/programs/base-token-pool/src/common.rs
@@ -456,7 +456,7 @@ pub fn validate_lock_or_burn<'info>(
         lock_or_burn_in.remote_chain_selector,
     )?;
 
-    outbound_rate_limit.consume(lock_or_burn_in.amount)
+    outbound_rate_limit.consume::<Clock>(lock_or_burn_in.amount)
 }
 
 // validate_lock_or_burn checks for correctness on inputs
@@ -494,7 +494,7 @@ pub fn validate_release_or_mint<'info>(
         release_or_mint_in.remote_chain_selector,
     )?;
 
-    inbound_rate_limit.consume(parsed_amount)
+    inbound_rate_limit.consume::<Clock>(parsed_amount)
 }
 
 pub fn verify_uncursed_cpi<'info>(

--- a/chains/solana/contracts/programs/base-token-pool/src/rate_limiter.rs
+++ b/chains/solana/contracts/programs/base-token-pool/src/rate_limiter.rs
@@ -11,7 +11,7 @@ use crate::common::CcipTokenPoolError;
 pub struct RateLimitTokenBucket {
     pub tokens: u64, // Current number of tokens that are in the bucket. Represents how many tokens a single transaction can consume in a single transaction - different than total number of tokens within a pool
     pub last_updated: u64, // Timestamp in seconds of the last token refill, good for 100+ years.
-    pub cfg: RateLimitConfig,
+    cfg: RateLimitConfig,
 }
 
 #[derive(InitSpace, Clone, AnchorSerialize, AnchorDeserialize)]
@@ -23,7 +23,7 @@ pub struct RateLimitConfig {
 
 pub trait Timestamper: Sized {
     fn unix_timestamp(&self) -> u64;
-    fn sysvar_get() -> std::result::Result<Self, ProgramError>;
+    fn instance() -> std::result::Result<Self, ProgramError>;
 }
 
 impl Timestamper for Clock {
@@ -31,7 +31,7 @@ impl Timestamper for Clock {
         self.unix_timestamp as u64
     }
 
-    fn sysvar_get() -> std::result::Result<Self, ProgramError> {
+    fn instance() -> std::result::Result<Self, ProgramError> {
         Self::get()
     }
 }
@@ -44,34 +44,20 @@ impl RateLimitTokenBucket {
             return Ok(());
         }
 
-        let clock = C::sysvar_get()?;
-        let current_timestamp = clock.unix_timestamp();
-
-        let mut tokens = self.tokens;
         let capacity = self.cfg.capacity;
-        let time_diff = current_timestamp.checked_sub(self.last_updated).unwrap();
-
-        if time_diff != 0 {
-            // this should never happen - requires manual resetting of config if this occurs
-            require!(tokens <= capacity, CcipTokenPoolError::RLBucketOverfilled);
-
-            // Refill tokens when arriving at a new block time
-            tokens = self.calculate_refill(capacity, tokens, time_diff, self.cfg.rate);
-
-            self.last_updated = current_timestamp;
-        }
-
         require!(
             capacity >= request_tokens,
             CcipTokenPoolError::RLMaxCapacityExceeded,
         );
 
-        if tokens < request_tokens {
+        self.refill::<C>()?;
+
+        if self.tokens < request_tokens {
             let rate = self.cfg.rate;
             // Wait required until the bucket is refilled enough to accept this value, round up to next higher second
             // Consume is not guaranteed to succeed after wait time passes if there is competing traffic.
             // This acts as a lower bound of wait time.
-            let min_wait_sec = (request_tokens.checked_sub(tokens).unwrap()
+            let min_wait_sec = (request_tokens.checked_sub(self.tokens).unwrap()
                 + rate.checked_sub(1).unwrap())
             .checked_div(self.cfg.rate)
             .unwrap();
@@ -79,13 +65,11 @@ impl RateLimitTokenBucket {
             // print human readable message before reverting with total wait time
             let msg = "min wait (s): ".to_owned() + &min_wait_sec.to_string();
             sol_log(&msg);
-        }
-        require!(
-            tokens >= request_tokens,
-            CcipTokenPoolError::RLRateLimitReached
-        );
 
-        self.tokens = tokens.checked_sub(request_tokens).unwrap();
+            return Err(CcipTokenPoolError::RLRateLimitReached.into());
+        }
+
+        self.tokens = self.tokens.checked_sub(request_tokens).unwrap();
         emit!(TokensConsumed {
             tokens: request_tokens
         });
@@ -93,34 +77,27 @@ impl RateLimitTokenBucket {
         Ok(())
     }
 
+    fn refill<C: Timestamper>(&mut self) -> Result<()> {
+        let current_timestamp = C::instance()?.unix_timestamp();
+        let time_diff = current_timestamp.checked_sub(self.last_updated).unwrap();
+        self.tokens = min(self.cfg.capacity, self.tokens + time_diff * self.cfg.rate);
+        self.last_updated = current_timestamp;
+        Ok(())
+    }
+
     // set_token_bucket_config sets + validates a new config and updates the number of tokens in the bucket
     pub fn set_token_bucket_config(&mut self, config: RateLimitConfig) -> Result<()> {
-        let clock: Clock = Clock::get()?;
-        let current_timestamp = clock.unix_timestamp as u64; // positive part of i64 will always fit in u64
-        let time_diff = current_timestamp.checked_sub(self.last_updated).unwrap();
-        if time_diff != 0 {
-            // Refill tokens when arriving at a new block time
-            self.tokens =
-                self.calculate_refill(self.cfg.capacity, self.tokens, time_diff, self.cfg.rate);
-
-            self.last_updated = current_timestamp;
-        }
-
-        self.tokens = min(config.capacity, self.tokens);
+        validate_token_bucket_config(&config)?;
         self.cfg = config.clone();
+        self.refill::<Clock>()?;
 
         emit!(ConfigChanged { config });
 
         Ok(())
     }
-
-    // calculate_refill returns either the maximum capacity of the bucket or the current + refill amount
-    fn calculate_refill(&self, capacity: u64, tokens: u64, time_diff: u64, rate: u64) -> u64 {
-        min(capacity, tokens + time_diff * rate)
-    }
 }
 
-pub fn validate_token_bucket_config(cfg: &RateLimitConfig) -> Result<()> {
+fn validate_token_bucket_config(cfg: &RateLimitConfig) -> Result<()> {
     if cfg.enabled {
         require!(
             cfg.rate < cfg.capacity && cfg.rate != 0,
@@ -164,8 +141,7 @@ mod tests {
             TIMESTAMP.with(|ts| *ts.borrow())
         }
 
-        fn sysvar_get() -> std::result::Result<Self, ProgramError> {
-            TIMESTAMP.with(|ts| *ts.borrow_mut() = 0);
+        fn instance() -> std::result::Result<Self, ProgramError> {
             Ok(Self)
         }
     }


### PR DESCRIPTION
Fixes a DoS bug that prevented the bucket from refilling during failed transactions. Introduces a shim testing layer so we can verify the behaviour without invoking the solana syscall.

Also addresses the audit feedback (NONEVM-1416) regarding config validation.