### PR TITLE
Fix exec quorum race condition.

### DIFF
--- a/execute/plugin.go
+++ b/execute/plugin.go
@@ -473,9 +473,9 @@ func validateMessagesRelatedObservations(
 func (p *Plugin) ObservationQuorum(
 	_ context.Context, outctx ocr3types.OutcomeContext, query types.Query, aos []types.AttributedObservation,
 ) (bool, error) {
-	// TODO: should we use f+1 (or less) instead of 2f+1 because it is not needed for security?
+	// 2f+1 is required for fChain consensus.
 	return quorumhelper.ObservationCountReachesObservationQuorum(
-		quorumhelper.QuorumFPlusOne, p.reportingCfg.N, p.reportingCfg.F, aos), nil
+		quorumhelper.QuorumTwoFPlusOne, p.reportingCfg.N, p.reportingCfg.F, aos), nil
 }
 
 // selectReport takes a list of reports in execution order and selects the first reports that fit within the

--- a/execute/plugin_test.go
+++ b/execute/plugin_test.go
@@ -854,6 +854,7 @@ func TestPlugin_ObservationQuorum(t *testing.T) {
 	got, err := p.ObservationQuorum(ctx, ocr3types.OutcomeContext{}, nil, []types.AttributedObservation{
 		{Observation: []byte{}},
 		{Observation: []byte{}},
+		{Observation: []byte{}},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, true, got)


### PR DESCRIPTION
fChain observations from the home chain require 2f+1 consensus. Having the top level ObservationQuorum set to f+1 was causing a race condition where the number of observations was between f+1 and 2f+1. Rather than waiting for the full observation window, OCR stopped early. This results in a failure to reach consensus on fChain, which causes the entire round to fail.