### PR TITLE
solana: clean up accept_ownerships

### DIFF
--- a/chains/solana/contracts/programs/base-token-pool/src/common.rs
+++ b/chains/solana/contracts/programs/base-token-pool/src/common.rs
@@ -101,8 +101,8 @@ impl BaseConfig {
 
     pub fn accept_ownership(&mut self) -> Result<()> {
         let old_owner = self.owner;
+        // NOTE: take() resets proposed_owner to default
         self.owner = std::mem::take(&mut self.proposed_owner);
-        self.proposed_owner = Pubkey::default();
 
         emit!(OwnershipTransferred {
             from: old_owner,

--- a/chains/solana/contracts/programs/ccip-offramp/src/instructions/v1/admin.rs
+++ b/chains/solana/contracts/programs/ccip-offramp/src/instructions/v1/admin.rs
@@ -43,8 +43,8 @@ impl Admin for Impl {
             from: config.owner,
             to: config.proposed_owner,
         });
+        // NOTE: take() resets proposed_owner to default
         config.owner = std::mem::take(&mut config.proposed_owner);
-        config.proposed_owner = Pubkey::new_from_array([0; 32]);
         Ok(())
     }
 

--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/admin.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/admin.rs
@@ -39,8 +39,8 @@ impl Admin for Impl {
             from: config.owner,
             to: config.proposed_owner,
         });
+        // NOTE: take() resets proposed_owner to default
         config.owner = std::mem::take(&mut config.proposed_owner);
-        config.proposed_owner = Pubkey::new_from_array([0; 32]);
         Ok(())
     }
 

--- a/chains/solana/contracts/programs/example-ccip-receiver/src/lib.rs
+++ b/chains/solana/contracts/programs/example-ccip-receiver/src/lib.rs
@@ -340,8 +340,8 @@ impl BaseState {
             proposed_owner,
             CcipReceiverError::OnlyProposedOwner
         );
-        self.proposed_owner = Pubkey::default();
-        self.owner = proposed_owner;
+        // NOTE: take() resets proposed_owner to default
+        self.owner = std::mem::take(&mut self.proposed_owner);
         Ok(())
     }
 

--- a/chains/solana/contracts/programs/fee-quoter/src/instructions/v1/admin.rs
+++ b/chains/solana/contracts/programs/fee-quoter/src/instructions/v1/admin.rs
@@ -40,7 +40,7 @@ impl Admin for Impl {
             to: config.proposed_owner,
         });
         // NOTE: take() resets proposed_owner to default
-        ctx.accounts.config.owner = std::mem::take(ctx.accounts.config.proposed_owner);
+        ctx.accounts.config.owner = std::mem::take(&mut ctx.accounts.config.proposed_owner);
         Ok(())
     }
 

--- a/chains/solana/contracts/programs/fee-quoter/src/instructions/v1/admin.rs
+++ b/chains/solana/contracts/programs/fee-quoter/src/instructions/v1/admin.rs
@@ -39,8 +39,8 @@ impl Admin for Impl {
             from: config.owner,
             to: config.proposed_owner,
         });
-        ctx.accounts.config.owner = ctx.accounts.config.proposed_owner;
-        ctx.accounts.config.proposed_owner = Pubkey::default();
+        // NOTE: take() resets proposed_owner to default
+        ctx.accounts.config.owner = std::mem::take(ctx.accounts.config.proposed_owner);
         Ok(())
     }
 

--- a/chains/solana/contracts/programs/mcm/src/lib.rs
+++ b/chains/solana/contracts/programs/mcm/src/lib.rs
@@ -117,8 +117,8 @@ pub mod mcm {
         ctx: Context<AcceptOwnership>,
         _multisig_id: [u8; MULTISIG_ID_PADDED],
     ) -> Result<()> {
+        // NOTE: take() resets proposed_owner to default
         ctx.accounts.config.owner = std::mem::take(&mut ctx.accounts.config.proposed_owner);
-        ctx.accounts.config.proposed_owner = Pubkey::new_from_array([0; 32]);
         Ok(())
     }
 

--- a/chains/solana/contracts/programs/rmn-remote/src/instructions/v1/admin.rs
+++ b/chains/solana/contracts/programs/rmn-remote/src/instructions/v1/admin.rs
@@ -28,8 +28,8 @@ impl Admin for Impl {
             from: config.owner,
             to: config.proposed_owner,
         });
-        ctx.accounts.config.owner = ctx.accounts.config.proposed_owner;
-        ctx.accounts.config.proposed_owner = Pubkey::default();
+        // NOTE: take() resets proposed_owner to default
+        ctx.accounts.config.owner = std::mem::take(&mut ctx.accounts.config.proposed_owner);
         Ok(())
     }
 

--- a/chains/solana/contracts/programs/timelock/src/lib.rs
+++ b/chains/solana/contracts/programs/timelock/src/lib.rs
@@ -489,8 +489,8 @@ pub mod timelock {
         _timelock_id: [u8; TIMELOCK_ID_PADDED],
     ) -> Result<()> {
         let mut config = ctx.accounts.config.load_mut()?;
+        // NOTE: take() resets proposed_owner to default
         config.owner = std::mem::take(&mut config.proposed_owner);
-        config.proposed_owner = Pubkey::zeroed();
         Ok(())
     }
 }

--- a/chains/solana/contracts/programs/timelock/src/lib.rs
+++ b/chains/solana/contracts/programs/timelock/src/lib.rs
@@ -41,8 +41,6 @@ use instructions::*;
 /// All operations enforce state transitions, size limits, and role-based access.
 pub mod timelock {
     #![warn(missing_docs)]
-    use bytemuck::Zeroable;
-
     use super::*;
 
     /// Initialize the timelock configuration.


### PR DESCRIPTION
`core ref: 727156662432a6bf8d782304b17c1a9488c6ee60`

This PR implements cleanup in `accept_ownership` logic across programs. Related to audit feedback `CCSO-06`

> Theuseof std::mem::take() inthecodemovesthevaluefrom config.proposed_owner to config.owner ,leaving
config.proposed_owner withitsdefaultvalue.Since std::mem::take() inherentlyresets config.proposed_owner to
its default state, explicitly assigning a zero pubkey to `config.proposed_owner` is redundant and unnecessary.

## Primary Changes
- Removed redundant assignments of zero Pubkey to `proposed_owner`
- Updated all `accept_ownership` implementations to rely solely on `std::mem::take()` for resetting `proposed_owner`

## Others
- Reviewed all `accept_ownership` implementations across the codebase to ensure consistent behavior
- Added comments clarifying `take()` behavior for future maintainability
