### PR TITLE
fix: processCommitReports: Log event rather than nil

### DIFF
--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -240,7 +240,7 @@ func (r *ccipChainReader) processCommitReports(
 	for _, item := range iter {
 		ev, err := validateCommitReportAcceptedEvent(item, ts)
 		if err != nil {
-			lggr.Errorw("validate commit report accepted event", "err", err, "ev", ev)
+			lggr.Errorw("validate commit report accepted event", "err", err, "ev", item.Data)
 			continue
 		}
 


### PR DESCRIPTION
validateCommitReportAcceptedEvent returns nil if there is an error so we were logging nil here, rather than the event.