### PR TITLE
fix: solana CI release workflow

### DIFF
--- a/.github/workflows/solana-verified-build.yml
+++ b/.github/workflows/solana-verified-build.yml
@@ -15,6 +15,9 @@ jobs:
   build:
     runs-on: ubuntu-latest-8cores-32GB
     steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Get Long and Short SHAs
       id: get_sha
       run: |


### PR DESCRIPTION
The solana release CI action needs to checkout the repo before running the other CI steps