### PR TITLE
Allow price report seqNum to be same as the latest

### DIFF
--- a/chains/solana/contracts/programs/ccip-offramp/src/instructions/v1/commit.rs
+++ b/chains/solana/contracts/programs/ccip-offramp/src/instructions/v1/commit.rs
@@ -348,7 +348,7 @@ mod helpers {
         let mut global_state: Account<'info, GlobalState> =
             Account::try_from(&remaining_accounts[0])?;
 
-        if global_state.latest_price_sequence_number < ocr_sequence_number {
+        if global_state.latest_price_sequence_number <= ocr_sequence_number {
             // Update the persisted sequence number
             global_state.latest_price_sequence_number = ocr_sequence_number;
             global_state.exit(&crate::ID)?; // as it is manually loaded, it also has to be manually written back


### PR DESCRIPTION
On Solana, we cap to max 3 price updates per Commit report due to Solana tx size limit, CommitDON splits commit outcome into multiple reports, each report contains the same OCR sequence number, therefore, OffRamp should accept price reports with the same latest OCR seqNum.

Downside is this allows price reports to be replayed, but given this only applies to the latest reports, this will not result in stale prices being accepted.