### PR TITLE
pkg/reader: rm unused method

### DIFF
--- a/internal/mocks/inmem/ccipreader_inmem.go
+++ b/internal/mocks/inmem/ccipreader_inmem.go
@@ -197,12 +197,6 @@ func (r InMemoryCCIPReader) Sync(_ context.Context, _ reader.ContractAddresses) 
 	return nil
 }
 
-func (r InMemoryCCIPReader) GetMedianDataAvailabilityGasConfig(
-	ctx context.Context,
-) (cciptypes.DataAvailabilityGasConfig, error) {
-	return cciptypes.DataAvailabilityGasConfig{}, nil
-}
-
 func (r InMemoryCCIPReader) GetLatestPriceSeqNr(ctx context.Context) (uint64, error) {
 	return 0, nil
 }

--- a/mocks/pkg/reader/ccip_reader.go
+++ b/mocks/pkg/reader/ccip_reader.go
@@ -543,62 +543,6 @@ func (_c *MockCCIPReader_GetLatestPriceSeqNr_Call) RunAndReturn(run func(context
 	return _c
 }
 
-// GetMedianDataAvailabilityGasConfig provides a mock function with given fields: ctx
-func (_m *MockCCIPReader) GetMedianDataAvailabilityGasConfig(ctx context.Context) (ccipocr3.DataAvailabilityGasConfig, error) {
-	ret := _m.Called(ctx)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetMedianDataAvailabilityGasConfig")
-	}
-
-	var r0 ccipocr3.DataAvailabilityGasConfig
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context) (ccipocr3.DataAvailabilityGasConfig, error)); ok {
-		return rf(ctx)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context) ccipocr3.DataAvailabilityGasConfig); ok {
-		r0 = rf(ctx)
-	} else {
-		r0 = ret.Get(0).(ccipocr3.DataAvailabilityGasConfig)
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockCCIPReader_GetMedianDataAvailabilityGasConfig_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetMedianDataAvailabilityGasConfig'
-type MockCCIPReader_GetMedianDataAvailabilityGasConfig_Call struct {
-	*mock.Call
-}
-
-// GetMedianDataAvailabilityGasConfig is a helper method to define mock.On call
-//   - ctx context.Context
-func (_e *MockCCIPReader_Expecter) GetMedianDataAvailabilityGasConfig(ctx interface{}) *MockCCIPReader_GetMedianDataAvailabilityGasConfig_Call {
-	return &MockCCIPReader_GetMedianDataAvailabilityGasConfig_Call{Call: _e.mock.On("GetMedianDataAvailabilityGasConfig", ctx)}
-}
-
-func (_c *MockCCIPReader_GetMedianDataAvailabilityGasConfig_Call) Run(run func(ctx context.Context)) *MockCCIPReader_GetMedianDataAvailabilityGasConfig_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context))
-	})
-	return _c
-}
-
-func (_c *MockCCIPReader_GetMedianDataAvailabilityGasConfig_Call) Return(_a0 ccipocr3.DataAvailabilityGasConfig, _a1 error) *MockCCIPReader_GetMedianDataAvailabilityGasConfig_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockCCIPReader_GetMedianDataAvailabilityGasConfig_Call) RunAndReturn(run func(context.Context) (ccipocr3.DataAvailabilityGasConfig, error)) *MockCCIPReader_GetMedianDataAvailabilityGasConfig_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetOffRampConfigDigest provides a mock function with given fields: ctx, pluginType
 func (_m *MockCCIPReader) GetOffRampConfigDigest(ctx context.Context, pluginType uint8) ([32]byte, error) {
 	ret := _m.Called(ctx, pluginType)

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -21,8 +21,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
 
-	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon/consensus"
-
 	rmntypes "github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn/types"
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/slicelib"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
@@ -1491,75 +1489,6 @@ func (r *ccipChainReader) getRMNRemoteAddress(
 	}
 
 	return config.RMNProxy.RemoteAddress, nil
-}
-
-// Get the DestChainConfig from the FeeQuoter contract on the given chain.
-func (r *ccipChainReader) getFeeQuoterDestChainConfig(
-	ctx context.Context,
-	chainSelector cciptypes.ChainSelector,
-) (cciptypes.FeeQuoterDestChainConfig, error) {
-	if err := validateExtendedReaderExistence(r.contractReaders, chainSelector); err != nil {
-		return cciptypes.FeeQuoterDestChainConfig{}, err
-	}
-
-	var destChainConfig cciptypes.FeeQuoterDestChainConfig
-	srcReader := r.contractReaders[chainSelector]
-	err := srcReader.ExtendedGetLatestValue(
-		ctx,
-		consts.ContractNameFeeQuoter,
-		consts.MethodNameGetDestChainConfig,
-		primitives.Unconfirmed,
-		map[string]any{
-			"destChainSelector": r.destChain,
-		},
-		&destChainConfig,
-	)
-
-	if err != nil {
-		return cciptypes.FeeQuoterDestChainConfig{},
-			fmt.Errorf("get dest chain config for source chain %d: %w",
-				chainSelector, err)
-	}
-
-	return destChainConfig, nil
-}
-
-// GetMedianDataAvailabilityGasConfig returns the median of the DataAvailabilityGasConfig values from all FeeQuoters
-// DA data lives in the FeeQuoter contract on the source chain. To get the config of the destination chain, we need to
-// read the FeeQuoter contract on the source chain. As nodes are not required to have all chains configured, we need to
-// read all FeeQuoter contracts to get the median.
-func (r *ccipChainReader) GetMedianDataAvailabilityGasConfig(
-	ctx context.Context,
-) (cciptypes.DataAvailabilityGasConfig, error) {
-	overheadGasValues := make([]uint32, 0)
-	gasPerByteValues := make([]uint16, 0)
-	multiplierBpsValues := make([]uint16, 0)
-
-	// TODO: pay attention to performance here, as we are looping through all chains
-	for chain := range r.contractReaders {
-		config, err := r.getFeeQuoterDestChainConfig(ctx, chain)
-		if err != nil {
-			continue
-		}
-		if config.IsEnabled && config.HasNonEmptyDAGasParams() {
-			overheadGasValues = append(overheadGasValues, config.DestDataAvailabilityOverheadGas)
-			gasPerByteValues = append(gasPerByteValues, config.DestGasPerDataAvailabilityByte)
-			multiplierBpsValues = append(multiplierBpsValues, config.DestDataAvailabilityMultiplierBps)
-		}
-	}
-
-	// Calculate medians
-	medianOverheadGas := consensus.Median(overheadGasValues, func(a, b uint32) bool { return a < b })
-	medianGasPerByte := consensus.Median(gasPerByteValues, func(a, b uint16) bool { return a < b })
-	medianMultiplierBps := consensus.Median(multiplierBpsValues, func(a, b uint16) bool { return a < b })
-
-	daConfig := cciptypes.DataAvailabilityGasConfig{
-		DestDataAvailabilityOverheadGas:   medianOverheadGas,
-		DestGasPerDataAvailabilityByte:    medianGasPerByte,
-		DestDataAvailabilityMultiplierBps: medianMultiplierBps,
-	}
-
-	return daConfig, nil
 }
 
 func (r *ccipChainReader) GetLatestPriceSeqNr(ctx context.Context) (uint64, error) {

--- a/pkg/reader/ccip_interface.go
+++ b/pkg/reader/ccip_interface.go
@@ -259,9 +259,6 @@ type CCIPReader interface {
 	// Returns a bool indicating whether something was updated.
 	Sync(ctx context.Context, contracts ContractAddresses) error
 
-	// GetMedianDataAvailabilityGasConfig returns the median of the DataAvailabilityGasConfig values from all FeeQuoters
-	GetMedianDataAvailabilityGasConfig(ctx context.Context) (cciptypes.DataAvailabilityGasConfig, error)
-
 	// GetLatestPriceSeqNr returns the latest price sequence number for the destination chain.
 	// Not to confuse with the sequence number of the messages. This is the OCR sequence number.
 	GetLatestPriceSeqNr(ctx context.Context) (uint64, error)

--- a/pkg/reader/ccip_test.go
+++ b/pkg/reader/ccip_test.go
@@ -939,147 +939,6 @@ func TestCCIPChainReader_LinkPriceUSD(t *testing.T) {
 	mockCache.AssertExpectations(t)
 }
 
-func TestCCIPChainReader_GetMedianDataAvailabilityGasConfig(t *testing.T) {
-	type mockValue struct {
-		overhead   uint32
-		perByte    uint16
-		multiplier uint16
-		enabled    bool
-	}
-
-	setupConfigMocks := func(
-		readers map[cciptypes.ChainSelector]*reader_mocks.MockExtended,
-		chains []cciptypes.ChainSelector,
-		values []mockValue) {
-		for i, chain := range chains {
-			readers[chain].EXPECT().
-				ExtendedGetLatestValue(
-					mock.Anything,
-					consts.ContractNameFeeQuoter,
-					consts.MethodNameGetDestChainConfig,
-					primitives.Unconfirmed,
-					mock.Anything,
-					mock.Anything,
-				).
-				Return(nil).
-				Run(withReturnValueOverridden(func(returnVal interface{}) {
-					cfg := returnVal.(*cciptypes.FeeQuoterDestChainConfig)
-					cfg.DestDataAvailabilityOverheadGas = values[i].overhead
-					cfg.DestGasPerDataAvailabilityByte = values[i].perByte
-					cfg.DestDataAvailabilityMultiplierBps = values[i].multiplier
-					cfg.IsEnabled = values[i].enabled
-				})).Once()
-		}
-	}
-
-	tests := []struct {
-		name           string
-		expectedConfig cciptypes.DataAvailabilityGasConfig
-		expectError    bool
-		chains         []cciptypes.ChainSelector
-		setupMocks     func(readers map[cciptypes.ChainSelector]*reader_mocks.MockExtended)
-	}{
-		{
-			name: "success - returns median values from multiple configs",
-			expectedConfig: cciptypes.DataAvailabilityGasConfig{
-				DestDataAvailabilityOverheadGas:   200,
-				DestGasPerDataAvailabilityByte:    20,
-				DestDataAvailabilityMultiplierBps: 2000,
-			},
-			chains: []cciptypes.ChainSelector{chainA, chainB, chainC},
-			setupMocks: func(readers map[cciptypes.ChainSelector]*reader_mocks.MockExtended) {
-				values := []mockValue{
-					{100, 10, 1000, true},
-					{200, 20, 2000, true},
-					{300, 30, 3000, true},
-				}
-				setupConfigMocks(readers, []cciptypes.ChainSelector{chainA, chainB, chainC}, values)
-			},
-		},
-		{
-			name: "success - skips disabled configs",
-			expectedConfig: cciptypes.DataAvailabilityGasConfig{
-				DestDataAvailabilityOverheadGas:   300,
-				DestGasPerDataAvailabilityByte:    30,
-				DestDataAvailabilityMultiplierBps: 3000,
-			},
-			chains: []cciptypes.ChainSelector{chainA, chainB, chainC},
-			setupMocks: func(readers map[cciptypes.ChainSelector]*reader_mocks.MockExtended) {
-				values := []mockValue{
-					{100, 10, 1000, true},
-					{200, 20, 2000, false},
-					{300, 30, 3000, true},
-				}
-				setupConfigMocks(readers, []cciptypes.ChainSelector{chainA, chainB, chainC}, values)
-			},
-		},
-		{
-			name: "no valid configs found due to empty DA params",
-			expectedConfig: cciptypes.DataAvailabilityGasConfig{
-				DestDataAvailabilityOverheadGas:   0,
-				DestGasPerDataAvailabilityByte:    0,
-				DestDataAvailabilityMultiplierBps: 0,
-			},
-			expectError: false,
-			chains:      []cciptypes.ChainSelector{chainA, chainB, chainC},
-			setupMocks: func(readers map[cciptypes.ChainSelector]*reader_mocks.MockExtended) {
-				values := []mockValue{
-					{0, 0, 0, true}, // Empty DA params
-					{0, 0, 0, true}, // Empty DA params
-					{0, 0, 0, true}, // Empty DA params
-				}
-				setupConfigMocks(readers, []cciptypes.ChainSelector{chainA, chainB, chainC}, values)
-			},
-		},
-		{
-			name:        "all configs disabled",
-			expectError: false,
-			expectedConfig: cciptypes.DataAvailabilityGasConfig{
-				DestDataAvailabilityOverheadGas:   0,
-				DestGasPerDataAvailabilityByte:    0,
-				DestDataAvailabilityMultiplierBps: 0,
-			},
-			chains: []cciptypes.ChainSelector{chainA, chainB},
-			setupMocks: func(readers map[cciptypes.ChainSelector]*reader_mocks.MockExtended) {
-				values := []mockValue{
-					{100, 10, 1000, false},
-					{200, 20, 2000, false},
-				}
-				setupConfigMocks(readers, []cciptypes.ChainSelector{chainA, chainB}, values)
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockReaders := make(map[cciptypes.ChainSelector]*reader_mocks.MockExtended)
-			contractReaders := make(map[cciptypes.ChainSelector]contractreader.Extended)
-
-			// Initialize mocks
-			for _, chain := range tt.chains {
-				mockReaders[chain] = reader_mocks.NewMockExtended(t)
-				contractReaders[chain] = mockReaders[chain]
-			}
-
-			tt.setupMocks(mockReaders)
-
-			reader := &ccipChainReader{
-				lggr:            logger.Test(t),
-				contractReaders: contractReaders,
-				destChain:       chainC,
-			}
-			config, err := reader.GetMedianDataAvailabilityGasConfig(context.Background())
-
-			if tt.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tt.expectedConfig, config)
-			}
-		})
-	}
-}
-
 func Test_getCurseInfoFromCursedSubjects(t *testing.T) {
 	testCases := []struct {
 		name              string
@@ -1099,7 +958,7 @@ func Test_getCurseInfoFromCursedSubjects(t *testing.T) {
 		},
 		{
 			name: "everything cursed",
-			cursedSubjectsSet: mapset.NewSet[[16]byte](
+			cursedSubjectsSet: mapset.NewSet(
 				chainSelectorToBytes16(chainB),
 				chainSelectorToBytes16(chainC),
 				chainSelectorToBytes16(chainA), // dest
@@ -1117,7 +976,7 @@ func Test_getCurseInfoFromCursedSubjects(t *testing.T) {
 		},
 		{
 			name: "no global curse",
-			cursedSubjectsSet: mapset.NewSet[[16]byte](
+			cursedSubjectsSet: mapset.NewSet(
 				chainSelectorToBytes16(chainB),
 				chainSelectorToBytes16(chainC),
 				chainSelectorToBytes16(chainA), // dest
@@ -1134,7 +993,7 @@ func Test_getCurseInfoFromCursedSubjects(t *testing.T) {
 		},
 		{
 			name: "dest cursed due to global curse",
-			cursedSubjectsSet: mapset.NewSet[[16]byte](
+			cursedSubjectsSet: mapset.NewSet(
 				chainSelectorToBytes16(chainB),
 				chainSelectorToBytes16(chainC),
 				GlobalCurseSubject,
@@ -1151,7 +1010,7 @@ func Test_getCurseInfoFromCursedSubjects(t *testing.T) {
 		},
 		{
 			name: "dest not cursed",
-			cursedSubjectsSet: mapset.NewSet[[16]byte](
+			cursedSubjectsSet: mapset.NewSet(
 				chainSelectorToBytes16(chainB),
 				chainSelectorToBytes16(chainC),
 			),
@@ -1167,7 +1026,7 @@ func Test_getCurseInfoFromCursedSubjects(t *testing.T) {
 		},
 		{
 			name: "source chain B not cursed",
-			cursedSubjectsSet: mapset.NewSet[[16]byte](
+			cursedSubjectsSet: mapset.NewSet(
 				chainSelectorToBytes16(chainC),
 				chainSelectorToBytes16(chainA), // dest
 				GlobalCurseSubject,


### PR DESCRIPTION
core ref: 48c0c5dbdeef8d07236e1e10e3fdd0289fab16a8

`GetMedianDataAvailabilityGasConfig` was something that was used for fee boosting logic, but since that has been removed we can remove this method entirely.