### PR TITLE
Truncate data logged when fetching commit reports.

### DIFF
--- a/pkg/chainaccessor/default_accessor.go
+++ b/pkg/chainaccessor/default_accessor.go
@@ -7,11 +7,12 @@ import (
 	"strconv"
 	"time"
 
+	"golang.org/x/exp/maps"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
-	"golang.org/x/exp/maps"
 
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/slicelib"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
@@ -749,6 +750,7 @@ func (l *DefaultAccessor) processCommitReports(
 	if len(reports) < limit {
 		return reports
 	}
+	lggr.Errorw("too many commit reports received, commit report results are truncated", "numTruncatedReports", len(reports)-limit)
 	return reports[:limit]
 }
 


### PR DESCRIPTION
During a recent incident it was difficult to tell which reports were being returned by the get commit reports query. The token and fee price reports were too spammy. This PR improves the logging situation with two improvements:
1. Discard token and fee price reports, instead log a number for how many updates there were.
2. Log an error if there are so many reports returned that results were truncated.