### PR TITLE
Add Solana chain writer config version flag to execute offchain config

### DIFF
--- a/pluginconfig/execute.go
+++ b/pluginconfig/execute.go
@@ -56,7 +56,8 @@ type ExecuteOffchainConfig struct {
 	// MultipleReportsEnabled is a flag to enable/disable multiple reports per round.
 	MultipleReportsEnabled bool `json:"multipleReports"`
 
-	// SolanaChainWriterConfigVersion is a flag to specify which version of Solana ChainWriter configs to initialize the plugin with.
+	// SolanaChainWriterConfigVersion is a flag to specify which version of Solana ChainWriter configs to initialize the
+	// plugin with.
 	SolanaChainWriterConfigVersion *string `json:"solanaAccountDerivation,omitempty"`
 }
 

--- a/pluginconfig/execute.go
+++ b/pluginconfig/execute.go
@@ -55,6 +55,9 @@ type ExecuteOffchainConfig struct {
 
 	// MultipleReportsEnabled is a flag to enable/disable multiple reports per round.
 	MultipleReportsEnabled bool `json:"multipleReports"`
+
+	// SolanaAccountDerivation is a flag to enable/disable the use of on-chain account derivation to build the execute account list for Solana
+	SolanaAccountDerivation bool `json:"solanaAccountDerivation"`
 }
 
 func (e *ExecuteOffchainConfig) ApplyDefaultsAndValidate() error {

--- a/pluginconfig/execute.go
+++ b/pluginconfig/execute.go
@@ -57,7 +57,7 @@ type ExecuteOffchainConfig struct {
 	MultipleReportsEnabled bool `json:"multipleReports"`
 
 	// SolanaChainWriterConfigVersion is a flag to specify which version of Solana ChainWriter configs to initialize the
-	// plugin with.
+	// plugin with. Leave empty to use a default configuration value.
 	SolanaChainWriterConfigVersion *string `json:"solanaAccountDerivation,omitempty"`
 }
 

--- a/pluginconfig/execute.go
+++ b/pluginconfig/execute.go
@@ -57,7 +57,7 @@ type ExecuteOffchainConfig struct {
 	MultipleReportsEnabled bool `json:"multipleReports"`
 
 	// SolanaAccountDerivation is a flag to enable/disable the use of on-chain account derivation to build the execute account list for Solana
-	SolanaAccountDerivation bool `json:"solanaAccountDerivation"`
+	SolanaAccountDerivation *string `json:"solanaAccountDerivation,omitempty"`
 }
 
 func (e *ExecuteOffchainConfig) ApplyDefaultsAndValidate() error {

--- a/pluginconfig/execute.go
+++ b/pluginconfig/execute.go
@@ -56,8 +56,8 @@ type ExecuteOffchainConfig struct {
 	// MultipleReportsEnabled is a flag to enable/disable multiple reports per round.
 	MultipleReportsEnabled bool `json:"multipleReports"`
 
-	// SolanaAccountDerivation is a flag to enable/disable the use of on-chain account derivation to build the execute account list for Solana
-	SolanaAccountDerivation *string `json:"solanaAccountDerivation,omitempty"`
+	// SolanaChainWriterConfigVersion is a flag to specify which version of Solana ChainWriter configs to initialize the plugin with.
+	SolanaChainWriterConfigVersion *string `json:"solanaAccountDerivation,omitempty"`
 }
 
 func (e *ExecuteOffchainConfig) ApplyDefaultsAndValidate() error {


### PR DESCRIPTION
Added the `SolanaChainWriterConfigVersion ` feature flag to specific which version of the Solana ChainWriter configs we want to initialize the plugin with.