### PR TITLE
solana: fix typo in comment & remove dup access

### DIFF
--- a/chains/solana/contracts/programs/base-token-pool/src/rate_limiter.rs
+++ b/chains/solana/contracts/programs/base-token-pool/src/rate_limiter.rs
@@ -59,7 +59,7 @@ impl RateLimitTokenBucket {
             // This acts as a lower bound of wait time.
             let min_wait_sec = (request_tokens.checked_sub(self.tokens).unwrap()
                 + rate.checked_sub(1).unwrap())
-            .checked_div(self.cfg.rate)
+            .checked_div(rate)
             .unwrap();
 
             // print human readable message before reverting with total wait time

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/token_admin_registry.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/token_admin_registry.rs
@@ -137,7 +137,7 @@ impl TokenAdminRegistry for Impl {
     ) -> Result<()> {
         let token_mint = ctx.accounts.mint.key().to_owned();
 
-        // Enable to overwrite the lookup table pool with 0 to deslist from CCIP
+        // Enable to overwrite the lookup table pool with 0 to delist from CCIP
         let token_admin_registry = &mut ctx.accounts.token_admin_registry;
         let previous_pool = token_admin_registry.lookup_table;
         let new_pool = ctx.accounts.pool_lookuptable.key();

--- a/chains/solana/contracts/programs/mcm/src/constant.rs
+++ b/chains/solana/contracts/programs/mcm/src/constant.rs
@@ -6,7 +6,7 @@ pub const NUM_GROUPS: usize = 32; // maximum number of signer groups supported
 pub const MULTISIG_ID_PADDED: usize = 32;
 
 // PDA seeds
-// Note: These seeds are not full seed, for unique seeds per instance, multisi_id should be appended
+// Note: These seeds are not full seed, for unique seeds per instance, multisig_id should be appended
 pub const SIGNER_SEED: &[u8] = b"multisig_signer"; // seed for dataless pda signing CPI
 pub const CONFIG_SEED: &[u8] = b"multisig_config";
 pub const CONFIG_SIGNERS_SEED: &[u8] = b"multisig_config_signers";


### PR DESCRIPTION
`core ref: 727156662432a6bf8d782304b17c1a9488c6ee60`

`CCSO-10`
- `multisi_id` -> `multisig_id`
- `deslist` -> `delist`
+ `self.cfg.rate` -> `rate`

