### PR TITLE
Reader helper tech debt cleanup.

### DIFF
--- a/pkg/contractreader/extended.go
+++ b/pkg/contractreader/extended.go
@@ -26,23 +26,8 @@ var (
 
 // Extended version of a ContractReader.
 type Extended interface {
-	// Unbind is included for compatibility with ContractReader
-	Unbind(ctx context.Context, bindings []types.BoundContract) error
-	// HealthReport is included for compatibility with ContractReader
-	HealthReport() map[string]error
-
-	Bind(ctx context.Context, bindings []types.BoundContract) error
-
-	GetBindings(contractName string) []ExtendedBoundContract
-
-	// QueryKey is from the base contract reader interface.
-	QueryKey(
-		ctx context.Context,
-		contract types.BoundContract,
-		filter query.KeyFilter,
-		limitAndSort query.LimitAndSort,
-		sequenceDataType any,
-	) ([]types.Sequence, error)
+	// ContractReaderFacade is the base interface that this extended interface builds upon.
+	ContractReaderFacade
 
 	// ExtendedQueryKey performs automatic binding from contractName to the first bound contract.
 	// An error is generated if there are more than one bound contract for the contractName.
@@ -54,14 +39,6 @@ type Extended interface {
 		sequenceDataType any,
 	) ([]types.Sequence, error)
 
-	// GetLatestValue is from the base contract reader interface.
-	GetLatestValue(
-		ctx context.Context,
-		readIdentifier string,
-		confidenceLevel primitives.ConfidenceLevel,
-		params, returnVal any,
-	) error
-
 	// ExtendedGetLatestValue performs automatic binding from contractName to the first bound contract, and
 	// constructs a read identifier for a given method name. An error is generated if there are more than one
 	// bound contract for the contractName.
@@ -71,12 +48,6 @@ type Extended interface {
 		confidenceLevel primitives.ConfidenceLevel,
 		params, returnVal any,
 	) error
-
-	// BatchGetLatestValues is from the base contract reader interface.
-	BatchGetLatestValues(
-		ctx context.Context,
-		request types.BatchGetLatestValuesRequest,
-	) (types.BatchGetLatestValuesResult, error)
 
 	// ExtendedBatchGetLatestValues performs automatic binding from contractNames to bound contracts,
 	// and constructs a BatchGetLatestValuesRequest with the resolved bindings.

--- a/pkg/contractreader/extended.go
+++ b/pkg/contractreader/extended.go
@@ -29,6 +29,9 @@ type Extended interface {
 	// ContractReaderFacade is the base interface that this extended interface builds upon.
 	ContractReaderFacade
 
+	// GetBindings returns current bindings for a given contract reader.
+	GetBindings(contractName string) []ExtendedBoundContract
+
 	// ExtendedQueryKey performs automatic binding from contractName to the first bound contract.
 	// An error is generated if there are more than one bound contract for the contractName.
 	ExtendedQueryKey(

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -207,7 +207,7 @@ func (r *ccipChainReader) CommitReportsGTETimestamp(
 	confidence primitives.ConfidenceLevel,
 	limit int) ([]cciptypes.CommitPluginReportWithMeta, error) {
 
-	if err := validateExtendedReaderExistence(r.contractReaders, r.destChain); err != nil {
+	if err := validateReaderExistence(r.contractReaders, r.destChain); err != nil {
 		return []cciptypes.CommitPluginReportWithMeta{}, err
 	}
 
@@ -374,7 +374,7 @@ func (r *ccipChainReader) ExecutedMessages(
 ) (map[cciptypes.ChainSelector][]cciptypes.SeqNum, error) {
 	lggr := logutil.WithContextValues(ctx, r.lggr)
 
-	if err := validateExtendedReaderExistence(r.contractReaders, r.destChain); err != nil {
+	if err := validateReaderExistence(r.contractReaders, r.destChain); err != nil {
 		return nil, err
 	}
 
@@ -493,7 +493,7 @@ func (r *ccipChainReader) MsgsBetweenSeqNums(
 	ctx context.Context, sourceChainSelector cciptypes.ChainSelector, seqNumRange cciptypes.SeqNumRange,
 ) ([]cciptypes.Message, error) {
 	lggr := logutil.WithContextValues(ctx, r.lggr)
-	if err := validateExtendedReaderExistence(r.contractReaders, sourceChainSelector); err != nil {
+	if err := validateReaderExistence(r.contractReaders, sourceChainSelector); err != nil {
 		return nil, err
 	}
 
@@ -583,7 +583,7 @@ func (r *ccipChainReader) MsgsBetweenSeqNums(
 func (r *ccipChainReader) LatestMsgSeqNum(
 	ctx context.Context, chain cciptypes.ChainSelector) (cciptypes.SeqNum, error) {
 	lggr := logutil.WithContextValues(ctx, r.lggr)
-	if err := validateExtendedReaderExistence(r.contractReaders, chain); err != nil {
+	if err := validateReaderExistence(r.contractReaders, chain); err != nil {
 		return 0, err
 	}
 
@@ -648,7 +648,7 @@ func (r *ccipChainReader) GetExpectedNextSequenceNumber(
 ) (cciptypes.SeqNum, error) {
 	lggr := logutil.WithContextValues(ctx, r.lggr)
 
-	if err := validateExtendedReaderExistence(r.contractReaders, sourceChainSelector); err != nil {
+	if err := validateReaderExistence(r.contractReaders, sourceChainSelector); err != nil {
 		return 0, err
 	}
 
@@ -741,7 +741,7 @@ func (r *ccipChainReader) Nonces(
 	addressesByChain map[cciptypes.ChainSelector][]string,
 ) (map[cciptypes.ChainSelector]map[string]uint64, error) {
 	lggr := logutil.WithContextValues(ctx, r.lggr)
-	if err := validateExtendedReaderExistence(r.contractReaders, r.destChain); err != nil {
+	if err := validateReaderExistence(r.contractReaders, r.destChain); err != nil {
 		return nil, err
 	}
 
@@ -960,7 +960,7 @@ func (r *ccipChainReader) GetWrappedNativeTokenPriceUSD(
 //nolint:lll
 func (r *ccipChainReader) GetChainFeePriceUpdate(ctx context.Context, selectors []cciptypes.ChainSelector) map[cciptypes.ChainSelector]cciptypes.TimestampedBig {
 	lggr := logutil.WithContextValues(ctx, r.lggr)
-	if err := validateExtendedReaderExistence(r.contractReaders, r.destChain); err != nil {
+	if err := validateReaderExistence(r.contractReaders, r.destChain); err != nil {
 		lggr.Errorw("GetChainFeePriceUpdate dest chain extended reader not exist, dest chain not supported", "err", err)
 		return nil
 	}
@@ -1126,7 +1126,7 @@ func (r *ccipChainReader) GetRMNRemoteConfig(ctx context.Context) (cciptypes.Rem
 // GetRmnCurseInfo returns rmn curse/pausing information about the provided chains
 // from the destination chain RMN remote contract.
 func (r *ccipChainReader) GetRmnCurseInfo(ctx context.Context) (CurseInfo, error) {
-	if err := validateExtendedReaderExistence(r.contractReaders, r.destChain); err != nil {
+	if err := validateReaderExistence(r.contractReaders, r.destChain); err != nil {
 		return CurseInfo{}, fmt.Errorf("validate dest=%d extended reader existence: %w", r.destChain, err)
 	}
 
@@ -1239,7 +1239,7 @@ func (r *ccipChainReader) DiscoverContracts(ctx context.Context,
 	lggr := logutil.WithContextValues(ctx, r.lggr)
 
 	// Discover destination contracts if the dest chain is supported.
-	if err := validateExtendedReaderExistence(r.contractReaders, r.destChain); err == nil {
+	if err := validateReaderExistence(r.contractReaders, r.destChain); err == nil {
 		resp, err = r.discoverOffRampContracts(ctx, lggr, chains)
 		// Can't continue with discovery if the destination chain is not available.
 		// We read source chains OnRamps from there, and onRamps are essential for feeQuoter and Router discovery.
@@ -1341,7 +1341,7 @@ func (r *ccipChainReader) Sync(ctx context.Context, contracts ContractAddresses)
 			}
 
 			// try to bind
-			_, err := bindExtendedReaderContract(ctx, lggr, r.contractReaders, chainSel, contractName, address, r.addrCodec)
+			_, err := bindReaderContract(ctx, lggr, r.contractReaders, chainSel, contractName, address, r.addrCodec)
 			if err != nil {
 				if errors.Is(err, ErrContractReaderNotFound) {
 					// don't support this chain
@@ -1367,7 +1367,7 @@ func (r *ccipChainReader) GetContractAddress(contractName string, chain cciptype
 // the price of ETH not in ETH but in wei (1e-18 ETH).
 func (r *ccipChainReader) LinkPriceUSD(ctx context.Context) (cciptypes.BigInt, error) {
 	// Ensure we can read from the destination chain.
-	if err := validateExtendedReaderExistence(r.contractReaders, r.destChain); err != nil {
+	if err := validateReaderExistence(r.contractReaders, r.destChain); err != nil {
 		return cciptypes.BigInt{}, fmt.Errorf("failed to validate dest chain reader existence: %w", err)
 	}
 
@@ -1487,7 +1487,7 @@ func (r *ccipChainReader) getOffRampSourceChainsConfig(
 	chains []cciptypes.ChainSelector,
 	includeDisabled bool,
 ) (map[cciptypes.ChainSelector]StaticSourceChainConfig, error) {
-	if err := validateExtendedReaderExistence(r.contractReaders, r.destChain); err != nil {
+	if err := validateReaderExistence(r.contractReaders, r.destChain); err != nil {
 		return nil, fmt.Errorf("validate extended reader existence: %w", err)
 	}
 
@@ -1677,7 +1677,7 @@ func (r *ccipChainReader) getRMNRemoteAddress(
 	lggr logger.Logger,
 	chain cciptypes.ChainSelector,
 	rmnRemoteProxyAddress []byte) ([]byte, error) {
-	_, err := bindExtendedReaderContract(ctx, lggr, r.contractReaders, chain, consts.ContractNameRMNProxy, rmnRemoteProxyAddress, r.addrCodec)
+	_, err := bindReaderContract(ctx, lggr, r.contractReaders, chain, consts.ContractNameRMNProxy, rmnRemoteProxyAddress, r.addrCodec)
 	if err != nil {
 		return nil, fmt.Errorf("bind RMN proxy contract: %w", err)
 	}
@@ -1692,7 +1692,7 @@ func (r *ccipChainReader) getRMNRemoteAddress(
 }
 
 func (r *ccipChainReader) GetLatestPriceSeqNr(ctx context.Context) (uint64, error) {
-	if err := validateExtendedReaderExistence(r.contractReaders, r.destChain); err != nil {
+	if err := validateReaderExistence(r.contractReaders, r.destChain); err != nil {
 		return 0, fmt.Errorf("validate dest=%d extended reader existence: %w", r.destChain, err)
 	}
 

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -684,7 +684,7 @@ func (r *ccipChainReader) GetExpectedNextSequenceNumber(
 func (r *ccipChainReader) NextSeqNum(
 	ctx context.Context, chains []cciptypes.ChainSelector,
 ) (map[cciptypes.ChainSelector]cciptypes.SeqNum, error) {
-	if err := validateExtendedReaderExistence(r.contractReaders, r.destChain); err != nil {
+	if err := validateReaderExistence(r.contractReaders, r.destChain); err != nil {
 		return nil, err
 	}
 
@@ -1092,7 +1092,7 @@ func (r *ccipChainReader) buildSigners(signers []signer) []cciptypes.RemoteSigne
 func (r *ccipChainReader) GetRMNRemoteConfig(ctx context.Context) (cciptypes.RemoteConfig, error) {
 	lggr := logutil.WithContextValues(ctx, r.lggr)
 
-	if err := validateExtendedReaderExistence(r.contractReaders, r.destChain); err != nil {
+	if err := validateReaderExistence(r.contractReaders, r.destChain); err != nil {
 		return cciptypes.RemoteConfig{}, fmt.Errorf("validate dest=%d extended reader existence: %w", r.destChain, err)
 	}
 
@@ -1713,7 +1713,7 @@ func (r *ccipChainReader) GetLatestPriceSeqNr(ctx context.Context) (uint64, erro
 }
 
 func (r *ccipChainReader) GetOffRampConfigDigest(ctx context.Context, pluginType uint8) ([32]byte, error) {
-	if err := validateExtendedReaderExistence(r.contractReaders, r.destChain); err != nil {
+	if err := validateReaderExistence(r.contractReaders, r.destChain); err != nil {
 		return [32]byte{}, fmt.Errorf("validate dest=%d extended reader existence: %w", r.destChain, err)
 	}
 

--- a/pkg/reader/helpers.go
+++ b/pkg/reader/helpers.go
@@ -23,67 +23,27 @@ const (
 	HomeChainPollingInterval = 15 * time.Second
 )
 
-// bindable is a helper interface to represent all different types of contract readers.
-// We expose per-reader type functions, but then cast to this common interface to avoid code duplication.
-type bindable interface {
-	Bind(ctx context.Context, bindings []types.BoundContract) error
-}
-
-func bindExtendedReaderContract(
-	ctx context.Context,
-	lggr logger.Logger,
-	readers map[cciptypes.ChainSelector]contractreader.Extended,
-	chainSel cciptypes.ChainSelector,
-	contractName string,
-	address []byte,
-	addrCodec cciptypes.AddressCodec,
-) (types.BoundContract, error) {
-	casted := make(map[cciptypes.ChainSelector]bindable, len(readers))
-	for k, v := range readers {
-		casted[k] = v
-	}
-	return bindReaderContract(ctx, lggr, casted, chainSel, contractName, address, addrCodec)
-}
-
-func bindFacadeReaderContract(
-	ctx context.Context,
-	lggr logger.Logger,
-	readers map[cciptypes.ChainSelector]contractreader.ContractReaderFacade,
-	chainSel cciptypes.ChainSelector,
-	contractName string,
-	address []byte,
-	addrCodec cciptypes.AddressCodec,
-) (types.BoundContract, error) {
-	casted := make(map[cciptypes.ChainSelector]bindable, len(readers))
-	for k, v := range readers {
-		casted[k] = v
-	}
-	return bindReaderContract(ctx, lggr, casted, chainSel, contractName, address, addrCodec)
-}
-
 // bindReaderContract is a generic helper for binding contracts to readers, the addresses input is the same object
 // returned by DiscoverContracts.
 //
 // No error is returned if contractName is not found in the contracts. This allows calling the function before all
 // contracts are discovered.
-func bindReaderContract(
+func bindReaderContract[T contractreader.ContractReaderFacade](
 	ctx context.Context,
 	lggr logger.Logger,
-	readers map[cciptypes.ChainSelector]bindable,
+	readers map[cciptypes.ChainSelector]T,
 	chainSel cciptypes.ChainSelector,
 	contractName string,
 	address []byte,
 	codec cciptypes.AddressCodec,
 ) (types.BoundContract, error) {
-	var empty types.BoundContract
-
 	if err := validateReaderExistence(readers, chainSel); err != nil {
-		return empty, fmt.Errorf("validate reader existence: %w", err)
+		return types.BoundContract{}, fmt.Errorf("validate reader existence: %w", err)
 	}
 
 	addressStr, err := codec.AddressBytesToString(address, chainSel)
 	if err != nil {
-		return empty, fmt.Errorf("unable to convert address bytes to string: %w, address: %v", err, address)
+		return types.BoundContract{}, fmt.Errorf("unable to convert address bytes to string: %w, address: %v", err, address)
 	}
 
 	contract := types.BoundContract{
@@ -101,25 +61,14 @@ func bindReaderContract(
 	// If the address is changed -> updates the address, overwrites the existing one
 	// If the contract not bound -> binds to the new address
 	if err := readers[chainSel].Bind(ctx, []types.BoundContract{contract}); err != nil {
-		return empty, fmt.Errorf("unable to bind %s %s for chain %d: %w", contractName, addressStr, chainSel, err)
+		return types.BoundContract{}, fmt.Errorf("unable to bind %s %s for chain %d: %w", contractName, addressStr, chainSel, err)
 	}
 
 	return contract, nil
 }
 
-func validateExtendedReaderExistence(
-	readers map[cciptypes.ChainSelector]contractreader.Extended,
-	chains ...cciptypes.ChainSelector,
-) error {
-	casted := make(map[cciptypes.ChainSelector]bindable, len(readers))
-	for k, v := range readers {
-		casted[k] = v
-	}
-	return validateReaderExistence(casted, chains...)
-}
-
-func validateReaderExistence(
-	readers map[cciptypes.ChainSelector]bindable,
+func validateReaderExistence[T contractreader.ContractReaderFacade](
+	readers map[cciptypes.ChainSelector]T,
 	chains ...cciptypes.ChainSelector,
 ) error {
 	for _, ch := range chains {

--- a/pkg/reader/usdc_reader.go
+++ b/pkg/reader/usdc_reader.go
@@ -89,7 +89,7 @@ func NewUSDCMessageReader(
 			return nil, err
 		}
 
-		contract, err := bindFacadeReaderContract(
+		contract, err := bindReaderContract(
 			ctx,
 			lggr,
 			contractReaders,


### PR DESCRIPTION
The readers became a bit messy during their initial implementation due to the number of people working on them and the chainlink-common interface disappearing.

This PR clarifies the relationship between `Extended` and `ContractReaderFacade` by embedding the latter into the former.

It also removes some odd casting required because maps are invariant. This is done by using generic functions. i.e.
```
func validateReaderExistence[T contractreader.ContractReaderFacade](
	readers map[cciptypes.ChainSelector]T,
	chains ...cciptypes.ChainSelector,
) error { ...}
```

Instead of
```
func validateExtendedReaderExistence(
	readers map[cciptypes.ChainSelector]Extended,
	chains ...cciptypes.ChainSelector,
) error { ... }

func validateFacadeReaderExistence(
	readers map[cciptypes.ChainSelector]ContractReaderFacade,
	chains ...cciptypes.ChainSelector,
) error { ... }
```