### PR TITLE
ChainAccessor - pipe core-created accessors down into CCIPReader and starting using them

### DIFF
--- a/commit/factory.go
+++ b/commit/factory.go
@@ -191,6 +191,7 @@ func (p *PluginFactory) NewReportingPlugin(ctx context.Context, config ocr3types
 	ccipReader, err := readerpkg.NewCCIPChainReader(
 		ctx,
 		logutil.WithComponent(lggr, "CCIPReader"),
+		p.chainAccessors,
 		readers,
 		p.chainWriters,
 		p.ocrConfig.Config.ChainSelector,

--- a/commit/factory_test.go
+++ b/commit/factory_test.go
@@ -8,35 +8,31 @@ import (
 	"testing"
 	"time"
 
+	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	reader_mocks "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/contractreader"
-	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
-	rmnpb "github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go/serialization"
-
-	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/merklemulti"
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
-
-	"github.com/smartcontractkit/chainlink-ccip/internal"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	"github.com/smartcontractkit/chainlink-ccip/commit/chainfee"
 	"github.com/smartcontractkit/chainlink-ccip/commit/committypes"
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot"
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn"
 	"github.com/smartcontractkit/chainlink-ccip/commit/tokenprice"
+	"github.com/smartcontractkit/chainlink-ccip/internal"
 	"github.com/smartcontractkit/chainlink-ccip/internal/mocks"
 	dt "github.com/smartcontractkit/chainlink-ccip/internal/plugincommon/discovery/discoverytypes"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
 	reader2 "github.com/smartcontractkit/chainlink-ccip/internal/reader"
-	writer_mocks "github.com/smartcontractkit/chainlink-ccip/mocks/chainlink_common/types"
+	writermocks "github.com/smartcontractkit/chainlink-ccip/mocks/chainlink_common/types"
+	readermocks "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/contractreader"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
 	ocrtypecodec "github.com/smartcontractkit/chainlink-ccip/pkg/ocrtypecodec/v1"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/reader"
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/merklemulti"
+	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+	rmnpb "github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go/serialization"
 )
 
 func Test_maxQueryLength(t *testing.T) {
@@ -309,7 +305,7 @@ func TestPluginFactory_NewReportingPlugin(t *testing.T) {
 		b, err := json.Marshal(offChainConfig)
 		require.NoError(t, err)
 
-		cw := writer_mocks.NewMockContractWriter(t)
+		cw := writermocks.NewMockContractWriter(t)
 		chainSel := ccipocr3.ChainSelector(12922642891491394802)
 		mockAddrCodec := internal.NewMockAddressCodecHex(t)
 		p := &PluginFactory{
@@ -325,7 +321,7 @@ func TestPluginFactory_NewReportingPlugin(t *testing.T) {
 				},
 			},
 			extendedReaders: map[ccipocr3.ChainSelector]contractreader.Extended{
-				chainSel: reader_mocks.NewMockExtended(t),
+				chainSel: readermocks.NewMockExtended(t),
 			},
 			chainWriters: map[ccipocr3.ChainSelector]types.ContractWriter{chainSel: cw},
 			addrCodec:    mockAddrCodec,

--- a/commit/factory_test.go
+++ b/commit/factory_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	reader_mocks "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/contractreader"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
 	rmnpb "github.com/smartcontractkit/chainlink-protos/rmn/v1.6/go/serialization"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
@@ -322,8 +324,8 @@ func TestPluginFactory_NewReportingPlugin(t *testing.T) {
 					ChainSelector: chainSel,
 				},
 			},
-			contractReaders: map[ccipocr3.ChainSelector]types.ContractReader{
-				chainSel: types.UnimplementedContractReader{},
+			extendedReaders: map[ccipocr3.ChainSelector]contractreader.Extended{
+				chainSel: reader_mocks.NewMockExtended(t),
 			},
 			chainWriters: map[ccipocr3.ChainSelector]types.ContractWriter{chainSel: cw},
 			addrCodec:    mockAddrCodec,

--- a/execute/factory.go
+++ b/execute/factory.go
@@ -136,10 +136,6 @@ func (p PluginFactory) NewReportingPlugin(
 	readerFacades := make(map[cciptypes.ChainSelector]contractreader.ContractReaderFacade)
 	for chain, cr := range p.extendedReaders {
 		readerFacades[chain] = cr
-		lggr.Infow("OGT exec factory extendedReader memory address",
-			"cr address", fmt.Sprintf("%p", cr),
-			"readerFacades[chain] reader address", fmt.Sprintf("%p", cr),
-			"chain", chain)
 	}
 
 	ccipReader, err := readerpkg.NewCCIPChainReader(

--- a/execute/factory.go
+++ b/execute/factory.go
@@ -137,15 +137,8 @@ func (p PluginFactory) NewReportingPlugin(
 
 	// Validate that the readerFacades were already wrapped in the Extended interface from core.
 	readerFacades := make(map[cciptypes.ChainSelector]contractreader.ContractReaderFacade)
-	//extended := make(map[cciptypes.ChainSelector]contractreader.Extended)
 	for chain, cr := range p.extendedReaders {
-		//extendedCr, ok := cr.(contractreader.Extended)
-		//if !ok {
-		//	return nil, ocr3types.ReportingPluginInfo{},
-		//		fmt.Errorf("contract reader %T does not implement Extended interface for chain %d", cr, chain)
-		//}
 		readerFacades[chain] = cr
-		//extended[chain] = extendedCr
 	}
 
 	ccipReader, err := readerpkg.NewCCIPChainReader(

--- a/execute/factory.go
+++ b/execute/factory.go
@@ -75,7 +75,6 @@ type PluginFactory struct {
 	estimateProvider cciptypes.EstimateProvider
 	tokenDataEncoder cciptypes.TokenDataEncoder
 	chainAccessors   map[cciptypes.ChainSelector]cciptypes.ChainAccessor
-	contractReaders  map[cciptypes.ChainSelector]types.ContractReader
 	extendedReaders  map[cciptypes.ChainSelector]contractreader.Extended
 	chainWriters     map[cciptypes.ChainSelector]types.ContractWriter
 }
@@ -91,7 +90,6 @@ type PluginFactoryParams struct {
 	TokenDataEncoder cciptypes.TokenDataEncoder
 	ChainAccessors   map[cciptypes.ChainSelector]cciptypes.ChainAccessor
 	EstimateProvider cciptypes.EstimateProvider
-	ContractReaders  map[cciptypes.ChainSelector]types.ContractReader
 	ExtendedReaders  map[cciptypes.ChainSelector]contractreader.Extended
 	ContractWriters  map[cciptypes.ChainSelector]types.ContractWriter
 }
@@ -110,7 +108,6 @@ func NewExecutePluginFactory(params PluginFactoryParams) *PluginFactory {
 		estimateProvider: params.EstimateProvider,
 		tokenDataEncoder: params.TokenDataEncoder,
 		chainAccessors:   params.ChainAccessors,
-		contractReaders:  params.ContractReaders,
 		extendedReaders:  params.ExtendedReaders,
 		chainWriters:     params.ContractWriters,
 	}
@@ -139,6 +136,10 @@ func (p PluginFactory) NewReportingPlugin(
 	readerFacades := make(map[cciptypes.ChainSelector]contractreader.ContractReaderFacade)
 	for chain, cr := range p.extendedReaders {
 		readerFacades[chain] = cr
+		lggr.Infow("OGT exec factory extendedReader memory address",
+			"cr address", fmt.Sprintf("%p", cr),
+			"readerFacades[chain] reader address", fmt.Sprintf("%p", cr),
+			"chain", chain)
 	}
 
 	ccipReader, err := readerpkg.NewCCIPChainReader(

--- a/execute/factory.go
+++ b/execute/factory.go
@@ -158,6 +158,7 @@ func (p PluginFactory) NewReportingPlugin(
 	ccipReader, err := readerpkg.NewCCIPChainReader(
 		ctx,
 		logutil.WithComponent(lggr, "CCIPReader"),
+		p.chainAccessors,
 		readers,
 		p.chainWriters,
 		p.ocrConfig.Config.ChainSelector,

--- a/pkg/chainaccessor/default_accessor.go
+++ b/pkg/chainaccessor/default_accessor.go
@@ -3,6 +3,7 @@ package chainaccessor
 import (
 	"context"
 	"fmt"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -95,6 +96,7 @@ func (l *DefaultAccessor) Sync(
 	contractName string,
 	contractAddress cciptypes.UnknownAddress,
 ) error {
+	fmt.Println("default_accessor.go Sync(). Process ID: ", os.Getpid())
 	lggr := logutil.WithContextValues(ctx, l.lggr)
 	addressStr, err := l.addrCodec.AddressBytesToString(contractAddress, l.chainSelector)
 	if err != nil {

--- a/pkg/chainaccessor/default_accessor.go
+++ b/pkg/chainaccessor/default_accessor.go
@@ -95,10 +95,6 @@ func (l *DefaultAccessor) Sync(
 	contractName string,
 	contractAddress cciptypes.UnknownAddress,
 ) error {
-	l.lggr.Infow("OGT l.contractReader memory address",
-		"address", fmt.Sprintf("%p", l.contractReader),
-		"chainSelector", l.chainSelector)
-
 	lggr := logutil.WithContextValues(ctx, l.lggr)
 	addressStr, err := l.addrCodec.AddressBytesToString(contractAddress, l.chainSelector)
 	if err != nil {

--- a/pkg/chainaccessor/default_accessor.go
+++ b/pkg/chainaccessor/default_accessor.go
@@ -3,7 +3,6 @@ package chainaccessor
 import (
 	"context"
 	"fmt"
-	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -96,7 +95,10 @@ func (l *DefaultAccessor) Sync(
 	contractName string,
 	contractAddress cciptypes.UnknownAddress,
 ) error {
-	fmt.Println("default_accessor.go Sync(). Process ID: ", os.Getpid())
+	l.lggr.Infow("OGT l.contractReader memory address",
+		"address", fmt.Sprintf("%p", l.contractReader),
+		"chainSelector", l.chainSelector)
+
 	lggr := logutil.WithContextValues(ctx, l.lggr)
 	addressStr, err := l.addrCodec.AddressBytesToString(contractAddress, l.chainSelector)
 	if err != nil {

--- a/pkg/contractreader/extended.go
+++ b/pkg/contractreader/extended.go
@@ -255,16 +255,14 @@ func (e *extendedContractReader) Bind(ctx context.Context, allBindings []types.B
 		return nil
 	}
 
-	e.mu.Lock()
-	defer e.mu.Unlock()
-
 	fmt.Println("Bind() Binding contracts:", validBindings)
 	err := e.reader.Bind(ctx, validBindings)
-
 	if err != nil {
 		return fmt.Errorf("failed to call ContractReader.Bind: %w", err)
 	}
 
+	e.mu.Lock()
+	defer e.mu.Unlock()
 	for _, binding := range validBindings {
 		if e.multiBindAllowed[binding.Name] {
 			e.contractBindingsByName[binding.Name] = append(e.contractBindingsByName[binding.Name], ExtendedBoundContract{

--- a/pkg/contractreader/extended.go
+++ b/pkg/contractreader/extended.go
@@ -310,7 +310,8 @@ func (e *extendedContractReader) bindingExists(b types.BoundContract) bool {
 	for _, boundContracts := range e.contractBindingsByName {
 		for _, boundContract := range boundContracts {
 			fmt.Println("bindingExists() - Checking binding:", boundContract.Binding, "against", b)
-			if boundContract.Binding.String() == b.String() {
+			// Ignore case when comparing addresses
+			if strings.EqualFold(boundContract.Binding.String(), strings.ToLower(b.String())) {
 				return true
 			}
 		}

--- a/pkg/contractreader/extended.go
+++ b/pkg/contractreader/extended.go
@@ -304,7 +304,7 @@ func (e *extendedContractReader) bindingExists(b types.BoundContract) bool {
 	for _, boundContracts := range e.contractBindingsByName {
 		for _, boundContract := range boundContracts {
 			// Ignore case when comparing addresses
-			if strings.EqualFold(boundContract.Binding.String(), strings.ToLower(b.String())) {
+			if strings.EqualFold(boundContract.Binding.String(), b.String()) {
 				return true
 			}
 		}

--- a/pkg/contractreader/extended.go
+++ b/pkg/contractreader/extended.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -250,12 +251,15 @@ func (e *extendedContractReader) ExtendedBatchGetLatestValues(
 }
 
 func (e *extendedContractReader) Bind(ctx context.Context, allBindings []types.BoundContract) error {
+	extendedReaderMemoryAddress := fmt.Sprintf("%p", e)
+	fmt.Println("extended.go Bind(). Process ID: ", os.Getpid(), " Extended reader memory address: ", extendedReaderMemoryAddress)
 	validBindings := slicelib.Filter(allBindings, func(b types.BoundContract) bool { return !e.bindingExists(b) })
 	if len(validBindings) == 0 {
 		return nil
 	}
 
-	fmt.Println("Bind() Binding contracts:", validBindings)
+	fmt.Printf("extended.go Bind() with memory address: %s, pid: %d, valid bindings: %d\n\n",
+		extendedReaderMemoryAddress, os.Getpid(), len(validBindings))
 	err := e.reader.Bind(ctx, validBindings)
 	if err != nil {
 		return fmt.Errorf("failed to call ContractReader.Bind: %w", err)
@@ -307,7 +311,6 @@ func (e *extendedContractReader) bindingExists(b types.BoundContract) bool {
 
 	for _, boundContracts := range e.contractBindingsByName {
 		for _, boundContract := range boundContracts {
-			fmt.Println("bindingExists() - Checking binding:", boundContract.Binding, "against", b)
 			// Ignore case when comparing addresses
 			if strings.EqualFold(boundContract.Binding.String(), strings.ToLower(b.String())) {
 				return true

--- a/pkg/contractreader/extended.go
+++ b/pkg/contractreader/extended.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -251,15 +250,10 @@ func (e *extendedContractReader) ExtendedBatchGetLatestValues(
 }
 
 func (e *extendedContractReader) Bind(ctx context.Context, allBindings []types.BoundContract) error {
-	extendedReaderMemoryAddress := fmt.Sprintf("%p", e)
-	fmt.Println("extended.go Bind(). Process ID: ", os.Getpid(), " Extended reader memory address: ", extendedReaderMemoryAddress)
 	validBindings := slicelib.Filter(allBindings, func(b types.BoundContract) bool { return !e.bindingExists(b) })
 	if len(validBindings) == 0 {
 		return nil
 	}
-
-	fmt.Printf("extended.go Bind() with memory address: %s, pid: %d, valid bindings: %d\n\n",
-		extendedReaderMemoryAddress, os.Getpid(), len(validBindings))
 	err := e.reader.Bind(ctx, validBindings)
 	if err != nil {
 		return fmt.Errorf("failed to call ContractReader.Bind: %w", err)
@@ -275,8 +269,6 @@ func (e *extendedContractReader) Bind(ctx context.Context, allBindings []types.B
 			})
 		} else {
 			if len(e.contractBindingsByName[binding.Name]) > 0 {
-				fmt.Println("Bind() unbinding: ", e.contractBindingsByName[binding.Name][0].Binding)
-
 				// Unbind the previous binding
 				err := e.reader.Unbind(ctx, []types.BoundContract{e.contractBindingsByName[binding.Name][0].Binding})
 				if err != nil {

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"os"
 	"slices"
 	"sort"
 	"sync"
@@ -768,6 +769,7 @@ func (r *ccipChainReader) DiscoverContracts(ctx context.Context,
 // NOTE: You should ensure that Sync is called deterministically for every oracle in the DON to guarantee
 // a consistent shared addressbook state.
 func (r *ccipChainReader) Sync(ctx context.Context, contracts ContractAddresses) error {
+	fmt.Println("ccip.go Sync(). Process ID: ", os.Getpid())
 	addressBookEntries := make(addressbook.ContractAddresses)
 	for name, addrs := range contracts {
 		addressBookEntries[addressbook.ContractName(name)] = addrs
@@ -796,6 +798,7 @@ func (r *ccipChainReader) Sync(ctx context.Context, contracts ContractAddresses)
 	var errGroup errgroup.Group
 	for chainSelector, boundContract := range chainToContractBinding {
 		errGroup.Go(func() error {
+			fmt.Println("ccip.go Sync() go func. Process ID: ", os.Getpid())
 			// defense in depth: don't bind if the address is empty.
 			// callers should ensure this but we double check here.
 			if len(boundContract.address) == 0 {

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -158,6 +158,19 @@ func (r *ccipChainReader) WithExtendedContractReader(
 			r.lggr.Errorw("failed to insert or update contract", "err", err)
 			continue
 		}
+
+		chainAccessor, err := getChainAccessor(r.accessors, ch)
+		if err != nil {
+			r.lggr.Errorw("failed to get chain accessor", "chain", ch, "err", err)
+			continue
+		}
+		// Register the contract address in the chain accessor
+		err = chainAccessor.Sync(context.Background(), contractName, addressBytes)
+		if err != nil {
+			r.lggr.Errorw("failed to sync contract address in chain accessor",
+				"chain", ch, "contractName", contractName, "address", lastBinding.Binding.Address, "err", err)
+			continue
+		}
 	}
 
 	return r

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -158,19 +158,6 @@ func (r *ccipChainReader) WithExtendedContractReader(
 			r.lggr.Errorw("failed to insert or update contract", "err", err)
 			continue
 		}
-
-		chainAccessor, err := getChainAccessor(r.accessors, ch)
-		if err != nil {
-			r.lggr.Errorw("failed to get chain accessor", "chain", ch, "err", err)
-			continue
-		}
-		// Register the contract address in the chain accessor
-		err = chainAccessor.Sync(context.Background(), contractName, addressBytes)
-		if err != nil {
-			r.lggr.Errorw("failed to sync contract address in chain accessor",
-				"chain", ch, "contractName", contractName, "address", lastBinding.Binding.Address, "err", err)
-			continue
-		}
 	}
 
 	return r

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -82,17 +82,8 @@ func newCCIPChainReaderWithConfigPollerInternal(
 	configPoller ConfigPoller,
 ) (*ccipChainReader, error) {
 	var crs = make(map[cciptypes.ChainSelector]contractreader.Extended)
-	lggr.Infow("OGT CCIPReader constructor",
-		"len(chainAccessors)", len(chainAccessors),
-		"len(contractReaders)", len(contractReaders),
-		"len(contractWriters)", len(contractWriters))
-
 	for chainSelector, cr := range contractReaders {
 		crs[chainSelector] = contractreader.NewExtendedContractReader(cr)
-		lggr.Infow("OGT CCIPReader constructor crs[chainSelector] memory address",
-			"crs[chainSelector] address", fmt.Sprintf("%p", crs[chainSelector]),
-			"cr reader address", fmt.Sprintf("%p", cr),
-			"chainSelector", chainSelector)
 	}
 
 	offrampAddrStr, err := addrCodec.AddressBytesToString(offrampAddress, destChain)
@@ -1019,10 +1010,6 @@ func (r *ccipChainReader) fetchFreshSourceChainConfigs(
 			ReturnVal: new(cciptypes.SourceChainConfig),
 		})
 	}
-
-	r.lggr.Debugw("OGT ccip.go fetchFreshSourceChainConfigs dest chain contract reader memory address:",
-		"memory_address", fmt.Sprintf("%p", reader),
-		"destChain", destChain)
 
 	// Execute batch request
 	results, _, err := reader.ExtendedBatchGetLatestValues(

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -24,7 +24,6 @@ import (
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	"github.com/smartcontractkit/chainlink-ccip/pkg/addressbook"
-	"github.com/smartcontractkit/chainlink-ccip/pkg/chainaccessor"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/consts"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/logutil"
@@ -51,6 +50,7 @@ type ccipChainReader struct {
 func newCCIPChainReaderInternal(
 	ctx context.Context,
 	lggr logger.Logger,
+	chainAccessors map[cciptypes.ChainSelector]cciptypes.ChainAccessor,
 	contractReaders map[cciptypes.ChainSelector]contractreader.ContractReaderFacade,
 	contractWriters map[cciptypes.ChainSelector]types.ContractWriter,
 	destChain cciptypes.ChainSelector,
@@ -60,6 +60,7 @@ func newCCIPChainReaderInternal(
 	return newCCIPChainReaderWithConfigPollerInternal(
 		ctx,
 		lggr,
+		chainAccessors,
 		contractReaders,
 		contractWriters,
 		destChain,
@@ -72,6 +73,7 @@ func newCCIPChainReaderInternal(
 func newCCIPChainReaderWithConfigPollerInternal(
 	ctx context.Context,
 	lggr logger.Logger,
+	chainAccessors map[cciptypes.ChainSelector]cciptypes.ChainAccessor,
 	contractReaders map[cciptypes.ChainSelector]contractreader.ContractReaderFacade,
 	contractWriters map[cciptypes.ChainSelector]types.ContractWriter,
 	destChain cciptypes.ChainSelector,
@@ -84,19 +86,6 @@ func newCCIPChainReaderWithConfigPollerInternal(
 
 	for chainSelector, cr := range contractReaders {
 		crs[chainSelector] = contractreader.NewExtendedContractReader(cr)
-
-		// TODO: remove instantiation of the accessor once accessors are passed down from above
-		accessor, err := chainaccessor.NewDefaultAccessor(
-			lggr,
-			chainSelector,
-			crs[chainSelector],
-			contractWriters[chainSelector],
-			addrCodec,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create chain accessor for chain %s: %w", chainSelector, err)
-		}
-		cas[chainSelector] = accessor
 	}
 
 	offrampAddrStr, err := addrCodec.AddressBytesToString(offrampAddress, destChain)

--- a/pkg/reader/ccip_interface.go
+++ b/pkg/reader/ccip_interface.go
@@ -123,6 +123,7 @@ func (s StaticSourceChainConfig) check() (bool /* enabled */, error) {
 func NewCCIPChainReader(
 	ctx context.Context,
 	lggr logger.Logger,
+	chainAccessors map[cciptypes.ChainSelector]cciptypes.ChainAccessor,
 	contractReaders map[cciptypes.ChainSelector]contractreader.ContractReaderFacade,
 	contractWriters map[cciptypes.ChainSelector]types.ContractWriter,
 	destChain cciptypes.ChainSelector,
@@ -132,6 +133,7 @@ func NewCCIPChainReader(
 	reader, err := newCCIPChainReaderInternal(
 		ctx,
 		lggr,
+		chainAccessors,
 		contractReaders,
 		contractWriters,
 		destChain,

--- a/pkg/reader/ccip_test.go
+++ b/pkg/reader/ccip_test.go
@@ -17,11 +17,12 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
-	commonccipocr3 "github.com/smartcontractkit/chainlink-ccip/mocks/chainlink_common/ccipocr3"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
+
+	commonccipocr3 "github.com/smartcontractkit/chainlink-ccip/mocks/chainlink_common/ccipocr3"
 
 	"github.com/smartcontractkit/chainlink-ccip/internal"
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/slicelib"
@@ -89,7 +90,7 @@ func TestCCIPChainReader_getSourceChainsConfig(t *testing.T) {
 	mockAddrCodec := internal.NewMockAddressCodecHex(t)
 	offrampAddress := []byte{0x3}
 	chainAccessors := createMockedChainAccessors(t, chainA, chainB, chainC)
-	mockExpectChainAccessorSyncCall(chainAccessors[chainC], consts.ContractNameOffRamp, offrampAddress, 1, nil)
+	mockExpectChainAccessorSyncCall(chainAccessors[chainC], consts.ContractNameOffRamp, offrampAddress, nil)
 	ccipReader, err := newCCIPChainReaderInternal(
 		t.Context(),
 		logger.Test(t),
@@ -168,10 +169,14 @@ func TestCCIPChainReader_Sync_HappyPath_BindsContractsSuccessfully(t *testing.T)
 	contractWriters[sourceChain2] = cw
 
 	chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1, sourceChain2)
-	mockExpectChainAccessorSyncCall(chainAccessors[sourceChain1], consts.ContractNameOnRamp, s1Onramp, 1, nil)        // OnRamp sourceChain1
-	mockExpectChainAccessorSyncCall(chainAccessors[sourceChain2], consts.ContractNameOnRamp, s2Onramp, 1, nil)        // OnRamp sourceChain2
-	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRamp, 1, nil)           // OffRamp dest chain
-	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameNonceManager, destNonceMgr, 1, nil) // NonceManager dest chain
+	// OnRamp sourceChain1
+	mockExpectChainAccessorSyncCall(chainAccessors[sourceChain1], consts.ContractNameOnRamp, s1Onramp, nil)
+	// OnRamp sourceChain2
+	mockExpectChainAccessorSyncCall(chainAccessors[sourceChain2], consts.ContractNameOnRamp, s2Onramp, nil)
+	// OffRamp dest chain
+	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRamp, nil)
+	// NonceManager dest chain
+	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameNonceManager, destNonceMgr, nil)
 	ccipReader, err := newCCIPChainReaderInternal(
 		ctx,
 		logger.Test(t),
@@ -228,10 +233,10 @@ func TestCCIPChainReader_Sync_HappyPath_SkipsEmptyAddress(t *testing.T) {
 
 	chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1)
 	// Sync() on OnRamp sourceChain1
-	mockExpectChainAccessorSyncCall(chainAccessors[sourceChain1], consts.ContractNameOnRamp, s1Onramp, 1, nil)
+	mockExpectChainAccessorSyncCall(chainAccessors[sourceChain1], consts.ContractNameOnRamp, s1Onramp, nil)
 	// Sync() OffRamp (from constructor) and NonceManager (from this test)
-	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRamp, 1, nil)
-	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameNonceManager, destNonceMgr, 1, nil)
+	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRamp, nil)
+	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameNonceManager, destNonceMgr, nil)
 	ccipReader, err := newCCIPChainReaderInternal(
 		ctx,
 		logger.Test(t),
@@ -285,10 +290,10 @@ func TestCCIPChainReader_Sync_HappyPath_DontSupportAllChains(t *testing.T) {
 
 	chainAccessors := createMockedChainAccessors(t, destChain, sourceChain2)
 	// OnRamp sourceChain2
-	mockExpectChainAccessorSyncCall(chainAccessors[sourceChain2], consts.ContractNameOnRamp, s2Onramp, 1, nil)
+	mockExpectChainAccessorSyncCall(chainAccessors[sourceChain2], consts.ContractNameOnRamp, s2Onramp, nil)
 	// OffRamp (during init) and NonceManager (from test)
-	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRamp, 1, nil)
-	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameNonceManager, destNonceMgr, 1, nil)
+	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRamp, nil)
+	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameNonceManager, destNonceMgr, nil)
 	ccipReader, err := newCCIPChainReaderInternal(
 		ctx,
 		logger.Test(t),
@@ -344,11 +349,11 @@ func TestCCIPChainReader_Sync_BindError(t *testing.T) {
 
 	chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1, sourceChain2)
 	// sourceChain1 accessor will fail with an error
-	mockExpectChainAccessorSyncCall(chainAccessors[sourceChain1], consts.ContractNameOnRamp, s1Onramp, 1, expectedErr)
-	mockExpectChainAccessorSyncCall(chainAccessors[sourceChain2], consts.ContractNameOnRamp, s2Onramp, 1, nil)
+	mockExpectChainAccessorSyncCall(chainAccessors[sourceChain1], consts.ContractNameOnRamp, s1Onramp, expectedErr)
+	mockExpectChainAccessorSyncCall(chainAccessors[sourceChain2], consts.ContractNameOnRamp, s2Onramp, nil)
 	// OffRamp (during init) + NonceManager (from test)
-	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRamp, 1, nil)
-	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameNonceManager, destNonceMgr, 1, nil)
+	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRamp, nil)
+	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameNonceManager, destNonceMgr, nil)
 	ccipReader, err := newCCIPChainReaderInternal(
 		ctx,
 		logger.Test(t),
@@ -770,7 +775,7 @@ func TestCCIPChainReader_getFeeQuoterTokenPriceUSD(t *testing.T) {
 	contractWriters[chainC] = cw
 
 	chainAccessors := createMockedChainAccessors(t, chainA, chainB, chainC)
-	mockExpectChainAccessorSyncCall(chainAccessors[chainC], consts.ContractNameOffRamp, offrampAddress, 1, nil)
+	mockExpectChainAccessorSyncCall(chainAccessors[chainC], consts.ContractNameOffRamp, offrampAddress, nil)
 	ccipReader, err := newCCIPChainReaderInternal(
 		t.Context(),
 		logger.Test(t),
@@ -820,7 +825,7 @@ func TestCCIPFeeComponents_HappyPath(t *testing.T) {
 
 	offRampAddress := []byte{0x3}
 	chainAccessors := createMockedChainAccessors(t, chainA, chainB, chainC)
-	mockExpectChainAccessorSyncCall(chainAccessors[chainC], consts.ContractNameOffRamp, offRampAddress, 1, nil)
+	mockExpectChainAccessorSyncCall(chainAccessors[chainC], consts.ContractNameOffRamp, offRampAddress, nil)
 	mockExpectChainAccessorGetChainFeeComponentsCall(chainAccessors[chainA], expectedFeeComponents, nil)
 	mockExpectChainAccessorGetChainFeeComponentsCall(chainAccessors[chainB], expectedFeeComponents, nil)
 	mockExpectChainAccessorGetChainFeeComponentsCall(chainAccessors[chainC], expectedFeeComponents, nil)
@@ -1167,7 +1172,7 @@ func TestCCIPChainReader_Nonces(t *testing.T) {
 			contractWriters[chainB] = cw
 			chainAccessors := createMockedChainAccessors(t, chainB)
 			offRampAddress := []byte{0x3}
-			mockExpectChainAccessorSyncCall(chainAccessors[chainB], consts.ContractNameOffRamp, offRampAddress, 1, nil)
+			mockExpectChainAccessorSyncCall(chainAccessors[chainB], consts.ContractNameOffRamp, offRampAddress, nil)
 			mockExpectChainAccessorNoncesCall(chainAccessors[chainB], tc.expectedNonces)
 			ccipReader, err := newCCIPChainReaderInternal(
 				t.Context(),
@@ -1376,7 +1381,7 @@ func TestCCIPChainReader_GetWrappedNativeTokenPriceUSD(t *testing.T) {
 
 		offRampAddress := []byte{0x3}
 		chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1, sourceChain2)
-		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, 1, nil)
+		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, nil)
 		mockExpectChainAccessorGetTokenPriceUSD(
 			chainAccessors[sourceChain1],
 			cciptypes.UnknownAddress(wrappedNative1),
@@ -1428,8 +1433,12 @@ func TestCCIPChainReader_GetWrappedNativeTokenPriceUSD(t *testing.T) {
 
 		offRampAddress := []byte{0x3}
 		chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1, sourceChain2)
-		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, 1, nil)
-		mockExpectChainAccessorGetTokenPriceUSD(chainAccessors[sourceChain2], cciptypes.UnknownAddress(wrappedNative2), cciptypes.TimestampedUnixBig{Value: big.NewInt(200), Timestamp: uint32(time.Now().Unix())})
+		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, nil)
+		mockExpectChainAccessorGetTokenPriceUSD(
+			chainAccessors[sourceChain2],
+			cciptypes.UnknownAddress(wrappedNative2),
+			cciptypes.TimestampedUnixBig{Value: big.NewInt(200), Timestamp: uint32(time.Now().Unix())},
+		)
 		ccipReader, err := newCCIPChainReaderWithConfigPollerInternal(
 			t.Context(),
 			logger.Test(t),
@@ -1469,7 +1478,7 @@ func TestCCIPChainReader_GetWrappedNativeTokenPriceUSD(t *testing.T) {
 
 		offRampAddress := []byte{0x3}
 		chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1, sourceChain2)
-		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, 1, nil)
+		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, nil)
 		chainAccessors[sourceChain1].(*commonccipocr3.MockChainAccessor).EXPECT().
 			GetTokenPriceUSD(mock.Anything, cciptypes.UnknownAddress(wrappedNative1)).
 			Return(cciptypes.TimestampedUnixBig{}, fmt.Errorf("price fetch failed"))
@@ -1591,7 +1600,7 @@ func TestCCIPChainReader_GetChainFeePriceUpdate(t *testing.T) {
 		contractWriters[chainB] = cw
 		offRampAddress := []byte{0x3}
 		chainAccessors := createMockedChainAccessors(t, destChain, chainB, sourceChain1, sourceChain2)
-		mockExpectChainAccessorSyncCall(chainAccessors[chainB], consts.ContractNameOffRamp, offRampAddress, 1, nil)
+		mockExpectChainAccessorSyncCall(chainAccessors[chainB], consts.ContractNameOffRamp, offRampAddress, nil)
 		expectedResult := map[cciptypes.ChainSelector]cciptypes.TimestampedUnixBig{
 			sourceChain1: {Value: big.NewInt(100), Timestamp: uint32(time.Now().Unix())},
 			sourceChain2: {Value: big.NewInt(200), Timestamp: uint32(time.Now().Unix())},
@@ -1649,7 +1658,7 @@ func TestCCIPChainReader_GetChainFeePriceUpdate(t *testing.T) {
 		contractWriters[destChain] = cw
 		offRampAddress := []byte{0x3}
 		chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1)
-		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, 1, nil)
+		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, nil)
 		chainAccessors[destChain].(*commonccipocr3.MockChainAccessor).EXPECT().
 			GetChainFeePriceUpdate(mock.Anything, selectors).
 			Return(map[cciptypes.ChainSelector]cciptypes.TimestampedBig{})
@@ -1682,7 +1691,7 @@ func TestCCIPChainReader_GetChainFeePriceUpdate(t *testing.T) {
 		contractWriters[destChain] = cw
 		offRampAddress := []byte{0x3}
 		chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1, sourceChain3)
-		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, 1, nil)
+		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, nil)
 		expectedResult := map[cciptypes.ChainSelector]cciptypes.TimestampedUnixBig{
 			sourceChain1: {Value: big.NewInt(100), Timestamp: uint32(time.Now().Unix())},
 			sourceChain3: {Value: big.NewInt(0), Timestamp: uint32(time.Now().Unix())},
@@ -1714,45 +1723,6 @@ func TestCCIPChainReader_GetChainFeePriceUpdate(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("partial success - one result error", func(t *testing.T) {
-		selectors := []cciptypes.ChainSelector{sourceChain1, sourceChain3}
-
-		cw := writer_mocks.NewMockContractWriter(t)
-		contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
-		contractWriters[destChain] = cw
-		offRampAddress := []byte{0x3}
-		chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1, sourceChain3)
-		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, 1, nil)
-		expectedResult := map[cciptypes.ChainSelector]cciptypes.TimestampedUnixBig{
-			sourceChain1: {Value: big.NewInt(100), Timestamp: uint32(time.Now().Unix())},
-		}
-		mockExpectChainAccessorGetChainFeePriceUpdate(chainAccessors[destChain], selectors, expectedResult)
-		ccipReader, err := newCCIPChainReaderInternal(
-			t.Context(),
-			logger.Test(t),
-			chainAccessors,
-			map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
-				destChain: reader_mocks.NewMockContractReaderFacade(t),
-			},
-			contractWriters,
-			destChain,
-			offRampAddress,
-			internal.NewMockAddressCodecHex(t),
-		)
-		require.NoError(t, err)
-
-		feeUpdates := ccipReader.GetChainFeePriceUpdate(ctx, selectors)
-
-		require.Len(t, feeUpdates, 1)
-		require.Contains(t, feeUpdates, sourceChain1)
-		assert.NotNil(t, feeUpdates[sourceChain1].Value)
-		assert.Equal(t, 0, feeUpdates[sourceChain1].Value.Cmp(big.NewInt(100)))
-		assert.NotContains(t, feeUpdates, sourceChain3)
-
-		err = ccipReader.Close()
-		require.NoError(t, err)
-	})
-
 	t.Run("result count mismatch", func(t *testing.T) {
 		// Request two selectors, but mock response only has one result
 		selectors := []cciptypes.ChainSelector{sourceChain1, sourceChain2}
@@ -1762,7 +1732,7 @@ func TestCCIPChainReader_GetChainFeePriceUpdate(t *testing.T) {
 		contractWriters[destChain] = cw
 		offRampAddress := []byte{0x3}
 		chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1, sourceChain2)
-		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, 1, nil)
+		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, nil)
 		expectedResult := map[cciptypes.ChainSelector]cciptypes.TimestampedUnixBig{
 			sourceChain1: {Value: big.NewInt(100), Timestamp: uint32(time.Now().Unix())},
 		}
@@ -1802,8 +1772,12 @@ func TestCCIPChainReader_GetChainFeePriceUpdate(t *testing.T) {
 		contractWriters[destChain] = cw
 		offRampAddress := []byte{0x3}
 		chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1)
-		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, 1, nil)
-		mockExpectChainAccessorGetChainFeePriceUpdate(chainAccessors[destChain], selectors, map[cciptypes.ChainSelector]cciptypes.TimestampedUnixBig{})
+		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, nil)
+		mockExpectChainAccessorGetChainFeePriceUpdate(
+			chainAccessors[destChain],
+			selectors,
+			map[cciptypes.ChainSelector]cciptypes.TimestampedUnixBig{},
+		)
 		ccipReader, err := newCCIPChainReaderInternal(
 			t.Context(),
 			logger.Test(t),
@@ -1863,28 +1837,44 @@ func mockExpectChainAccessorSyncCall(
 	chainAccessor cciptypes.ChainAccessor,
 	expectedContractName string,
 	expectedContractAddress []byte,
-	expectedCalls int, err error,
+	err error,
 ) {
 	chainAccessor.(*commonccipocr3.MockChainAccessor).EXPECT().
-		Sync(mock.Anything, expectedContractName, cciptypes.UnknownAddress(expectedContractAddress)).Times(expectedCalls).Return(err)
+		Sync(mock.Anything, expectedContractName, cciptypes.UnknownAddress(expectedContractAddress)).
+		Once().Return(err)
 }
 
-func mockExpectChainAccessorNoncesCall(chainAccessor cciptypes.ChainAccessor, expectedResult map[cciptypes.ChainSelector]map[string]uint64) {
+func mockExpectChainAccessorNoncesCall(
+	chainAccessor cciptypes.ChainAccessor,
+	expectedResult map[cciptypes.ChainSelector]map[string]uint64,
+) {
 	chainAccessor.(*commonccipocr3.MockChainAccessor).EXPECT().
 		Nonces(mock.Anything, mock.Anything).Return(expectedResult, nil)
 }
 
-func mockExpectChainAccessorGetTokenPriceUSD(chainAccessor cciptypes.ChainAccessor, token cciptypes.UnknownAddress, price cciptypes.TimestampedUnixBig) {
+func mockExpectChainAccessorGetTokenPriceUSD(
+	chainAccessor cciptypes.ChainAccessor,
+	token cciptypes.UnknownAddress,
+	price cciptypes.TimestampedUnixBig,
+) {
 	chainAccessor.(*commonccipocr3.MockChainAccessor).EXPECT().
 		GetTokenPriceUSD(mock.Anything, token).Return(price, nil)
 }
 
-func mockExpectChainAccessorGetChainFeeComponentsCall(chainAccessor cciptypes.ChainAccessor, feeComponents cciptypes.ChainFeeComponents, err error) {
+func mockExpectChainAccessorGetChainFeeComponentsCall(
+	chainAccessor cciptypes.ChainAccessor,
+	feeComponents cciptypes.ChainFeeComponents,
+	err error,
+) {
 	chainAccessor.(*commonccipocr3.MockChainAccessor).EXPECT().
 		GetChainFeeComponents(mock.Anything).Return(feeComponents, err)
 }
 
-func mockExpectChainAccessorGetChainFeePriceUpdate(chainAccessor cciptypes.ChainAccessor, selectors []cciptypes.ChainSelector, expectedResult map[cciptypes.ChainSelector]cciptypes.TimestampedUnixBig) {
+func mockExpectChainAccessorGetChainFeePriceUpdate(
+	chainAccessor cciptypes.ChainAccessor,
+	selectors []cciptypes.ChainSelector,
+	expectedResult map[cciptypes.ChainSelector]cciptypes.TimestampedUnixBig,
+) {
 	// Convert TimestampedUnixBig to TimestampedBig
 	convertedResult := make(map[cciptypes.ChainSelector]cciptypes.TimestampedBig)
 	for k, v := range expectedResult {

--- a/pkg/reader/ccip_test.go
+++ b/pkg/reader/ccip_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	commonccipocr3 "github.com/smartcontractkit/chainlink-ccip/mocks/chainlink_common/ccipocr3"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
@@ -87,9 +88,12 @@ func TestCCIPChainReader_getSourceChainsConfig(t *testing.T) {
 
 	mockAddrCodec := internal.NewMockAddressCodecHex(t)
 	offrampAddress := []byte{0x3}
+	chainAccessors := createMockedChainAccessors(t, chainA, chainB, chainC)
+	mockExpectChainAccessorSyncCall(chainAccessors[chainC], consts.ContractNameOffRamp, offrampAddress, 1, nil)
 	ccipReader, err := newCCIPChainReaderInternal(
 		t.Context(),
 		logger.Test(t),
+		chainAccessors,
 		map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
 			chainA: sourceCRs[chainA],
 			chainB: sourceCRs[chainB],
@@ -153,47 +157,9 @@ func TestCCIPChainReader_Sync_HappyPath_BindsContractsSuccessfully(t *testing.T)
 	offRamp := []byte{0x4}
 
 	mockAddrCodec := internal.NewMockAddressCodecHex(t)
-	destNonceMgrAddrStr, err := mockAddrCodec.AddressBytesToString(destNonceMgr, destChain)
-	require.NoError(t, err)
-	offRampAddrStr, err := mockAddrCodec.AddressBytesToString(offRamp, destChain)
-	require.NoError(t, err)
 	destExtended := reader_mocks.NewMockExtended(t)
-	destExtended.EXPECT().Bind(mock.Anything, []types.BoundContract{
-		{
-			Name:    consts.ContractNameOffRamp,
-			Address: offRampAddrStr,
-		},
-	}).Return(nil)
-	destExtended.EXPECT().Bind(mock.Anything, []types.BoundContract{
-		{
-			Name:    consts.ContractNameNonceManager,
-			Address: destNonceMgrAddrStr,
-		},
-	}).Return(nil)
-
-	s1OnrampAddrStr, err := mockAddrCodec.AddressBytesToString(s1Onramp, sourceChain1)
-	require.NoError(t, err)
 	source1Extended := reader_mocks.NewMockExtended(t)
-	source1Extended.EXPECT().Bind(mock.Anything, []types.BoundContract{
-		{
-			Name:    consts.ContractNameOnRamp,
-			Address: s1OnrampAddrStr,
-		},
-	}).Return(nil)
-
-	sourceChain2AddrStr, err := mockAddrCodec.AddressBytesToString(s2Onramp, sourceChain2)
-	require.NoError(t, err)
 	source2Extended := reader_mocks.NewMockExtended(t)
-	source2Extended.EXPECT().Bind(mock.Anything, []types.BoundContract{
-		{
-			Name:    consts.ContractNameOnRamp,
-			Address: sourceChain2AddrStr,
-		},
-	}).Return(nil)
-
-	defer destExtended.AssertExpectations(t)
-	defer source1Extended.AssertExpectations(t)
-	defer source2Extended.AssertExpectations(t)
 
 	cw := writer_mocks.NewMockContractWriter(t)
 	contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
@@ -201,9 +167,15 @@ func TestCCIPChainReader_Sync_HappyPath_BindsContractsSuccessfully(t *testing.T)
 	contractWriters[sourceChain1] = cw
 	contractWriters[sourceChain2] = cw
 
+	chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1, sourceChain2)
+	mockExpectChainAccessorSyncCall(chainAccessors[sourceChain1], consts.ContractNameOnRamp, s1Onramp, 1, nil)        // OnRamp sourceChain1
+	mockExpectChainAccessorSyncCall(chainAccessors[sourceChain2], consts.ContractNameOnRamp, s2Onramp, 1, nil)        // OnRamp sourceChain2
+	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRamp, 1, nil)           // OffRamp dest chain
+	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameNonceManager, destNonceMgr, 1, nil) // NonceManager dest chain
 	ccipReader, err := newCCIPChainReaderInternal(
 		ctx,
 		logger.Test(t),
+		chainAccessors,
 		map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
 			destChain:    destExtended,
 			sourceChain1: source1Extended,
@@ -240,45 +212,13 @@ func TestCCIPChainReader_Sync_HappyPath_SkipsEmptyAddress(t *testing.T) {
 	s1Onramp := []byte{0x1}
 	offRamp := []byte{0x4}
 
-	// empty address, should get skipped
 	s2Onramp := []byte{}
 
 	destNonceMgr := []byte{0x3}
-	destExtended := reader_mocks.NewMockExtended(t)
 	mockAddrCodec := internal.NewMockAddressCodecHex(t)
-	destNonceMgrAddrStr, err := mockAddrCodec.AddressBytesToString(destNonceMgr, destChain)
-	require.NoError(t, err)
-	offRampAddrStr, err := mockAddrCodec.AddressBytesToString(offRamp, destChain)
-	require.NoError(t, err)
-	destExtended.EXPECT().Bind(mock.Anything, []types.BoundContract{
-		{
-			Name:    consts.ContractNameOffRamp,
-			Address: offRampAddrStr,
-		},
-	}).Return(nil)
-	destExtended.EXPECT().Bind(mock.Anything, []types.BoundContract{
-		{
-			Name:    consts.ContractNameNonceManager,
-			Address: destNonceMgrAddrStr,
-		},
-	}).Return(nil)
-
-	sourceChain1AddrStr, err := mockAddrCodec.AddressBytesToString(s1Onramp, sourceChain1)
-	require.NoError(t, err)
+	destExtended := reader_mocks.NewMockExtended(t)
 	source1Extended := reader_mocks.NewMockExtended(t)
-	source1Extended.EXPECT().Bind(mock.Anything, []types.BoundContract{
-		{
-			Name:    consts.ContractNameOnRamp,
-			Address: sourceChain1AddrStr,
-		},
-	}).Return(nil)
-
-	// bind should not be called on this one.
 	source2Extended := reader_mocks.NewMockExtended(t)
-
-	defer destExtended.AssertExpectations(t)
-	defer source1Extended.AssertExpectations(t)
-	defer source2Extended.AssertExpectations(t)
 
 	cw := writer_mocks.NewMockContractWriter(t)
 	contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
@@ -286,9 +226,16 @@ func TestCCIPChainReader_Sync_HappyPath_SkipsEmptyAddress(t *testing.T) {
 	contractWriters[sourceChain1] = cw
 	contractWriters[sourceChain2] = cw
 
+	chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1)
+	// Sync() on OnRamp sourceChain1
+	mockExpectChainAccessorSyncCall(chainAccessors[sourceChain1], consts.ContractNameOnRamp, s1Onramp, 1, nil)
+	// Sync() OffRamp (from constructor) and NonceManager (from this test)
+	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRamp, 1, nil)
+	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameNonceManager, destNonceMgr, 1, nil)
 	ccipReader, err := newCCIPChainReaderInternal(
 		ctx,
 		logger.Test(t),
+		chainAccessors,
 		map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
 			destChain:    destExtended,
 			sourceChain1: source1Extended,
@@ -326,48 +273,26 @@ func TestCCIPChainReader_Sync_HappyPath_DontSupportAllChains(t *testing.T) {
 	s2Onramp := []byte{0x2}
 	destNonceMgr := []byte{0x3}
 	offRamp := []byte{0x4}
-	destExtended := reader_mocks.NewMockExtended(t)
 	mockAddrCodec := internal.NewMockAddressCodecHex(t)
-
-	destNonceMgrAddrStr, err := mockAddrCodec.AddressBytesToString(destNonceMgr, destChain)
-	require.NoError(t, err)
-	offRampAddrStr, err := mockAddrCodec.AddressBytesToString(offRamp, destChain)
-	require.NoError(t, err)
-	destExtended.EXPECT().Bind(mock.Anything, []types.BoundContract{
-		{
-			Name:    consts.ContractNameOffRamp,
-			Address: offRampAddrStr,
-		},
-	}).Return(nil)
-	destExtended.EXPECT().Bind(mock.Anything, []types.BoundContract{
-		{
-			Name:    consts.ContractNameNonceManager,
-			Address: destNonceMgrAddrStr,
-		},
-	}).Return(nil)
-
+	destExtended := reader_mocks.NewMockExtended(t)
 	// only support source2, source1 unsupported.
-	sourceChain2AddrStr, err := mockAddrCodec.AddressBytesToString(s2Onramp, sourceChain2)
-	require.NoError(t, err)
 	source2Extended := reader_mocks.NewMockExtended(t)
-	source2Extended.EXPECT().Bind(mock.Anything, []types.BoundContract{
-		{
-			Name:    consts.ContractNameOnRamp,
-			Address: sourceChain2AddrStr,
-		},
-	}).Return(nil)
-
-	defer destExtended.AssertExpectations(t)
-	defer source2Extended.AssertExpectations(t)
 
 	cw := writer_mocks.NewMockContractWriter(t)
 	contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
 	contractWriters[destChain] = cw
 	contractWriters[sourceChain2] = cw
 
+	chainAccessors := createMockedChainAccessors(t, destChain, sourceChain2)
+	// OnRamp sourceChain2
+	mockExpectChainAccessorSyncCall(chainAccessors[sourceChain2], consts.ContractNameOnRamp, s2Onramp, 1, nil)
+	// OffRamp (during init) and NonceManager (from test)
+	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRamp, 1, nil)
+	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameNonceManager, destNonceMgr, 1, nil)
 	ccipReader, err := newCCIPChainReaderInternal(
 		ctx,
 		logger.Test(t),
+		chainAccessors,
 		map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
 			destChain:    destExtended,
 			sourceChain2: source2Extended,
@@ -405,49 +330,11 @@ func TestCCIPChainReader_Sync_BindError(t *testing.T) {
 	destNonceMgr := []byte{0x3}
 	offRamp := []byte{0x4}
 
-	mockAddrCodec := internal.NewMockAddressCodecHex(t)
-	destNonceMgrAddrStr, err := mockAddrCodec.AddressBytesToString(destNonceMgr, destChain)
-	require.NoError(t, err)
-	offRampAddrStr, err := mockAddrCodec.AddressBytesToString(offRamp, destChain)
-	require.NoError(t, err)
-	destExtended := reader_mocks.NewMockExtended(t)
-	destExtended.EXPECT().Bind(mock.Anything, []types.BoundContract{
-		{
-			Name:    consts.ContractNameOffRamp,
-			Address: offRampAddrStr,
-		},
-	}).Return(nil)
-	destExtended.EXPECT().Bind(mock.Anything, []types.BoundContract{
-		{
-			Name:    consts.ContractNameNonceManager,
-			Address: destNonceMgrAddrStr,
-		},
-	}).Return(nil)
-
-	s1OnrampAddrStr, err := mockAddrCodec.AddressBytesToString(s1Onramp, sourceChain1)
-	require.NoError(t, err)
 	expectedErr := errors.New("some error")
+	mockAddrCodec := internal.NewMockAddressCodecHex(t)
+	destExtended := reader_mocks.NewMockExtended(t)
 	source1Extended := reader_mocks.NewMockExtended(t)
-	source1Extended.EXPECT().Bind(mock.Anything, []types.BoundContract{
-		{
-			Name:    consts.ContractNameOnRamp,
-			Address: s1OnrampAddrStr,
-		},
-	}).Return(expectedErr)
-
-	s2OnrampAddrStr, err := mockAddrCodec.AddressBytesToString(s2Onramp, sourceChain2)
-	require.NoError(t, err)
 	source2Extended := reader_mocks.NewMockExtended(t)
-	source2Extended.EXPECT().Bind(mock.Anything, []types.BoundContract{
-		{
-			Name:    consts.ContractNameOnRamp,
-			Address: s2OnrampAddrStr,
-		},
-	}).Return(nil)
-
-	defer destExtended.AssertExpectations(t)
-	defer source1Extended.AssertExpectations(t)
-	defer source2Extended.AssertExpectations(t)
 
 	cw := writer_mocks.NewMockContractWriter(t)
 	contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
@@ -455,9 +342,17 @@ func TestCCIPChainReader_Sync_BindError(t *testing.T) {
 	contractWriters[sourceChain1] = cw
 	contractWriters[sourceChain2] = cw
 
+	chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1, sourceChain2)
+	// sourceChain1 accessor will fail with an error
+	mockExpectChainAccessorSyncCall(chainAccessors[sourceChain1], consts.ContractNameOnRamp, s1Onramp, 1, expectedErr)
+	mockExpectChainAccessorSyncCall(chainAccessors[sourceChain2], consts.ContractNameOnRamp, s2Onramp, 1, nil)
+	// OffRamp (during init) + NonceManager (from test)
+	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRamp, 1, nil)
+	mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameNonceManager, destNonceMgr, 1, nil)
 	ccipReader, err := newCCIPChainReaderInternal(
 		ctx,
 		logger.Test(t),
+		chainAccessors,
 		map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
 			destChain:    destExtended,
 			sourceChain1: source1Extended,
@@ -874,9 +769,12 @@ func TestCCIPChainReader_getFeeQuoterTokenPriceUSD(t *testing.T) {
 	contractWriters[chainB] = cw
 	contractWriters[chainC] = cw
 
+	chainAccessors := createMockedChainAccessors(t, chainA, chainB, chainC)
+	mockExpectChainAccessorSyncCall(chainAccessors[chainC], consts.ContractNameOffRamp, offrampAddress, 1, nil)
 	ccipReader, err := newCCIPChainReaderInternal(
 		t.Context(),
 		logger.Test(t),
+		chainAccessors,
 		map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
 			chainC: destCR,
 		}, contractWriters, chainC, offrampAddress, mockAddrCodec,
@@ -905,13 +803,6 @@ func TestCCIPChainReader_getFeeQuoterTokenPriceUSD(t *testing.T) {
 
 func TestCCIPFeeComponents_HappyPath(t *testing.T) {
 	cw := writer_mocks.NewMockContractWriter(t)
-	cw.EXPECT().GetFeeComponents(mock.Anything).Return(
-		&types.ChainFeeComponents{
-			ExecutionFee:        big.NewInt(1),
-			DataAvailabilityFee: big.NewInt(2),
-		}, nil,
-	)
-
 	contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
 	contractWriters[chainA] = cw
 	contractWriters[chainB] = cw
@@ -922,12 +813,21 @@ func TestCCIPFeeComponents_HappyPath(t *testing.T) {
 		sourceCRs[chain] = reader_mocks.NewMockContractReaderFacade(t)
 	}
 
-	destChain := chainC
-	sourceCRs[destChain].EXPECT().Bind(mock.Anything, mock.Anything).Return(nil)
+	expectedFeeComponents := cciptypes.ChainFeeComponents{
+		ExecutionFee:        big.NewInt(1),
+		DataAvailabilityFee: big.NewInt(2),
+	}
 
+	offRampAddress := []byte{0x3}
+	chainAccessors := createMockedChainAccessors(t, chainA, chainB, chainC)
+	mockExpectChainAccessorSyncCall(chainAccessors[chainC], consts.ContractNameOffRamp, offRampAddress, 1, nil)
+	mockExpectChainAccessorGetChainFeeComponentsCall(chainAccessors[chainA], expectedFeeComponents, nil)
+	mockExpectChainAccessorGetChainFeeComponentsCall(chainAccessors[chainB], expectedFeeComponents, nil)
+	mockExpectChainAccessorGetChainFeeComponentsCall(chainAccessors[chainC], expectedFeeComponents, nil)
 	ccipReader, err := newCCIPChainReaderInternal(
 		t.Context(),
 		logger.Test(t),
+		chainAccessors,
 		map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
 			chainA: sourceCRs[chainA],
 			chainB: sourceCRs[chainB],
@@ -935,7 +835,7 @@ func TestCCIPFeeComponents_HappyPath(t *testing.T) {
 		},
 		contractWriters,
 		chainC,
-		[]byte{0x3},
+		offRampAddress,
 		internal.NewMockAddressCodecHex(t),
 	)
 	require.NoError(t, err)
@@ -1148,15 +1048,14 @@ func TestCCIPChainReader_Nonces(t *testing.T) {
 	}
 
 	var (
-		addr1            = "0x1234567890123456789012345678901234567890"
-		addr2            = "0x2234567890123456789012345678901234567890"
-		addr3            = "0x3234567890123456789012345678901234567890"
-		addr4            = "0x4234567890123456789012345678901234567890"
-		nonceManagerAddr = "0x5234567890123456789012345678901234567890"
-		nonce1           = uint64(5)
-		nonce2           = uint64(10)
-		nonce3           = uint64(15)
-		nonce4           = uint64(20)
+		addr1  = "0x1234567890123456789012345678901234567890"
+		addr2  = "0x2234567890123456789012345678901234567890"
+		addr3  = "0x3234567890123456789012345678901234567890"
+		addr4  = "0x4234567890123456789012345678901234567890"
+		nonce1 = uint64(5)
+		nonce2 = uint64(10)
+		nonce3 = uint64(15)
+		nonce4 = uint64(20)
 	)
 	testCases := []testCase{
 		{
@@ -1262,40 +1161,24 @@ func TestCCIPChainReader_Nonces(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			destReader := reader_mocks.NewMockExtended(t)
-
-			results := make([]types.BatchReadResult, 0, len(tc.mockResults))
-			for _, res := range tc.mockResults {
-				r := &types.BatchReadResult{ReadName: consts.MethodNameGetInboundNonce}
-				r.SetResult(res, nil)
-				results = append(results, *r)
-			}
-			responses := types.BatchGetLatestValuesResult{
-				types.BoundContract{
-					Name:    consts.ContractNameNonceManager,
-					Address: nonceManagerAddr,
-				}: results,
-			}
-
-			destReader.EXPECT().ExtendedBatchGetLatestValues(
-				mock.Anything,
-				mock.MatchedBy(tc.matchedBy),
-				false,
-			).Return(responses, []string{}, nil)
-			destReader.EXPECT().Bind(mock.Anything, mock.Anything).Return(nil)
-
+			destReader := reader_mocks.NewMockContractReaderFacade(t)
 			cw := writer_mocks.NewMockContractWriter(t)
 			contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
 			contractWriters[chainB] = cw
+			chainAccessors := createMockedChainAccessors(t, chainB)
+			offRampAddress := []byte{0x3}
+			mockExpectChainAccessorSyncCall(chainAccessors[chainB], consts.ContractNameOffRamp, offRampAddress, 1, nil)
+			mockExpectChainAccessorNoncesCall(chainAccessors[chainB], tc.expectedNonces)
 			ccipReader, err := newCCIPChainReaderInternal(
 				t.Context(),
 				logger.Test(t),
+				chainAccessors,
 				map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
 					chainB: destReader,
 				},
 				contractWriters,
 				chainB,
-				[]byte("0x3"),
+				offRampAddress,
 				internal.NewMockAddressCodecHex(t),
 			)
 			require.NoError(t, err)
@@ -1486,77 +1369,39 @@ func TestCCIPChainReader_GetWrappedNativeTokenPriceUSD(t *testing.T) {
 		mockCache.On("GetChainConfig", mock.Anything, sourceChain2).Return(sourceChain2Config, nil)
 		mockCache.On("Start", mock.Anything).Return(nil)
 
-		// Setup readers with price responses
-		sourceReader1 := reader_mocks.NewMockExtended(t)
-		price1 := cciptypes.TimestampedUnixBig{
-			Value:     big.NewInt(100),
-			Timestamp: uint32(time.Now().Unix()),
-		}
-		sourceReader1.EXPECT().ExtendedGetLatestValue(
-			mock.Anything,
-			consts.ContractNameFeeQuoter,
-			consts.MethodNameFeeQuoterGetTokenPrice,
-			primitives.Unconfirmed,
-			map[string]interface{}{"token": cciptypes.UnknownAddress(wrappedNative1)},
-			mock.Anything,
-		).Run(
-			func(
-				ctx context.Context,
-				contractName, methodName string,
-				confidence primitives.ConfidenceLevel,
-				params any,
-				returnVal any) {
-				pricePtr := returnVal.(*cciptypes.TimestampedUnixBig)
-				*pricePtr = price1
-			}).Return(nil)
-
-		sourceReader2 := reader_mocks.NewMockExtended(t)
-		price2 := cciptypes.TimestampedUnixBig{
-			Value:     big.NewInt(200),
-			Timestamp: uint32(time.Now().Unix()),
-		}
-		sourceReader2.EXPECT().ExtendedGetLatestValue(
-			mock.Anything,
-			consts.ContractNameFeeQuoter,
-			consts.MethodNameFeeQuoterGetTokenPrice,
-			primitives.Unconfirmed,
-			map[string]interface{}{"token": cciptypes.UnknownAddress(wrappedNative2)},
-			mock.Anything,
-		).Run(
-			func(
-				ctx context.Context,
-				contractName, methodName string,
-				confidence primitives.ConfidenceLevel,
-				params any,
-				returnVal any) {
-				pricePtr := returnVal.(*cciptypes.TimestampedUnixBig)
-				*pricePtr = price2
-			}).Return(nil)
-
 		cw := writer_mocks.NewMockContractWriter(t)
 		contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
 		contractWriters[sourceChain1] = cw
 		contractWriters[sourceChain2] = cw
 
+		offRampAddress := []byte{0x3}
+		chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1, sourceChain2)
+		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, 1, nil)
+		mockExpectChainAccessorGetTokenPriceUSD(
+			chainAccessors[sourceChain1],
+			cciptypes.UnknownAddress(wrappedNative1),
+			cciptypes.TimestampedUnixBig{Value: big.NewInt(100), Timestamp: uint32(time.Now().Unix())},
+		)
+		mockExpectChainAccessorGetTokenPriceUSD(
+			chainAccessors[sourceChain2],
+			cciptypes.UnknownAddress(wrappedNative2),
+			cciptypes.TimestampedUnixBig{Value: big.NewInt(200), Timestamp: uint32(time.Now().Unix())},
+		)
 		ccipReader, err := newCCIPChainReaderWithConfigPollerInternal(
 			t.Context(),
 			logger.Test(t),
+			chainAccessors,
 			map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
-				sourceChain1: sourceReader1,
-				sourceChain2: sourceReader2,
+				sourceChain1: reader_mocks.NewMockContractReaderFacade(t),
+				sourceChain2: reader_mocks.NewMockContractReaderFacade(t),
 			},
 			contractWriters,
 			destChain,
-			[]byte{0x3}, // Mock offramp address
+			offRampAddress,
 			internal.NewMockAddressCodecHex(t),
 			mockCache,
 		)
 		require.NoError(t, err)
-
-		ccipReader.contractReaders = map[cciptypes.ChainSelector]contractreader.Extended{
-			sourceChain1: sourceReader1,
-			sourceChain2: sourceReader2,
-		}
 
 		prices := ccipReader.GetWrappedNativeTokenPriceUSD(ctx, []cciptypes.ChainSelector{sourceChain1, sourceChain2})
 		require.Len(t, prices, 2)
@@ -1576,52 +1421,30 @@ func TestCCIPChainReader_GetWrappedNativeTokenPriceUSD(t *testing.T) {
 		}, nil)
 		mockCache.On("Start", mock.Anything).Return(nil)
 
-		sourceReader2 := reader_mocks.NewMockExtended(t)
-		price2 := cciptypes.TimestampedUnixBig{
-			Value:     big.NewInt(200),
-			Timestamp: uint32(time.Now().Unix()),
-		}
-		sourceReader2.EXPECT().ExtendedGetLatestValue(
-			mock.Anything,
-			consts.ContractNameFeeQuoter,
-			consts.MethodNameFeeQuoterGetTokenPrice,
-			primitives.Unconfirmed,
-			map[string]interface{}{"token": cciptypes.UnknownAddress(wrappedNative2)},
-			mock.Anything,
-		).Run(func(
-			ctx context.Context,
-			contractName, methodName string,
-			confidence primitives.ConfidenceLevel,
-			params any,
-			returnVal any) {
-			pricePtr := returnVal.(*cciptypes.TimestampedUnixBig)
-			*pricePtr = price2
-		}).Return(nil)
-
 		cw := writer_mocks.NewMockContractWriter(t)
 		contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
 		contractWriters[sourceChain1] = cw
 		contractWriters[sourceChain2] = cw
 
+		offRampAddress := []byte{0x3}
+		chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1, sourceChain2)
+		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, 1, nil)
+		mockExpectChainAccessorGetTokenPriceUSD(chainAccessors[sourceChain2], cciptypes.UnknownAddress(wrappedNative2), cciptypes.TimestampedUnixBig{Value: big.NewInt(200), Timestamp: uint32(time.Now().Unix())})
 		ccipReader, err := newCCIPChainReaderWithConfigPollerInternal(
 			t.Context(),
 			logger.Test(t),
+			chainAccessors,
 			map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
 				sourceChain1: reader_mocks.NewMockContractReaderFacade(t),
-				sourceChain2: sourceReader2,
+				sourceChain2: reader_mocks.NewMockContractReaderFacade(t),
 			},
 			contractWriters,
 			destChain,
-			[]byte{0x3}, // Mock offramp address
+			offRampAddress,
 			internal.NewMockAddressCodecHex(t),
 			mockCache,
 		)
 		require.NoError(t, err)
-
-		ccipReader.contractReaders = map[cciptypes.ChainSelector]contractreader.Extended{
-			sourceChain1: reader_mocks.NewMockExtended(t),
-			sourceChain2: sourceReader2,
-		}
 
 		prices := ccipReader.GetWrappedNativeTokenPriceUSD(ctx, []cciptypes.ChainSelector{sourceChain1, sourceChain2})
 		require.Len(t, prices, 1)
@@ -1640,37 +1463,30 @@ func TestCCIPChainReader_GetWrappedNativeTokenPriceUSD(t *testing.T) {
 		mockCache.On("GetChainConfig", mock.Anything, sourceChain1).Return(sourceConfig, nil)
 		mockCache.On("Start", mock.Anything).Return(nil)
 
-		sourceReader := reader_mocks.NewMockExtended(t)
-		sourceReader.EXPECT().ExtendedGetLatestValue(
-			mock.Anything,
-			consts.ContractNameFeeQuoter,
-			consts.MethodNameFeeQuoterGetTokenPrice,
-			primitives.Unconfirmed,
-			map[string]interface{}{"token": cciptypes.UnknownAddress(wrappedNative1)},
-			mock.Anything,
-		).Return(fmt.Errorf("price fetch failed"))
-
 		cw := writer_mocks.NewMockContractWriter(t)
 		contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
 		contractWriters[sourceChain1] = cw
 
+		offRampAddress := []byte{0x3}
+		chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1, sourceChain2)
+		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, 1, nil)
+		chainAccessors[sourceChain1].(*commonccipocr3.MockChainAccessor).EXPECT().
+			GetTokenPriceUSD(mock.Anything, cciptypes.UnknownAddress(wrappedNative1)).
+			Return(cciptypes.TimestampedUnixBig{}, fmt.Errorf("price fetch failed"))
 		ccipReader, err := newCCIPChainReaderWithConfigPollerInternal(
 			t.Context(),
 			logger.Test(t),
+			chainAccessors,
 			map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
-				sourceChain1: sourceReader,
+				sourceChain1: reader_mocks.NewMockContractReaderFacade(t),
 			},
 			contractWriters,
 			destChain,
-			[]byte{0x3}, // Mock offramp address
+			offRampAddress,
 			internal.NewMockAddressCodecHex(t),
 			mockCache,
 		)
 		require.NoError(t, err)
-
-		ccipReader.contractReaders = map[cciptypes.ChainSelector]contractreader.Extended{
-			sourceChain1: sourceReader,
-		}
 
 		prices := ccipReader.GetWrappedNativeTokenPriceUSD(ctx, []cciptypes.ChainSelector{sourceChain1})
 		require.Empty(t, prices)
@@ -1767,73 +1583,30 @@ func TestCCIPChainReader_GetChainFeePriceUpdate(t *testing.T) {
 
 	lggr := logger.Test(t)
 
-	// Helper to create BatchReadResult
-	createBatchReadResult := func(value *big.Int, ts uint32, err error) types.BatchReadResult {
-		var resultVal *cciptypes.TimestampedUnixBig
-		if value != nil {
-			resultVal = &cciptypes.TimestampedUnixBig{
-				Value:     value,
-				Timestamp: ts,
-			}
-		}
-		brr := types.BatchReadResult{ReadName: consts.MethodNameGetFeePriceUpdate}
-		brr.SetResult(resultVal, err)
-		return brr
-	}
-
 	t.Run("happy path", func(t *testing.T) {
-		mockReader := reader_mocks.NewMockExtended(t)
 		selectors := []cciptypes.ChainSelector{sourceChain1, sourceChain2}
-
-		// Expected batch request structure
-		expectedBatchRequest := contractreader.ExtendedBatchGetLatestValuesRequest{
-			consts.ContractNameFeeQuoter: []types.BatchRead{
-				{
-					ReadName:  consts.MethodNameGetFeePriceUpdate,
-					Params:    map[string]any{"destChainSelector": sourceChain1},
-					ReturnVal: new(cciptypes.TimestampedUnixBig),
-				},
-				{
-					ReadName:  consts.MethodNameGetFeePriceUpdate,
-					Params:    map[string]any{"destChainSelector": sourceChain2},
-					ReturnVal: new(cciptypes.TimestampedUnixBig),
-				},
-			},
-		}
-
-		// Mock response
-		mockResults := types.BatchGetLatestValuesResult{
-			types.BoundContract{Name: consts.ContractNameFeeQuoter}: []types.BatchReadResult{
-				createBatchReadResult(big.NewInt(100), uint32(time.Now().Unix()), nil), // sourceChain1
-				createBatchReadResult(big.NewInt(200), uint32(time.Now().Unix()), nil), // sourceChain2
-			},
-		}
-
-		mockReader.EXPECT().ExtendedBatchGetLatestValues(
-			ctx,
-			expectedBatchRequest,
-			false,
-		).
-			Return(
-				mockResults,
-				nil,
-				nil,
-			).Once()
-
-		mockReader.EXPECT().Bind(mock.Anything, mock.Anything).Return(nil)
 
 		cw := writer_mocks.NewMockContractWriter(t)
 		contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
 		contractWriters[chainB] = cw
+		offRampAddress := []byte{0x3}
+		chainAccessors := createMockedChainAccessors(t, destChain, chainB, sourceChain1, sourceChain2)
+		mockExpectChainAccessorSyncCall(chainAccessors[chainB], consts.ContractNameOffRamp, offRampAddress, 1, nil)
+		expectedResult := map[cciptypes.ChainSelector]cciptypes.TimestampedUnixBig{
+			sourceChain1: {Value: big.NewInt(100), Timestamp: uint32(time.Now().Unix())},
+			sourceChain2: {Value: big.NewInt(200), Timestamp: uint32(time.Now().Unix())},
+		}
+		mockExpectChainAccessorGetChainFeePriceUpdate(chainAccessors[chainB], selectors, expectedResult)
 		ccipReader, err := newCCIPChainReaderInternal(
 			t.Context(),
 			logger.Test(t),
+			chainAccessors,
 			map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
-				chainB: mockReader,
+				chainB: reader_mocks.NewMockContractReaderFacade(t),
 			},
 			contractWriters,
 			chainB,
-			[]byte("0x3"),
+			offRampAddress,
 			internal.NewMockAddressCodecHex(t),
 		)
 		require.NoError(t, err)
@@ -1847,8 +1620,6 @@ func TestCCIPChainReader_GetChainFeePriceUpdate(t *testing.T) {
 		assert.NotNil(t, feeUpdates[sourceChain2].Value)
 		assert.Equal(t, 0, feeUpdates[sourceChain2].Value.Cmp(big.NewInt(200)))
 		assert.NotZero(t, feeUpdates[sourceChain2].Timestamp)
-
-		mockReader.AssertExpectations(t)
 
 		err = ccipReader.Close()
 		require.NoError(t, err)
@@ -1871,25 +1642,27 @@ func TestCCIPChainReader_GetChainFeePriceUpdate(t *testing.T) {
 	})
 
 	t.Run("batch call error", func(t *testing.T) {
-		mockReader := reader_mocks.NewMockExtended(t)
 		selectors := []cciptypes.ChainSelector{sourceChain1}
-		expectedErr := errors.New("batch failed")
-
-		mockReader.EXPECT().ExtendedBatchGetLatestValues(ctx, mock.Anything, false).Return(nil, nil, expectedErr).Once()
-		mockReader.EXPECT().Bind(mock.Anything, mock.Anything).Return(nil)
 
 		cw := writer_mocks.NewMockContractWriter(t)
 		contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
 		contractWriters[destChain] = cw
+		offRampAddress := []byte{0x3}
+		chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1)
+		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, 1, nil)
+		chainAccessors[destChain].(*commonccipocr3.MockChainAccessor).EXPECT().
+			GetChainFeePriceUpdate(mock.Anything, selectors).
+			Return(map[cciptypes.ChainSelector]cciptypes.TimestampedBig{})
 		ccipReader, err := newCCIPChainReaderInternal(
 			t.Context(),
 			logger.Test(t),
+			chainAccessors,
 			map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
-				destChain: mockReader,
+				destChain: reader_mocks.NewMockContractReaderFacade(t),
 			},
 			contractWriters,
 			destChain,
-			[]byte("0x3"),
+			offRampAddress,
 			internal.NewMockAddressCodecHex(t),
 		)
 		require.NoError(t, err)
@@ -1902,32 +1675,29 @@ func TestCCIPChainReader_GetChainFeePriceUpdate(t *testing.T) {
 	})
 
 	t.Run("partial success - one result empty", func(t *testing.T) {
-		mockReader := reader_mocks.NewMockExtended(t)
 		selectors := []cciptypes.ChainSelector{sourceChain1, sourceChain3}
-
-		// Mock response
-		mockResults := types.BatchGetLatestValuesResult{
-			types.BoundContract{Name: consts.ContractNameFeeQuoter}: []types.BatchReadResult{
-				createBatchReadResult(big.NewInt(100), uint32(time.Now().Unix()), nil), // sourceChain1
-				createBatchReadResult(big.NewInt(0), uint32(time.Now().Unix()), nil),   // sourceChain3 (empty value)
-			},
-		}
-
-		mockReader.EXPECT().ExtendedBatchGetLatestValues(ctx, mock.Anything, false).Return(mockResults, nil, nil).Once()
-		mockReader.EXPECT().Bind(mock.Anything, mock.Anything).Return(nil)
 
 		cw := writer_mocks.NewMockContractWriter(t)
 		contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
 		contractWriters[destChain] = cw
+		offRampAddress := []byte{0x3}
+		chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1, sourceChain3)
+		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, 1, nil)
+		expectedResult := map[cciptypes.ChainSelector]cciptypes.TimestampedUnixBig{
+			sourceChain1: {Value: big.NewInt(100), Timestamp: uint32(time.Now().Unix())},
+			sourceChain3: {Value: big.NewInt(0), Timestamp: uint32(time.Now().Unix())},
+		}
+		mockExpectChainAccessorGetChainFeePriceUpdate(chainAccessors[destChain], selectors, expectedResult)
 		ccipReader, err := newCCIPChainReaderInternal(
 			t.Context(),
 			logger.Test(t),
+			chainAccessors,
 			map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
-				destChain: mockReader,
+				destChain: reader_mocks.NewMockContractReaderFacade(t),
 			},
 			contractWriters,
 			destChain,
-			[]byte("0x3"),
+			offRampAddress,
 			internal.NewMockAddressCodecHex(t),
 		)
 		require.NoError(t, err)
@@ -1940,40 +1710,33 @@ func TestCCIPChainReader_GetChainFeePriceUpdate(t *testing.T) {
 		assert.Equal(t, 0, feeUpdates[sourceChain1].Value.Cmp(big.NewInt(100)))
 		assert.Contains(t, feeUpdates, sourceChain3)
 
-		mockReader.AssertExpectations(t)
-
 		err = ccipReader.Close()
 		require.NoError(t, err)
 	})
 
 	t.Run("partial success - one result error", func(t *testing.T) {
-		mockReader := reader_mocks.NewMockExtended(t)
 		selectors := []cciptypes.ChainSelector{sourceChain1, sourceChain3}
-		getResultError := errors.New("get result failed")
-
-		// Mock response
-		mockResults := types.BatchGetLatestValuesResult{
-			types.BoundContract{Name: consts.ContractNameFeeQuoter}: []types.BatchReadResult{
-				createBatchReadResult(big.NewInt(100), uint32(time.Now().Unix()), nil), // sourceChain1
-				createBatchReadResult(nil, 0, getResultError),                          // sourceChain3 (error)
-			},
-		}
-
-		mockReader.EXPECT().ExtendedBatchGetLatestValues(ctx, mock.Anything, false).Return(mockResults, nil, nil).Once()
-		mockReader.EXPECT().Bind(mock.Anything, mock.Anything).Return(nil)
 
 		cw := writer_mocks.NewMockContractWriter(t)
 		contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
 		contractWriters[destChain] = cw
+		offRampAddress := []byte{0x3}
+		chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1, sourceChain3)
+		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, 1, nil)
+		expectedResult := map[cciptypes.ChainSelector]cciptypes.TimestampedUnixBig{
+			sourceChain1: {Value: big.NewInt(100), Timestamp: uint32(time.Now().Unix())},
+		}
+		mockExpectChainAccessorGetChainFeePriceUpdate(chainAccessors[destChain], selectors, expectedResult)
 		ccipReader, err := newCCIPChainReaderInternal(
 			t.Context(),
 			logger.Test(t),
+			chainAccessors,
 			map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
-				destChain: mockReader,
+				destChain: reader_mocks.NewMockContractReaderFacade(t),
 			},
 			contractWriters,
 			destChain,
-			[]byte("0x3"),
+			offRampAddress,
 			internal.NewMockAddressCodecHex(t),
 		)
 		require.NoError(t, err)
@@ -1986,39 +1749,34 @@ func TestCCIPChainReader_GetChainFeePriceUpdate(t *testing.T) {
 		assert.Equal(t, 0, feeUpdates[sourceChain1].Value.Cmp(big.NewInt(100)))
 		assert.NotContains(t, feeUpdates, sourceChain3)
 
-		mockReader.AssertExpectations(t)
-
 		err = ccipReader.Close()
 		require.NoError(t, err)
 	})
 
 	t.Run("result count mismatch", func(t *testing.T) {
-		mockReader := reader_mocks.NewMockExtended(t)
 		// Request two selectors, but mock response only has one result
 		selectors := []cciptypes.ChainSelector{sourceChain1, sourceChain2}
-
-		// Mock response with fewer results than selectors
-		mockResults := types.BatchGetLatestValuesResult{
-			types.BoundContract{Name: consts.ContractNameFeeQuoter}: []types.BatchReadResult{
-				createBatchReadResult(big.NewInt(100), uint32(time.Now().Unix()), nil), // Only result for sourceChain1
-			},
-		}
-
-		mockReader.EXPECT().ExtendedBatchGetLatestValues(ctx, mock.Anything, false).Return(mockResults, nil, nil).Once()
-		mockReader.EXPECT().Bind(mock.Anything, mock.Anything).Return(nil)
 
 		cw := writer_mocks.NewMockContractWriter(t)
 		contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
 		contractWriters[destChain] = cw
+		offRampAddress := []byte{0x3}
+		chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1, sourceChain2)
+		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, 1, nil)
+		expectedResult := map[cciptypes.ChainSelector]cciptypes.TimestampedUnixBig{
+			sourceChain1: {Value: big.NewInt(100), Timestamp: uint32(time.Now().Unix())},
+		}
+		mockExpectChainAccessorGetChainFeePriceUpdate(chainAccessors[destChain], selectors, expectedResult)
 		ccipReader, err := newCCIPChainReaderInternal(
 			t.Context(),
 			logger.Test(t),
+			chainAccessors,
 			map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
-				destChain: mockReader,
+				destChain: reader_mocks.NewMockContractReaderFacade(t),
 			},
 			contractWriters,
 			destChain,
-			[]byte("0x3"),
+			offRampAddress,
 			internal.NewMockAddressCodecHex(t),
 		)
 		require.NoError(t, err)
@@ -2032,43 +1790,36 @@ func TestCCIPChainReader_GetChainFeePriceUpdate(t *testing.T) {
 		assert.Equal(t, 0, feeUpdates[sourceChain1].Value.Cmp(big.NewInt(100)))
 		assert.NotContains(t, feeUpdates, sourceChain2)
 
-		mockReader.AssertExpectations(t)
-
 		err = ccipReader.Close()
 		require.NoError(t, err)
 	})
 
 	t.Run("missing fee quoter result in batch response", func(t *testing.T) {
-		mockReader := reader_mocks.NewMockExtended(t)
 		selectors := []cciptypes.ChainSelector{sourceChain1}
-
-		// Mock response without the FeeQuoter contract key
-		mockResults := types.BatchGetLatestValuesResult{
-			// Empty map, or map with a different contract
-		}
-
-		mockReader.EXPECT().ExtendedBatchGetLatestValues(ctx, mock.Anything, false).Return(mockResults, nil, nil).Once()
-		mockReader.EXPECT().Bind(mock.Anything, mock.Anything).Return(nil)
 
 		cw := writer_mocks.NewMockContractWriter(t)
 		contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
 		contractWriters[destChain] = cw
+		offRampAddress := []byte{0x3}
+		chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1)
+		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, 1, nil)
+		mockExpectChainAccessorGetChainFeePriceUpdate(chainAccessors[destChain], selectors, map[cciptypes.ChainSelector]cciptypes.TimestampedUnixBig{})
 		ccipReader, err := newCCIPChainReaderInternal(
 			t.Context(),
 			logger.Test(t),
+			chainAccessors,
 			map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
-				destChain: mockReader,
+				destChain: reader_mocks.NewMockContractReaderFacade(t),
 			},
 			contractWriters,
 			destChain,
-			[]byte("0x3"),
+			offRampAddress,
 			internal.NewMockAddressCodecHex(t),
 		)
 		require.NoError(t, err)
 
 		feeUpdates := ccipReader.GetChainFeePriceUpdate(ctx, selectors)
 		require.Empty(t, feeUpdates)
-		mockReader.AssertExpectations(t)
 
 		err = ccipReader.Close()
 		require.NoError(t, err)
@@ -2078,6 +1829,7 @@ func TestCCIPChainReader_GetChainFeePriceUpdate(t *testing.T) {
 		ccipReader, err := newCCIPChainReaderInternal(
 			t.Context(),
 			logger.Test(t),
+			nil,
 			nil,
 			nil,
 			destChain,
@@ -2093,6 +1845,56 @@ func TestCCIPChainReader_GetChainFeePriceUpdate(t *testing.T) {
 		err = ccipReader.Close()
 		require.NoError(t, err)
 	})
+}
+
+func createMockedChainAccessors(
+	t *testing.T,
+	chains ...cciptypes.ChainSelector,
+) map[cciptypes.ChainSelector]cciptypes.ChainAccessor {
+	chainAccessors := make(map[cciptypes.ChainSelector]cciptypes.ChainAccessor)
+	for _, chain := range chains {
+		mockAccessor := commonccipocr3.NewMockChainAccessor(t)
+		chainAccessors[chain] = mockAccessor
+	}
+	return chainAccessors
+}
+
+func mockExpectChainAccessorSyncCall(
+	chainAccessor cciptypes.ChainAccessor,
+	expectedContractName string,
+	expectedContractAddress []byte,
+	expectedCalls int, err error,
+) {
+	chainAccessor.(*commonccipocr3.MockChainAccessor).EXPECT().
+		Sync(mock.Anything, expectedContractName, cciptypes.UnknownAddress(expectedContractAddress)).Times(expectedCalls).Return(err)
+}
+
+func mockExpectChainAccessorNoncesCall(chainAccessor cciptypes.ChainAccessor, expectedResult map[cciptypes.ChainSelector]map[string]uint64) {
+	chainAccessor.(*commonccipocr3.MockChainAccessor).EXPECT().
+		Nonces(mock.Anything, mock.Anything).Return(expectedResult, nil)
+}
+
+func mockExpectChainAccessorGetTokenPriceUSD(chainAccessor cciptypes.ChainAccessor, token cciptypes.UnknownAddress, price cciptypes.TimestampedUnixBig) {
+	chainAccessor.(*commonccipocr3.MockChainAccessor).EXPECT().
+		GetTokenPriceUSD(mock.Anything, token).Return(price, nil)
+}
+
+func mockExpectChainAccessorGetChainFeeComponentsCall(chainAccessor cciptypes.ChainAccessor, feeComponents cciptypes.ChainFeeComponents, err error) {
+	chainAccessor.(*commonccipocr3.MockChainAccessor).EXPECT().
+		GetChainFeeComponents(mock.Anything).Return(feeComponents, err)
+}
+
+func mockExpectChainAccessorGetChainFeePriceUpdate(chainAccessor cciptypes.ChainAccessor, selectors []cciptypes.ChainSelector, expectedResult map[cciptypes.ChainSelector]cciptypes.TimestampedUnixBig) {
+	// Convert TimestampedUnixBig to TimestampedBig
+	convertedResult := make(map[cciptypes.ChainSelector]cciptypes.TimestampedBig)
+	for k, v := range expectedResult {
+		convertedResult[k] = cciptypes.TimestampedBig{
+			Value:     cciptypes.NewBigInt(v.Value),
+			Timestamp: time.Unix(int64(v.Timestamp), 0),
+		}
+	}
+	chainAccessor.(*commonccipocr3.MockChainAccessor).EXPECT().
+		GetChainFeePriceUpdate(mock.Anything, selectors).Return(convertedResult)
 }
 
 type mockConfigCache struct {

--- a/pkg/reader/config_poller.go
+++ b/pkg/reader/config_poller.go
@@ -498,10 +498,6 @@ func (c *configPoller) GetChainConfig(
 		return ChainConfigSnapshot{}, fmt.Errorf("no contract reader for chain %d", chainSel)
 	}
 
-	c.lggr.Debugw("OGT config_poller.go GetChainConfig contract reader memory address:",
-		"address", fmt.Sprintf("%p", reader),
-		"chain", chainSel)
-
 	chainCache := c.getOrCreateChainCache(chainSel)
 
 	chainCache.chainConfigMu.RLock()
@@ -528,15 +524,11 @@ func (c *configPoller) GetOfframpSourceChainConfigs(
 	sourceChains []cciptypes.ChainSelector,
 ) (map[cciptypes.ChainSelector]StaticSourceChainConfig, error) {
 	// Verify we have a reader for the destination chain
-	reader, exists := c.reader.getContractReader(destChain)
+	_, exists := c.reader.getContractReader(destChain)
 	if !exists {
 		c.lggr.Errorw("No contract reader for destination chain", "chain", destChain)
 		return nil, fmt.Errorf("no contract reader for destination chain %d", destChain)
 	}
-
-	c.lggr.Debugw("OGT config_poller.go GetOfframpSourceChainConfigs dest chain contract reader memory address:",
-		"memory_address", fmt.Sprintf("%p", reader),
-		"destChain", destChain)
 
 	// Filter out destination chain from source chains
 	filteredSourceChains := filterOutChainSelector(sourceChains, destChain)

--- a/pkg/reader/config_poller.go
+++ b/pkg/reader/config_poller.go
@@ -498,6 +498,10 @@ func (c *configPoller) GetChainConfig(
 		return ChainConfigSnapshot{}, fmt.Errorf("no contract reader for chain %d", chainSel)
 	}
 
+	c.lggr.Debugw("OGT config_poller.go GetChainConfig contract reader memory address:",
+		"address", fmt.Sprintf("%p", reader),
+		"chain", chainSel)
+
 	chainCache := c.getOrCreateChainCache(chainSel)
 
 	chainCache.chainConfigMu.RLock()
@@ -524,10 +528,15 @@ func (c *configPoller) GetOfframpSourceChainConfigs(
 	sourceChains []cciptypes.ChainSelector,
 ) (map[cciptypes.ChainSelector]StaticSourceChainConfig, error) {
 	// Verify we have a reader for the destination chain
-	if _, exists := c.reader.getContractReader(destChain); !exists {
+	reader, exists := c.reader.getContractReader(destChain)
+	if !exists {
 		c.lggr.Errorw("No contract reader for destination chain", "chain", destChain)
 		return nil, fmt.Errorf("no contract reader for destination chain %d", destChain)
 	}
+
+	c.lggr.Debugw("OGT config_poller.go GetOfframpSourceChainConfigs dest chain contract reader memory address:",
+		"memory_address", fmt.Sprintf("%p", reader),
+		"destChain", destChain)
 
 	// Filter out destination chain from source chains
 	filteredSourceChains := filterOutChainSelector(sourceChains, destChain)


### PR DESCRIPTION
core ref: e627da764ca7feeaa3a57e30001d6ed10064bba1

TL;DR: Use the accessors created in chainlink core in CCIPReader instead of the `DefaultAccessor` created in CCIPReader's constructor

More info:
- Previously, while the migration to chain accessors was still in the early phases, the `DefaultAccessors` were being created inline inside the CCIPReader constructor
- Now that we have the accessor factories inside of chainlink core, we can now rely on those accessors instead which will support all accessors, not just `DefaultAccessor`

NOTE: this PR must be merged after https://github.com/smartcontractkit/chainlink/pull/18791