### PR TITLE
Allow verify build task to map short sha

### DIFF
--- a/.github/workflows/solana-verified-build.yml
+++ b/.github/workflows/solana-verified-build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        description: 'SHA to build'
+        description: 'SHA to build (can be short)'
         required: true
         type: string
 
@@ -12,9 +12,12 @@ jobs:
   build:
     runs-on: ubuntu-latest-8cores-32GB
     steps:
+    - name: Get full SHA
+      id: get_sha
+      run: echo "full_sha=$(git rev-parse ${{ github.event.inputs.sha }})" >> $GITHUB_OUTPUT
     - uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.inputs.sha }}
+        ref: ${{ steps.get_sha.outputs.full_sha }}
         fetch-depth: 0
     - uses: actions-rust-lang/setup-rust-toolchain@9399c7bb15d4c7d47b27263d024f0a4978346ba4 # v1
     - name: Install Solana Verify
@@ -39,8 +42,8 @@ jobs:
       uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        tag_name: solana-artifacts-localtest-${{ github.event.inputs.sha }}
-        target_commitish: ${{ github.event.inputs.sha }}
+        tag_name: solana-artifacts-localtest-${{ steps.get_sha.outputs.full_sha }}
+        target_commitish: ${{ steps.get_sha.outputs.full_sha }}
         files: |
           chains/solana/contracts/artifacts.tar.gz
           chains/solana/contracts/target/deploy/*.so

--- a/.github/workflows/solana-verified-build.yml
+++ b/.github/workflows/solana-verified-build.yml
@@ -12,9 +12,16 @@ jobs:
   build:
     runs-on: ubuntu-latest-8cores-32GB
     steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.inputs.sha }}
+        fetch-depth: 0
     - name: Get full SHA
       id: get_sha
-      run: echo "full_sha=$(git rev-parse ${{ github.event.inputs.sha }})" >> $GITHUB_OUTPUT
+      run: |
+        FULL_SHA=$(git rev-parse ${{ github.event.inputs.sha }})
+        echo "full_sha=$FULL_SHA" >> $GITHUB_OUTPUT
+        echo "short_sha=${FULL_SHA:0:12}" >> $GITHUB_OUTPUT
     - uses: actions/checkout@v4
       with:
         ref: ${{ steps.get_sha.outputs.full_sha }}
@@ -42,7 +49,7 @@ jobs:
       uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        tag_name: solana-artifacts-localtest-${{ steps.get_sha.outputs.full_sha }}
+        tag_name: solana-artifacts-localtest-${{ steps.get_sha.outputs.short_sha }}
         target_commitish: ${{ steps.get_sha.outputs.full_sha }}
         files: |
           chains/solana/contracts/artifacts.tar.gz

--- a/.github/workflows/solana-verified-build.yml
+++ b/.github/workflows/solana-verified-build.yml
@@ -14,7 +14,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        ref: ${{ github.event.inputs.sha }}
         fetch-depth: 0
     - name: Get full SHA
       id: get_sha


### PR DESCRIPTION
Update task so it accepts a short sha and standardise the release name to 12 chars