### PR TITLE
Add CalculateUsdPerUnitGas to EstimateProvider interface

### DIFF
--- a/commit/chainfee/outcome.go
+++ b/commit/chainfee/outcome.go
@@ -68,8 +68,11 @@ func (p *processor) Outcome(
 		// 1 gas = 1 wei = XUSD18
 		// execFee = 30 Gwei = 30e9 wei = 30e9 * XUSD18
 		chainFeeUsd := ComponentsUSDPrices{
-			ExecutionFeePriceUSD: mathslib.CalculateUsdPerUnitGas(feeComp.ExecutionFee, usdPerFeeToken.Int),
-			DataAvFeePriceUSD:    mathslib.CalculateUsdPerUnitGas(feeComp.DataAvailabilityFee, usdPerFeeToken.Int),
+			ExecutionFeePriceUSD: p.estimateProvider.CalculateUsdPerUnitGas(feeComp.ExecutionFee, usdPerFeeToken.Int),
+			DataAvFeePriceUSD: p.estimateProvider.CalculateUsdPerUnitGas(
+				feeComp.DataAvailabilityFee,
+				usdPerFeeToken.Int,
+			),
 		}
 
 		chainFeeUSDPrices[chain] = chainFeeUsd

--- a/commit/chainfee/outcome_test.go
+++ b/commit/chainfee/outcome_test.go
@@ -1,10 +1,11 @@
 package chainfee
 
 import (
-	mock_ccipocr3 "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/types/ccipocr3"
 	"math/big"
 	"testing"
 	"time"
+
+	mock_ccipocr3 "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/types/ccipocr3"
 
 	"github.com/stretchr/testify/mock"
 
@@ -477,9 +478,8 @@ func TestProcessor_OutcomeWithDifferentDecimalCalculation(t *testing.T) {
 	expectedDataAvFeeUSD := big.NewInt(200000) // 200 * 1e3
 
 	// Calculate packed fee: (dataAvFeeUSD << 112) | executionFeeUSD
-	expectedPackedFee := new(big.Int)
 	dataAvShifted := new(big.Int).Lsh(expectedDataAvFeeUSD, 112)
-	expectedPackedFee = new(big.Int).Or(dataAvShifted, expectedExecFeeUSD)
+	expectedPackedFee := new(big.Int).Or(dataAvShifted, expectedExecFeeUSD)
 
 	// Verify outcome contains expected gas price
 	require.Len(t, outcome.GasPrices, 1)

--- a/commit/chainfee/processor.go
+++ b/commit/chainfee/processor.go
@@ -17,14 +17,15 @@ type processor struct {
 	oracleID  commontypes.OracleID
 	destChain cciptypes.ChainSelector
 	// Don't use this logger directly but rather through logutil\.WithContextValues where possible
-	lggr            logger.Logger
-	homeChain       reader.HomeChain
-	ccipReader      readerpkg.CCIPReader
-	cfg             pluginconfig.CommitOffchainConfig
-	chainSupport    plugincommon.ChainSupport
-	metricsReporter plugincommon.MetricsReporter
-	fRoleDON        int
-	obs             observer
+	lggr             logger.Logger
+	homeChain        reader.HomeChain
+	ccipReader       readerpkg.CCIPReader
+	cfg              pluginconfig.CommitOffchainConfig
+	chainSupport     plugincommon.ChainSupport
+	metricsReporter  plugincommon.MetricsReporter
+	estimateProvider cciptypes.EstimateProvider
+	fRoleDON         int
+	obs              observer
 }
 
 func NewProcessor(
@@ -37,6 +38,7 @@ func NewProcessor(
 	chainSupport plugincommon.ChainSupport,
 	fRoleDON int,
 	metricsReporter plugincommon.MetricsReporter,
+	estimateProvider cciptypes.EstimateProvider,
 ) plugincommon.PluginProcessor[Query, Observation, Outcome] {
 	var obs observer
 	baseObs := newBaseObserver(
@@ -57,16 +59,17 @@ func NewProcessor(
 	}
 
 	p := &processor{
-		lggr:            lggr,
-		oracleID:        oracleID,
-		destChain:       destChain,
-		homeChain:       homeChain,
-		ccipReader:      ccipReader,
-		fRoleDON:        fRoleDON,
-		chainSupport:    chainSupport,
-		cfg:             offChainConfig,
-		metricsReporter: metricsReporter,
-		obs:             obs,
+		lggr:             lggr,
+		oracleID:         oracleID,
+		destChain:        destChain,
+		homeChain:        homeChain,
+		ccipReader:       ccipReader,
+		fRoleDON:         fRoleDON,
+		chainSupport:     chainSupport,
+		cfg:              offChainConfig,
+		metricsReporter:  metricsReporter,
+		obs:              obs,
+		estimateProvider: estimateProvider,
 	}
 	return plugincommon.NewTrackedProcessor(lggr, p, processorLabel, metricsReporter)
 }

--- a/commit/factory.go
+++ b/commit/factory.go
@@ -77,6 +77,7 @@ type PluginFactory struct {
 	chainWriters      map[cciptypes.ChainSelector]types.ContractWriter
 	rmnPeerClient     rmn.PeerClient
 	rmnCrypto         cciptypes.RMNCrypto
+	estimateProvider  cciptypes.EstimateProvider
 }
 
 type CommitPluginFactoryParams struct {
@@ -92,6 +93,7 @@ type CommitPluginFactoryParams struct {
 	ContractWriters   map[cciptypes.ChainSelector]types.ContractWriter
 	RmnPeerClient     rmn.PeerClient
 	RmnCrypto         cciptypes.RMNCrypto
+	EstimateProvider  cciptypes.EstimateProvider
 }
 
 // NewCommitPluginFactory creates a new PluginFactory instance. For commit plugin, oracle instances are not managed by
@@ -110,6 +112,7 @@ func NewCommitPluginFactory(params CommitPluginFactoryParams) *PluginFactory {
 		chainWriters:      params.ContractWriters,
 		rmnPeerClient:     params.RmnPeerClient,
 		rmnCrypto:         params.RmnCrypto,
+		estimateProvider:  params.EstimateProvider,
 	}
 }
 
@@ -244,6 +247,7 @@ func (p *PluginFactory) NewReportingPlugin(ctx context.Context, config ocr3types
 			metricsReporter,
 			p.addrCodec,
 			reportBuilder,
+			p.estimateProvider,
 		), ocr3types.ReportingPluginInfo{
 			Name: "CCIPRoleCommit",
 			Limits: ocr3types.ReportingPluginLimits{

--- a/commit/factory.go
+++ b/commit/factory.go
@@ -121,6 +121,9 @@ func (p *PluginFactory) NewReportingPlugin(ctx context.Context, config ocr3types
 ) (ocr3types.ReportingPlugin[[]byte], ocr3types.ReportingPluginInfo, error) {
 	lggr := logutil.WithPluginConstants(p.baseLggr, "Commit", p.donID, config.OracleID, config.ConfigDigest)
 
+	if p.estimateProvider == nil {
+		return nil, ocr3types.ReportingPluginInfo{}, fmt.Errorf("estimate provider must be set")
+	}
 	offchainConfig, err := pluginconfig.DecodeCommitOffchainConfig(config.OffchainConfig)
 	if err != nil {
 		return nil, ocr3types.ReportingPluginInfo{}, fmt.Errorf("failed to decode commit offchain config: %w", err)

--- a/commit/factory_test.go
+++ b/commit/factory_test.go
@@ -3,11 +3,12 @@ package commit
 import (
 	"encoding/json"
 	"fmt"
-	mock_ccipocr3 "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/types/ccipocr3"
 	"math"
 	"strings"
 	"testing"
 	"time"
+
+	mock_ccipocr3 "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/types/ccipocr3"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/commit/factory_test.go
+++ b/commit/factory_test.go
@@ -3,6 +3,7 @@ package commit
 import (
 	"encoding/json"
 	"fmt"
+	mock_ccipocr3 "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/types/ccipocr3"
 	"math"
 	"strings"
 	"testing"
@@ -318,7 +319,8 @@ func TestPluginFactory_NewReportingPlugin(t *testing.T) {
 					ChainSelector: 12922642891491394802,
 				},
 			},
-			addrCodec: mockAddrCodec,
+			addrCodec:        mockAddrCodec,
+			estimateProvider: mock_ccipocr3.NewMockEstimateProvider(t),
 		}
 
 		plugin, pluginInfo, err := p.NewReportingPlugin(ctx, ocr3types.ReportingPluginConfig{

--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -85,6 +85,7 @@ func NewPlugin(
 	reporter metrics.Reporter,
 	addressCodec cciptypes.AddressCodec,
 	reportBuilder builder.ReportBuilderFunc,
+	estimateProvider cciptypes.EstimateProvider,
 ) *Plugin {
 	lggr.Infow("creating new plugin instance", "p2pID", oracleIDToP2pID[reportingCfg.OracleID])
 
@@ -163,6 +164,7 @@ func NewPlugin(
 		chainSupport,
 		reportingCfg.F,
 		reporter,
+		estimateProvider,
 	)
 
 	return &Plugin{

--- a/commit/plugin_e2e_test.go
+++ b/commit/plugin_e2e_test.go
@@ -46,6 +46,8 @@ import (
 	reader2 "github.com/smartcontractkit/chainlink-ccip/pkg/reader"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
+
+	mock_ccipocr3 "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/types/ccipocr3"
 )
 
 const (
@@ -925,6 +927,7 @@ func setupNode(params SetupNodeParams) nodeSetup {
 		&metrics.Noop{},
 		mockAddrCodec,
 		reportBuilder,
+		mock_ccipocr3.NewMockEstimateProvider(params.t),
 	)
 
 	if !params.enableDiscovery {

--- a/mocks/pkg/types/ccipocr3/estimate_provider.go
+++ b/mocks/pkg/types/ccipocr3/estimate_provider.go
@@ -3,6 +3,8 @@
 package ccipocr3
 
 import (
+	big "math/big"
+
 	ccipocr3 "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -108,6 +110,55 @@ func (_c *MockEstimateProvider_CalculateMessageMaxGas_Call) Return(_a0 uint64) *
 }
 
 func (_c *MockEstimateProvider_CalculateMessageMaxGas_Call) RunAndReturn(run func(ccipocr3.Message) uint64) *MockEstimateProvider_CalculateMessageMaxGas_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// CalculateUsdPerUnitGas provides a mock function with given fields: sourceGasPrice, usdPerFeeCoin
+func (_m *MockEstimateProvider) CalculateUsdPerUnitGas(sourceGasPrice *big.Int, usdPerFeeCoin *big.Int) *big.Int {
+	ret := _m.Called(sourceGasPrice, usdPerFeeCoin)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CalculateUsdPerUnitGas")
+	}
+
+	var r0 *big.Int
+	if rf, ok := ret.Get(0).(func(*big.Int, *big.Int) *big.Int); ok {
+		r0 = rf(sourceGasPrice, usdPerFeeCoin)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*big.Int)
+		}
+	}
+
+	return r0
+}
+
+// MockEstimateProvider_CalculateUsdPerUnitGas_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CalculateUsdPerUnitGas'
+type MockEstimateProvider_CalculateUsdPerUnitGas_Call struct {
+	*mock.Call
+}
+
+// CalculateUsdPerUnitGas is a helper method to define mock.On call
+//   - sourceGasPrice *big.Int
+//   - usdPerFeeCoin *big.Int
+func (_e *MockEstimateProvider_Expecter) CalculateUsdPerUnitGas(sourceGasPrice interface{}, usdPerFeeCoin interface{}) *MockEstimateProvider_CalculateUsdPerUnitGas_Call {
+	return &MockEstimateProvider_CalculateUsdPerUnitGas_Call{Call: _e.mock.On("CalculateUsdPerUnitGas", sourceGasPrice, usdPerFeeCoin)}
+}
+
+func (_c *MockEstimateProvider_CalculateUsdPerUnitGas_Call) Run(run func(sourceGasPrice *big.Int, usdPerFeeCoin *big.Int)) *MockEstimateProvider_CalculateUsdPerUnitGas_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*big.Int), args[1].(*big.Int))
+	})
+	return _c
+}
+
+func (_c *MockEstimateProvider_CalculateUsdPerUnitGas_Call) Return(_a0 *big.Int) *MockEstimateProvider_CalculateUsdPerUnitGas_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockEstimateProvider_CalculateUsdPerUnitGas_Call) RunAndReturn(run func(*big.Int, *big.Int) *big.Int) *MockEstimateProvider_CalculateUsdPerUnitGas_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/types/ccipocr3/interfaces.go
+++ b/pkg/types/ccipocr3/interfaces.go
@@ -2,6 +2,7 @@ package ccipocr3
 
 import (
 	"context"
+	"math/big"
 )
 
 // TODO: Consolidate CommitPluginCodec, ExecutePluginCodec, MessageHasher, ExtraDataCodec into a single Codec interface.
@@ -50,4 +51,5 @@ type TokenDataEncoder interface {
 type EstimateProvider interface {
 	CalculateMerkleTreeGas(numRequests int) uint64
 	CalculateMessageMaxGas(msg Message) uint64
+	CalculateUsdPerUnitGas(sourceGasPrice *big.Int, usdPerFeeCoin *big.Int) *big.Int
 }


### PR DESCRIPTION
This allows the usd per gas per chain to be calculated differently based on the chain family.

core ref: 777ca421ae5e95e95bed4e7cb62cdaccb26c7092