### PR TITLE
[CAL][10] - Implement Nonces and GetChainFeePriceUpdate

### DIFF
--- a/pkg/chainaccessor/types.go
+++ b/pkg/chainaccessor/types.go
@@ -51,3 +51,9 @@ type PriceUpdates struct {
 	TokenPriceUpdates []TokenPriceUpdate
 	GasPriceUpdates   []GasPriceUpdate
 }
+
+type chainAddressNonce struct {
+	chain    cciptypes.ChainSelector
+	address  string
+	response uint64
+}


### PR DESCRIPTION

- Implements `Nonces()`, `GetChainFeePriceUpdate()` in DefaultAccessor
- For more context, see NONEVM-1865

Stack:
1. https://github.com/smartcontractkit/chainlink-ccip/pull/978
2. https://github.com/smartcontractkit/chainlink-ccip/pull/980
3. https://github.com/smartcontractkit/chainlink-ccip/pull/985
4. https://github.com/smartcontractkit/chainlink-ccip/pull/987
5. https://github.com/smartcontractkit/chainlink-ccip/pull/988
6. https://github.com/smartcontractkit/chainlink-ccip/pull/989
7. https://github.com/smartcontractkit/chainlink-ccip/pull/990
8. https://github.com/smartcontractkit/chainlink-ccip/pull/999
9. https://github.com/smartcontractkit/chainlink-ccip/pull/1000
10. ➡️ https://github.com/smartcontractkit/chainlink-ccip/pull/1014
11. https://github.com/smartcontractkit/chainlink-ccip/pull/1017