### PR TITLE
remove cache from solana verified builds

### DIFF
--- a/.github/workflows/solana-verified-build.yml
+++ b/.github/workflows/solana-verified-build.yml
@@ -32,14 +32,7 @@ jobs:
     - name: Install Solana Verify
       run: |
         cargo install solana-verify
-    - name: Cache cargo target dir
-      id: cache-target
-      uses: actions/cache@v4 # v4
-      with:
-        path: chains/solana/contracts/target/deploy/*.so
-        key: ${{ runner.os }}-solana-contract-verified-${{ hashFiles('**/Cargo.lock') }}
     - name: Build Verified Artifacts
-      if: steps.cache-target.outputs.cache-hit != 'true'
       run: |
         cd chains/solana/contracts
         solana-verify build


### PR DESCRIPTION
We were seeing cache hits preventing rebuilds when updating keys (e.g. https://github.com/smartcontractkit/chainlink-ccip/actions/runs/14055240353/job/39353160110). Because this workflow is now explicit, we should be able to rebuild safely so artifacts are not inadvertently stale.