### PR TITLE
[CAL][7] - implement GetExpectedNextSequenceNumber

### DIFF
--- a/pkg/chainaccessor/legacy_accessor.go
+++ b/pkg/chainaccessor/legacy_accessor.go
@@ -219,10 +219,30 @@ func (l *LegacyAccessor) LatestMsgSeqNum(
 
 func (l *LegacyAccessor) GetExpectedNextSequenceNumber(
 	ctx context.Context,
-	dest cciptypes.ChainSelector,
+	destChainSelector cciptypes.ChainSelector,
 ) (cciptypes.SeqNum, error) {
-	// TODO(NONEVM-1865): implement
-	panic("implement me")
+	var expectedNextSequenceNumber uint64
+	err := l.contractReader.ExtendedGetLatestValue(
+		ctx,
+		consts.ContractNameOnRamp,
+		consts.MethodNameGetExpectedNextSequenceNumber,
+		primitives.Unconfirmed,
+		map[string]any{
+			"destChainSelector": destChainSelector,
+		},
+		&expectedNextSequenceNumber,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get expected next sequence number from onramp, source chain: %d, dest chain: %d: %w",
+			l.chainSelector, destChainSelector, err)
+	}
+
+	if expectedNextSequenceNumber == 0 {
+		return 0, fmt.Errorf("the returned expected next sequence num is 0, source chain: %d, dest chain: %d",
+			l.chainSelector, destChainSelector)
+	}
+
+	return cciptypes.SeqNum(expectedNextSequenceNumber), nil
 }
 
 func (l *LegacyAccessor) GetTokenPriceUSD(


### PR DESCRIPTION
core ref: aad88a584c81e0be68f68927d5ab041fc65ca646

- Implement GetExpectedNextSequenceNumber()
- For more context, see NONEVM-1865

Stack:
1. https://github.com/smartcontractkit/chainlink-ccip/pull/978
2. https://github.com/smartcontractkit/chainlink-ccip/pull/980
3. https://github.com/smartcontractkit/chainlink-ccip/pull/985
4. https://github.com/smartcontractkit/chainlink-ccip/pull/987
5. https://github.com/smartcontractkit/chainlink-ccip/pull/988
6. https://github.com/smartcontractkit/chainlink-ccip/pull/989
7. ➡️ https://github.com/smartcontractkit/chainlink-ccip/pull/990