### PR TITLE
Only rebalancer address can modify liquidity

### DIFF
--- a/chains/solana/contracts/programs/lockrelease-token-pool/src/context.rs
+++ b/chains/solana/contracts/programs/lockrelease-token-pool/src/context.rs
@@ -427,7 +427,7 @@ pub struct DeleteChainConfig<'info> {
 }
 
 #[derive(Accounts)]
-pub struct TokenTransfer<'info> {
+pub struct RebalancerTokenTransfer<'info> {
     #[account(
         seeds = [POOL_STATE_SEED, mint.key().as_ref()],
         bump,
@@ -450,7 +450,8 @@ pub struct TokenTransfer<'info> {
 
     #[account(mut, token::mint = mint, token::token_program = token_program)]
     pub remote_token_account: InterfaceAccount<'info, TokenAccount>,
-    #[account(constraint = authority.key() == state.config.owner || authority.key() == state.config.rebalancer @ CcipTokenPoolError::Unauthorized)]
+    // Only the owner or rebalancer can rebalance the token pool (provide or withdraw liquidity)
+    #[account(constraint = authority.key() == state.config.rebalancer @ CcipTokenPoolError::Unauthorized)]
     pub authority: Signer<'info>,
 }
 

--- a/chains/solana/contracts/programs/lockrelease-token-pool/src/lib.rs
+++ b/chains/solana/contracts/programs/lockrelease-token-pool/src/lib.rs
@@ -275,6 +275,7 @@ pub mod lockrelease_token_pool {
         })
     }
 
+    // set the rebalancer address for the pool, if the rebalancer is the default address then only the pool owner can rebalance
     pub fn set_rebalancer(ctx: Context<SetConfig>, rebalancer: Pubkey) -> Result<()> {
         ctx.accounts.state.config.set_rebalancer(rebalancer)
     }
@@ -283,7 +284,7 @@ pub mod lockrelease_token_pool {
         ctx.accounts.state.config.set_can_accept_liquidity(allow)
     }
 
-    pub fn provide_liquidity(ctx: Context<TokenTransfer>, amount: u64) -> Result<()> {
+    pub fn provide_liquidity(ctx: Context<RebalancerTokenTransfer>, amount: u64) -> Result<()> {
         require!(
             ctx.accounts.state.config.can_accept_liquidity,
             CcipTokenPoolError::LiquidityNotAccepted
@@ -301,7 +302,7 @@ pub mod lockrelease_token_pool {
     }
 
     // withdraw liquidity can be used to transfer liquidity from one pool to another by setting the `rebalancer` to the calling pool
-    pub fn withdraw_liquidity(ctx: Context<TokenTransfer>, amount: u64) -> Result<()> {
+    pub fn withdraw_liquidity(ctx: Context<RebalancerTokenTransfer>, amount: u64) -> Result<()> {
         transfer_tokens(
             ctx.accounts.token_program.key(),
             ctx.accounts.remote_token_account.to_account_info(), // to

--- a/chains/solana/contracts/tests/examples/pools_test.go
+++ b/chains/solana/contracts/tests/examples/pools_test.go
@@ -386,17 +386,22 @@ func TestBaseTokenPoolHappyPath(t *testing.T) {
 						acceptIx, err := tokenpool.NewSetCanAcceptLiquidityInstruction(true, poolConfig, mint, admin.PublicKey()).ValidateAndBuild()
 						require.NoError(t, err)
 
+						setRebalancerIx, err := tokenpool.NewSetRebalancerInstruction(admin.PublicKey(), poolConfig, mint, admin.PublicKey()).ValidateAndBuild()
+						require.NoError(t, err)
+
 						provideIx, err := tokenpool.NewProvideLiquidityInstruction(amount, poolConfig, v.tokenProgram, tokenPool.Mint, poolSigner, poolTokenAccount, tokenPool.User[admin.PublicKey()], admin.PublicKey()).ValidateAndBuild()
 						require.NoError(t, err)
 
 						testutils.SendAndFailWith(ctx, t, solanaGoClient, []solana.Instruction{
 							approveIx,
+							&tokens.TokenInstruction{Instruction: setRebalancerIx, Program: poolProgram},
 							&tokens.TokenInstruction{Instruction: provideIx, Program: poolProgram},
 						}, admin, rpc.CommitmentConfirmed, []string{"Liquidity not accepted"})
 
 						testutils.SendAndConfirm(ctx, t, solanaGoClient, []solana.Instruction{
 							approveIx,
 							&tokens.TokenInstruction{Instruction: acceptIx, Program: poolProgram},
+							&tokens.TokenInstruction{Instruction: setRebalancerIx, Program: poolProgram},
 							&tokens.TokenInstruction{Instruction: provideIx, Program: poolProgram},
 						}, admin, rpc.CommitmentConfirmed)
 


### PR DESCRIPTION
Modify the Liquidity Operations so only the rebalancer can withdraw or provide liquidity.