### PR TITLE
Skip e2e on solidity-only changes

### DIFF
--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -11,7 +11,7 @@ jobs:
     name: Detect changes
     runs-on: ubuntu-latest
     outputs:
-      non_src_changes: ${{ steps.changes.outputs.non_src }}
+      e2e_should_run: ${{ steps.changes.outputs.e2e_should_run }}
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4

--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -7,7 +7,32 @@ on:
       - 'main'
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      non_src_changes: ${{ steps.changes.outputs.non_src }}
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Detect changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        with:
+          list-files: "shell"
+          # Run on all, except the chains/evm folder unless it's in a released version.
+          filters: |
+            e2e_should_run:
+              - '**'
+              - '!chains/evm/**'
+              - 'chains/evm/gobindings/generated/**'
+              - '!chains/evm/gobindings/generated/latest'
+
   integration-test-matrix:
+    needs: [changes]
+    if: ${{ needs.changes.outputs.e2e_should_run == 'true' }}
     env:
       # We explicitly have this env var not be "CL_DATABASE_URL" to avoid having it be used by core related tests
       # when they should not be using it, while still allowing us to DRY up the setup

--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the chainlink-ccip repo
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4
       - name: Determine Go version
         id: go_version
         run: echo "GO_VERSION=$(cat go.mod |grep "^go"|cut -d' ' -f 2)" >> $GITHUB_ENV
@@ -119,7 +119,7 @@ jobs:
             echo "::set-output name=ref::$default"
           fi
       - name: Clone Chainlink repo
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4
         with:
           repository: smartcontractkit/chainlink
           ref: ${{ steps.get_chainlink_sha.outputs.ref }}

--- a/.github/workflows/ccip-ocr3-build-lint-test.yml
+++ b/.github/workflows/ccip-ocr3-build-lint-test.yml
@@ -14,7 +14,7 @@ jobs:
         working-directory: .
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Determine Go version

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -14,7 +14,7 @@ jobs:
       run:
         working-directory: .
     steps:
-      - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      - uses: actions/checkout@v4
       - name: Determine Go version
         id: go_version
         run: echo "GO_VERSION=$(cat go.mod |grep "^go"|cut -d' ' -f 2)" >> $GITHUB_ENV

--- a/.github/workflows/solana-verified-build.yml
+++ b/.github/workflows/solana-verified-build.yml
@@ -16,7 +16,7 @@ jobs:
     name: Detect changes
     runs-on: ubuntu-latest
     outputs:
-      non_src_changes: ${{ steps.changes.outputs.non_src }}
+      solana_changes: ${{ steps.changes.outputs.solana_changes }}
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4

--- a/.github/workflows/solana-verified-build.yml
+++ b/.github/workflows/solana-verified-build.yml
@@ -12,7 +12,29 @@ on:
       - main
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      non_src_changes: ${{ steps.changes.outputs.non_src }}
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Detect changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        with:
+          list-files: "shell"
+          filters: |
+            solana_changes:
+              - 'chains/solana/**'
+              - '.github/workflows/solana*.yml'
+
   build:
+    needs: [ changes ]
+    if: ${{ needs.changes.outputs.solana_changes == 'true' }}
     runs-on: ubuntu-latest-8cores-32GB
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/solana.yml
+++ b/.github/workflows/solana.yml
@@ -19,7 +19,7 @@ jobs:
     name: Detect changes
     runs-on: ubuntu-latest
     outputs:
-      non_src_changes: ${{ steps.changes.outputs.non_src }}
+      solana_changes: ${{ steps.changes.outputs.solana_changes }}
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4

--- a/.github/workflows/solana.yml
+++ b/.github/workflows/solana.yml
@@ -44,7 +44,7 @@ jobs:
       anchor_version: ${{ steps.anchorversion.outputs.anchor }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+        uses: actions/checkout@v4
       - name: Get Anchor Version
         id: anchorversion
         run: |
@@ -57,7 +57,7 @@ jobs:
     name: cache build artifacts
     runs-on: ubuntu-latest-8cores-32GB
     steps:
-    - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+    - uses: actions/checkout@v4
     - name: cache docker build image
       id: cache-image
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
@@ -95,7 +95,7 @@ jobs:
     name: rust tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+    - uses: actions/checkout@v4
     - name: Cache cargo target dir
       uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       with:
@@ -130,7 +130,7 @@ jobs:
     name: go tests
     runs-on: ubuntu-latest-8cores-32GB
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      - uses: actions/checkout@v4
       - name: Cache cargo target dir
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
@@ -177,7 +177,7 @@ jobs:
     name: lint + check artifacts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+      - uses: actions/checkout@v4
       - name: Cache cargo target dir
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:

--- a/.github/workflows/solana.yml
+++ b/.github/workflows/solana.yml
@@ -15,7 +15,29 @@ defaults:
     working-directory: ./chains/solana
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      non_src_changes: ${{ steps.changes.outputs.non_src }}
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Detect changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        with:
+          list-files: "shell"
+          filters: |
+            solana_changes:
+              - 'chains/solana/**'
+              - '.github/workflows/solana*.yml'
+
   get_anchor_version:
+    needs: [ changes ]
+    if: ${{ needs.changes.outputs.solana_changes == 'true' }}
     name: Get Anchor Version
     runs-on: ubuntu-latest
     outputs:
@@ -30,9 +52,10 @@ jobs:
           echo "anchor=${anchor}" >>$GITHUB_OUTPUT
 
   build_solana:
+    needs: [changes, get_anchor_version]
+    if: ${{ needs.changes.outputs.solana_changes == 'true' }}
     name: cache build artifacts
     runs-on: ubuntu-latest-8cores-32GB
-    needs: [get_anchor_version]
     steps:
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
     - name: cache docker build image
@@ -67,9 +90,10 @@ jobs:
           chmod -R 755 ./target"
 
   rust:
+    needs: [ changes, get_anchor_version, build_solana ]
+    if: ${{ needs.changes.outputs.solana_changes == 'true' }}
     name: rust tests
     runs-on: ubuntu-latest
-    needs: [get_anchor_version, build_solana]
     steps:
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
     - name: Cache cargo target dir
@@ -101,9 +125,10 @@ jobs:
           cargo test --workspace"
 
   go:
+    needs: [ changes, get_anchor_version, build_solana ]
+    if: ${{ needs.changes.outputs.solana_changes == 'true' }}
     name: go tests
     runs-on: ubuntu-latest-8cores-32GB
-    needs: [get_anchor_version, build_solana]
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Cache cargo target dir
@@ -147,9 +172,10 @@ jobs:
           make go-tests
 
   lint:
+    needs: [ changes, get_anchor_version, build_solana ]
+    if: ${{ needs.changes.outputs.solana_changes == 'true' }}
     name: lint + check artifacts
     runs-on: ubuntu-latest
-    needs: [get_anchor_version, build_solana]
     steps:
       - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
       - name: Cache cargo target dir


### PR DESCRIPTION
After this is merged, there should be a significant drop in CI runs and therefore delays, flakiness and cost

- Solana onchain CI only runs on Solana onchain changes 
- E2E tests are skipped for Solidity changes, except for changes to released versions. 

TODOs: apply the E2E skip logic to the offchain Go tests as well. That means normal Solidity changes should only run Solidity CI. 

This PR also makes all CI use a consistent v4 version of `actions/checkout`