### PR TITLE
[CAL][1] - Add initial CAL scaffolding to CCIPReader with legacy accessor

### DIFF
--- a/commit/factory.go
+++ b/commit/factory.go
@@ -177,7 +177,7 @@ func (p *PluginFactory) NewReportingPlugin(ctx context.Context, config ocr3types
 		return nil, ocr3types.ReportingPluginInfo{}, fmt.Errorf("validate ocr config: %w", err)
 	}
 
-	ccipReader := readerpkg.NewCCIPChainReader(
+	ccipReader, err := readerpkg.NewCCIPChainReader(
 		ctx,
 		logutil.WithComponent(lggr, "CCIPReader"),
 		readers,
@@ -186,6 +186,9 @@ func (p *PluginFactory) NewReportingPlugin(ctx context.Context, config ocr3types
 		p.ocrConfig.Config.OfframpAddress,
 		p.addrCodec,
 	)
+	if err != nil {
+		return nil, ocr3types.ReportingPluginInfo{}, fmt.Errorf("failed to create CCIP chain reader: %w", err)
+	}
 
 	// The node supports the chain that the token prices are on.
 	_, ok := readers[offchainConfig.PriceFeedChainSelector]

--- a/execute/factory.go
+++ b/execute/factory.go
@@ -143,7 +143,7 @@ func (p PluginFactory) NewReportingPlugin(
 			contractreader.NewObserverReader(cr, lggr, chainID))
 	}
 
-	ccipReader := readerpkg.NewCCIPChainReader(
+	ccipReader, err := readerpkg.NewCCIPChainReader(
 		ctx,
 		logutil.WithComponent(lggr, "CCIPReader"),
 		readers,
@@ -152,6 +152,9 @@ func (p PluginFactory) NewReportingPlugin(
 		p.ocrConfig.Config.OfframpAddress,
 		p.addrCodec,
 	)
+	if err != nil {
+		return nil, ocr3types.ReportingPluginInfo{}, fmt.Errorf("failed to create ccip reader: %w", err)
+	}
 
 	tokenDataObserver, err := observer.NewConfigBasedCompositeObservers(
 		ctx,

--- a/pkg/chainaccessor/legacy_accessor.go
+++ b/pkg/chainaccessor/legacy_accessor.go
@@ -1,0 +1,175 @@
+package chainaccessor
+
+import (
+	"context"
+	"time"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+
+	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
+	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+)
+
+// LegacyAccessor is an implementation of cciptypes.ChainAccessor that allows the CCIPReader
+// to cutover and migrate away from depending directly on contract reader and contract writer.
+type LegacyAccessor struct {
+	lggr           logger.Logger
+	chainSelector  cciptypes.ChainSelector
+	contractReader contractreader.Extended
+	contractWriter types.ContractWriter
+	addrCodec      cciptypes.AddressCodec
+}
+
+var _ cciptypes.ChainAccessor = (*LegacyAccessor)(nil)
+
+func NewLegacyAccessor(
+	lggr logger.Logger,
+	chainSelector cciptypes.ChainSelector,
+	contractReader contractreader.Extended,
+	contractWriter types.ContractWriter,
+	addrCodec cciptypes.AddressCodec,
+) cciptypes.ChainAccessor {
+	return &LegacyAccessor{
+		lggr:           lggr,
+		chainSelector:  chainSelector,
+		contractReader: contractReader,
+		contractWriter: contractWriter,
+		addrCodec:      addrCodec,
+	}
+}
+
+func (l *LegacyAccessor) Metadata() cciptypes.AccessorMetadata {
+	// TODO(NONEVM-1865): implement
+	panic("implement me")
+}
+
+func (l *LegacyAccessor) GetContractAddress(contractName string) ([]byte, error) {
+	// TODO(NONEVM-1865): implement
+	panic("implement me")
+}
+
+func (l *LegacyAccessor) GetChainFeeComponents(
+	ctx context.Context,
+) map[cciptypes.ChainSelector]cciptypes.ChainFeeComponents {
+	// TODO(NONEVM-1865): implement
+	panic("implement me")
+}
+
+func (l *LegacyAccessor) GetDestChainFeeComponents(ctx context.Context) (types.ChainFeeComponents, error) {
+	// TODO(NONEVM-1865): implement
+	panic("implement me")
+}
+
+func (l *LegacyAccessor) Sync(ctx context.Context, contracts cciptypes.ContractAddresses) error {
+	// TODO(NONEVM-1865): implement
+	panic("implement me")
+}
+
+func (l *LegacyAccessor) MsgsBetweenSeqNums(
+	ctx context.Context,
+	dest cciptypes.ChainSelector,
+	seqNumRange cciptypes.SeqNumRange,
+) ([]cciptypes.Message, error) {
+	// TODO(NONEVM-1865): implement
+	panic("implement me")
+}
+
+func (l *LegacyAccessor) LatestMsgSeqNum(ctx context.Context, dest cciptypes.ChainSelector) (cciptypes.SeqNum, error) {
+	// TODO(NONEVM-1865): implement
+	panic("implement me")
+}
+
+func (l *LegacyAccessor) GetExpectedNextSequenceNumber(
+	ctx context.Context,
+	dest cciptypes.ChainSelector,
+) (cciptypes.SeqNum, error) {
+	// TODO(NONEVM-1865): implement
+	panic("implement me")
+}
+
+func (l *LegacyAccessor) GetTokenPriceUSD(
+	ctx context.Context,
+	address cciptypes.UnknownAddress,
+) (cciptypes.BigInt, error) {
+	// TODO(NONEVM-1865): implement
+	panic("implement me")
+}
+
+func (l *LegacyAccessor) GetFeeQuoterDestChainConfig(
+	ctx context.Context,
+	dest cciptypes.ChainSelector,
+) (cciptypes.FeeQuoterDestChainConfig, error) {
+	// TODO(NONEVM-1865): implement
+	panic("implement me")
+}
+
+func (l *LegacyAccessor) CommitReportsGTETimestamp(
+	ctx context.Context,
+	ts time.Time,
+	limit int,
+) ([]cciptypes.CommitPluginReportWithMeta, error) {
+	// TODO(NONEVM-1865): implement
+	panic("implement me")
+}
+
+func (l *LegacyAccessor) ExecutedMessages(
+	ctx context.Context,
+	ranges map[cciptypes.ChainSelector]cciptypes.SeqNumRange,
+	confidence cciptypes.ConfidenceLevel,
+) (map[cciptypes.ChainSelector][]cciptypes.SeqNum, error) {
+	// TODO(NONEVM-1865): implement
+	panic("implement me")
+}
+
+func (l *LegacyAccessor) NextSeqNum(
+	ctx context.Context,
+	sources []cciptypes.ChainSelector,
+) (seqNum map[cciptypes.ChainSelector]cciptypes.SeqNum, err error) {
+	// TODO(NONEVM-1865): implement
+	panic("implement me")
+}
+
+func (l *LegacyAccessor) Nonces(
+	ctx context.Context,
+	addresses map[cciptypes.ChainSelector][]cciptypes.UnknownEncodedAddress,
+) (map[cciptypes.ChainSelector]map[string]uint64, error) {
+	// TODO(NONEVM-1865): implement
+	panic("implement me")
+}
+
+func (l *LegacyAccessor) GetChainFeePriceUpdate(
+	ctx context.Context,
+	selectors []cciptypes.ChainSelector,
+) map[cciptypes.ChainSelector]cciptypes.TimestampedBig {
+	// TODO(NONEVM-1865): implement
+	panic("implement me")
+}
+
+func (l *LegacyAccessor) GetLatestPriceSeqNr(ctx context.Context) (uint64, error) {
+	// TODO(NONEVM-1865): implement
+	panic("implement me")
+}
+
+func (l *LegacyAccessor) GetOffRampConfigDigest(ctx context.Context, pluginType uint8) ([32]byte, error) {
+	// TODO(NONEVM-1865): implement
+	panic("implement me")
+}
+
+func (l *LegacyAccessor) GetOffRampSourceChainsConfig(
+	ctx context.Context,
+	sourceChains []cciptypes.ChainSelector,
+) (map[cciptypes.ChainSelector]cciptypes.SourceChainConfig, error) {
+	// TODO(NONEVM-1865): implement
+	panic("implement me")
+}
+
+func (l *LegacyAccessor) GetRMNRemoteConfig(ctx context.Context) (cciptypes.RemoteConfig, error) {
+	// TODO(NONEVM-1865): implement
+	panic("implement me")
+}
+
+func (l *LegacyAccessor) GetRmnCurseInfo(ctx context.Context) (cciptypes.CurseInfo, error) {
+	// TODO(NONEVM-1865): implement
+	panic("implement me")
+}

--- a/pkg/reader/ccip_test.go
+++ b/pkg/reader/ccip_test.go
@@ -346,17 +346,24 @@ func TestCCIPChainReader_getSourceChainsConfig(t *testing.T) {
 		return results, nil
 	})
 
+	cw := writer_mocks.NewMockContractWriter(t)
+	contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
+	contractWriters[chainA] = cw
+	contractWriters[chainB] = cw
+	contractWriters[chainC] = cw
+
 	mockAddrCodec := internal.NewMockAddressCodecHex(t)
 	offrampAddress := []byte{0x3}
-	ccipReader := newCCIPChainReaderInternal(
+	ccipReader, err := newCCIPChainReaderInternal(
 		tests.Context(t),
 		logger.Test(t),
 		map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
 			chainA: sourceCRs[chainA],
 			chainB: sourceCRs[chainB],
 			chainC: destCR,
-		}, nil, chainC, offrampAddress, mockAddrCodec,
+		}, contractWriters, chainC, offrampAddress, mockAddrCodec,
 	)
+	require.NoError(t, err)
 
 	// Add cleanup to ensure resources are released
 	t.Cleanup(func() {
@@ -1042,13 +1049,20 @@ func TestCCIPChainReader_getFeeQuoterTokenPriceUSD(t *testing.T) {
 
 	mockAddrCodec := internal.NewMockAddressCodecHex(t)
 
-	ccipReader := newCCIPChainReaderInternal(
+	cw := writer_mocks.NewMockContractWriter(t)
+	contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
+	contractWriters[chainA] = cw
+	contractWriters[chainB] = cw
+	contractWriters[chainC] = cw
+
+	ccipReader, err := newCCIPChainReaderInternal(
 		tests.Context(t),
 		logger.Test(t),
 		map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
 			chainC: destCR,
-		}, nil, chainC, offrampAddress, mockAddrCodec,
+		}, contractWriters, chainC, offrampAddress, mockAddrCodec,
 	)
+	require.NoError(t, err)
 
 	// Add cleanup to properly shut down the background polling
 	t.Cleanup(func() {
@@ -1071,6 +1085,9 @@ func TestCCIPChainReader_getFeeQuoterTokenPriceUSD(t *testing.T) {
 }
 
 func TestCCIPFeeComponents_HappyPath(t *testing.T) {
+	destCR := reader_mocks.NewMockContractReaderFacade(t)
+	destCR.EXPECT().Bind(mock.Anything, mock.Anything).Return(nil)
+
 	cw := writer_mocks.NewMockContractWriter(t)
 	cw.EXPECT().GetFeeComponents(mock.Anything).Return(
 		&types.ChainFeeComponents{
@@ -1084,15 +1101,18 @@ func TestCCIPFeeComponents_HappyPath(t *testing.T) {
 	contractWriters[chainA] = cw
 	contractWriters[chainC] = cw
 
-	ccipReader := newCCIPChainReaderInternal(
+	ccipReader, err := newCCIPChainReaderInternal(
 		tests.Context(t),
 		logger.Test(t),
-		nil,
+		map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
+			chainC: destCR,
+		},
 		contractWriters,
 		chainC,
 		[]byte{0x3},
 		internal.NewMockAddressCodecHex(t),
 	)
+	require.NoError(t, err)
 
 	// Add cleanup to ensure resources are released
 	t.Cleanup(func() {
@@ -1114,34 +1134,6 @@ func TestCCIPFeeComponents_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, big.NewInt(1), destChainFeeComponent.ExecutionFee)
 	assert.Equal(t, big.NewInt(2), destChainFeeComponent.DataAvailabilityFee)
-}
-
-func TestCCIPFeeComponents_NotFoundErrors(t *testing.T) {
-	cw := writer_mocks.NewMockContractWriter(t)
-	contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
-	// Missing writer for dest chain chainC
-	contractWriters[chainA] = cw
-	ccipReader := newCCIPChainReaderInternal(
-		tests.Context(t),
-		logger.Test(t),
-		nil,
-		contractWriters,
-		chainC,
-		[]byte{0x3},
-		internal.NewMockAddressCodecHex(t),
-	)
-
-	// Add cleanup to ensure resources are released
-	t.Cleanup(func() {
-		err := ccipReader.Close()
-		if err != nil {
-			t.Logf("Error closing ccipReader: %v", err)
-		}
-	})
-
-	ctx := context.Background()
-	_, err := ccipReader.GetDestChainFeeComponents(ctx)
-	require.Error(t, err)
 }
 
 func TestCCIPChainReader_LinkPriceUSD(t *testing.T) {


### PR DESCRIPTION
core ref: 7404f6349ac2bdb222f3c5889669d98760920168

- Add initial support for the chain accessor to ccip.go (CCIPReader)
- Merging the skeleton with the outlined and unimplemented functions should allow us to more easily chip away at the migration from `CCIPReader --> CR/CW` to `CCIPReader --> CAL` on a per-function basis. 
- Taking this approach where we can test incrementally should ideally be less risky than a single PR where all functions are migrated at once
- For more context, see NONEVM-1865

Stack:
1. ➡ https://github.com/smartcontractkit/chainlink-ccip/pull/978
2. https://github.com/smartcontractkit/chainlink-ccip/pull/980
3. https://github.com/smartcontractkit/chainlink-ccip/pull/985
4. https://github.com/smartcontractkit/chainlink-ccip/pull/987
5. https://github.com/smartcontractkit/chainlink-ccip/pull/988
6. https://github.com/smartcontractkit/chainlink-ccip/pull/989
7. https://github.com/smartcontractkit/chainlink-ccip/pull/990
8. https://github.com/smartcontractkit/chainlink-ccip/pull/999
9. https://github.com/smartcontractkit/chainlink-ccip/pull/1000
10. https://github.com/smartcontractkit/chainlink-ccip/pull/1014
11. https://github.com/smartcontractkit/chainlink-ccip/pull/1017