### PR TITLE
[Solana][NONEVM-1360] Restrict token pool instantiation to upgrade authority

### DIFF
--- a/chains/solana/contracts/programs/fee-quoter/src/context.rs
+++ b/chains/solana/contracts/programs/fee-quoter/src/context.rs
@@ -38,7 +38,6 @@ pub struct Initialize<'info> {
     )]
     pub config: Account<'info, Config>,
 
-    #[account()]
     pub link_token_mint: InterfaceAccount<'info, Mint>,
 
     #[account(mut)]

--- a/chains/solana/contracts/programs/lockrelease-token-pool/src/context.rs
+++ b/chains/solana/contracts/programs/lockrelease-token-pool/src/context.rs
@@ -10,7 +10,7 @@ use base_token_pool::common::{
 };
 use ccip_common::seed;
 
-use crate::{ChainConfig, State};
+use crate::{program::LockreleaseTokenPool, ChainConfig, State};
 
 #[derive(Accounts)]
 pub struct InitializeTokenPool<'info> {
@@ -24,8 +24,16 @@ pub struct InitializeTokenPool<'info> {
     pub state: Account<'info, State>, // config PDA for token pool
     pub mint: InterfaceAccount<'info, Mint>, // underlying token that the pool wraps
     #[account(mut)]
-    pub authority: Signer<'info>, // anyone can init token pool for a token, but ccip token admin registry controlls who can register pool for token
+    pub authority: Signer<'info>,
     pub system_program: Program<'info, System>,
+
+    #[account(constraint = program.programdata_address()? == Some(program_data.key()))]
+    pub program: Program<'info, LockreleaseTokenPool>,
+
+    // Token pool initialization only allowed by program upgrade authority. Initializing token pools managed
+    // by the CLL deployment of this program is limited to CLL. Users must deploy their own instance of this program.
+    #[account(constraint = program_data.upgrade_authority_address == Some(authority.key()) @ CcipTokenPoolError::Unauthorized)]
+    pub program_data: Account<'info, ProgramData>,
 }
 
 #[derive(Accounts)]

--- a/chains/solana/contracts/programs/test-token-pool/src/context.rs
+++ b/chains/solana/contracts/programs/test-token-pool/src/context.rs
@@ -6,7 +6,7 @@ use anchor_spl::{
 use base_token_pool::common::*;
 use ccip_common::seed;
 
-use crate::{ChainConfig, State};
+use crate::{program::TestTokenPool, ChainConfig, State};
 
 #[derive(Accounts)]
 pub struct InitializeTokenPool<'info> {
@@ -21,8 +21,16 @@ pub struct InitializeTokenPool<'info> {
     #[account(constraint = mint.is_initialized)]
     pub mint: InterfaceAccount<'info, Mint>, // underlying token that the pool wraps
     #[account(mut)]
-    pub authority: Signer<'info>, // anyone can init token pool for a token, but ccip token admin registry controlls who can register pool for token
+    pub authority: Signer<'info>,
     pub system_program: Program<'info, System>,
+
+    #[account(constraint = program.programdata_address()? == Some(program_data.key()))]
+    pub program: Program<'info, TestTokenPool>,
+
+    // Token pool initialization only allowed by program upgrade authority. Initializing token pools managed
+    // by the CLL deployment of this program is limited to CLL. Users must deploy their own instance of this program.
+    #[account(constraint = program_data.upgrade_authority_address == Some(authority.key()) @ CcipTokenPoolError::Unauthorized)]
+    pub program_data: Account<'info, ProgramData>,
 }
 
 #[derive(Accounts)]

--- a/chains/solana/contracts/target/idl/burnmint_token_pool.json
+++ b/chains/solana/contracts/target/idl/burnmint_token_pool.json
@@ -24,6 +24,16 @@
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false
+        },
+        {
+          "name": "program",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "programData",
+          "isMut": false,
+          "isSigner": false
         }
       ],
       "args": [

--- a/chains/solana/contracts/target/idl/lockrelease_token_pool.json
+++ b/chains/solana/contracts/target/idl/lockrelease_token_pool.json
@@ -24,6 +24,16 @@
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false
+        },
+        {
+          "name": "program",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "programData",
+          "isMut": false,
+          "isSigner": false
         }
       ],
       "args": [

--- a/chains/solana/contracts/target/idl/test_token_pool.json
+++ b/chains/solana/contracts/target/idl/test_token_pool.json
@@ -24,6 +24,16 @@
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false
+        },
+        {
+          "name": "program",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "programData",
+          "isMut": false,
+          "isSigner": false
         }
       ],
       "args": [

--- a/chains/solana/contracts/target/types/burnmint_token_pool.ts
+++ b/chains/solana/contracts/target/types/burnmint_token_pool.ts
@@ -24,6 +24,16 @@ export type BurnmintTokenPool = {
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false
+        },
+        {
+          "name": "program",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "programData",
+          "isMut": false,
+          "isSigner": false
         }
       ],
       "args": [
@@ -588,6 +598,16 @@ export const IDL: BurnmintTokenPool = {
         },
         {
           "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "program",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "programData",
           "isMut": false,
           "isSigner": false
         }

--- a/chains/solana/contracts/target/types/lockrelease_token_pool.ts
+++ b/chains/solana/contracts/target/types/lockrelease_token_pool.ts
@@ -24,6 +24,16 @@ export type LockreleaseTokenPool = {
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false
+        },
+        {
+          "name": "program",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "programData",
+          "isMut": false,
+          "isSigner": false
         }
       ],
       "args": [
@@ -732,6 +742,16 @@ export const IDL: LockreleaseTokenPool = {
         },
         {
           "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "program",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "programData",
           "isMut": false,
           "isSigner": false
         }

--- a/chains/solana/contracts/target/types/test_token_pool.ts
+++ b/chains/solana/contracts/target/types/test_token_pool.ts
@@ -24,6 +24,16 @@ export type TestTokenPool = {
           "name": "systemProgram",
           "isMut": false,
           "isSigner": false
+        },
+        {
+          "name": "program",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "programData",
+          "isMut": false,
+          "isSigner": false
         }
       ],
       "args": [
@@ -560,6 +570,16 @@ export const IDL: TestTokenPool = {
         },
         {
           "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "program",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "programData",
           "isMut": false,
           "isSigner": false
         }

--- a/chains/solana/contracts/tests/ccip/ccip_router_test.go
+++ b/chains/solana/contracts/tests/ccip/ccip_router_test.go
@@ -252,14 +252,29 @@ func TestCCIPRouter(t *testing.T) {
 		t.Run("token-pool", func(t *testing.T) {
 			token0.AdditionalAccounts = append(token0.AdditionalAccounts, solana.MemoProgramID) // add test additional accounts in pool interactions
 
+			type ProgramData struct {
+				DataType uint32
+				Address  solana.PublicKey
+			}
+			// get program data account
+			data, err := solanaGoClient.GetAccountInfoWithOpts(ctx, config.CcipTokenPoolProgram, &rpc.GetAccountInfoOpts{
+				Commitment: config.DefaultCommitment,
+			})
+			require.NoError(t, err)
+			// Decode program data
+			var programData ProgramData
+			require.NoError(t, bin.UnmarshalBorsh(&programData, data.Bytes()))
+
 			ixInit0, err := test_token_pool.NewInitializeInstruction(
 				test_token_pool.BurnAndMint_PoolType,
 				config.CcipRouterProgram,
 				config.RMNRemoteProgram,
 				token0.PoolConfig,
 				token0.Mint,
-				token0PoolAdmin.PublicKey(),
+				legacyAdmin.PublicKey(),
 				solana.SystemProgramID,
+				config.CcipTokenPoolProgram,
+				programData.Address,
 			).ValidateAndBuild()
 			require.NoError(t, err)
 
@@ -269,8 +284,10 @@ func TestCCIPRouter(t *testing.T) {
 				config.RMNRemoteProgram,
 				token1.PoolConfig,
 				token1.Mint,
-				token1PoolAdmin.PublicKey(),
+				legacyAdmin.PublicKey(),
 				solana.SystemProgramID,
+				config.CcipTokenPoolProgram,
+				programData.Address,
 			).ValidateAndBuild()
 			require.NoError(t, err)
 
@@ -280,10 +297,50 @@ func TestCCIPRouter(t *testing.T) {
 				config.RMNRemoteProgram,
 				token2.PoolConfig,
 				token2.Mint,
-				token2PoolAdmin.PublicKey(),
+				legacyAdmin.PublicKey(),
 				solana.SystemProgramID,
+				config.CcipTokenPoolProgram,
+				programData.Address,
 			).ValidateAndBuild()
 			require.NoError(t, err)
+
+			// The pools are nitially owned by the CCIP admin. For the purposes of this test, they're now transferred to the individual
+			// token admins. In practice, these token pools would've been original instantiated under separate token pool programs
+			// owned by each individual admin instead.
+			ixTransfer0, err := test_token_pool.NewTransferOwnershipInstruction(
+				token0PoolAdmin.PublicKey(),
+				token0.PoolConfig,
+				token0.Mint,
+				legacyAdmin.PublicKey(),
+			).ValidateAndBuild()
+			ixTransfer1, err := test_token_pool.NewTransferOwnershipInstruction(
+				token1PoolAdmin.PublicKey(),
+				token1.PoolConfig,
+				token1.Mint,
+				legacyAdmin.PublicKey(),
+			).ValidateAndBuild()
+			ixTransfer2, err := test_token_pool.NewTransferOwnershipInstruction(
+				token2PoolAdmin.PublicKey(),
+				token2.PoolConfig,
+				token2.Mint,
+				legacyAdmin.PublicKey(),
+			).ValidateAndBuild()
+
+			ixAccept0, err := test_token_pool.NewAcceptOwnershipInstruction(
+				token0.PoolConfig,
+				token0.Mint,
+				token0PoolAdmin.PublicKey(),
+			).ValidateAndBuild()
+			ixAccept1, err := test_token_pool.NewAcceptOwnershipInstruction(
+				token1.PoolConfig,
+				token1.Mint,
+				token1PoolAdmin.PublicKey(),
+			).ValidateAndBuild()
+			ixAccept2, err := test_token_pool.NewAcceptOwnershipInstruction(
+				token2.PoolConfig,
+				token2.Mint,
+				token2PoolAdmin.PublicKey(),
+			).ValidateAndBuild()
 
 			ixAta0, addr0, err := tokens.CreateAssociatedTokenAccount(token0.Program, token0.Mint, token0.PoolSigner, token0PoolAdmin.PublicKey())
 			require.NoError(t, err)
@@ -301,7 +358,9 @@ func TestCCIPRouter(t *testing.T) {
 			ixAuth, err := tokens.SetTokenMintAuthority(token0.Program, token0.PoolSigner, token0.Mint, token0PoolAdmin.PublicKey())
 			require.NoError(t, err)
 
-			testutils.SendAndConfirm(ctx, t, solanaGoClient, []solana.Instruction{ixInit0, ixInit1, ixAta0, ixAta1, ixAuth, ixInit2, ixAta2}, token0PoolAdmin, config.DefaultCommitment, common.AddSigners(token1PoolAdmin, token2PoolAdmin))
+			testutils.SendAndConfirm(ctx, t, solanaGoClient, []solana.Instruction{ixInit0, ixInit1, ixInit2}, legacyAdmin, config.DefaultCommitment)
+			testutils.SendAndConfirm(ctx, t, solanaGoClient, []solana.Instruction{ixTransfer0, ixTransfer1, ixTransfer2, ixAccept0, ixAccept1, ixAccept2}, legacyAdmin, config.DefaultCommitment, common.AddSigners(token0PoolAdmin, token1PoolAdmin, token2PoolAdmin))
+			testutils.SendAndConfirm(ctx, t, solanaGoClient, []solana.Instruction{ixAta0, ixAta1, ixAuth, ixAta2}, token0PoolAdmin, config.DefaultCommitment, common.AddSigners(token1PoolAdmin, token2PoolAdmin))
 
 			// Lookup Table for Tokens
 			require.NoError(t, token0.SetupLookupTable(ctx, solanaGoClient, token0PoolAdmin))

--- a/chains/solana/contracts/tests/ccip/tokenpool_test.go
+++ b/chains/solana/contracts/tests/ccip/tokenpool_test.go
@@ -166,6 +166,20 @@ func TestTokenPool(t *testing.T) {
 					releaseOrMint := poolMethodName[1]
 
 					t.Run("setup", func(t *testing.T) {
+
+						type ProgramData struct {
+							DataType uint32
+							Address  solana.PublicKey
+						}
+						// get program data account
+						data, err := solanaGoClient.GetAccountInfoWithOpts(ctx, config.CcipTokenPoolProgram, &rpc.GetAccountInfoOpts{
+							Commitment: config.DefaultCommitment,
+						})
+						require.NoError(t, err)
+						// Decode program data
+						var programData ProgramData
+						require.NoError(t, bin.UnmarshalBorsh(&programData, data.Bytes()))
+
 						poolInitI, err := test_token_pool.NewInitializeInstruction(
 							poolType,
 							dumbRamp,
@@ -173,7 +187,11 @@ func TestTokenPool(t *testing.T) {
 							poolConfig,
 							mint,
 							admin.PublicKey(),
-							solana.SystemProgramID).ValidateAndBuild()
+							solana.SystemProgramID,
+							config.CcipTokenPoolProgram,
+							programData.Address,
+						).ValidateAndBuild()
+
 						require.NoError(t, err)
 
 						// make pool mint_authority for token (required for burn/mint)
@@ -686,6 +704,19 @@ func TestTokenPool(t *testing.T) {
 			instructions, err := tokens.CreateToken(ctx, solana.TokenProgramID, mint, admin.PublicKey(), 0, solanaGoClient, config.DefaultCommitment)
 			require.NoError(t, err)
 
+			type ProgramData struct {
+				DataType uint32
+				Address  solana.PublicKey
+			}
+			// get program data account
+			data, err := solanaGoClient.GetAccountInfoWithOpts(ctx, config.CcipTokenPoolProgram, &rpc.GetAccountInfoOpts{
+				Commitment: config.DefaultCommitment,
+			})
+			require.NoError(t, err)
+			// Decode program data
+			var programData ProgramData
+			require.NoError(t, bin.UnmarshalBorsh(&programData, data.Bytes()))
+
 			// create pool
 			poolInitI, err := test_token_pool.NewInitializeInstruction(
 				test_token_pool.Wrapped_PoolType,
@@ -695,6 +726,8 @@ func TestTokenPool(t *testing.T) {
 				mint,
 				admin.PublicKey(),
 				solana.SystemProgramID,
+				config.CcipTokenPoolProgram,
+				programData.Address,
 			).ValidateAndBuild()
 			require.NoError(t, err)
 

--- a/chains/solana/gobindings/burnmint_token_pool/Initialize.go
+++ b/chains/solana/gobindings/burnmint_token_pool/Initialize.go
@@ -22,13 +22,17 @@ type Initialize struct {
 	// [2] = [WRITE, SIGNER] authority
 	//
 	// [3] = [] systemProgram
+	//
+	// [4] = [] program
+	//
+	// [5] = [] programData
 	ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
 }
 
 // NewInitializeInstructionBuilder creates a new `Initialize` instruction builder.
 func NewInitializeInstructionBuilder() *Initialize {
 	nd := &Initialize{
-		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 4),
+		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 6),
 	}
 	return nd
 }
@@ -89,6 +93,28 @@ func (inst *Initialize) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice[3]
 }
 
+// SetProgramAccount sets the "program" account.
+func (inst *Initialize) SetProgramAccount(program ag_solanago.PublicKey) *Initialize {
+	inst.AccountMetaSlice[4] = ag_solanago.Meta(program)
+	return inst
+}
+
+// GetProgramAccount gets the "program" account.
+func (inst *Initialize) GetProgramAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[4]
+}
+
+// SetProgramDataAccount sets the "programData" account.
+func (inst *Initialize) SetProgramDataAccount(programData ag_solanago.PublicKey) *Initialize {
+	inst.AccountMetaSlice[5] = ag_solanago.Meta(programData)
+	return inst
+}
+
+// GetProgramDataAccount gets the "programData" account.
+func (inst *Initialize) GetProgramDataAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[5]
+}
+
 func (inst Initialize) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
@@ -131,6 +157,12 @@ func (inst *Initialize) Validate() error {
 		if inst.AccountMetaSlice[3] == nil {
 			return errors.New("accounts.SystemProgram is not set")
 		}
+		if inst.AccountMetaSlice[4] == nil {
+			return errors.New("accounts.Program is not set")
+		}
+		if inst.AccountMetaSlice[5] == nil {
+			return errors.New("accounts.ProgramData is not set")
+		}
 	}
 	return nil
 }
@@ -150,11 +182,13 @@ func (inst *Initialize) EncodeToTree(parent ag_treeout.Branches) {
 					})
 
 					// Accounts of the instruction:
-					instructionBranch.Child("Accounts[len=4]").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+					instructionBranch.Child("Accounts[len=6]").ParentFunc(func(accountsBranch ag_treeout.Branches) {
 						accountsBranch.Child(ag_format.Meta("        state", inst.AccountMetaSlice[0]))
 						accountsBranch.Child(ag_format.Meta("         mint", inst.AccountMetaSlice[1]))
 						accountsBranch.Child(ag_format.Meta("    authority", inst.AccountMetaSlice[2]))
 						accountsBranch.Child(ag_format.Meta("systemProgram", inst.AccountMetaSlice[3]))
+						accountsBranch.Child(ag_format.Meta("      program", inst.AccountMetaSlice[4]))
+						accountsBranch.Child(ag_format.Meta("  programData", inst.AccountMetaSlice[5]))
 					})
 				})
 		})
@@ -196,12 +230,16 @@ func NewInitializeInstruction(
 	state ag_solanago.PublicKey,
 	mint ag_solanago.PublicKey,
 	authority ag_solanago.PublicKey,
-	systemProgram ag_solanago.PublicKey) *Initialize {
+	systemProgram ag_solanago.PublicKey,
+	program ag_solanago.PublicKey,
+	programData ag_solanago.PublicKey) *Initialize {
 	return NewInitializeInstructionBuilder().
 		SetRouter(router).
 		SetRmnRemote(rmnRemote).
 		SetStateAccount(state).
 		SetMintAccount(mint).
 		SetAuthorityAccount(authority).
-		SetSystemProgramAccount(systemProgram)
+		SetSystemProgramAccount(systemProgram).
+		SetProgramAccount(program).
+		SetProgramDataAccount(programData)
 }

--- a/chains/solana/gobindings/lockrelease_token_pool/Initialize.go
+++ b/chains/solana/gobindings/lockrelease_token_pool/Initialize.go
@@ -22,13 +22,17 @@ type Initialize struct {
 	// [2] = [WRITE, SIGNER] authority
 	//
 	// [3] = [] systemProgram
+	//
+	// [4] = [] program
+	//
+	// [5] = [] programData
 	ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
 }
 
 // NewInitializeInstructionBuilder creates a new `Initialize` instruction builder.
 func NewInitializeInstructionBuilder() *Initialize {
 	nd := &Initialize{
-		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 4),
+		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 6),
 	}
 	return nd
 }
@@ -89,6 +93,28 @@ func (inst *Initialize) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice[3]
 }
 
+// SetProgramAccount sets the "program" account.
+func (inst *Initialize) SetProgramAccount(program ag_solanago.PublicKey) *Initialize {
+	inst.AccountMetaSlice[4] = ag_solanago.Meta(program)
+	return inst
+}
+
+// GetProgramAccount gets the "program" account.
+func (inst *Initialize) GetProgramAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[4]
+}
+
+// SetProgramDataAccount sets the "programData" account.
+func (inst *Initialize) SetProgramDataAccount(programData ag_solanago.PublicKey) *Initialize {
+	inst.AccountMetaSlice[5] = ag_solanago.Meta(programData)
+	return inst
+}
+
+// GetProgramDataAccount gets the "programData" account.
+func (inst *Initialize) GetProgramDataAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[5]
+}
+
 func (inst Initialize) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
@@ -131,6 +157,12 @@ func (inst *Initialize) Validate() error {
 		if inst.AccountMetaSlice[3] == nil {
 			return errors.New("accounts.SystemProgram is not set")
 		}
+		if inst.AccountMetaSlice[4] == nil {
+			return errors.New("accounts.Program is not set")
+		}
+		if inst.AccountMetaSlice[5] == nil {
+			return errors.New("accounts.ProgramData is not set")
+		}
 	}
 	return nil
 }
@@ -150,11 +182,13 @@ func (inst *Initialize) EncodeToTree(parent ag_treeout.Branches) {
 					})
 
 					// Accounts of the instruction:
-					instructionBranch.Child("Accounts[len=4]").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+					instructionBranch.Child("Accounts[len=6]").ParentFunc(func(accountsBranch ag_treeout.Branches) {
 						accountsBranch.Child(ag_format.Meta("        state", inst.AccountMetaSlice[0]))
 						accountsBranch.Child(ag_format.Meta("         mint", inst.AccountMetaSlice[1]))
 						accountsBranch.Child(ag_format.Meta("    authority", inst.AccountMetaSlice[2]))
 						accountsBranch.Child(ag_format.Meta("systemProgram", inst.AccountMetaSlice[3]))
+						accountsBranch.Child(ag_format.Meta("      program", inst.AccountMetaSlice[4]))
+						accountsBranch.Child(ag_format.Meta("  programData", inst.AccountMetaSlice[5]))
 					})
 				})
 		})
@@ -196,12 +230,16 @@ func NewInitializeInstruction(
 	state ag_solanago.PublicKey,
 	mint ag_solanago.PublicKey,
 	authority ag_solanago.PublicKey,
-	systemProgram ag_solanago.PublicKey) *Initialize {
+	systemProgram ag_solanago.PublicKey,
+	program ag_solanago.PublicKey,
+	programData ag_solanago.PublicKey) *Initialize {
 	return NewInitializeInstructionBuilder().
 		SetRouter(router).
 		SetRmnRemote(rmnRemote).
 		SetStateAccount(state).
 		SetMintAccount(mint).
 		SetAuthorityAccount(authority).
-		SetSystemProgramAccount(systemProgram)
+		SetSystemProgramAccount(systemProgram).
+		SetProgramAccount(program).
+		SetProgramDataAccount(programData)
 }

--- a/chains/solana/gobindings/test_token_pool/Initialize.go
+++ b/chains/solana/gobindings/test_token_pool/Initialize.go
@@ -23,13 +23,17 @@ type Initialize struct {
 	// [2] = [WRITE, SIGNER] authority
 	//
 	// [3] = [] systemProgram
+	//
+	// [4] = [] program
+	//
+	// [5] = [] programData
 	ag_solanago.AccountMetaSlice `bin:"-" borsh_skip:"true"`
 }
 
 // NewInitializeInstructionBuilder creates a new `Initialize` instruction builder.
 func NewInitializeInstructionBuilder() *Initialize {
 	nd := &Initialize{
-		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 4),
+		AccountMetaSlice: make(ag_solanago.AccountMetaSlice, 6),
 	}
 	return nd
 }
@@ -96,6 +100,28 @@ func (inst *Initialize) GetSystemProgramAccount() *ag_solanago.AccountMeta {
 	return inst.AccountMetaSlice[3]
 }
 
+// SetProgramAccount sets the "program" account.
+func (inst *Initialize) SetProgramAccount(program ag_solanago.PublicKey) *Initialize {
+	inst.AccountMetaSlice[4] = ag_solanago.Meta(program)
+	return inst
+}
+
+// GetProgramAccount gets the "program" account.
+func (inst *Initialize) GetProgramAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[4]
+}
+
+// SetProgramDataAccount sets the "programData" account.
+func (inst *Initialize) SetProgramDataAccount(programData ag_solanago.PublicKey) *Initialize {
+	inst.AccountMetaSlice[5] = ag_solanago.Meta(programData)
+	return inst
+}
+
+// GetProgramDataAccount gets the "programData" account.
+func (inst *Initialize) GetProgramDataAccount() *ag_solanago.AccountMeta {
+	return inst.AccountMetaSlice[5]
+}
+
 func (inst Initialize) Build() *Instruction {
 	return &Instruction{BaseVariant: ag_binary.BaseVariant{
 		Impl:   inst,
@@ -141,6 +167,12 @@ func (inst *Initialize) Validate() error {
 		if inst.AccountMetaSlice[3] == nil {
 			return errors.New("accounts.SystemProgram is not set")
 		}
+		if inst.AccountMetaSlice[4] == nil {
+			return errors.New("accounts.Program is not set")
+		}
+		if inst.AccountMetaSlice[5] == nil {
+			return errors.New("accounts.ProgramData is not set")
+		}
 	}
 	return nil
 }
@@ -161,11 +193,13 @@ func (inst *Initialize) EncodeToTree(parent ag_treeout.Branches) {
 					})
 
 					// Accounts of the instruction:
-					instructionBranch.Child("Accounts[len=4]").ParentFunc(func(accountsBranch ag_treeout.Branches) {
+					instructionBranch.Child("Accounts[len=6]").ParentFunc(func(accountsBranch ag_treeout.Branches) {
 						accountsBranch.Child(ag_format.Meta("        state", inst.AccountMetaSlice[0]))
 						accountsBranch.Child(ag_format.Meta("         mint", inst.AccountMetaSlice[1]))
 						accountsBranch.Child(ag_format.Meta("    authority", inst.AccountMetaSlice[2]))
 						accountsBranch.Child(ag_format.Meta("systemProgram", inst.AccountMetaSlice[3]))
+						accountsBranch.Child(ag_format.Meta("      program", inst.AccountMetaSlice[4]))
+						accountsBranch.Child(ag_format.Meta("  programData", inst.AccountMetaSlice[5]))
 					})
 				})
 		})
@@ -218,7 +252,9 @@ func NewInitializeInstruction(
 	state ag_solanago.PublicKey,
 	mint ag_solanago.PublicKey,
 	authority ag_solanago.PublicKey,
-	systemProgram ag_solanago.PublicKey) *Initialize {
+	systemProgram ag_solanago.PublicKey,
+	program ag_solanago.PublicKey,
+	programData ag_solanago.PublicKey) *Initialize {
 	return NewInitializeInstructionBuilder().
 		SetPoolType(poolType).
 		SetRouter(router).
@@ -226,5 +262,7 @@ func NewInitializeInstruction(
 		SetStateAccount(state).
 		SetMintAccount(mint).
 		SetAuthorityAccount(authority).
-		SetSystemProgramAccount(systemProgram)
+		SetSystemProgramAccount(systemProgram).
+		SetProgramAccount(program).
+		SetProgramDataAccount(programData)
 }


### PR DESCRIPTION
I've leveraged the upgrade authority to authorize the entity capable of instantiating token pools, in an approach similar to the one used in `rmn_remote`. This seems simpler and cleaner than adding another PDA with an explicit authority set on instantiation.

There's a minor drawback I suppose, which is that if ever a user wants to deploy their own immutable variant of our contract templates, they won't have an upgrade authority. But in such cases, they can just modify their code and add the PDA as necessary.