### PR TITLE
retry on lut update

### DIFF
--- a/chains/solana/utils/common/lookuptable.go
+++ b/chains/solana/utils/common/lookuptable.go
@@ -88,19 +88,19 @@ func CreateLookupTable(ctx context.Context, client *rpc.Client, admin solana.Pri
 		return solana.PublicKey{}, ierr
 	}
 
-	_, err := SendAndConfirm(ctx, client, []solana.Instruction{instruction}, admin, rpc.CommitmentConfirmed)
+	_, err := SendAndConfirmWithLookupTablesAndRetries(ctx, client, []solana.Instruction{instruction}, admin, rpc.CommitmentConfirmed, map[solana.PublicKey]solana.PublicKeySlice{})
 	return table, err
 }
 
 func ExtendLookupTable(ctx context.Context, client *rpc.Client, table solana.PublicKey, admin solana.PrivateKey, entries []solana.PublicKey) error {
-	_, err := SendAndConfirm(ctx, client, []solana.Instruction{
+	_, err := SendAndConfirmWithLookupTablesAndRetries(ctx, client, []solana.Instruction{
 		NewExtendLookupTableInstruction(
 			table,
 			admin.PublicKey(),
 			admin.PublicKey(),
 			entries,
 		),
-	}, admin, rpc.CommitmentConfirmed)
+	}, admin, rpc.CommitmentConfirmed, map[solana.PublicKey]solana.PublicKeySlice{})
 	return err
 }
 


### PR DESCRIPTION
```
Error getting transaction: not found
2025-07-11T22:18:06.070Z	ERROR	solana/cs_deploy_chain.go:196	Failed to deploy CCIP contracts	{"err": "failed to extend lookup table: failed to extend lookup table: not found", "newAddresses": {}}
```

Switches LUT create/extend to use the retry version of send and confirm.