### PR TITLE
Add Role DON e2e test with previous outcome

### DIFF
--- a/commit/plugin_roledon_e2e_test.go
+++ b/commit/plugin_roledon_e2e_test.go
@@ -298,7 +298,7 @@ func (s roleDonTestSetup) newRoleDonTestPlugin(oracleID commontypes.OracleID) *P
 			MerkleRootAsyncObserverDisabled: true,
 			ChainFeeAsyncObserverDisabled:   true,
 			TokenPriceAsyncObserverDisabled: true,
-			EnableDonBreakingChanges:        true,
+			DonBreakingChangesVersion:       pluginconfig.DonBreakingChangesVersion1RoleDonSupport,
 		},
 		s.destChain,
 		deps.ccipReader,


### PR DESCRIPTION
This test asserts expectations when we have inflight prices and seq num ranges previously selected (in this state we build roots and wait for previous prices to make it onchain).

Also updated the existing role don test by adding a chain without enough oracles supporting it and asserting that there are no results for this chain while we still get results for the others.