### PR TITLE
Filter out empty root in the deduplicate report 

### DIFF
--- a/execute/internal/cache/commit_report_cache.go
+++ b/execute/internal/cache/commit_report_cache.go
@@ -298,6 +298,13 @@ func DeduplicateReports(
 	deduplicated := make([]ccipocr3.CommitPluginReportWithMeta, 0, len(reports))
 
 	for _, report := range reports {
+		if len(report.Report.BlessedMerkleRoots) == 0 && len(report.Report.UnblessedMerkleRoots) == 0 {
+			lggr.Debugw("DeduplicateReports: skipping report with no Merkle roots",
+				"timestamp", report.Timestamp,
+				"blockNum", report.BlockNum)
+			continue
+		}
+
 		key, err := generateKey(report) // generateKey is already in the package
 		if err != nil {
 			lggr.Errorw("DeduplicateReports: Failed to generate key for report, skipping",

--- a/execute/internal/cache/commit_report_cache_test.go
+++ b/execute/internal/cache/commit_report_cache_test.go
@@ -673,6 +673,11 @@ func TestCommitReportCache_DeduplicateReports(t *testing.T) {
 				r1, r2, r4, r7DiffChain,
 			}, // r3Dupe, r5NoRoots, r6Dupe should be filtered out
 		},
+		{
+			name:     "Multiple reports without roots",
+			reports:  []ccipocr3.CommitPluginReportWithMeta{r5NoRoots, r5NoRoots, r5NoRoots},
+			expected: []ccipocr3.CommitPluginReportWithMeta{}, // All reports should be skipped
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
The `DeduplicateReports` is receiving both reports from the cache (only merkle root reports) and from the increment queried from ccip reader (can have any type of reports). Hence, the `generateKey` function is spamming failed key generation logs as it is possible to get empty reports.