### PR TITLE
CCIP-6264 Removing redundant filter for data word > 0x0

### DIFF
--- a/pkg/chainaccessor/default_accessor.go
+++ b/pkg/chainaccessor/default_accessor.go
@@ -439,12 +439,6 @@ func createExecutedMessagesKeyFilter(
 		Key: consts.EventNameExecutionStateChanged,
 		Expressions: []query.Expression{
 			extendedQuery,
-			// We don't need to wait for an execute state changed event to be finalized
-			// before we optimistically mark a message as executed.
-			query.Comparator(consts.EventAttributeState, primitives.ValueComparator{
-				Value:    0, // > 0 corresponds to:  IN_PROGRESS, SUCCESS, FAILURE
-				Operator: primitives.Gt,
-			}),
 			query.Confidence(confidence),
 		},
 	}

--- a/pkg/chainaccessor/default_accessor_test.go
+++ b/pkg/chainaccessor/default_accessor_test.go
@@ -64,12 +64,6 @@ func TestCCIPChainReader_CreateExecutedMessagesKeyFilter(t *testing.T) {
 							},
 						},
 					},
-					{
-						Primitive: &primitives.Comparator{
-							Name:             consts.EventAttributeState,
-							ValueComparators: []primitives.ValueComparator{{Value: 0, Operator: primitives.Gt}},
-						},
-					},
 					{Primitive: &primitives.Confidence{ConfidenceLevel: primitives.Finalized}},
 				},
 			},
@@ -138,12 +132,6 @@ func TestCCIPChainReader_CreateExecutedMessagesKeyFilter(t *testing.T) {
 									},
 								},
 							},
-						},
-					},
-					{
-						Primitive: &primitives.Comparator{
-							Name:             consts.EventAttributeState,
-							ValueComparators: []primitives.ValueComparator{{Value: 0, Operator: primitives.Gt}},
 						},
 					},
 					{Primitive: &primitives.Confidence{ConfidenceLevel: primitives.Finalized}},
@@ -255,12 +243,6 @@ func TestCCIPChainReader_CreateExecutedMessagesKeyFilter(t *testing.T) {
 									},
 								},
 							},
-						},
-					},
-					{
-						Primitive: &primitives.Comparator{
-							Name:             consts.EventAttributeState,
-							ValueComparators: []primitives.ValueComparator{{Value: 0, Operator: primitives.Gt}},
 						},
 					},
 					{Primitive: &primitives.Confidence{ConfidenceLevel: primitives.Finalized}},

--- a/pkg/chainaccessor/event_validators.go
+++ b/pkg/chainaccessor/event_validators.go
@@ -154,8 +154,12 @@ func validateExecutionStateChangedEvent(
 		return fmt.Errorf("message ID is zero")
 	}
 
-	if ev.State == 0 {
-		return fmt.Errorf("state is zero")
+	// This should never happen, because UNTOUCHED(0) are internal
+	// statuses used by the contract to track the state of the message during TX.
+	// ExecutionStateChange event must never be emitted with anything other than
+	// IN_PROGRESS(1) or SUCCESS(2) or FAILURE(3)
+	if ev.State < 1 {
+		return fmt.Errorf("state UNTOUCHED(0) spotted in logs, got %d", ev.State)
 	}
 
 	return nil


### PR DESCRIPTION
ExecutionStateChange.State > 0 filter was redundant. It was translated to the following filter in the SQL query
```sql
substring(data from 32 * 1 + 1 for 32) > '\x0000000000000000000000000000000000000000000000000000000000000000'
```

That requires an additional index scan to verify whether the state is greater than or equal to 0. However, events with state = 0 must never land in the logs table, because UNTOUCHED(0) is an internal status used by the contract to track the state of the message during TX.

`ExecutionStateChange` event must never be emitted with anything other than INPROGRESS(1), SUCCESS(2) or FAILURE(3). Therefore, we can safely assume that extra filtering on the database level is not required. However, to stay defensive, we will add a check that will ignore events containing UNTOUCHED

