### PR TITLE
Add chain accessor map to plugin factories

### DIFF
--- a/commit/factory.go
+++ b/commit/factory.go
@@ -74,6 +74,7 @@ type PluginFactory struct {
 	addrCodec         cciptypes.AddressCodec
 	homeChainReader   reader.HomeChain
 	homeChainSelector cciptypes.ChainSelector
+	chainAccessors    map[cciptypes.ChainSelector]cciptypes.ChainAccessor
 	contractReaders   map[cciptypes.ChainSelector]types.ContractReader
 	chainWriters      map[cciptypes.ChainSelector]types.ContractWriter
 	rmnPeerClient     rmn.PeerClient
@@ -89,6 +90,7 @@ type CommitPluginFactoryParams struct {
 	AddrCodec         cciptypes.AddressCodec
 	HomeChainReader   reader.HomeChain
 	HomeChainSelector cciptypes.ChainSelector
+	ChainAccessors    map[cciptypes.ChainSelector]cciptypes.ChainAccessor
 	ContractReaders   map[cciptypes.ChainSelector]types.ContractReader
 	ContractWriters   map[cciptypes.ChainSelector]types.ContractWriter
 	RmnPeerClient     rmn.PeerClient
@@ -107,6 +109,7 @@ func NewCommitPluginFactory(params CommitPluginFactoryParams) *PluginFactory {
 		addrCodec:         params.AddrCodec,
 		homeChainReader:   params.HomeChainReader,
 		homeChainSelector: params.HomeChainSelector,
+		chainAccessors:    params.ChainAccessors,
 		contractReaders:   params.ContractReaders,
 		chainWriters:      params.ContractWriters,
 		rmnPeerClient:     params.RmnPeerClient,

--- a/execute/factory.go
+++ b/execute/factory.go
@@ -76,6 +76,7 @@ type PluginFactory struct {
 	homeChainReader  reader.HomeChain
 	estimateProvider cciptypes.EstimateProvider
 	tokenDataEncoder cciptypes.TokenDataEncoder
+	chainAccessors   map[cciptypes.ChainSelector]cciptypes.ChainAccessor
 	contractReaders  map[cciptypes.ChainSelector]types.ContractReader
 	chainWriters     map[cciptypes.ChainSelector]types.ContractWriter
 }
@@ -89,6 +90,7 @@ type PluginFactoryParams struct {
 	AddrCodec        cciptypes.AddressCodec
 	HomeChainReader  reader.HomeChain
 	TokenDataEncoder cciptypes.TokenDataEncoder
+	ChainAccessors   map[cciptypes.ChainSelector]cciptypes.ChainAccessor
 	EstimateProvider cciptypes.EstimateProvider
 	ContractReaders  map[cciptypes.ChainSelector]types.ContractReader
 	ContractWriters  map[cciptypes.ChainSelector]types.ContractWriter
@@ -107,6 +109,7 @@ func NewExecutePluginFactory(params PluginFactoryParams) *PluginFactory {
 		homeChainReader:  params.HomeChainReader,
 		estimateProvider: params.EstimateProvider,
 		tokenDataEncoder: params.TokenDataEncoder,
+		chainAccessors:   params.ChainAccessors,
 		contractReaders:  params.ContractReaders,
 		chainWriters:     params.ContractWriters,
 	}

--- a/pkg/chainaccessor/default_accessor.go
+++ b/pkg/chainaccessor/default_accessor.go
@@ -7,11 +7,12 @@ import (
 	"strconv"
 	"time"
 
+	"golang.org/x/exp/maps"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
-	"golang.org/x/exp/maps"
 
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
@@ -39,14 +40,20 @@ func NewDefaultAccessor(
 	contractReader contractreader.Extended,
 	contractWriter types.ContractWriter,
 	addrCodec cciptypes.AddressCodec,
-) cciptypes.ChainAccessor {
+) (cciptypes.ChainAccessor, error) {
+	if contractReader == nil {
+		return nil, fmt.Errorf("contractReader cannot be nil")
+	}
+	if contractWriter == nil {
+		return nil, fmt.Errorf("contractWriter cannot be nil")
+	}
 	return &DefaultAccessor{
 		lggr:           lggr,
 		chainSelector:  chainSelector,
 		contractReader: contractReader,
 		contractWriter: contractWriter,
 		addrCodec:      addrCodec,
-	}
+	}, nil
 }
 
 func (l *DefaultAccessor) GetContractAddress(contractName string) ([]byte, error) {

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -84,16 +84,19 @@ func newCCIPChainReaderWithConfigPollerInternal(
 
 	for chainSelector, cr := range contractReaders {
 		crs[chainSelector] = contractreader.NewExtendedContractReader(cr)
-		if contractWriters[chainSelector] == nil {
-			return nil, fmt.Errorf("contract writer for chain %s is not provided", chainSelector)
-		}
-		cas[chainSelector] = chainaccessor.NewDefaultAccessor(
+
+		// TODO: remove instantiation of the accessor once accessors are passed down from above
+		accessor, err := chainaccessor.NewDefaultAccessor(
 			lggr,
 			chainSelector,
 			crs[chainSelector],
 			contractWriters[chainSelector],
 			addrCodec,
 		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create chain accessor for chain %s: %w", chainSelector, err)
+		}
+		cas[chainSelector] = accessor
 	}
 
 	offrampAddrStr, err := addrCodec.AddressBytesToString(offrampAddress, destChain)

--- a/pkg/reader/ccip_interface.go
+++ b/pkg/reader/ccip_interface.go
@@ -166,13 +166,18 @@ func NewCCIPReaderWithExtendedContractReaders(
 	var cas = make(map[cciptypes.ChainSelector]cciptypes.ChainAccessor)
 	for ch, extendedCr := range extendedContractReaders {
 		cr.WithExtendedContractReader(ch, extendedCr)
-		cas[ch] = chainaccessor.NewDefaultAccessor(
+		accessor, err := chainaccessor.NewDefaultAccessor(
 			lggr,
 			ch,
 			extendedCr,
 			contractWriters[ch],
 			addrCodec,
 		)
+		if err != nil {
+			// Panic here since this is only called from tests in core
+			panic(fmt.Errorf("failed to create chain accessor for %s: %w", ch, err))
+		}
+		cas[ch] = accessor
 	}
 
 	cr.accessors = cas


### PR DESCRIPTION
core ref: 100e771b1ed3b3d69adba4e625e192d34c2138cf

This PR:
- Adds chain accessors to the plugin factory params. This portion is **effectively a no-op** since we don't actually use these chain accessors anywhere yet
- Does some minor cleanup in the `CCIPReader` and the `DefaultAccessor` constructors