### PR TITLE
[CCIP-5898] chain fee per-dest deviation

### DIFF
--- a/chainconfig/chainconfig.go
+++ b/chainconfig/chainconfig.go
@@ -13,37 +13,60 @@ import (
 // solidity struct.
 type ChainConfig struct {
 	// GasPriceDeviationPPB is the maximum deviation in parts per billion that the
-	// gas price of this chain is allowed to deviate from the last written gas price
-	// on-chain before we write a new gas price.
+	// gas price being reported to this chain is allowed to deviate from the last
+	// written gas price before we write a new gas price.
+	//
+	// Note that this applies to ALL source chains that can send messages to this chain.
+	// For example, if the ChainConfig for Ethereum has a GasPriceDeviationPPB of 1e9 (100%),
+	// then the gas price for ALL source chains that send messages to Ethereum
+	// will be allowed to deviate by up to 100% from the last written gas price on-chain
+	// before we write a new gas price.
 	GasPriceDeviationPPB cciptypes.BigInt `json:"gasPriceDeviationPPB"`
 
 	// DAGasPriceDeviationPPB is the maximum deviation in parts per billion that the
-	// data-availability gas price of this chain is allowed to deviate from the last
-	// written data-availability gas price on-chain before we write a new data-availability
-	// gas price.
+	// data-availability gas prices being reported to this chain are allowed to deviate
+	// from the last written data-availability gas price on-chain before we write a new
+	// data-availability gas price.
+	//
+	// Note that this applies to ALL source chains that can send messages to this chain.
+	// For example, if the ChainConfig for Ethereum has a DAGasPriceDeviationPPB of 5e8 (50%),
+	// then the data-availability gas price for ALL source chains that send messages to Ethereum
+	// will be allowed to deviate by up to 50% from the last written data-availability gas price on-chain
+	// before we write a new data-availability gas price.
+	//
 	// This is only applicable for some chains, such as L2's.
 	DAGasPriceDeviationPPB cciptypes.BigInt `json:"daGasPriceDeviationPPB"`
 
 	// OptimisticConfirmations is the number of confirmations of a chain event before
 	// it is considered optimistically confirmed (i.e not necessarily finalized).
+	// Deprecated: this is no longer used, setting it will have no effect.
 	OptimisticConfirmations uint32 `json:"optimisticConfirmations"`
 
-	// ChainFeeDeviationDisabled is a flag to disable deviation-based reporting. If true, we will only report
-	// prices based on the heartbeat.
+	// ChainFeeDeviationDisabled is a flag to disable deviation-based reporting of gas prices
+	// on this chain. If true, we will only report prices based on the heartbeat (configured
+	// in the commit plugin offchain config).
 	ChainFeeDeviationDisabled bool `json:"chainFeeDeviationDisabled"`
 }
 
 func (cc ChainConfig) Validate() error {
+	if cc.GasPriceDeviationPPB.Int == nil {
+		return errors.New("GasPriceDeviationPPB not set")
+	}
+
 	if cc.GasPriceDeviationPPB.Int.Cmp(big.NewInt(0)) <= 0 {
 		return errors.New("GasPriceDeviationPPB not set or negative")
 	}
 
-	// No validation for DAGasPriceDeviationPPB as it is optional
-	// and only applicable to L2's.
-
-	if cc.OptimisticConfirmations == 0 {
-		return errors.New("OptimisticConfirmations not set")
+	if cc.DAGasPriceDeviationPPB.Int == nil {
+		return errors.New("DAGasPriceDeviationPPB not set")
 	}
+
+	if cc.DAGasPriceDeviationPPB.Int.Cmp(big.NewInt(0)) <= 0 {
+		return errors.New("DAGasPriceDeviationPPB not set or negative")
+	}
+
+	// No validation for OptimisticConfirmations as it is deprecated
+	// and no longer used.
 
 	return nil
 }

--- a/chainconfig/chainconfig_test.go
+++ b/chainconfig/chainconfig_test.go
@@ -21,27 +21,56 @@ func TestChainConfig_Validate(t *testing.T) {
 		{
 			"valid",
 			fields{
-				GasPriceDeviationPPB:    cciptypes.BigInt{Int: big.NewInt(1)},
-				DAGasPriceDeviationPPB:  cciptypes.BigInt{Int: big.NewInt(1)},
-				OptimisticConfirmations: 1,
+				GasPriceDeviationPPB:   cciptypes.BigInt{Int: big.NewInt(1)},
+				DAGasPriceDeviationPPB: cciptypes.BigInt{Int: big.NewInt(1)},
 			},
 			false,
 		},
 		{
-			"invalid, gas price deviation not set",
+			"invalid, gas price deviation is nil",
 			fields{
-				GasPriceDeviationPPB:    cciptypes.BigInt{Int: big.NewInt(0)},
-				DAGasPriceDeviationPPB:  cciptypes.BigInt{Int: big.NewInt(1)},
-				OptimisticConfirmations: 1,
+				GasPriceDeviationPPB:   cciptypes.BigInt{},
+				DAGasPriceDeviationPPB: cciptypes.BigInt{Int: big.NewInt(1)},
 			},
 			true,
 		},
 		{
-			"invalid, optimistic confirmations not set",
+			"invalid, da gas price deviation is nil",
 			fields{
-				GasPriceDeviationPPB:    cciptypes.BigInt{Int: big.NewInt(1)},
-				DAGasPriceDeviationPPB:  cciptypes.BigInt{Int: big.NewInt(1)},
-				OptimisticConfirmations: 0,
+				GasPriceDeviationPPB:   cciptypes.BigInt{Int: big.NewInt(1)},
+				DAGasPriceDeviationPPB: cciptypes.BigInt{},
+			},
+			true,
+		},
+		{
+			"invalid, gas price deviation not set",
+			fields{
+				GasPriceDeviationPPB:   cciptypes.BigInt{Int: big.NewInt(0)},
+				DAGasPriceDeviationPPB: cciptypes.BigInt{Int: big.NewInt(1)},
+			},
+			true,
+		},
+		{
+			"invalid, gas price deviation is negative",
+			fields{
+				GasPriceDeviationPPB:   cciptypes.BigInt{Int: big.NewInt(-1)},
+				DAGasPriceDeviationPPB: cciptypes.BigInt{Int: big.NewInt(1)},
+			},
+			true,
+		},
+		{
+			"invalid, data-availability gas price deviation not set",
+			fields{
+				GasPriceDeviationPPB:   cciptypes.BigInt{Int: big.NewInt(1)},
+				DAGasPriceDeviationPPB: cciptypes.BigInt{Int: big.NewInt(0)},
+			},
+			true,
+		},
+		{
+			"invalid, data-availability gas price deviation is negative",
+			fields{
+				GasPriceDeviationPPB:   cciptypes.BigInt{Int: big.NewInt(1)},
+				DAGasPriceDeviationPPB: cciptypes.BigInt{Int: big.NewInt(-1)},
 			},
 			true,
 		},

--- a/commit/chainfee/outcome.go
+++ b/commit/chainfee/outcome.go
@@ -231,6 +231,14 @@ func (p *processor) getGasPricesToUpdate(
 ) []cciptypes.GasPriceChain {
 	var gasPrices []cciptypes.GasPriceChain
 
+	destChainCfg, err := p.homeChain.GetChainConfig(p.destChain)
+	if err != nil {
+		lggr.Errorw("error getting dest chain config", "chain", p.destChain, "err", err)
+		return gasPrices
+	}
+	execGasPriceDeviation := destChainCfg.Config.GasPriceDeviationPPB.Int64()
+	daGasPriceDeviation := destChainCfg.Config.DAGasPriceDeviationPPB.Int64()
+
 	for chain, currentChainFee := range currentChainUSDFees {
 		chainCfg, err := p.homeChain.GetChainConfig(chain)
 		if err != nil {
@@ -284,13 +292,13 @@ func (p *processor) getGasPricesToUpdate(
 		executionFeeDeviates := mathslib.Deviates(
 			currentChainFee.ExecutionFeePriceUSD,
 			lastUpdate.ChainFee.ExecutionFeePriceUSD,
-			feeConfig.GasPriceDeviationPPB.Int64(),
+			execGasPriceDeviation,
 		)
 
 		dataAvFeeDeviates := mathslib.Deviates(
 			currentChainFee.DataAvFeePriceUSD,
 			lastUpdate.ChainFee.DataAvFeePriceUSD,
-			feeConfig.DAGasPriceDeviationPPB.Int64(),
+			daGasPriceDeviation,
 		)
 
 		if executionFeeDeviates || dataAvFeeDeviates {

--- a/commit/plugin_e2e_test.go
+++ b/commit/plugin_e2e_test.go
@@ -696,7 +696,7 @@ func TestPlugin_E2E_AllNodesAgree_ChainFee(t *testing.T) {
 			}
 
 			encodedPrevOutcome, err := ocrTypCodec.EncodeOutcome(tc.prevOutcome)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			runner := testhelpers.NewOCR3Runner(nodes, oracleIDs, encodedPrevOutcome)
 			res, err := runner.RunRound(params.ctx)
 			require.NoError(t, err)
@@ -963,9 +963,18 @@ func defaultNodeParams(t *testing.T) SetupNodeParams {
 
 	peerIDsMap := mapset.NewSet(peerIDs...)
 	homeChainConfig := map[ccipocr3.ChainSelector]reader.ChainConfig{
-		destChain:       {FChain: 1, SupportedNodes: peerIDsMap, Config: chainconfig.ChainConfig{}},
-		sourceEvmChain1: {FChain: 1, SupportedNodes: peerIDsMap, Config: chainconfig.ChainConfig{}},
-		sourceSolChain:  {FChain: 1, SupportedNodes: peerIDsMap, Config: chainconfig.ChainConfig{}},
+		destChain: {FChain: 1, SupportedNodes: peerIDsMap, Config: chainconfig.ChainConfig{
+			GasPriceDeviationPPB:   ccipocr3.NewBigInt(big.NewInt(1e9)), // 100% deviation
+			DAGasPriceDeviationPPB: ccipocr3.NewBigInt(big.NewInt(5e8)), // 50% deviation
+		}},
+		sourceEvmChain1: {FChain: 1, SupportedNodes: peerIDsMap, Config: chainconfig.ChainConfig{
+			GasPriceDeviationPPB:   ccipocr3.NewBigInt(big.NewInt(1e9)), // 100% deviation
+			DAGasPriceDeviationPPB: ccipocr3.NewBigInt(big.NewInt(5e8)), // 50% deviation
+		}},
+		sourceSolChain: {FChain: 1, SupportedNodes: peerIDsMap, Config: chainconfig.ChainConfig{
+			GasPriceDeviationPPB:   ccipocr3.NewBigInt(big.NewInt(1e9)), // 100% deviation
+			DAGasPriceDeviationPPB: ccipocr3.NewBigInt(big.NewInt(5e8)), // 50% deviation
+		}},
 	}
 
 	offRampNextSeqNum := map[ccipocr3.ChainSelector]ccipocr3.SeqNum{


### PR DESCRIPTION
core ref: bb2b9fe22de7636ed41d76cfb620384afdbba218

Gas price deviation are meant to be per-dest-chain, not per-soure-chain.

For example, when reporting onto Ethereum, the deviation threshold is 400% for all source chain gas prices.

This is because the deviation threshold is chosen largely based on how expensive writing to the dest chain is, hence it is a function of the dest chain.