### PR TITLE
Use warn instead of err on missing native token address

### DIFF
--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -893,8 +893,9 @@ func (r *ccipChainReader) GetWrappedNativeTokenPriceUSD(
 		}
 		nativeTokenAddress := config.Router.WrappedNativeAddress
 
-		if nativeTokenAddress.String() == "0x" {
-			lggr.Errorw("native token address is empty", "chain", chain)
+		if cciptypes.UnknownAddress(nativeTokenAddress).IsZeroOrEmpty() {
+			lggr.Warnw("Native token address is zero or empty. Ignore for disabled chains otherwise "+
+				"check for router misconfiguration", "chain", chain, "address", nativeTokenAddress.String())
 			continue
 		}
 


### PR DESCRIPTION
Making the error a `warn` since it is likely to happen on disabled chains and more verbose to prevent confusion.
nit: Improved the way we check for an empty address
