### PR TITLE
[CAL][6] - move SourceChainConfig to chainaccessor types

### DIFF
--- a/pkg/chainaccessor/legacy_accessor.go
+++ b/pkg/chainaccessor/legacy_accessor.go
@@ -219,10 +219,30 @@ func (l *LegacyAccessor) LatestMsgSeqNum(
 
 func (l *LegacyAccessor) GetExpectedNextSequenceNumber(
 	ctx context.Context,
-	dest cciptypes.ChainSelector,
+	destChainSelector cciptypes.ChainSelector,
 ) (cciptypes.SeqNum, error) {
-	// TODO(NONEVM-1865): implement
-	panic("implement me")
+	var expectedNextSequenceNumber uint64
+	err := l.contractReader.ExtendedGetLatestValue(
+		ctx,
+		consts.ContractNameOnRamp,
+		consts.MethodNameGetExpectedNextSequenceNumber,
+		primitives.Unconfirmed,
+		map[string]any{
+			"destChainSelector": destChainSelector,
+		},
+		&expectedNextSequenceNumber,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get expected next sequence number from onramp, source chain: %d, dest chain: %d: %w",
+			l.chainSelector, destChainSelector, err)
+	}
+
+	if expectedNextSequenceNumber == 0 {
+		return 0, fmt.Errorf("the returned expected next sequence num is 0, source chain: %d, dest chain: %d",
+			l.chainSelector, destChainSelector)
+	}
+
+	return cciptypes.SeqNum(expectedNextSequenceNumber), nil
 }
 
 func (l *LegacyAccessor) GetTokenPriceUSD(

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -1369,18 +1369,6 @@ func (r *ccipChainReader) getFeeQuoterTokenPriceUSD(ctx context.Context, tokenAd
 	return cciptypes.NewBigInt(price), nil
 }
 
-// sourceChainConfig is used to parse the response from the offRamp contract's getSourceChainConfig method.
-// See: https://github.com/smartcontractkit/ccip/blob/a3f61f7458e4499c2c62eb38581c60b4942b1160/contracts/src/v0.8/ccip/offRamp/OffRamp.sol#L94
-//
-//nolint:lll // It's a URL.
-type SourceChainConfig struct {
-	Router                    []byte // local router
-	IsEnabled                 bool
-	IsRMNVerificationDisabled bool
-	MinSeqNr                  uint64
-	OnRamp                    cciptypes.UnknownAddress
-}
-
 // GetOffRampSourceChainsConfig returns the static source chain configs for all the provided source chains.
 // This method returns configurations without the MinSeqNr field, which should be fetched separately when needed.
 func (r *ccipChainReader) GetOffRampSourceChainsConfig(ctx context.Context, chains []cciptypes.ChainSelector,
@@ -1436,7 +1424,7 @@ func (r *ccipChainReader) fetchFreshSourceChainConfigs(
 	ctx context.Context,
 	destChain cciptypes.ChainSelector,
 	sourceChains []cciptypes.ChainSelector,
-) (map[cciptypes.ChainSelector]SourceChainConfig, error) {
+) (map[cciptypes.ChainSelector]cciptypes.SourceChainConfig, error) {
 	lggr := logutil.WithContextValues(ctx, r.lggr)
 
 	reader, exists := r.contractReaders[destChain]
@@ -1447,7 +1435,7 @@ func (r *ccipChainReader) fetchFreshSourceChainConfigs(
 	// Filter out destination chain
 	filteredSourceChains := filterOutChainSelector(sourceChains, destChain)
 	if len(filteredSourceChains) == 0 {
-		return make(map[cciptypes.ChainSelector]SourceChainConfig), nil
+		return make(map[cciptypes.ChainSelector]cciptypes.SourceChainConfig), nil
 	}
 
 	// Prepare batch requests for the sourceChains to fetch the latest Unfinalized config values.
@@ -1461,7 +1449,7 @@ func (r *ccipChainReader) fetchFreshSourceChainConfigs(
 			Params: map[string]any{
 				"sourceChainSelector": chain,
 			},
-			ReturnVal: new(SourceChainConfig),
+			ReturnVal: new(cciptypes.SourceChainConfig),
 		})
 	}
 
@@ -1483,7 +1471,7 @@ func (r *ccipChainReader) fetchFreshSourceChainConfigs(
 	}
 
 	// Process results
-	configs := make(map[cciptypes.ChainSelector]SourceChainConfig)
+	configs := make(map[cciptypes.ChainSelector]cciptypes.SourceChainConfig)
 
 	for _, readResult := range results {
 		if len(readResult) != len(validSourceChains) {
@@ -1500,7 +1488,7 @@ func (r *ccipChainReader) fetchFreshSourceChainConfigs(
 				return nil, fmt.Errorf("GetSourceChainConfig for chainSelector=%d failed: %w", chain, err)
 			}
 
-			cfg, ok := v.(*SourceChainConfig)
+			cfg, ok := v.(*cciptypes.SourceChainConfig)
 			if !ok {
 				lggr.Errorw("Invalid result type from GetSourceChainConfig",
 					"chain", chain,
@@ -2128,7 +2116,7 @@ type ccipReaderInternal interface {
 	// fetchFreshSourceChainConfigs fetches source chain configurations from the specified destination chain
 	fetchFreshSourceChainConfigs(
 		ctx context.Context, destChain cciptypes.ChainSelector,
-		sourceChains []cciptypes.ChainSelector) (map[cciptypes.ChainSelector]SourceChainConfig, error)
+		sourceChains []cciptypes.ChainSelector) (map[cciptypes.ChainSelector]cciptypes.SourceChainConfig, error)
 }
 
 // getDestChain returns the destination chain selector

--- a/pkg/reader/ccip_interface.go
+++ b/pkg/reader/ccip_interface.go
@@ -87,8 +87,8 @@ type StaticSourceChainConfig struct {
 
 // ToSourceChainConfig converts a CachedSourceChainConfig to a full SourceChainConfig
 // by adding the provided sequence number.
-func (s StaticSourceChainConfig) ToSourceChainConfig(minSeqNr uint64) SourceChainConfig {
-	return SourceChainConfig{
+func (s StaticSourceChainConfig) ToSourceChainConfig(minSeqNr uint64) cciptypes.SourceChainConfig {
+	return cciptypes.SourceChainConfig{
 		Router:                    s.Router,
 		IsEnabled:                 s.IsEnabled,
 		IsRMNVerificationDisabled: s.IsRMNVerificationDisabled,

--- a/pkg/reader/ccip_test.go
+++ b/pkg/reader/ccip_test.go
@@ -330,7 +330,7 @@ func TestCCIPChainReader_getSourceChainsConfig(t *testing.T) {
 				}
 				params := readReq.Params.(map[string]any)
 				sourceChain := params["sourceChainSelector"].(cciptypes.ChainSelector)
-				v := readReq.ReturnVal.(*SourceChainConfig)
+				v := readReq.ReturnVal.(*cciptypes.SourceChainConfig)
 
 				fromString, err := cciptypes.NewBytesFromString(fmt.Sprintf(
 					"0x%d000000000000000000000000000000000000000", sourceChain),

--- a/pkg/reader/config_poller.go
+++ b/pkg/reader/config_poller.go
@@ -263,8 +263,8 @@ func (c *configPoller) processSourceChainResults(
 	batchResult types.BatchGetLatestValuesResult,
 	standardOffRampRequestCount int,
 	filteredSourceChains []cciptypes.ChainSelector,
-) map[cciptypes.ChainSelector]SourceChainConfig {
-	sourceConfigs := make(map[cciptypes.ChainSelector]SourceChainConfig)
+) map[cciptypes.ChainSelector]cciptypes.SourceChainConfig {
+	sourceConfigs := make(map[cciptypes.ChainSelector]cciptypes.SourceChainConfig)
 
 	// Find the OffRamp results
 	for contract, results := range batchResult {
@@ -291,7 +291,7 @@ func (c *configPoller) processSourceChainResults(
 						continue
 					}
 
-					cfg, ok := v.(*SourceChainConfig)
+					cfg, ok := v.(*cciptypes.SourceChainConfig)
 					if !ok {
 						c.lggr.Errorw("Invalid result type from GetSourceChainConfig",
 							"chain", chain,
@@ -320,7 +320,7 @@ func (c *configPoller) prepareSourceChainQueries(sourceChains []cciptypes.ChainS
 			Params: map[string]any{
 				"sourceChainSelector": chain,
 			},
-			ReturnVal: new(SourceChainConfig),
+			ReturnVal: new(cciptypes.SourceChainConfig),
 		})
 	}
 	return sourceConfigQueries
@@ -760,7 +760,7 @@ func filterOutChainSelector(
 
 // StaticSourceChainConfigFromSourceChainConfig creates a StaticSourceChainConfig from a SourceChainConfig,
 // omitting the MinSeqNr field.
-func staticSourceChainConfigFromSourceChainConfig(sc SourceChainConfig) StaticSourceChainConfig {
+func staticSourceChainConfigFromSourceChainConfig(sc cciptypes.SourceChainConfig) StaticSourceChainConfig {
 	return StaticSourceChainConfig{
 		Router:                    sc.Router,
 		IsEnabled:                 sc.IsEnabled,

--- a/pkg/reader/config_poller_test.go
+++ b/pkg/reader/config_poller_test.go
@@ -88,9 +88,9 @@ func setupBatchMockResponse(reader *reader_mocks.MockExtended) {
 
 	// Source chain config part
 	resultB := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	resultB.SetResult(&SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{1, 2, 3}}, nil)
+	resultB.SetResult(&cciptypes.SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{1, 2, 3}}, nil)
 	resultC := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	resultC.SetResult(&SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{4, 5, 6}}, nil)
+	resultC.SetResult(&cciptypes.SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{4, 5, 6}}, nil)
 
 	// Combined response
 	responses := types.BatchGetLatestValuesResult{
@@ -123,9 +123,9 @@ func setupInitialData(ctx context.Context, cache *configPoller, reader *reader_m
 	sourceChains := []cciptypes.ChainSelector{chainB, chainC}
 
 	result1 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	result1.SetResult(&SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{1, 2, 3}}, nil)
+	result1.SetResult(&cciptypes.SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{1, 2, 3}}, nil)
 	result2 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	result2.SetResult(&SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{4, 5, 6}}, nil)
+	result2.SetResult(&cciptypes.SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{4, 5, 6}}, nil)
 
 	response := types.BatchGetLatestValuesResult{
 		types.BoundContract{Name: consts.ContractNameOffRamp}: {
@@ -1107,9 +1107,9 @@ func TestConfigCache_GetOfframpSourceChainConfigs_CacheHit(t *testing.T) {
 
 	// Create batch read results for source chains
 	result1 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	result1.SetResult(&SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{1, 2, 3}}, nil)
+	result1.SetResult(&cciptypes.SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{1, 2, 3}}, nil)
 	result2 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	result2.SetResult(&SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{4, 5, 6}}, nil)
+	result2.SetResult(&cciptypes.SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{4, 5, 6}}, nil)
 
 	responses := types.BatchGetLatestValuesResult{
 		types.BoundContract{Name: consts.ContractNameOffRamp}: {
@@ -1150,9 +1150,9 @@ func TestConfigCache_GetOfframpSourceChainConfigs_Update(t *testing.T) {
 
 	// Setup mock response for first fetch
 	result1 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	result1.SetResult(&SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{1, 2, 3}}, nil)
+	result1.SetResult(&cciptypes.SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{1, 2, 3}}, nil)
 	result2 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	result2.SetResult(&SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{4, 5, 6}}, nil)
+	result2.SetResult(&cciptypes.SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{4, 5, 6}}, nil)
 
 	firstResponse := types.BatchGetLatestValuesResult{
 		types.BoundContract{Name: consts.ContractNameOffRamp}: {
@@ -1177,9 +1177,9 @@ func TestConfigCache_GetOfframpSourceChainConfigs_Update(t *testing.T) {
 
 	// Setup mock response for second fetch with different data
 	result3 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	result3.SetResult(&SourceChainConfig{IsEnabled: false, OnRamp: cciptypes.UnknownAddress{7, 8, 9}}, nil)
+	result3.SetResult(&cciptypes.SourceChainConfig{IsEnabled: false, OnRamp: cciptypes.UnknownAddress{7, 8, 9}}, nil)
 	result4 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	result4.SetResult(&SourceChainConfig{IsEnabled: false, OnRamp: cciptypes.UnknownAddress{10, 11, 12}}, nil)
+	result4.SetResult(&cciptypes.SourceChainConfig{IsEnabled: false, OnRamp: cciptypes.UnknownAddress{10, 11, 12}}, nil)
 
 	secondResponse := types.BatchGetLatestValuesResult{
 		types.BoundContract{Name: consts.ContractNameOffRamp}: {
@@ -1228,9 +1228,9 @@ func TestConfigCache_GetOfframpSourceChainConfigs_MixedSet(t *testing.T) {
 
 	// Setup mock response for first fetch
 	result1 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	result1.SetResult(&SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{1, 2, 3}}, nil)
+	result1.SetResult(&cciptypes.SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{1, 2, 3}}, nil)
 	result2 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	result2.SetResult(&SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{4, 5, 6}}, nil)
+	result2.SetResult(&cciptypes.SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{4, 5, 6}}, nil)
 
 	firstResponse := types.BatchGetLatestValuesResult{
 		types.BoundContract{Name: consts.ContractNameOffRamp}: {
@@ -1254,7 +1254,7 @@ func TestConfigCache_GetOfframpSourceChainConfigs_MixedSet(t *testing.T) {
 
 	// Setup mock response for second fetch (only D should be fetched)
 	result3 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	result3.SetResult(&SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{7, 8, 9}}, nil)
+	result3.SetResult(&cciptypes.SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{7, 8, 9}}, nil)
 
 	secondResponse := types.BatchGetLatestValuesResult{
 		types.BoundContract{Name: consts.ContractNameOffRamp}: {
@@ -1291,9 +1291,9 @@ func TestConfigCache_RefreshSourceChainConfigs(t *testing.T) {
 
 	// Setup mock response
 	result1 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	result1.SetResult(&SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{1, 2, 3}}, nil)
+	result1.SetResult(&cciptypes.SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{1, 2, 3}}, nil)
 	result2 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	result2.SetResult(&SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{4, 5, 6}}, nil)
+	result2.SetResult(&cciptypes.SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{4, 5, 6}}, nil)
 
 	response := types.BatchGetLatestValuesResult{
 		types.BoundContract{Name: consts.ContractNameOffRamp}: {
@@ -1316,9 +1316,9 @@ func TestConfigCache_RefreshSourceChainConfigs(t *testing.T) {
 
 	// Setup mock for a second call with different data
 	result3 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	result3.SetResult(&SourceChainConfig{IsEnabled: false, OnRamp: cciptypes.UnknownAddress{7, 8, 9}}, nil)
+	result3.SetResult(&cciptypes.SourceChainConfig{IsEnabled: false, OnRamp: cciptypes.UnknownAddress{7, 8, 9}}, nil)
 	result4 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	result4.SetResult(&SourceChainConfig{IsEnabled: false, OnRamp: cciptypes.UnknownAddress{10, 11, 12}}, nil)
+	result4.SetResult(&cciptypes.SourceChainConfig{IsEnabled: false, OnRamp: cciptypes.UnknownAddress{10, 11, 12}}, nil)
 
 	response2 := types.BatchGetLatestValuesResult{
 		types.BoundContract{Name: consts.ContractNameOffRamp}: {
@@ -1356,7 +1356,7 @@ func TestConfigCache_GetOfframpSourceChainConfigs_Error(t *testing.T) {
 
 	// First fetch - one chain succeeds, one fails with error
 	result1 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	result1.SetResult(&SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{1, 2, 3}}, nil)
+	result1.SetResult(&cciptypes.SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{1, 2, 3}}, nil)
 
 	result2 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
 	result2.SetResult(nil, errors.New("read error"))
@@ -1393,9 +1393,9 @@ func TestConfigCache_GlobalSourceChainRefreshTime(t *testing.T) {
 
 	// Setup mock response for first fetch
 	result1 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	result1.SetResult(&SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{1, 2, 3}}, nil)
+	result1.SetResult(&cciptypes.SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{1, 2, 3}}, nil)
 	result2 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	result2.SetResult(&SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{4, 5, 6}}, nil)
+	result2.SetResult(&cciptypes.SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{4, 5, 6}}, nil)
 
 	firstResponse := types.BatchGetLatestValuesResult{
 		types.BoundContract{Name: consts.ContractNameOffRamp}: {
@@ -1422,7 +1422,7 @@ func TestConfigCache_GlobalSourceChainRefreshTime(t *testing.T) {
 
 	// Setup mock for D fetch only
 	resultD := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	resultD.SetResult(&SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{7, 8, 9}}, nil)
+	resultD.SetResult(&cciptypes.SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{7, 8, 9}}, nil)
 
 	secondResponse := types.BatchGetLatestValuesResult{
 		types.BoundContract{Name: consts.ContractNameOffRamp}: {
@@ -1452,11 +1452,11 @@ func TestConfigCache_GlobalSourceChainRefreshTime(t *testing.T) {
 
 	// Setup mock for manual refresh of all chains
 	resultB2 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	resultB2.SetResult(&SourceChainConfig{IsEnabled: false, OnRamp: cciptypes.UnknownAddress{10, 11, 12}}, nil)
+	resultB2.SetResult(&cciptypes.SourceChainConfig{IsEnabled: false, OnRamp: cciptypes.UnknownAddress{10, 11, 12}}, nil)
 	resultC2 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	resultC2.SetResult(&SourceChainConfig{IsEnabled: false, OnRamp: cciptypes.UnknownAddress{13, 14, 15}}, nil)
+	resultC2.SetResult(&cciptypes.SourceChainConfig{IsEnabled: false, OnRamp: cciptypes.UnknownAddress{13, 14, 15}}, nil)
 	resultD2 := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	resultD2.SetResult(&SourceChainConfig{IsEnabled: false, OnRamp: cciptypes.UnknownAddress{16, 17, 18}}, nil)
+	resultD2.SetResult(&cciptypes.SourceChainConfig{IsEnabled: false, OnRamp: cciptypes.UnknownAddress{16, 17, 18}}, nil)
 
 	thirdResponse := types.BatchGetLatestValuesResult{
 		types.BoundContract{Name: consts.ContractNameOffRamp}: {
@@ -1522,7 +1522,7 @@ func TestConfigCache_RefreshSourceChainConfigs_SetsGlobalTimestamp(t *testing.T)
 
 	// Setup mock response
 	result := &types.BatchReadResult{ReadName: consts.MethodNameGetSourceChainConfig}
-	result.SetResult(&SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{1, 2, 3}}, nil)
+	result.SetResult(&cciptypes.SourceChainConfig{IsEnabled: true, OnRamp: cciptypes.UnknownAddress{1, 2, 3}}, nil)
 
 	response := types.BatchGetLatestValuesResult{
 		types.BoundContract{Name: consts.ContractNameOffRamp}: {


### PR DESCRIPTION
core ref: aad88a584c81e0be68f68927d5ab041fc65ca646

- Remove `SourceChainConfig` definition in ccip.go in favor of the one defined in `pkg/types/ccipocr3/chain_accessor.go` since we will need this in `legacy_accessor.go`
- For more context, see NONEVM-1865

Stack:
1. https://github.com/smartcontractkit/chainlink-ccip/pull/978
2. https://github.com/smartcontractkit/chainlink-ccip/pull/980
3. https://github.com/smartcontractkit/chainlink-ccip/pull/985
4. https://github.com/smartcontractkit/chainlink-ccip/pull/987
5. https://github.com/smartcontractkit/chainlink-ccip/pull/988
6. ➡️ https://github.com/smartcontractkit/chainlink-ccip/pull/989
7. https://github.com/smartcontractkit/chainlink-ccip/pull/990