### PR TITLE
solana: PoC for timelock worker, retrieving accounts from the scheduled operation account

### DIFF
--- a/chains/solana/contracts/tests/mcms/timelock_schedule_execute_test.go
+++ b/chains/solana/contracts/tests/mcms/timelock_schedule_execute_test.go
@@ -516,7 +516,7 @@ func TestTimelockScheduleAndExecute(t *testing.T) {
 						executor.PublicKey(),
 					)
 
-					// todo: remove this
+					// todo: remove this comment after PoC, use accounts retrieved from the op account instead of predefined ones
 					// ix.AccountMetaSlice = append(ix.AccountMetaSlice, op1.RemainingAccounts()...)
 					ix.AccountMetaSlice = append(ix.AccountMetaSlice, remainingAccounts...)
 


### PR DESCRIPTION
This PR provides a demonstrative test case for extracting accounts directly from on-chain operation accounts for timelock execution.

## Primary Changes
- Implemented test case showing how to use accounts from operation PDA
- Added proper handling of program IDs required for CPI execution
- Ensured account flags (IsWritable) are preserved with the most permissive setting when deduplicating

## Context
- This allows timelock worker services to execute operations using only on-chain data, removing dependency on the original operation creation context.