### PR TITLE
Remove some owner checks on accounts that have to be passed in but might not be initialized

### DIFF
--- a/chains/solana/contracts/programs/ccip-common/src/context.rs
+++ b/chains/solana/contracts/programs/ccip-common/src/context.rs
@@ -28,7 +28,6 @@ pub struct TokenAccountsValidationContext<'info> {
             mint.key().as_ref(),
         ],
         seeds::program = fee_quoter.key(),
-        owner = fee_quoter.key() @ CommonCcipError::InvalidInputsTokenAccounts,
         bump
     )]
     pub token_billing_config: UncheckedAccount<'info>,
@@ -101,7 +100,6 @@ pub struct TokenAccountsValidationContext<'info> {
             mint.key().as_ref()
         ],
         seeds::program = fee_quoter.key(),
-        owner = fee_quoter.key() @ CommonCcipError::InvalidInputsTokenAccounts,
         bump
     )]
     pub fee_token_config: UncheckedAccount<'info>,


### PR DESCRIPTION
This reverts some of the changes from #761 
The fee quoter accounts have to passed in, so that _if_ there are any token-specific billing configs they are evaluated, but those accounts might not exist for many tokens (especially the ones that users bring in themselves). So, we should still check that the address is correctly derived, but we can't enforce an ownership check as uninitialized accounts will belong to the system program. Nonetheless, as they are PDAs, by checking their derivation we're already guaranteeing that they can only belong to desired program whenever they happen to be initialized and to the system program if they're not.