### PR TITLE
Ignore local claude files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@
 .idea
 
 vendor/
+
+# Ignore personal settings
+**/.claude/settings.local.json


### PR DESCRIPTION
Claude code inserts these automatically, they are local configs that capture cmd line decisions that should be ignored.