### PR TITLE
[CAL][4] - Implement MsgsBetweenSeqNums() function in accessor

### DIFF
--- a/pkg/chainaccessor/legacy_accessor.go
+++ b/pkg/chainaccessor/legacy_accessor.go
@@ -7,8 +7,12 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
 
+	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/logutil"
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
 
@@ -75,11 +79,82 @@ func (l *LegacyAccessor) Sync(ctx context.Context, contracts cciptypes.ContractA
 
 func (l *LegacyAccessor) MsgsBetweenSeqNums(
 	ctx context.Context,
-	dest cciptypes.ChainSelector,
+	destChainSelector cciptypes.ChainSelector,
 	seqNumRange cciptypes.SeqNumRange,
 ) ([]cciptypes.Message, error) {
-	// TODO(NONEVM-1865): implement
-	panic("implement me")
+	lggr := logutil.WithContextValues(ctx, l.lggr)
+	seq, err := l.contractReader.ExtendedQueryKey(
+		ctx,
+		consts.ContractNameOnRamp,
+		query.KeyFilter{
+			Key: consts.EventNameCCIPMessageSent,
+			Expressions: []query.Expression{
+				query.Comparator(consts.EventAttributeSourceChain, primitives.ValueComparator{
+					Value:    l.chainSelector,
+					Operator: primitives.Eq,
+				}),
+				query.Comparator(consts.EventAttributeDestChain, primitives.ValueComparator{
+					Value:    destChainSelector,
+					Operator: primitives.Eq,
+				}),
+				query.Comparator(consts.EventAttributeSequenceNumber, primitives.ValueComparator{
+					Value:    seqNumRange.Start(),
+					Operator: primitives.Gte,
+				}, primitives.ValueComparator{
+					Value:    seqNumRange.End(),
+					Operator: primitives.Lte,
+				}),
+				query.Confidence(primitives.Finalized),
+			},
+		},
+		query.LimitAndSort{
+			SortBy: []query.SortBy{
+				query.NewSortBySequence(query.Asc),
+			},
+			Limit: query.Limit{
+				Count: uint64(seqNumRange.End() - seqNumRange.Start() + 1),
+			},
+		},
+		&SendRequestedEvent{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query onRamp: %w", err)
+	}
+
+	lggr.Infow("queried messages between sequence numbers",
+		"numMsgs", len(seq),
+		"sourceChainSelector", l.chainSelector,
+		"seqNumRange", seqNumRange.String(),
+	)
+
+	onRampAddress, err := l.GetContractAddress(consts.ContractNameOnRamp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get onRamp contract address: %w", err)
+	}
+
+	msgs := make([]cciptypes.Message, 0)
+	for _, item := range seq {
+		msg, ok := item.Data.(*SendRequestedEvent)
+		if !ok {
+			return nil, fmt.Errorf("failed to cast %v to Message", item.Data)
+		}
+
+		if err := ValidateSendRequestedEvent(msg, l.chainSelector, destChainSelector, seqNumRange); err != nil {
+			lggr.Errorw("validate send requested event", "err", err, "message", msg)
+			continue
+		}
+
+		msg.Message.Header.OnRamp = onRampAddress
+		msgs = append(msgs, msg.Message)
+	}
+
+	lggr.Infow("decoded messages between sequence numbers",
+		"msgs", msgs,
+		"sourceChainSelector", l.chainSelector,
+		"seqNumRange", seqNumRange.String(),
+	)
+
+	return msgs, nil
 }
 
 func (l *LegacyAccessor) LatestMsgSeqNum(ctx context.Context, dest cciptypes.ChainSelector) (cciptypes.SeqNum, error) {

--- a/pkg/chainaccessor/types.go
+++ b/pkg/chainaccessor/types.go
@@ -1,0 +1,10 @@
+package chainaccessor
+
+import cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+
+// SendRequestedEvent represents the contents of the event emitted by the CCIP onramp when a message is sent.
+type SendRequestedEvent struct {
+	DestChainSelector cciptypes.ChainSelector
+	SequenceNumber    cciptypes.SeqNum
+	Message           cciptypes.Message
+}

--- a/pkg/chainaccessor/validators.go
+++ b/pkg/chainaccessor/validators.go
@@ -1,0 +1,57 @@
+package chainaccessor
+
+import (
+	"fmt"
+
+	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
+)
+
+func ValidateSendRequestedEvent(
+	ev *SendRequestedEvent, source, dest cciptypes.ChainSelector, seqNumRange cciptypes.SeqNumRange,
+) error {
+	if ev == nil {
+		return fmt.Errorf("send requested event is nil")
+	}
+
+	if ev.Message.Header.DestChainSelector != dest {
+		return fmt.Errorf("msg dest chain is not the expected queried one")
+	}
+	if ev.DestChainSelector != dest {
+		return fmt.Errorf("dest chain is not the expected queried one")
+	}
+
+	if ev.Message.Header.SourceChainSelector != source {
+		return fmt.Errorf("source chain is not the expected queried one")
+	}
+
+	if ev.SequenceNumber != ev.Message.Header.SequenceNumber {
+		return fmt.Errorf("event sequence number does not match the message sequence number %d != %d",
+			ev.SequenceNumber, ev.Message.Header.SequenceNumber)
+	}
+
+	if ev.SequenceNumber < seqNumRange.Start() || ev.SequenceNumber > seqNumRange.End() {
+		return fmt.Errorf("send requested event sequence number is not in the expected range")
+	}
+
+	if ev.Message.Header.MessageID.IsEmpty() {
+		return fmt.Errorf("message ID is zero")
+	}
+
+	if len(ev.Message.Receiver) == 0 {
+		return fmt.Errorf("empty receiver address: %s", ev.Message.Receiver.String())
+	}
+
+	if ev.Message.Sender.IsZeroOrEmpty() {
+		return fmt.Errorf("invalid sender address: %s", ev.Message.Sender.String())
+	}
+
+	if ev.Message.FeeTokenAmount.IsEmpty() {
+		return fmt.Errorf("fee token amount is zero")
+	}
+
+	if ev.Message.FeeToken.IsZeroOrEmpty() {
+		return fmt.Errorf("invalid fee token: %s", ev.Message.FeeToken.String())
+	}
+
+	return nil
+}


### PR DESCRIPTION
core ref: aad88a584c81e0be68f68927d5ab041fc65ca646

- Implement MsgsBetweenSeqNums() functions for Chain Access Layer in legacy accessor
- For more context, see NONEVM-1865

Stack:
1. https://github.com/smartcontractkit/chainlink-ccip/pull/978
2. https://github.com/smartcontractkit/chainlink-ccip/pull/980
3. https://github.com/smartcontractkit/chainlink-ccip/pull/985
4. ➡️ https://github.com/smartcontractkit/chainlink-ccip/pull/987
5. https://github.com/smartcontractkit/chainlink-ccip/pull/988
6. https://github.com/smartcontractkit/chainlink-ccip/pull/989
7. https://github.com/smartcontractkit/chainlink-ccip/pull/990
8. https://github.com/smartcontractkit/chainlink-ccip/pull/999
9. https://github.com/smartcontractkit/chainlink-ccip/pull/1000
10. https://github.com/smartcontractkit/chainlink-ccip/pull/1014
11. https://github.com/smartcontractkit/chainlink-ccip/pull/1017