### PR TITLE
add simple foundry scripts for off-chain testing

### DIFF
--- a/chains/evm/.solhintignore
+++ b/chains/evm/.solhintignore
@@ -1,3 +1,4 @@
 # Test files run with a different solhint ruleset, ignore them here.
 ./**/*.t.sol
+./**/*.s.sol
 ./node_modules/

--- a/chains/evm/contracts/script/CCIPManualExecutionScript.s.sol
+++ b/chains/evm/contracts/script/CCIPManualExecutionScript.s.sol
@@ -1,0 +1,61 @@
+pragma solidity ^0.8.24;
+
+import {Internal} from "../libraries/Internal.sol";
+import {OffRamp} from "../offRamp/OffRamp.sol";
+
+import {IERC20} from "@vendor/openzeppelin-solidity/v5.0.2/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@vendor/openzeppelin-solidity/v5.0.2/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import {Script} from "forge-std/Script.sol";
+import {Test} from "forge-std/Test.sol";
+
+// solhint-disable-next-line no-console
+import {console2 as console} from "forge-std/console2.sol";
+
+/* solhint-disable no-console */
+contract CCIPSendTestScript is Script, Test {
+  using SafeERC20 for IERC20;
+
+  // Ex: "ETHEREUM_RPC_URL" as defined in .env
+  string public RPC_IDENTIFIER;
+  
+  OffRamp public s_offRamp;
+
+  bytes32 public s_messageId;
+
+  uint64 public s_sourceChainSelector;
+  uint64 public s_sequenceNumber;
+  bytes public s_manualExecutionData;
+
+  function run() public {
+    vm.createSelectFork(RPC_IDENTIFIER);
+
+    uint256 privateKey = vm.envUint("PRIVATE_KEY");
+
+    address sender = vm.rememberKey(privateKey);
+
+    vm.startBroadcast(privateKey);
+
+    console.log("Sender: %s", sender);
+    console.log("Starting Script...");
+
+    // Check that the messageId is not empty
+    Internal.MessageExecutionState executionState = s_offRamp.getExecutionState(s_sourceChainSelector, s_sequenceNumber);
+    assertTrue(
+      executionState == Internal.MessageExecutionState.FAILURE
+        || executionState == Internal.MessageExecutionState.UNTOUCHED,
+      "Message is not ready for Manual Execution"
+    );
+
+    // Manual Execution data can be invoked from a different tool or front-end to avoid having to 
+    // gather execution report data manually
+    (bool success,) = address(s_offRamp).call(s_manualExecutionData);
+    assertTrue(success, "Manual execution call reverted");
+
+    executionState = s_offRamp.getExecutionState(s_sourceChainSelector, s_sequenceNumber);
+    assertTrue(executionState == Internal.MessageExecutionState.SUCCESS, "Message was not executed successfully");
+
+    console.log("Script completed...");
+  }
+}
+/* solhint-enable no-console */

--- a/chains/evm/contracts/script/CCIPSendTestScript.s.sol
+++ b/chains/evm/contracts/script/CCIPSendTestScript.s.sol
@@ -1,0 +1,102 @@
+pragma solidity ^0.8.24;
+
+import {Router} from "../Router.sol";
+import {Client} from "../libraries/Client.sol";
+
+import {IERC20} from "@vendor/openzeppelin-solidity/v5.0.2/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "@vendor/openzeppelin-solidity/v5.0.2/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import {Script} from "forge-std/Script.sol";
+
+/* solhint-disable-next-line no-console */
+import {console2 as console} from "forge-std/console2.sol";
+
+/* solhint-disable no-console */
+contract CCIPSendTestScript is Script {
+  using SafeERC20 for IERC20;
+
+  address public ROUTER;
+  address public FEE_TOKEN;
+
+  address public TOKEN0;
+  uint256 public TOKEN0_AMOUNT;
+
+  uint64 public DESTINATION_CHAIN_SELECTOR;
+  uint64 public SOURCE_CHAIN_SELECTOR;
+
+  // Ex: "ETHEREUM_RPC_URL" as defined in .env
+  string public RPC_DESCRIPTOR;
+
+  bytes public s_extraArgs;
+  bytes public s_recipient;
+  bytes public s_data;
+
+  function run() public {
+    vm.createSelectFork(RPC_DESCRIPTOR);
+
+    uint256 privateKey = vm.envUint("PRIVATE_KEY");
+
+    address sender = vm.rememberKey(privateKey);
+    s_recipient = abi.encode(sender);
+
+    vm.startBroadcast(privateKey);
+
+    console.log("Sender: %s", sender);
+    console.log("Starting Script...");
+
+    Client.EVMTokenAmount[] memory tokens;
+    if (TOKEN0 != address(0)) {
+      tokens = new Client.EVMTokenAmount[](1);
+      tokens[0] = Client.EVMTokenAmount({token: TOKEN0, amount: TOKEN0_AMOUNT});
+    }
+
+    Client.EVM2AnyMessage memory message = Client.EVM2AnyMessage({
+      receiver: abi.encode(sender),
+      data: s_data,
+      tokenAmounts: tokens,
+      feeToken: address(0),
+      extraArgs: s_extraArgs
+    });
+
+    uint256 fee = Router(ROUTER).getFee(DESTINATION_CHAIN_SELECTOR, message);
+
+    console.log("Fee in WEI: %s", fee);
+
+    console.log("1. Approving Send Tokens...");
+
+    for (uint256 i = 0; i < tokens.length; i++) {
+      // Since sender may be an EOA with an existing approval, the allowance should be checked first
+      uint256 allowance = IERC20(tokens[i].token).allowance(sender, ROUTER);
+
+      // Approving Tokens for Router if allowance is currently insufficient.
+      if (allowance < tokens[i].amount) {
+        console.log("Approving %i tokens to Router for %s", tokens[i].amount, tokens[i].token);
+        IERC20(tokens[i].token).safeIncreaseAllowance(ROUTER, tokens[i].amount);
+      }
+    }
+
+    // Uncomment the following line for debugging purposes
+    console.log("--- Tokens Approved ---");
+
+    console.log("2. Approving Fee Token");
+    if (FEE_TOKEN != address(0)) {
+      console.log("Approving Fee Token %s to Router", FEE_TOKEN);
+      IERC20(FEE_TOKEN).safeIncreaseAllowance(ROUTER, fee);
+    }
+    // --- Fee Token Approved ---
+
+    console.log("3. Sending message from: %i to %i", SOURCE_CHAIN_SELECTOR, DESTINATION_CHAIN_SELECTOR);
+
+    // Send the message, forwarding native tokens if necessary to pay the fee
+    bytes32 messageId =
+      Router(ROUTER).ccipSend{value: FEE_TOKEN == address(0) ? fee : 0}(DESTINATION_CHAIN_SELECTOR, message);
+
+    console.log("--- Message sent: MessageId ---");
+
+    console.logBytes32(messageId);
+    vm.stopBroadcast();
+
+    console.log("Script completed...");
+  }
+}
+/* solhint-enable no-console */

--- a/chains/evm/foundry.toml
+++ b/chains/evm/foundry.toml
@@ -4,6 +4,7 @@ evm_version = 'paris'
 
 src = 'contracts'
 test = 'contracts'
+script = 'contracts'
 out = 'foundry-artifacts'
 cache_path = 'foundry-cache'
 libs = ['node_modules']


### PR DESCRIPTION
To better perform live testing on deployed contracts this PR creates some simple foundry scripts instead of relying on transporter, etherscan, or go scripts.

1. Sending a message via CCIP
2. Manually executing a message on a destination chain
3. 