### PR TITLE
Remove msg.data bytes from exec logs

### DIFF
--- a/execute/exectypes/commit_data.go
+++ b/execute/exectypes/commit_data.go
@@ -40,3 +40,23 @@ type CommitData struct {
 	// Length of this slice should equal to the length of Messages slice.
 	MessageTokenData []MessageTokenData `json:"messageTokenData"`
 }
+
+// CopyNoMsgData creates a copy of the CommitData without the messages.Data
+func (cd CommitData) CopyNoMsgData() CommitData {
+	msgsWitoutData := make([]cciptypes.Message, len(cd.Messages))
+	for i, msg := range cd.Messages {
+		msgsWitoutData[i] = msg.CopyWithoutData()
+	}
+	return CommitData{
+		SourceChain:         cd.SourceChain,
+		OnRampAddress:       cd.OnRampAddress,
+		Timestamp:           cd.Timestamp,
+		BlockNum:            cd.BlockNum,
+		MerkleRoot:          cd.MerkleRoot,
+		SequenceNumberRange: cd.SequenceNumberRange,
+		ExecutedMessages:    append([]cciptypes.SeqNum{}, cd.ExecutedMessages...),
+		Messages:            msgsWitoutData,
+		Hashes:              append([]cciptypes.Bytes32{}, cd.Hashes...),
+		MessageTokenData:    append([]MessageTokenData{}, cd.MessageTokenData...),
+	}
+}

--- a/execute/exectypes/observation.go
+++ b/execute/exectypes/observation.go
@@ -136,6 +136,39 @@ type Observation struct {
 	FChain map[cciptypes.ChainSelector]int `json:"fChain"`
 }
 
+// CopyNoMsgData creates a copy of the outcome with the messages data removed.
+func (o Observation) CopyNoMsgData() Observation {
+	msgsWithEmptyData := make(MessageObservations)
+	for srcChain, msgs := range o.Messages {
+		msgsWithEmptyData[srcChain] = make(map[cciptypes.SeqNum]cciptypes.Message)
+		for seqNum, msg := range msgs {
+			msgsWithEmptyData[srcChain][seqNum] = msg.CopyWithoutData()
+		}
+	}
+	newObs := Observation{
+		CommitReports: o.CommitReports,
+		Hashes:        o.Hashes,
+		TokenData:     o.TokenData,
+		Nonces:        o.Nonces,
+		FChain:        o.FChain,
+		Messages:      msgsWithEmptyData,
+	}
+	return newObs
+}
+
+func (o Observation) CopyNoDiscoveryData() Observation {
+	newObs := Observation{
+		CommitReports: o.CommitReports,
+		Hashes:        o.Hashes,
+		TokenData:     o.TokenData,
+		Nonces:        o.Nonces,
+		FChain:        o.FChain,
+		Messages:      o.Messages,
+		Contracts:     dt.Observation{},
+	}
+	return newObs
+}
+
 func (co CommitObservations) Flatten() []CommitData {
 	var results []CommitData
 	for _, reports := range co {

--- a/execute/exectypes/outcome.go
+++ b/execute/exectypes/outcome.go
@@ -87,17 +87,11 @@ func (o *Outcome) Stats() map[string]int {
 func (o Outcome) CopyNoMsgData() Outcome {
 	commitReports := make([]CommitData, len(o.CommitReports))
 	for i, report := range o.CommitReports {
-		commitReports[i] = report
-		for j, msg := range report.Messages {
-			commitReports[i].Messages[j] = msg.CopyWithoutData()
-		}
+		commitReports[i] = report.CopyNoMsgData()
 	}
 	reports := make([]cciptypes.ExecutePluginReportSingleChain, len(o.Report.ChainReports))
 	for i, report := range o.Report.ChainReports {
-		reports[i] = report
-		for j, msg := range report.Messages {
-			reports[i].Messages[j] = msg.CopyWithoutData()
-		}
+		reports[i] = report.CopyNoMsgData()
 	}
 	newOutcome := Outcome{
 		State:         o.State,

--- a/execute/exectypes/outcome.go
+++ b/execute/exectypes/outcome.go
@@ -83,6 +83,32 @@ func (o *Outcome) Stats() map[string]int {
 	return counters
 }
 
+// CopyNoMsgData creates a copy of the outcome with the messages data removed.
+func (o Outcome) CopyNoMsgData() Outcome {
+	commitReports := make([]CommitData, len(o.CommitReports))
+	for i, report := range o.CommitReports {
+		commitReports[i] = report
+		for j, msg := range report.Messages {
+			commitReports[i].Messages[j] = msg.CopyWithoutData()
+		}
+	}
+	reports := make([]cciptypes.ExecutePluginReportSingleChain, len(o.Report.ChainReports))
+	for i, report := range o.Report.ChainReports {
+		reports[i] = report
+		for j, msg := range report.Messages {
+			reports[i].Messages[j] = msg.CopyWithoutData()
+		}
+	}
+	newOutcome := Outcome{
+		State:         o.State,
+		CommitReports: commitReports,
+		Report: cciptypes.ExecutePluginReport{
+			ChainReports: reports,
+		},
+	}
+	return newOutcome
+}
+
 // NewOutcome creates a new Outcome with the pending commit reports and the chain reports sorted.
 func NewOutcome(
 	state PluginState,

--- a/execute/observation.go
+++ b/execute/observation.go
@@ -112,7 +112,8 @@ func (p *Plugin) Observation(
 	}
 
 	p.observer.TrackObservation(observation, state)
-	lggr.Infow("execute plugin got observation", "observation", observation,
+	lggr.Infow("execute plugin got observation",
+		"observation w/o (msg data & discovery data)", observation.CopyNoMsgData().CopyNoDiscoveryData(),
 		"duration", time.Since(tStart),
 		"state", state,
 		"numCommitReports", len(observation.CommitReports),

--- a/execute/observation.go
+++ b/execute/observation.go
@@ -113,7 +113,7 @@ func (p *Plugin) Observation(
 
 	p.observer.TrackObservation(observation, state)
 	lggr.Infow("execute plugin got observation",
-		"observation w/o (msg data & discovery data)", observation.CopyNoMsgData().CopyNoDiscoveryData(),
+		"observationWithoutMsgDataAndDiscoveryObs", observation.CopyNoMsgData().CopyNoDiscoveryData(),
 		"duration", time.Since(tStart),
 		"state", state,
 		"numCommitReports", len(observation.CommitReports),

--- a/execute/outcome.go
+++ b/execute/outcome.go
@@ -100,7 +100,7 @@ func (p *Plugin) Outcome(
 
 	p.observer.TrackOutcome(outcome, state)
 	lggr.Infow("generated outcome",
-		"outcome", outcome.CopyNoMsgData(),
+		"outcomeWithoutMsgData", outcome.CopyNoMsgData(),
 		"numCommitReports", len(outcome.CommitReports),
 		"numChainReports", len(outcome.Report.ChainReports),
 		"numMessages", observation.Messages.Count(),

--- a/execute/outcome.go
+++ b/execute/outcome.go
@@ -100,7 +100,7 @@ func (p *Plugin) Outcome(
 
 	p.observer.TrackOutcome(outcome, state)
 	lggr.Infow("generated outcome",
-		"outcome", outcome,
+		"outcome", outcome.CopyNoMsgData(),
 		"numCommitReports", len(outcome.CommitReports),
 		"numChainReports", len(outcome.Report.ChainReports),
 		"numMessages", observation.Messages.Count(),

--- a/pkg/types/ccipocr3/generic_types.go
+++ b/pkg/types/ccipocr3/generic_types.go
@@ -183,6 +183,20 @@ type Message struct {
 	TokenAmounts []RampTokenAmount `json:"tokenAmounts"`
 }
 
+func (m Message) CopyWithoutData() Message {
+	return Message{
+		Header:         m.Header,
+		Sender:         m.Sender,
+		Data:           []byte{},
+		Receiver:       m.Receiver,
+		ExtraArgs:      m.ExtraArgs,
+		FeeToken:       m.FeeToken,
+		FeeTokenAmount: m.FeeTokenAmount,
+		FeeValueJuels:  m.FeeValueJuels,
+		TokenAmounts:   m.TokenAmounts,
+	}
+}
+
 func (m Message) String() string {
 	js, _ := json.Marshal(m)
 	return string(js)

--- a/pkg/types/ccipocr3/plugin_execute_types.go
+++ b/pkg/types/ccipocr3/plugin_execute_types.go
@@ -25,6 +25,20 @@ type ExecuteReportInfo struct {
 	MerkleRoots     []MerkleRootChain
 }
 
+func (e ExecutePluginReportSingleChain) CopyNoMsgData() ExecutePluginReportSingleChain {
+	msgsWithoutData := make([]Message, len(e.Messages))
+	for i, msg := range e.Messages {
+		msgsWithoutData[i] = msg.CopyWithoutData()
+	}
+	return ExecutePluginReportSingleChain{
+		SourceChainSelector: e.SourceChainSelector,
+		Messages:            msgsWithoutData,
+		OffchainTokenData:   e.OffchainTokenData,
+		Proofs:              append([]Bytes32{}, e.Proofs...),
+		ProofFlagBits:       e.ProofFlagBits,
+	}
+}
+
 // Encode v1 execute report info. Very basic versioning in the first byte to
 // allow for future encoding optimizations.
 func (eri ExecuteReportInfo) Encode() ([]byte, error) {


### PR DESCRIPTION
`Message.Data` field is not important to log, this is user data and doesn't affect debugging while taking too much space unnecessarily.