### PR TITLE
reduce USDCHybridLockReleasePool opt runs to 5000

### DIFF
--- a/chains/evm/scripts/compile_all
+++ b/chains/evm/scripts/compile_all
@@ -10,7 +10,7 @@ echo " └───────────────────────�
 # as specified in the foundry.toml.
 OPTIMIZE_RUNS_OFFRAMP=800
 OPTIMIZE_RUNS_FEE_QUOTER=8000
-OPTIMIZE_RUNS_BURN_MINT_FAST_TRASNFER_TOKEN_POOL=5000
+OPTIMIZE_RUNS_LARGE_TOKEN_POOL=5000
 PROJECT="ccip"
 FOUNDRY_PROJECT_SUFFIX="-compile"
 export FOUNDRY_PROFILE="$PROJECT"$FOUNDRY_PROJECT_SUFFIX
@@ -61,8 +61,8 @@ function getOptimizations() {
       "FeeQuoter")
         optimize_runs_override="--optimizer-runs $OPTIMIZE_RUNS_FEE_QUOTER"
         ;;
-      "BurnMintFastTransferTokenPool")
-        optimize_runs_override="--optimizer-runs $OPTIMIZE_RUNS_BURN_MINT_FAST_TRASNFER_TOKEN_POOL"
+      "BurnMintFastTransferTokenPool" | "HybridLockReleaseUSDCTokenPool")
+        optimize_runs_override="--optimizer-runs $OPTIMIZE_RUNS_LARGE_TOKEN_POOL"
         ;;
     esac
 


### PR DESCRIPTION
USDCHybridLockReleasePool was 400 oversize at 80k opt runs, changing to 5000 runs to be same as the other large burn mint pool