### PR TITLE
Deterministic plugins Outcome related to `discovery` call

### DIFF
--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -430,11 +430,12 @@ func (p *Plugin) Outcome(
 	for _, ao := range aos {
 		obs, err := p.ocrTypeCodec.DecodeObservation(ao.Observation)
 		if err != nil {
-			lggr.Warnw("failed to decode observation, observation skipped", "err", err)
+			lggr.Warnw("failed to decode observation, observation skipped",
+				"err", err, "observer", ao.Observer, "observation", ao.Observation)
 			continue
 		}
 
-		lggr.Debugw("Commit plugin outcome decoded observation", "observation", obs)
+		lggr.Debugw("Commit plugin outcome decoded observation", "observation", obs, "observer", ao.Observer)
 
 		merkleRootObservations = append(merkleRootObservations, attributedMerkleRootObservation{
 			OracleID: ao.Observer, Observation: obs.MerkleRootObs})
@@ -457,9 +458,9 @@ func (p *Plugin) Outcome(
 		_, err = p.discoveryProcessor.Outcome(ctx, dt.Outcome{}, dt.Query{}, discoveryObservations)
 		if err != nil {
 			lggr.Errorw("failed to get discovery processor outcome", "err", err)
-			return nil, nil
+		} else {
+			p.contractsInitialized.Store(true)
 		}
-		p.contractsInitialized.Store(true)
 	}
 
 	merkleRootOutcome, err := p.merkleRootProcessor.Outcome(

--- a/execute/outcome.go
+++ b/execute/outcome.go
@@ -61,9 +61,10 @@ func (p *Plugin) Outcome(
 		discoveryAos := slicelib.Map(decodedAos, mapper)
 		_, err = p.discovery.Outcome(ctx, dt.Outcome{}, dt.Query{}, discoveryAos)
 		if err != nil {
-			return nil, fmt.Errorf("unable to process outcome of discovery processor: %w", err)
+			lggr.Errorw("discovery processor outcome errored", "err", err)
+		} else {
+			p.contractsInitialized = true
 		}
-		p.contractsInitialized = true
 	}
 
 	observation, err := computeConsensusObservation(lggr, decodedAos, p.destChain, p.reportingCfg.F)


### PR DESCRIPTION
- Make Outcome deterministic, even if the discovery outcome fails (rpc issues / etc..), oracles can still contribute to the outcome.
- Improve logs