### PR TITLE
commit/chainfee: execution fee can be zero

### DIFF
--- a/commit/chainfee/validate_observation.go
+++ b/commit/chainfee/validate_observation.go
@@ -65,12 +65,12 @@ func validateChainFeeUpdates(
 	ao plugincommon.AttributedObservation[Observation],
 ) error {
 	for _, update := range ao.Observation.ChainFeeUpdates {
-		if update.ChainFee.ExecutionFeePriceUSD == nil || update.ChainFee.ExecutionFeePriceUSD.Cmp(big.NewInt(0)) <= 0 {
-			return fmt.Errorf("nil or non-positive %s", "execution fee price")
+		if update.ChainFee.ExecutionFeePriceUSD == nil || update.ChainFee.ExecutionFeePriceUSD.Cmp(big.NewInt(0)) < 0 {
+			return fmt.Errorf("nil or negative execution fee: %+v", update.ChainFee.ExecutionFeePriceUSD)
 		}
 
 		if update.ChainFee.DataAvFeePriceUSD == nil || update.ChainFee.DataAvFeePriceUSD.Cmp(big.NewInt(0)) < 0 {
-			return fmt.Errorf("nil or negative %s", "data availability fee price")
+			return fmt.Errorf("nil or negative data availability fee: %+v", update.ChainFee.DataAvFeePriceUSD)
 		}
 		if update.Timestamp.IsZero() {
 			return fmt.Errorf("timestamp cannot be zero")
@@ -86,12 +86,12 @@ func validateFeeComponents(
 	ao plugincommon.AttributedObservation[Observation],
 ) error {
 	for _, feeComponent := range ao.Observation.FeeComponents {
-		if feeComponent.ExecutionFee == nil || feeComponent.ExecutionFee.Cmp(big.NewInt(0)) <= 0 {
-			return fmt.Errorf("nil or non-positive %s", "execution fee")
+		if feeComponent.ExecutionFee == nil || feeComponent.ExecutionFee.Cmp(big.NewInt(0)) < 0 {
+			return fmt.Errorf("nil or negative execution fee: %+v", feeComponent.ExecutionFee)
 		}
 
 		if feeComponent.DataAvailabilityFee == nil || feeComponent.DataAvailabilityFee.Cmp(big.NewInt(0)) < 0 {
-			return fmt.Errorf("nil or negative %s", "data availability fee")
+			return fmt.Errorf("nil or negative data availability fee: %+v", feeComponent.DataAvailabilityFee)
 		}
 	}
 	return nil

--- a/commit/chainfee/validate_observation.go
+++ b/commit/chainfee/validate_observation.go
@@ -64,19 +64,21 @@ func (p *processor) ValidateObservation(
 func validateChainFeeUpdates(
 	ao plugincommon.AttributedObservation[Observation],
 ) error {
-	for _, update := range ao.Observation.ChainFeeUpdates {
+	for chainSelector, update := range ao.Observation.ChainFeeUpdates {
 		if update.ChainFee.ExecutionFeePriceUSD == nil || update.ChainFee.ExecutionFeePriceUSD.Cmp(big.NewInt(0)) < 0 {
-			return fmt.Errorf("nil or negative execution fee: %+v", update.ChainFee.ExecutionFeePriceUSD)
+			return fmt.Errorf("nil or negative execution fee: %+v, chain: %d",
+				update.ChainFee.ExecutionFeePriceUSD, chainSelector)
 		}
 
 		if update.ChainFee.DataAvFeePriceUSD == nil || update.ChainFee.DataAvFeePriceUSD.Cmp(big.NewInt(0)) < 0 {
-			return fmt.Errorf("nil or negative data availability fee: %+v", update.ChainFee.DataAvFeePriceUSD)
+			return fmt.Errorf("nil or negative data availability fee: %+v, chain: %d",
+				update.ChainFee.DataAvFeePriceUSD, chainSelector)
 		}
 		if update.Timestamp.IsZero() {
-			return fmt.Errorf("timestamp cannot be zero")
+			return fmt.Errorf("timestamp cannot be zero, chain: %d", chainSelector)
 		}
 		if update.Timestamp.After(time.Now().UTC()) {
-			return fmt.Errorf("timestamp %s cannot be in the future", update.Timestamp.String())
+			return fmt.Errorf("timestamp %s cannot be in the future, chain: %d", update.Timestamp.String(), chainSelector)
 		}
 	}
 	return nil
@@ -85,13 +87,15 @@ func validateChainFeeUpdates(
 func validateFeeComponents(
 	ao plugincommon.AttributedObservation[Observation],
 ) error {
-	for _, feeComponent := range ao.Observation.FeeComponents {
+	for chainSelector, feeComponent := range ao.Observation.FeeComponents {
 		if feeComponent.ExecutionFee == nil || feeComponent.ExecutionFee.Cmp(big.NewInt(0)) < 0 {
-			return fmt.Errorf("nil or negative execution fee: %+v", feeComponent.ExecutionFee)
+			return fmt.Errorf("nil or negative execution fee: %+v, chain: %d",
+				feeComponent.ExecutionFee, chainSelector)
 		}
 
 		if feeComponent.DataAvailabilityFee == nil || feeComponent.DataAvailabilityFee.Cmp(big.NewInt(0)) < 0 {
-			return fmt.Errorf("nil or negative data availability fee: %+v", feeComponent.DataAvailabilityFee)
+			return fmt.Errorf("nil or negative data availability fee: %+v, chain: %d",
+				feeComponent.DataAvailabilityFee, chainSelector)
 		}
 	}
 	return nil

--- a/commit/chainfee/validate_observation_test.go
+++ b/commit/chainfee/validate_observation_test.go
@@ -42,17 +42,17 @@ func Test_validateFeeComponentsAndChainFeeUpdates(t *testing.T) {
 					DataAvailabilityFee: big.NewInt(20),
 				},
 			},
-			expectedFeeComponentError: "nil or non-positive execution fee",
+			expectedFeeComponentError: "nil or negative execution fee: <nil>",
 		},
 		{
-			name: "non-positive execution fee",
+			name: "negative execution fee",
 			feeComponents: map[ccipocr3.ChainSelector]types.ChainFeeComponents{
 				1: {
-					ExecutionFee:        big.NewInt(0),
+					ExecutionFee:        big.NewInt(-1),
 					DataAvailabilityFee: big.NewInt(20),
 				},
 			},
-			expectedFeeComponentError: "nil or non-positive execution fee",
+			expectedFeeComponentError: "nil or negative execution fee: -1",
 		},
 		{
 			name: "nil data availability fee",
@@ -62,7 +62,7 @@ func Test_validateFeeComponentsAndChainFeeUpdates(t *testing.T) {
 					DataAvailabilityFee: nil,
 				},
 			},
-			expectedFeeComponentError: "nil or negative data availability fee",
+			expectedFeeComponentError: "nil or negative data availability fee: <nil>",
 		},
 		{
 			name: "negative data availability fee",
@@ -72,7 +72,7 @@ func Test_validateFeeComponentsAndChainFeeUpdates(t *testing.T) {
 					DataAvailabilityFee: big.NewInt(-1),
 				},
 			},
-			expectedFeeComponentError: "nil or negative data availability fee",
+			expectedFeeComponentError: "nil or negative data availability fee: -1",
 		},
 		{
 			name: "valid chain fee updates",
@@ -98,20 +98,20 @@ func Test_validateFeeComponentsAndChainFeeUpdates(t *testing.T) {
 					Timestamp: fourHoursAgo,
 				},
 			},
-			expectedChainFeeUpdatesError: "nil or non-positive execution fee price",
+			expectedChainFeeUpdatesError: "nil or negative execution fee: <nil>",
 		},
 		{
-			name: "non-positive execution fee price - chain fee updates",
+			name: "negative execution fee price - chain fee updates",
 			chainFeeUpdates: map[ccipocr3.ChainSelector]Update{
 				1: {
 					ChainFee: ComponentsUSDPrices{
-						ExecutionFeePriceUSD: big.NewInt(0),
+						ExecutionFeePriceUSD: big.NewInt(-1),
 						DataAvFeePriceUSD:    big.NewInt(20),
 					},
 					Timestamp: fourHoursAgo,
 				},
 			},
-			expectedChainFeeUpdatesError: "nil or non-positive execution fee price",
+			expectedChainFeeUpdatesError: "nil or negative execution fee: -1",
 		},
 		{
 			name: "nil data availability fee price - chain fee updates",
@@ -124,7 +124,7 @@ func Test_validateFeeComponentsAndChainFeeUpdates(t *testing.T) {
 					Timestamp: fourHoursAgo,
 				},
 			},
-			expectedChainFeeUpdatesError: "nil or negative data availability fee price",
+			expectedChainFeeUpdatesError: "nil or negative data availability fee: <nil>",
 		},
 		{
 			name: "negative data availability fee price - chain fee updates",
@@ -137,7 +137,7 @@ func Test_validateFeeComponentsAndChainFeeUpdates(t *testing.T) {
 					Timestamp: fourHoursAgo,
 				},
 			},
-			expectedChainFeeUpdatesError: "nil or negative data availability fee price",
+			expectedChainFeeUpdatesError: "nil or negative data availability fee: -1",
 		},
 		{
 			name: "zero timestamp - chain fee updates",


### PR DESCRIPTION
We were getting this failure:

```
{"level":"warn","ts":"2025-04-29T14:48:51.241Z","logger":"CCIPCCIPCommitOCR3.evm.421614.0x9B73Aa7b0b92B8d8c79b9A85Ef9b810e73c1e901","caller":"protocol/outcome_generation_leader.go:403","msg":"dropping MessageObservation carrying invalid Observation","version":"2.23.1@d95319b","sender":3,"seqNr":2992,"error":"validate chain fee observation: failed to validate chain fee updates: nil or non-positive execution fee price","e":1018,"l":1,"oid":1,"configDigest":"000a5d4169c135bfc1ac893a5dd1f818a7960e70817ac5ec0b393cf0a5b98877","proto":"outgen"}
```