### PR TITLE
solana: revert message with zero token amount

### DIFF
--- a/chains/solana/contracts/programs/ccip-router/src/instructions/v1/onramp.rs
+++ b/chains/solana/contracts/programs/ccip-router/src/instructions/v1/onramp.rs
@@ -188,6 +188,12 @@ impl OnRamp for Impl {
                 CcipRouterError::InvalidInputsTokenAccounts,
             );
 
+            require_gt!(
+                token_amount.amount,
+                0,
+                CcipRouterError::InvalidInputsTokenAmount
+            );
+
             let seeds = &[
                 seed::EXTERNAL_TOKEN_POOLS_SIGNER,
                 current_token_accounts.pool_program.key.as_ref(),


### PR DESCRIPTION
## Primary Changes

- Added validation to prevent routing tokens with zero amount
- Implemented strict check to reject token transfers with zero token amount

**Rationale**
- Ensuring token transfers have a non-zero amount prevents potential unintended transactions in the CCIP router.