### PR TITLE
Validate not zero when rebalancing

### DIFF
--- a/chains/solana/contracts/programs/base-token-pool/src/common.rs
+++ b/chains/solana/contracts/programs/base-token-pool/src/common.rs
@@ -473,6 +473,8 @@ pub enum CcipTokenPoolError {
     // Lock/Release errors
     #[msg("Liquidity not accepted")]
     LiquidityNotAccepted,
+    #[msg("Transfering zero tokens is not allowed")]
+    TransferZeroTokensNotAllowed,
 }
 
 // validate_lock_or_burn checks for correctness on inputs

--- a/chains/solana/contracts/programs/lockrelease-token-pool/src/lib.rs
+++ b/chains/solana/contracts/programs/lockrelease-token-pool/src/lib.rs
@@ -284,6 +284,7 @@ pub mod lockrelease_token_pool {
     }
 
     pub fn provide_liquidity(ctx: Context<TokenTransfer>, amount: u64) -> Result<()> {
+        require_gt!(amount, 0, CcipTokenPoolError::TransferZeroTokensNotAllowed);
         require!(
             ctx.accounts.state.config.can_accept_liquidity,
             CcipTokenPoolError::LiquidityNotAccepted
@@ -302,6 +303,11 @@ pub mod lockrelease_token_pool {
 
     // withdraw liquidity can be used to transfer liquidity from one pool to another by setting the `rebalancer` to the calling pool
     pub fn withdraw_liquidity(ctx: Context<TokenTransfer>, amount: u64) -> Result<()> {
+        require_gt!(amount, 0, CcipTokenPoolError::TransferZeroTokensNotAllowed);
+        require!(
+            ctx.accounts.state.config.can_accept_liquidity,
+            CcipTokenPoolError::LiquidityNotAccepted
+        );
         transfer_tokens(
             ctx.accounts.token_program.key(),
             ctx.accounts.remote_token_account.to_account_info(), // to

--- a/chains/solana/contracts/target/idl/base_token_pool.json
+++ b/chains/solana/contracts/target/idl/base_token_pool.json
@@ -722,6 +722,11 @@
       "code": 6019,
       "name": "LiquidityNotAccepted",
       "msg": "Liquidity not accepted"
+    },
+    {
+      "code": 6020,
+      "name": "TransferZeroTokensNotAllowed",
+      "msg": "Transfering zero tokens is not allowed"
     }
   ]
 }

--- a/chains/solana/contracts/target/types/base_token_pool.ts
+++ b/chains/solana/contracts/target/types/base_token_pool.ts
@@ -722,6 +722,11 @@ export type BaseTokenPool = {
       "code": 6019,
       "name": "LiquidityNotAccepted",
       "msg": "Liquidity not accepted"
+    },
+    {
+      "code": 6020,
+      "name": "TransferZeroTokensNotAllowed",
+      "msg": "Transfering zero tokens is not allowed"
     }
   ]
 };
@@ -1450,6 +1455,11 @@ export const IDL: BaseTokenPool = {
       "code": 6019,
       "name": "LiquidityNotAccepted",
       "msg": "Liquidity not accepted"
+    },
+    {
+      "code": 6020,
+      "name": "TransferZeroTokensNotAllowed",
+      "msg": "Transfering zero tokens is not allowed"
     }
   ]
 };


### PR DESCRIPTION
Validate the amount is not zero when rebalancing to avoid spending compute units and add the validation for rebalancing enabled when withdrawing.