### PR TITLE
Bugfix in chainfee validation

### DIFF
--- a/commit/chainfee/validate_observation.go
+++ b/commit/chainfee/validate_observation.go
@@ -31,7 +31,7 @@ func (p *processor) ValidateObservation(
 	if err != nil {
 		return fmt.Errorf("failed to get supported chains: %w", err)
 	}
-	if err := validateObservedChains(ao, observerSupportedChains); err != nil {
+	if err := validateObservedChains(ao, observerSupportedChains, p.destChain); err != nil {
 		return fmt.Errorf("failed to validate observed chains: %w", err)
 	}
 
@@ -104,6 +104,7 @@ func validateFeeComponents(
 func validateObservedChains(
 	ao plugincommon.AttributedObservation[Observation],
 	observerSupportedChains mapset.Set[ccipocr3.ChainSelector],
+	destChain ccipocr3.ChainSelector,
 ) error {
 	obs := ao.Observation
 	if !areMapKeysEqual(obs.FeeComponents, obs.NativeTokenPrices) {
@@ -111,7 +112,12 @@ func validateObservedChains(
 	}
 
 	observedChains := append(maps.Keys(obs.FeeComponents), maps.Keys(obs.NativeTokenPrices)...)
-	observedChains = append(observedChains, maps.Keys(obs.ChainFeeUpdates)...)
+	if len(obs.ChainFeeUpdates) > 0 {
+		// chainFeeUpdates are read from the destination chain, if the oracle observed any chain fee updates
+		// it should support the destination chain.
+		observedChains = append(observedChains, destChain)
+	}
+
 	for _, chain := range observedChains {
 		if !observerSupportedChains.Contains(chain) {
 			return fmt.Errorf("chain %d is not supported by observer", chain)

--- a/commit/chainfee/validate_observation_test.go
+++ b/commit/chainfee/validate_observation_test.go
@@ -186,6 +186,7 @@ func Test_validateObservedChains(t *testing.T) {
 		ao                      plugincommon.AttributedObservation[Observation]
 		observerSupportedChains mapset.Set[ccipocr3.ChainSelector]
 		expectedError           string
+		destChain               ccipocr3.ChainSelector
 	}{
 		{
 			name: "valid observed chains",
@@ -213,7 +214,8 @@ func Test_validateObservedChains(t *testing.T) {
 					},
 				},
 			},
-			observerSupportedChains: mapset.NewSet[ccipocr3.ChainSelector](1),
+			destChain:               2,
+			observerSupportedChains: mapset.NewSet[ccipocr3.ChainSelector](1, 2),
 			expectedError:           "",
 		},
 		{
@@ -278,7 +280,7 @@ func Test_validateObservedChains(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateObservedChains(tt.ao, tt.observerSupportedChains)
+			err := validateObservedChains(tt.ao, tt.observerSupportedChains, tt.destChain)
 			if tt.expectedError == "" {
 				require.NoError(t, err)
 			} else {


### PR DESCRIPTION
While validating chain fee observations the wrong chains were used.

Which means that even when an oracle observed the actual chains it is supposed to observe it's observation might be blocked.

This is because chain fee update observations are only read from the destination chain and not from their individual source chains.