### PR TITLE
Common asynclib and token price processor timeouts and parallelizations

### DIFF
--- a/internal/libs/asynclib/goroutines.go
+++ b/internal/libs/asynclib/goroutines.go
@@ -1,0 +1,40 @@
+package asynclib
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+type AsyncNoErrOperationsMap map[string]func(ctx context.Context, l logger.Logger)
+
+// WaitForAllNoErrOperations spawns goroutines for each operation in the map and waits for
+// all of them to finish. It creates a child context with a timeout to ensure that the operations
+// do not run indefinitely.
+func WaitForAllNoErrOperations(
+	ctx context.Context,
+	timeout time.Duration,
+	operations AsyncNoErrOperationsMap,
+	lggr logger.Logger,
+) {
+	callCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	lggr.Debugw("spawning goroutines", "timeout", timeout)
+
+	var wg sync.WaitGroup
+	wg.Add(len(operations))
+
+	for opName, op := range operations {
+		go func(opName string, op func(context.Context, logger.Logger)) {
+			defer wg.Done()
+			tStart := time.Now()
+			op(callCtx, logger.With(lggr, "opID", opName))
+			lggr.Debugw("observing goroutine finished", "opID", opName, "duration", time.Since(tStart))
+		}(opName, op)
+	}
+
+	wg.Wait()
+}

--- a/internal/libs/asynclib/goroutines_test.go
+++ b/internal/libs/asynclib/goroutines_test.go
@@ -1,0 +1,90 @@
+package asynclib
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+func TestWaitForAllNoErrOperations_AllOpsRun(t *testing.T) {
+	ctx := context.Background()
+	lggr := logger.Test(t)
+	var mu sync.Mutex
+	var calledOps []string
+
+	ops := AsyncNoErrOperationsMap{
+		"op1": func(_ context.Context, _ logger.Logger) {
+			mu.Lock()
+			defer mu.Unlock()
+			calledOps = append(calledOps, "op1")
+		},
+		"op2": func(_ context.Context, _ logger.Logger) {
+			mu.Lock()
+			defer mu.Unlock()
+			calledOps = append(calledOps, "op2")
+		},
+	}
+
+	WaitForAllNoErrOperations(ctx, 2*time.Second, ops, lggr)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.ElementsMatch(t, []string{"op1", "op2"}, calledOps)
+}
+
+func TestWaitForAllNoErrOperations_ContextTimeoutRespected(t *testing.T) {
+	ctx := context.Background()
+	lggr := logger.Test(t)
+	start := time.Now()
+
+	ops := AsyncNoErrOperationsMap{
+		"slowOp": func(ctx context.Context, _ logger.Logger) {
+			select {
+			case <-ctx.Done():
+			case <-time.After(24 * time.Hour):
+			}
+		},
+	}
+
+	timeout := 100 * time.Millisecond
+	WaitForAllNoErrOperations(ctx, timeout, ops, lggr)
+
+	elapsed := time.Since(start)
+	assert.LessOrEqual(t, elapsed.Milliseconds(), int64(500), "timeout not respected")
+}
+
+func TestWaitForAllNoErrOperations_ContextIsPropagated(t *testing.T) {
+	ctx := context.Background()
+	lggr := logger.Test(t)
+
+	done := make(chan struct{})
+
+	ops := AsyncNoErrOperationsMap{
+		"checkCtx": func(ctx context.Context, _ logger.Logger) {
+			_, ok := ctx.Deadline()
+			assert.True(t, ok, "context should have a deadline")
+			close(done)
+		},
+	}
+
+	WaitForAllNoErrOperations(ctx, 500*time.Millisecond, ops, lggr)
+
+	select {
+	case <-done:
+	case <-time.After(24 * time.Hour):
+		t.Fatal("operation did not complete")
+	}
+}
+
+func TestWaitForAllNoErrOperations_NoOps(t *testing.T) {
+	ctx := context.Background()
+	lggr := logger.Test(t)
+
+	// should not panic or block
+	WaitForAllNoErrOperations(ctx, 500*time.Millisecond, AsyncNoErrOperationsMap{}, lggr)
+}

--- a/pluginconfig/commit.go
+++ b/pluginconfig/commit.go
@@ -147,7 +147,9 @@ type CommitOffchainConfig struct {
 	// TokenPriceAsyncObserverSyncFreq defines how frequently the async token price observer should sync.
 	TokenPriceAsyncObserverSyncFreq commonconfig.Duration `json:"tokenPriceAsyncObserverSyncFreq"`
 
-	// TokenPriceAsyncObserverSyncTimeout defines the timeout for a single sync operation (e.g. fetch token prices).
+	// TokenPriceAsyncObserverSyncTimeout defines the timeout for a single
+	// token price observation operation (e.g. fetch token prices).
+	// NOTE: It is also used when the async observer is disabled, while making the sync calls.
 	TokenPriceAsyncObserverSyncTimeout commonconfig.Duration `json:"tokenPriceAsyncObserverSyncTimeout"`
 
 	// MaxRootsPerReport is the maximum number of roots to include in a single report.


### PR DESCRIPTION
- parallelize token price processor calls
- add timeout to token price precessor individual calls
- create a small lib for common async ops
- if fChain observation fails continue with observing the other components