### PR TITLE
[CAL][8] - Some minor cleanup and renaming

### DIFF
--- a/pkg/chainaccessor/legacy_accessor.go
+++ b/pkg/chainaccessor/legacy_accessor.go
@@ -16,9 +16,9 @@ import (
 	cciptypes "github.com/smartcontractkit/chainlink-ccip/pkg/types/ccipocr3"
 )
 
-// LegacyAccessor is an implementation of cciptypes.ChainAccessor that allows the CCIPReader
+// DefaultAccessor is an implementation of cciptypes.ChainAccessor that allows the CCIPReader
 // to cutover and migrate away from depending directly on contract reader and contract writer.
-type LegacyAccessor struct {
+type DefaultAccessor struct {
 	lggr           logger.Logger
 	chainSelector  cciptypes.ChainSelector
 	contractReader contractreader.Extended
@@ -26,16 +26,16 @@ type LegacyAccessor struct {
 	addrCodec      cciptypes.AddressCodec
 }
 
-var _ cciptypes.ChainAccessor = (*LegacyAccessor)(nil)
+var _ cciptypes.ChainAccessor = (*DefaultAccessor)(nil)
 
-func NewLegacyAccessor(
+func NewDefaultAccessor(
 	lggr logger.Logger,
 	chainSelector cciptypes.ChainSelector,
 	contractReader contractreader.Extended,
 	contractWriter types.ContractWriter,
 	addrCodec cciptypes.AddressCodec,
 ) cciptypes.ChainAccessor {
-	return &LegacyAccessor{
+	return &DefaultAccessor{
 		lggr:           lggr,
 		chainSelector:  chainSelector,
 		contractReader: contractReader,
@@ -44,12 +44,12 @@ func NewLegacyAccessor(
 	}
 }
 
-func (l *LegacyAccessor) Metadata() cciptypes.AccessorMetadata {
+func (l *DefaultAccessor) Metadata() cciptypes.AccessorMetadata {
 	// TODO(NONEVM-1865): implement or remove from CAL interface
 	panic("implement me")
 }
 
-func (l *LegacyAccessor) GetContractAddress(contractName string) ([]byte, error) {
+func (l *DefaultAccessor) GetContractAddress(contractName string) ([]byte, error) {
 	bindings := l.contractReader.GetBindings(contractName)
 	if len(bindings) != 1 {
 		return nil, fmt.Errorf("expected one binding for the %s contract, got %d", contractName, len(bindings))
@@ -63,7 +63,7 @@ func (l *LegacyAccessor) GetContractAddress(contractName string) ([]byte, error)
 	return addressBytes, nil
 }
 
-func (l *LegacyAccessor) GetChainFeeComponents(ctx context.Context) (cciptypes.ChainFeeComponents, error) {
+func (l *DefaultAccessor) GetChainFeeComponents(ctx context.Context) (cciptypes.ChainFeeComponents, error) {
 	fc, err := l.contractWriter.GetFeeComponents(ctx)
 	if err != nil {
 		return cciptypes.ChainFeeComponents{}, fmt.Errorf("get fee components: %w", err)
@@ -72,12 +72,12 @@ func (l *LegacyAccessor) GetChainFeeComponents(ctx context.Context) (cciptypes.C
 	return *fc, nil
 }
 
-func (l *LegacyAccessor) Sync(ctx context.Context, contracts cciptypes.ContractAddresses) error {
+func (l *DefaultAccessor) Sync(ctx context.Context, contracts cciptypes.ContractAddresses) error {
 	// TODO(NONEVM-1865): implement
 	panic("implement me")
 }
 
-func (l *LegacyAccessor) MsgsBetweenSeqNums(
+func (l *DefaultAccessor) MsgsBetweenSeqNums(
 	ctx context.Context,
 	destChainSelector cciptypes.ChainSelector,
 	seqNumRange cciptypes.SeqNumRange,
@@ -157,7 +157,7 @@ func (l *LegacyAccessor) MsgsBetweenSeqNums(
 	return msgs, nil
 }
 
-func (l *LegacyAccessor) LatestMsgSeqNum(
+func (l *DefaultAccessor) LatestMsgSeqNum(
 	ctx context.Context,
 	destChainSelector cciptypes.ChainSelector,
 ) (cciptypes.SeqNum, error) {
@@ -217,7 +217,7 @@ func (l *LegacyAccessor) LatestMsgSeqNum(
 	return msg.SequenceNumber, nil
 }
 
-func (l *LegacyAccessor) GetExpectedNextSequenceNumber(
+func (l *DefaultAccessor) GetExpectedNextSequenceNumber(
 	ctx context.Context,
 	destChainSelector cciptypes.ChainSelector,
 ) (cciptypes.SeqNum, error) {
@@ -245,7 +245,7 @@ func (l *LegacyAccessor) GetExpectedNextSequenceNumber(
 	return cciptypes.SeqNum(expectedNextSequenceNumber), nil
 }
 
-func (l *LegacyAccessor) GetTokenPriceUSD(
+func (l *DefaultAccessor) GetTokenPriceUSD(
 	ctx context.Context,
 	address cciptypes.UnknownAddress,
 ) (cciptypes.BigInt, error) {
@@ -253,7 +253,7 @@ func (l *LegacyAccessor) GetTokenPriceUSD(
 	panic("implement me")
 }
 
-func (l *LegacyAccessor) GetFeeQuoterDestChainConfig(
+func (l *DefaultAccessor) GetFeeQuoterDestChainConfig(
 	ctx context.Context,
 	dest cciptypes.ChainSelector,
 ) (cciptypes.FeeQuoterDestChainConfig, error) {
@@ -261,7 +261,7 @@ func (l *LegacyAccessor) GetFeeQuoterDestChainConfig(
 	panic("implement me")
 }
 
-func (l *LegacyAccessor) CommitReportsGTETimestamp(
+func (l *DefaultAccessor) CommitReportsGTETimestamp(
 	ctx context.Context,
 	ts time.Time,
 	limit int,
@@ -270,7 +270,7 @@ func (l *LegacyAccessor) CommitReportsGTETimestamp(
 	panic("implement me")
 }
 
-func (l *LegacyAccessor) ExecutedMessages(
+func (l *DefaultAccessor) ExecutedMessages(
 	ctx context.Context,
 	ranges map[cciptypes.ChainSelector]cciptypes.SeqNumRange,
 	confidence cciptypes.ConfidenceLevel,
@@ -279,7 +279,7 @@ func (l *LegacyAccessor) ExecutedMessages(
 	panic("implement me")
 }
 
-func (l *LegacyAccessor) NextSeqNum(
+func (l *DefaultAccessor) NextSeqNum(
 	ctx context.Context,
 	sources []cciptypes.ChainSelector,
 ) (seqNum map[cciptypes.ChainSelector]cciptypes.SeqNum, err error) {
@@ -287,7 +287,7 @@ func (l *LegacyAccessor) NextSeqNum(
 	panic("implement me")
 }
 
-func (l *LegacyAccessor) Nonces(
+func (l *DefaultAccessor) Nonces(
 	ctx context.Context,
 	addresses map[cciptypes.ChainSelector][]cciptypes.UnknownEncodedAddress,
 ) (map[cciptypes.ChainSelector]map[string]uint64, error) {
@@ -295,7 +295,7 @@ func (l *LegacyAccessor) Nonces(
 	panic("implement me")
 }
 
-func (l *LegacyAccessor) GetChainFeePriceUpdate(
+func (l *DefaultAccessor) GetChainFeePriceUpdate(
 	ctx context.Context,
 	selectors []cciptypes.ChainSelector,
 ) map[cciptypes.ChainSelector]cciptypes.TimestampedBig {
@@ -303,17 +303,17 @@ func (l *LegacyAccessor) GetChainFeePriceUpdate(
 	panic("implement me")
 }
 
-func (l *LegacyAccessor) GetLatestPriceSeqNr(ctx context.Context) (uint64, error) {
+func (l *DefaultAccessor) GetLatestPriceSeqNr(ctx context.Context) (uint64, error) {
 	// TODO(NONEVM-1865): implement
 	panic("implement me")
 }
 
-func (l *LegacyAccessor) GetOffRampConfigDigest(ctx context.Context, pluginType uint8) ([32]byte, error) {
+func (l *DefaultAccessor) GetOffRampConfigDigest(ctx context.Context, pluginType uint8) ([32]byte, error) {
 	// TODO(NONEVM-1865): implement
 	panic("implement me")
 }
 
-func (l *LegacyAccessor) GetOffRampSourceChainsConfig(
+func (l *DefaultAccessor) GetOffRampSourceChainsConfig(
 	ctx context.Context,
 	sourceChains []cciptypes.ChainSelector,
 ) (map[cciptypes.ChainSelector]cciptypes.SourceChainConfig, error) {
@@ -321,12 +321,12 @@ func (l *LegacyAccessor) GetOffRampSourceChainsConfig(
 	panic("implement me")
 }
 
-func (l *LegacyAccessor) GetRMNRemoteConfig(ctx context.Context) (cciptypes.RemoteConfig, error) {
+func (l *DefaultAccessor) GetRMNRemoteConfig(ctx context.Context) (cciptypes.RemoteConfig, error) {
 	// TODO(NONEVM-1865): implement
 	panic("implement me")
 }
 
-func (l *LegacyAccessor) GetRmnCurseInfo(ctx context.Context) (cciptypes.CurseInfo, error) {
+func (l *DefaultAccessor) GetRmnCurseInfo(ctx context.Context) (cciptypes.CurseInfo, error) {
 	// TODO(NONEVM-1865): implement
 	panic("implement me")
 }

--- a/pkg/reader/ccip_interface.go
+++ b/pkg/reader/ccip_interface.go
@@ -164,7 +164,7 @@ func NewCCIPReaderWithExtendedContractReaders(
 	var cas = make(map[cciptypes.ChainSelector]cciptypes.ChainAccessor)
 	for ch, extendedCr := range extendedContractReaders {
 		cr.WithExtendedContractReader(ch, extendedCr)
-		cas[ch] = chainaccessor.NewLegacyAccessor(
+		cas[ch] = chainaccessor.NewDefaultAccessor(
 			lggr,
 			ch,
 			extendedCr,

--- a/pkg/reader/helpers.go
+++ b/pkg/reader/helpers.go
@@ -81,12 +81,12 @@ func validateReaderExistence[T contractreader.ContractReaderFacade](
 	return nil
 }
 
-func validateAccessorExistence(
+func getChainAccessor(
 	accessors map[cciptypes.ChainSelector]cciptypes.ChainAccessor,
 	chainSelector cciptypes.ChainSelector,
-) error {
-	if _, exists := accessors[chainSelector]; !exists {
-		return fmt.Errorf("chain accessor not found for chain %d", chainSelector)
+) (cciptypes.ChainAccessor, error) {
+	if accessor, exists := accessors[chainSelector]; exists {
+		return accessor, nil
 	}
-	return nil
+	return nil, fmt.Errorf("chain accessor not found for chain %d", chainSelector)
 }


### PR DESCRIPTION
Some cleanup follow-ups mentioned in the previous PRs:
1. Renames `LegacyAccessor` --> `DefaultAccessor`
2. Replaces `validateAccessorExistence()` with `getChainAccessor()` to bundle the null check and avoid using `r.accessors[chain]` each time
3. Replaces `UnimplementedTestContractWriter` with mocked contract writer

For more context, see NONEVM-1865

Stack:
1. https://github.com/smartcontractkit/chainlink-ccip/pull/978
4. https://github.com/smartcontractkit/chainlink-ccip/pull/980
5. https://github.com/smartcontractkit/chainlink-ccip/pull/985
6. https://github.com/smartcontractkit/chainlink-ccip/pull/987
7. https://github.com/smartcontractkit/chainlink-ccip/pull/988
8. https://github.com/smartcontractkit/chainlink-ccip/pull/989
9. https://github.com/smartcontractkit/chainlink-ccip/pull/990
10. ➡️ https://github.com/smartcontractkit/chainlink-ccip/pull/999