### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -562,10 +563,8 @@ func (p *Plugin) getMainOutcomeAndCacheInvalidation(
 
 	// check if the inflight prices made it on-chain
 	// first validate and agree on fDestChain and current onChainOcrSeqNum
-	for _, v := range observedOnChainOcrSeqNums {
-		if v == 0 {
-			return committypes.MainOutcome{}, false, fmt.Errorf("observed ocr seq num cannot be zero at this point")
-		}
+	if slices.Contains(observedOnChainOcrSeqNums, 0) {
+		return committypes.MainOutcome{}, false, fmt.Errorf("observed ocr seq num cannot be zero at this point")
 	}
 
 	donThresh := consensus.MakeConstantThreshold[cciptypes.ChainSelector](consensus.TwoFPlus1(p.reportingCfg.F))

--- a/execute/tokendata/observer/observer.go
+++ b/execute/tokendata/observer/observer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
@@ -278,13 +279,7 @@ func (n *NoopTokenDataObserver) isError(selector cciptypes.ChainSelector, seq cc
 		return false
 	}
 
-	for _, idx := range tokenIdxs {
-		if idx == tokenIdx {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(tokenIdxs, tokenIdx)
 }
 
 func (n *NoopTokenDataObserver) IsTokenSupported(_ cciptypes.ChainSelector, _ cciptypes.RampTokenAmount) bool {


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.