### PR TITLE
only gen metadata when required

### DIFF
--- a/.github/workflows/solidity-build-and-publish.yml
+++ b/.github/workflows/solidity-build-and-publish.yml
@@ -92,15 +92,20 @@ jobs:
           working-directory: chains/evm
 
       - name: Run native compile and generate wrappers
+        if: ${{ !(needs.tag-check.outputs.is-release-ccip == 'true' || needs.tag-check.outputs.is-pre-release-ccip == 'true') }}
         working-directory: chains/evm
         run: make wrappers
+
+      - name: Run native compile and generate wrappers including metadata
+        if: ${{ needs.tag-check.outputs.is-release-ccip == 'true' || needs.tag-check.outputs.is-pre-release-ccip == 'true' }}
+        working-directory: chains/evm
+        run: make wrappers-release
 
       - name: Install and run forge --zksync, and generate wrappers
         working-directory: chains/evm
         run: make wrappers-zksync
 
       - name: Check if Go solidity wrappers are updated
-        if: ${{ needs.changes.outputs.changes == 'true' }}
         working-directory: chains/evm
         run: |
           git add --all

--- a/.github/workflows/solidity-build-and-publish.yml
+++ b/.github/workflows/solidity-build-and-publish.yml
@@ -83,7 +83,6 @@ jobs:
       - name: Run native compile and generate wrappers
         if: ${{ !(needs.tag-check.outputs.is-release-ccip == 'true' || needs.tag-check.outputs.is-pre-release-ccip == 'true') }}
         working-directory: chains/evm
-
         run: make wrappers
 
       - name: Run native compile and generate wrappers including metadata

--- a/.github/workflows/solidity-build-and-publish.yml
+++ b/.github/workflows/solidity-build-and-publish.yml
@@ -64,17 +64,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Checkout diff-so-fancy
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-          repository: so-fancy/diff-so-fancy
-          ref: a673cb4d2707f64d92b86498a2f5f71c8e2643d5 # v1.4.3
-          path: diff-so-fancy
-
-      - name: Install diff-so-fancy
-        run: echo "$GITHUB_WORKSPACE/diff-so-fancy" >> $GITHUB_PATH
-
       - name: Setup NodeJS
         uses: smartcontractkit/.github/actions/setup-nodejs@c094a1482049b2b9c0a7cde3f715bd76a60afd97
         with:
@@ -94,6 +83,7 @@ jobs:
       - name: Run native compile and generate wrappers
         if: ${{ !(needs.tag-check.outputs.is-release-ccip == 'true' || needs.tag-check.outputs.is-pre-release-ccip == 'true') }}
         working-directory: chains/evm
+
         run: make wrappers
 
       - name: Run native compile and generate wrappers including metadata
@@ -110,7 +100,7 @@ jobs:
         working-directory: chains/evm
         run: |
           git add --all
-          git diff --minimal --color --cached --exit-code | diff-so-fancy
+          git diff --minimal --color --cached --exit-code
 
   # The if statements for steps after checkout repo is a workaround for
   # passing required check for PRs that don't have filtered changes.

--- a/.github/workflows/solidity-build-and-publish.yml
+++ b/.github/workflows/solidity-build-and-publish.yml
@@ -102,6 +102,7 @@ jobs:
         run: make wrappers-release
 
       - name: Install and run forge --zksync, and generate wrappers
+        if: ${{ needs.tag-check.outputs.is-release-ccip == 'true' || needs.tag-check.outputs.is-pre-release-ccip == 'true' }}
         working-directory: chains/evm
         run: make wrappers-zksync
 

--- a/.github/workflows/solidity-build-and-publish.yml
+++ b/.github/workflows/solidity-build-and-publish.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           list-files: 'csv'
           filters: |
-            src:
+            changes:
               - 'chains/evm/**/*'
               - '.github/workflows/solidity-build-and-publish.yml'
               - '.github/workflows/solidity-wrappers.yml'

--- a/chains/evm/GNUmakefile
+++ b/chains/evm/GNUmakefile
@@ -38,6 +38,11 @@ wrappers: pnpmdep mockery abigen
 	./scripts/compile_all
 	go generate ./gobindings
 
+wrappers-release: export metadata=true
+.PHONY: wrappers-release
+wrappers-release: ## Generate the gethwrappers for release which includes metadata.
+	 make wrappers
+
 .PHONY: wrappers-zksync
 wrappers-zksync: pnpmdep foundry-zksync
 	ZKSYNC=true make wrappers

--- a/chains/evm/gobindings/generation/abigen.go
+++ b/chains/evm/gobindings/generation/abigen.go
@@ -98,13 +98,14 @@ func Abigen(a AbigenArgs) {
 
 	ImproveAbigenOutput(a.Out, a.ABI)
 
-	if !includeMetadata {
-		// If metadata is not included, we are done here.
-		return
+	if includeMetadata {
+		genMetadata(a)
 	}
+}
 
+func genMetadata(abigenArgs AbigenArgs) {
 	// Add build info to exported package
-	info, err := os.ReadFile(a.BuildInfo)
+	info, err := os.ReadFile(abigenArgs.BuildInfo)
 	if err != nil {
 		Exit("Error while reading build info file", err)
 	}
@@ -116,7 +117,7 @@ func Abigen(a AbigenArgs) {
 		Exit("Error while unmarshalling build info JSON", err)
 	}
 	// Get version from metadata file, as it contains the commit hash required by etherscan
-	metadataBytes, err := os.ReadFile(a.Metadata)
+	metadataBytes, err := os.ReadFile(abigenArgs.Metadata)
 	if err != nil {
 		Exit("Error while reading metadata file", err)
 	}
@@ -135,7 +136,7 @@ func Abigen(a AbigenArgs) {
 	if err != nil {
 		Exit("Error while marshalling build info JSON", err)
 	}
-	// Export the metadata as a variable in the generated Go file
+	// Export the metadata as abigenArgs variable in the generated Go file
 	var buf bytes.Buffer
 	if err := json.Compact(&buf, refinedMeta); err != nil {
 		Exit("Error while compacting build info JSON", err)
@@ -143,10 +144,10 @@ func Abigen(a AbigenArgs) {
 	code := fmt.Sprintf(
 		"%s\npackage %s\n\nvar SolidityStandardInput = %s\n",
 		headerComment,
-		a.Pkg,
+		abigenArgs.Pkg,
 		strconv.Quote(buf.String()),
 	)
-	err = os.WriteFile(a.BuildInfoOut, []byte(code), 0600)
+	err = os.WriteFile(abigenArgs.BuildInfoOut, []byte(code), 0600)
 	if err != nil {
 		Exit("Error while writing build info file", err)
 	}

--- a/chains/evm/gobindings/generation/abigen.go
+++ b/chains/evm/gobindings/generation/abigen.go
@@ -64,6 +64,8 @@ type buildInfo struct {
 //
 // Check whether native abigen is installed, and has correct version
 func Abigen(a AbigenArgs) {
+	includeMetadata := os.Getenv("metadata") == "true"
+
 	var versionResponse bytes.Buffer
 	abigenExecutablePath := filepath.Join(GetProjectRoot(), "chains/evm/scripts/abigen")
 	abigenVersionCheck := exec.Command(abigenExecutablePath, "--version")
@@ -95,6 +97,11 @@ func Abigen(a AbigenArgs) {
 	}
 
 	ImproveAbigenOutput(a.Out, a.ABI)
+
+	if !includeMetadata {
+		// If metadata is not included, we are done here.
+		return
+	}
 
 	// Add build info to exported package
 	info, err := os.ReadFile(a.BuildInfo)


### PR DESCRIPTION
Only run ZK wrappers and metadata generation for releases, not every PR. 

Fix bug in changes checker, should result in properly running CI for non-release PRs