### PR TITLE
[CCIP-5450] Deprecate FeeInfo in favor of ChainConfig in ChainFee processor

### DIFF
--- a/chainconfig/chainconfig.go
+++ b/chainconfig/chainconfig.go
@@ -27,6 +27,10 @@ type ChainConfig struct {
 	// OptimisticConfirmations is the number of confirmations of a chain event before
 	// it is considered optimistically confirmed (i.e not necessarily finalized).
 	OptimisticConfirmations uint32 `json:"optimisticConfirmations"`
+
+	// ChainFeeDeviationDisabled is a flag to disable deviation-based reporting. If true, we will only report
+	// prices based on the heartbeat.
+	ChainFeeDeviationDisabled bool `json:"chainFeeDeviationDisabled"`
 }
 
 func (cc ChainConfig) Validate() error {

--- a/commit/chainfee/outcome.go
+++ b/commit/chainfee/outcome.go
@@ -217,9 +217,15 @@ func (p *processor) getGasPricesToUpdate(
 	obsTimestamp time.Time,
 ) []cciptypes.GasPriceChain {
 	var gasPrices []cciptypes.GasPriceChain
-	feeInfo := p.cfg.FeeInfo
 
 	for chain, currentChainFee := range currentChainUSDFees {
+		chainCfg, err := p.homeChain.GetChainConfig(chain)
+
+		feeConfig := chainCfg.Config
+		if err != nil {
+			lggr.Errorw("error getting chain config", "chain", chain, "err", err)
+			continue
+		}
 		packedFee := cciptypes.NewBigInt(FeeComponentsToPackedFee(currentChainFee))
 		lastUpdate, exists := latestUpdates[chain]
 		// If the chain is not in the fee quoter updates or is stale, then we should update it
@@ -240,30 +246,27 @@ func (p *processor) getGasPricesToUpdate(
 			continue
 		}
 
-		if feeInfo == nil {
-			continue
-		}
-		ci, ok := feeInfo[chain]
-		if !ok {
-			lggr.Warnf("could not find fee info for chain %d", chain)
+		if feeConfig.ChainFeeDeviationDisabled {
+			lggr.Debugw("chain fee deviation disabled", "chain", chain)
 			continue
 		}
 
-		if ci.ChainFeeDeviationDisabled {
-			lggr.Debugw("chain fee deviation disabled", "chain", chain)
+		// Validating later as chain can be updated even if the config is invalid when write frequency is reached
+		if feeConfig.Validate() != nil {
+			lggr.Errorw("invalid chain config", "chain", chain, "err", err)
 			continue
 		}
 
 		executionFeeDeviates := mathslib.Deviates(
 			currentChainFee.ExecutionFeePriceUSD,
 			lastUpdate.ChainFee.ExecutionFeePriceUSD,
-			ci.ExecDeviationPPB.Int64(),
+			feeConfig.GasPriceDeviationPPB.Int64(),
 		)
 
 		dataAvFeeDeviates := mathslib.Deviates(
 			currentChainFee.DataAvFeePriceUSD,
 			lastUpdate.ChainFee.DataAvFeePriceUSD,
-			ci.DataAvailabilityDeviationPPB.Int64(),
+			feeConfig.DAGasPriceDeviationPPB.Int64(),
 		)
 
 		if executionFeeDeviates || dataAvFeeDeviates {

--- a/commit/chainfee/outcome_test.go
+++ b/commit/chainfee/outcome_test.go
@@ -5,6 +5,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/mock"
+
+	"github.com/smartcontractkit/chainlink-ccip/internal/libs/mathslib"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	libocrtypes "github.com/smartcontractkit/libocr/ragep2p/types"
+
+	"github.com/smartcontractkit/chainlink-ccip/chainconfig"
+	mock_home_chain "github.com/smartcontractkit/chainlink-ccip/mocks/internal_/reader"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/reader"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -44,8 +55,20 @@ var obsNeedUpdate = Observation{
 	NativeTokenPrices: nativeTokenPricesMap,
 	FChain:            fChains,
 	ChainFeeUpdates: map[cciptypes.ChainSelector]Update{
-		1: {Timestamp: ts},
-		2: {Timestamp: ts.Add(-chainFeePriceBatchWriteFrequency.Duration() * 2)}, // Needs updating
+		1: {
+			Timestamp: ts,
+			ChainFee: ComponentsUSDPrices{
+				ExecutionFeePriceUSD: mathslib.CalculateUsdPerUnitGas(feeComponentsMap[1].ExecutionFee, nativeTokenPricesMap[1].Int),
+				DataAvFeePriceUSD:    mathslib.CalculateUsdPerUnitGas(feeComponentsMap[1].DataAvailabilityFee, nativeTokenPricesMap[1].Int),
+			},
+		},
+		2: {
+			Timestamp: ts.Add(-chainFeePriceBatchWriteFrequency.Duration() * 2),
+			ChainFee: ComponentsUSDPrices{
+				ExecutionFeePriceUSD: mathslib.CalculateUsdPerUnitGas(feeComponentsMap[2].ExecutionFee, nativeTokenPricesMap[2].Int),
+				DataAvFeePriceUSD:    mathslib.CalculateUsdPerUnitGas(feeComponentsMap[2].DataAvailabilityFee, nativeTokenPricesMap[2].Int),
+			},
+		}, // Needs updating
 	},
 	TimestampNow: ts,
 }
@@ -55,10 +78,33 @@ var obsNoUpdate = Observation{
 	NativeTokenPrices: nativeTokenPricesMap,
 	FChain:            fChains,
 	ChainFeeUpdates: map[cciptypes.ChainSelector]Update{
-		1: {Timestamp: ts},
-		2: {Timestamp: ts},
+		1: {
+			ChainFee: ComponentsUSDPrices{
+				ExecutionFeePriceUSD: mathslib.CalculateUsdPerUnitGas(feeComponentsMap[1].ExecutionFee, nativeTokenPricesMap[1].Int),
+				DataAvFeePriceUSD:    mathslib.CalculateUsdPerUnitGas(feeComponentsMap[1].DataAvailabilityFee, nativeTokenPricesMap[1].Int),
+			},
+			Timestamp: ts,
+		},
+		2: {
+			ChainFee: ComponentsUSDPrices{
+				ExecutionFeePriceUSD: mathslib.CalculateUsdPerUnitGas(feeComponentsMap[2].ExecutionFee, nativeTokenPricesMap[2].Int),
+				DataAvFeePriceUSD:    mathslib.CalculateUsdPerUnitGas(feeComponentsMap[2].DataAvailabilityFee, nativeTokenPricesMap[2].Int),
+			},
+			Timestamp: ts,
+		},
 	},
 	TimestampNow: ts,
+}
+
+var defaultChainConfig = reader.ChainConfig{
+	FChain: 1,
+	// not necessary for test, using some peerIDs
+	SupportedNodes: mapset.NewSet(libocrtypes.PeerID{1}, libocrtypes.PeerID{2}),
+	Config: chainconfig.ChainConfig{
+		GasPriceDeviationPPB:    cciptypes.NewBigInt(big.NewInt(1)),
+		DAGasPriceDeviationPPB:  cciptypes.NewBigInt(big.NewInt(1)),
+		OptimisticConfirmations: 1,
+	},
 }
 
 // sameObs returns n observations with the same observation but from different oracle ids
@@ -68,6 +114,20 @@ func sameObs(n int, obs Observation) []plugincommon.AttributedObservation[Observ
 		aos[i] = plugincommon.AttributedObservation[Observation]{OracleID: commontypes.OracleID(i), Observation: obs}
 	}
 	return aos
+}
+
+type FeeInfo struct {
+	// ExecDeviationPPB is the deviation threshold in parts per billion that determines whether or not
+	// the exec portion of the gas price has deviated and needs to be reported on chain.
+	ExecDeviationPPB cciptypes.BigInt `json:"execDeviationPPB"`
+
+	// DataAvailabilityDeviationPPB is the deviation threshold in parts per billion that determines whether or not
+	// the data availability portion of the gas price has deviated and needs to be reported on chain.
+	DataAvailabilityDeviationPPB cciptypes.BigInt `json:"dataAvailabilityDeviationPPB"`
+
+	// ChainFeeDeviationDisabled is a flag to disable deviation-based reporting. If true, we will only report
+	// prices based on the heartbeat.
+	ChainFeeDeviationDisabled bool `json:"chainFeeDeviationDisabled"`
 }
 
 func TestGetConsensusObservation(t *testing.T) {
@@ -117,7 +177,7 @@ func TestProcessor_Outcome(t *testing.T) {
 	cases := []struct {
 		name                   string
 		chainFeeWriteFrequency commonconfig.Duration
-		feeInfo                map[cciptypes.ChainSelector]pluginconfig.FeeInfo
+		feeInfo                map[cciptypes.ChainSelector]FeeInfo
 		aos                    []plugincommon.AttributedObservation[Observation]
 		expectedError          bool
 		expectedOutcome        func() Outcome
@@ -165,7 +225,7 @@ func TestProcessor_Outcome(t *testing.T) {
 		{
 			name:                   "happy path with a price deviation",
 			chainFeeWriteFrequency: *commonconfig.MustNewDuration(time.Hour),
-			feeInfo: map[cciptypes.ChainSelector]pluginconfig.FeeInfo{
+			feeInfo: map[cciptypes.ChainSelector]FeeInfo{
 				1: {
 					ExecDeviationPPB:             cciptypes.NewBigInt(big.NewInt(1)),
 					DataAvailabilityDeviationPPB: cciptypes.NewBigInt(big.NewInt(1)),
@@ -216,7 +276,7 @@ func TestProcessor_Outcome(t *testing.T) {
 		{
 			name:                   "deviation check disabled",
 			chainFeeWriteFrequency: *commonconfig.MustNewDuration(time.Hour),
-			feeInfo: map[cciptypes.ChainSelector]pluginconfig.FeeInfo{
+			feeInfo: map[cciptypes.ChainSelector]FeeInfo{
 				1: {
 					ExecDeviationPPB:             cciptypes.NewBigInt(big.NewInt(1)),
 					DataAvailabilityDeviationPPB: cciptypes.NewBigInt(big.NewInt(1)),
@@ -253,15 +313,33 @@ func TestProcessor_Outcome(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := tests.Context(t)
+			homeChainMock := mock_home_chain.NewMockHomeChain(t)
+			if tt.feeInfo == nil {
+				homeChainMock.EXPECT().GetChainConfig(mock.Anything).
+					Return(defaultChainConfig, nil).Maybe()
+			}
+			for chain, info := range tt.feeInfo {
+				homeChainMock.EXPECT().GetChainConfig(chain).Return(reader.ChainConfig{
+					FChain: 1,
+					// not necessary for test, using some peerIDs
+					SupportedNodes: mapset.NewSet(libocrtypes.PeerID{1}, libocrtypes.PeerID{2}),
+					Config: chainconfig.ChainConfig{
+						GasPriceDeviationPPB:      info.ExecDeviationPPB,
+						DAGasPriceDeviationPPB:    info.DataAvailabilityDeviationPPB,
+						OptimisticConfirmations:   1,
+						ChainFeeDeviationDisabled: info.ChainFeeDeviationDisabled,
+					},
+				}, nil).Maybe()
+			}
 			p := &processor{
 				lggr:      logger.Test(t),
 				destChain: 1,
 				fRoleDON:  1,
 				cfg: pluginconfig.CommitOffchainConfig{
 					RemoteGasPriceBatchWriteFrequency: tt.chainFeeWriteFrequency,
-					FeeInfo:                           tt.feeInfo,
 				},
 				metricsReporter: plugincommon.NoopReporter{},
+				homeChain:       homeChainMock,
 			}
 
 			outcome, err := p.Outcome(ctx, Outcome{}, Query{}, tt.aos)

--- a/commit/chainfee/outcome_test.go
+++ b/commit/chainfee/outcome_test.go
@@ -58,17 +58,29 @@ var obsNeedUpdate = Observation{
 		1: {
 			Timestamp: ts,
 			ChainFee: ComponentsUSDPrices{
-				ExecutionFeePriceUSD: mathslib.CalculateUsdPerUnitGas(feeComponentsMap[1].ExecutionFee, nativeTokenPricesMap[1].Int),
-				DataAvFeePriceUSD:    mathslib.CalculateUsdPerUnitGas(feeComponentsMap[1].DataAvailabilityFee, nativeTokenPricesMap[1].Int),
+				ExecutionFeePriceUSD: mathslib.CalculateUsdPerUnitGas(
+					feeComponentsMap[1].ExecutionFee, nativeTokenPricesMap[1].Int,
+				),
+				DataAvFeePriceUSD: mathslib.CalculateUsdPerUnitGas(
+					feeComponentsMap[1].DataAvailabilityFee,
+					nativeTokenPricesMap[1].Int,
+				),
 			},
 		},
 		2: {
+			// Need update because timestamp is older than batch write frequency
 			Timestamp: ts.Add(-chainFeePriceBatchWriteFrequency.Duration() * 2),
 			ChainFee: ComponentsUSDPrices{
-				ExecutionFeePriceUSD: mathslib.CalculateUsdPerUnitGas(feeComponentsMap[2].ExecutionFee, nativeTokenPricesMap[2].Int),
-				DataAvFeePriceUSD:    mathslib.CalculateUsdPerUnitGas(feeComponentsMap[2].DataAvailabilityFee, nativeTokenPricesMap[2].Int),
+				ExecutionFeePriceUSD: mathslib.CalculateUsdPerUnitGas(
+					feeComponentsMap[2].ExecutionFee,
+					nativeTokenPricesMap[2].Int,
+				),
+				DataAvFeePriceUSD: mathslib.CalculateUsdPerUnitGas(
+					feeComponentsMap[2].DataAvailabilityFee,
+					nativeTokenPricesMap[2].Int,
+				),
 			},
-		}, // Needs updating
+		},
 	},
 	TimestampNow: ts,
 }
@@ -80,15 +92,26 @@ var obsNoUpdate = Observation{
 	ChainFeeUpdates: map[cciptypes.ChainSelector]Update{
 		1: {
 			ChainFee: ComponentsUSDPrices{
-				ExecutionFeePriceUSD: mathslib.CalculateUsdPerUnitGas(feeComponentsMap[1].ExecutionFee, nativeTokenPricesMap[1].Int),
-				DataAvFeePriceUSD:    mathslib.CalculateUsdPerUnitGas(feeComponentsMap[1].DataAvailabilityFee, nativeTokenPricesMap[1].Int),
+				ExecutionFeePriceUSD: mathslib.CalculateUsdPerUnitGas(
+					feeComponentsMap[1].ExecutionFee, nativeTokenPricesMap[1].Int,
+				),
+				DataAvFeePriceUSD: mathslib.CalculateUsdPerUnitGas(
+					feeComponentsMap[1].DataAvailabilityFee,
+					nativeTokenPricesMap[1].Int,
+				),
 			},
 			Timestamp: ts,
 		},
 		2: {
 			ChainFee: ComponentsUSDPrices{
-				ExecutionFeePriceUSD: mathslib.CalculateUsdPerUnitGas(feeComponentsMap[2].ExecutionFee, nativeTokenPricesMap[2].Int),
-				DataAvFeePriceUSD:    mathslib.CalculateUsdPerUnitGas(feeComponentsMap[2].DataAvailabilityFee, nativeTokenPricesMap[2].Int),
+				ExecutionFeePriceUSD: mathslib.CalculateUsdPerUnitGas(
+					feeComponentsMap[2].ExecutionFee,
+					nativeTokenPricesMap[2].Int,
+				),
+				DataAvFeePriceUSD: mathslib.CalculateUsdPerUnitGas(
+					feeComponentsMap[2].DataAvailabilityFee,
+					nativeTokenPricesMap[2].Int,
+				),
 			},
 			Timestamp: ts,
 		},

--- a/pluginconfig/commit.go
+++ b/pluginconfig/commit.go
@@ -22,7 +22,6 @@ const (
 	defaultNewMsgScanBatchSize                = merklemulti.MaxNumberTreeLeaves
 	defaultEvmDefaultMaxMerkleTreeSize        = merklemulti.MaxNumberTreeLeaves
 	defaultMaxReportTransmissionCheckAttempts = 5
-	defaultRMNEnabled                         = false
 	defaultRemoteGasPriceBatchWriteFrequency  = 1 * time.Minute
 	defaultSignObservationPrefix              = "chainlink ccip 1.6 rmn observation"
 	defaultTransmissionDelayMultiplier        = 30 * time.Second

--- a/pluginconfig/commit.go
+++ b/pluginconfig/commit.go
@@ -31,20 +31,6 @@ const (
 	defaultAsyncObserverSyncTimeout           = 10 * time.Second
 )
 
-type FeeInfo struct {
-	// ExecDeviationPPB is the deviation threshold in parts per billion that determines whether or not
-	// the exec portion of the gas price has deviated and needs to be reported on chain.
-	ExecDeviationPPB cciptypes.BigInt `json:"execDeviationPPB"`
-
-	// DataAvailabilityDeviationPPB is the deviation threshold in parts per billion that determines whether or not
-	// the data availability portion of the gas price has deviated and needs to be reported on chain.
-	DataAvailabilityDeviationPPB cciptypes.BigInt `json:"dataAvailabilityDeviationPPB"`
-
-	// ChainFeeDeviationDisabled is a flag to disable deviation-based reporting. If true, we will only report
-	// prices based on the heartbeat.
-	ChainFeeDeviationDisabled bool `json:"chainFeeDeviationDisabled"`
-}
-
 type TokenInfo struct {
 	// AggregatorAddress is the address of the price feed TOKEN/USD aggregator on the feed chain.
 	AggregatorAddress cciptypes.UnknownEncodedAddress `json:"aggregatorAddress"`
@@ -92,8 +78,6 @@ type CommitOffchainConfig struct {
 	// should write gas prices to the remote chain.
 	//TODO: Rename to something with ChainFee
 	RemoteGasPriceBatchWriteFrequency commonconfig.Duration `json:"remoteGasPriceBatchWriteFrequency"`
-
-	FeeInfo map[cciptypes.ChainSelector]FeeInfo `json:"feeInfo"`
 
 	// TokenPriceBatchWriteFrequency is the frequency at which the commit plugin should
 	// write token prices to the remote chain.


### PR DESCRIPTION
So far in ChainFeeProcessor we've been using [FeeInfo](https://github.com/smartcontractkit/chainlink-ccip/blob/main/pluginconfig/commit.go#L35-L41).  It makes sense to use [ChainConfig](https://github.com/smartcontractkit/chainlink-ccip/blob/main/chainconfig/chainconfig.go#L15-L25) as it will be more dynamic. Checking the test setups in Chainlink, all FeeInfo related code seems to be removed and we're using [CCIPHome](https://github.com/smartcontractkit/chainlink/blob/3822907f158219b2b87cb3442d1360984c4c3b9c/deployment/ccip/changeset/testhelpers/test_environment.go#L711-L719) config. 

This PR fixes this by removing FeeInfo completely from the code an relying on ChainConfig