### PR TITLE
CCIP-6264 Removing redundant filter for data word > 0x0

### DIFF
--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -1644,12 +1644,12 @@ func validateExecutionStateChangedEvent(
 		return fmt.Errorf("message ID is zero")
 	}
 
-	// This should never happen, because UNTOUCHED(0) and IN_PROGRESS(1) are internal
+	// This should never happen, because UNTOUCHED(0) are internal
 	// statuses used by the contract to track the state of the message during TX.
 	// ExecutionStateChange event must never be emitted with anything other than
-	// SUCCESS(2) or FAILURE(3)
-	if ev.State < 2 {
-		return fmt.Errorf("state is not SUCCESS(2) or FAILURE(3), got %d", ev.State)
+	// IN_PROGRESS(1) or SUCCESS(2) or FAILURE(3)
+	if ev.State < 1 {
+		return fmt.Errorf("state UNTOUCHED(0) spotted in logs, got %d", ev.State)
 	}
 
 	return nil

--- a/pkg/reader/ccip_test.go
+++ b/pkg/reader/ccip_test.go
@@ -376,9 +376,10 @@ func TestCCIPChainReader_ExecutedStateEvent_WithInvalidStates(t *testing.T) {
 		primitives.Unconfirmed,
 	)
 	require.NoError(t, err)
-	require.Len(t, results, 2)
+	require.Len(t, results, 3)
 
 	require.Equal(t, cciptypes.SeqNum(2), results[chainB][0])
+	require.Equal(t, cciptypes.SeqNum(3), results[chainC][0])
 	require.Equal(t, cciptypes.SeqNum(4), results[chainD][0])
 }
 


### PR DESCRIPTION
ExecutionStateChange.State > 0 filter was redundant. It was translated to the following filter in the SQL query
```sql
substring(data from 32 * 1 + 1 for 32) > '\x0000000000000000000000000000000000000000000000000000000000000000'
```

That requires an additional index scan to verify whether the state is greater than or equal to 0. However, events with state = 0 or state = 1 must never land in the `evm.logs` table, because UNTOUCHED(0) and IN_PROGRESS(1) are internal statuses used by the contract to track the state of the message during TX.

`ExecutionStateChange` event must never be emitted with anything other than SUCCESS(2) or FAILURE(3).
Therefore, we can safely assume that extra filtering on the database level is not required. However, to stay defensive, we will add a check that will ignore events containing states other than SUCCESS or FAILURE

