### PR TITLE
rm ParseLog from wrapper gen

### DIFF
--- a/chains/evm/gobindings/generated/latest/burn_from_mint_token_pool/burn_from_mint_token_pool.go
+++ b/chains/evm/gobindings/generated/latest/burn_from_mint_token_pool/burn_from_mint_token_pool.go
@@ -5,7 +5,6 @@ package burn_from_mint_token_pool
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -2750,46 +2748,6 @@ func (_BurnFromMintTokenPool *BurnFromMintTokenPoolFilterer) ParseRouterUpdated(
 	return event, nil
 }
 
-func (_BurnFromMintTokenPool *BurnFromMintTokenPool) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _BurnFromMintTokenPool.abi.Events["AllowListAdd"].ID:
-		return _BurnFromMintTokenPool.ParseAllowListAdd(log)
-	case _BurnFromMintTokenPool.abi.Events["AllowListRemove"].ID:
-		return _BurnFromMintTokenPool.ParseAllowListRemove(log)
-	case _BurnFromMintTokenPool.abi.Events["ChainAdded"].ID:
-		return _BurnFromMintTokenPool.ParseChainAdded(log)
-	case _BurnFromMintTokenPool.abi.Events["ChainConfigured"].ID:
-		return _BurnFromMintTokenPool.ParseChainConfigured(log)
-	case _BurnFromMintTokenPool.abi.Events["ChainRemoved"].ID:
-		return _BurnFromMintTokenPool.ParseChainRemoved(log)
-	case _BurnFromMintTokenPool.abi.Events["ConfigChanged"].ID:
-		return _BurnFromMintTokenPool.ParseConfigChanged(log)
-	case _BurnFromMintTokenPool.abi.Events["InboundRateLimitConsumed"].ID:
-		return _BurnFromMintTokenPool.ParseInboundRateLimitConsumed(log)
-	case _BurnFromMintTokenPool.abi.Events["LockedOrBurned"].ID:
-		return _BurnFromMintTokenPool.ParseLockedOrBurned(log)
-	case _BurnFromMintTokenPool.abi.Events["OutboundRateLimitConsumed"].ID:
-		return _BurnFromMintTokenPool.ParseOutboundRateLimitConsumed(log)
-	case _BurnFromMintTokenPool.abi.Events["OwnershipTransferRequested"].ID:
-		return _BurnFromMintTokenPool.ParseOwnershipTransferRequested(log)
-	case _BurnFromMintTokenPool.abi.Events["OwnershipTransferred"].ID:
-		return _BurnFromMintTokenPool.ParseOwnershipTransferred(log)
-	case _BurnFromMintTokenPool.abi.Events["RateLimitAdminSet"].ID:
-		return _BurnFromMintTokenPool.ParseRateLimitAdminSet(log)
-	case _BurnFromMintTokenPool.abi.Events["ReleasedOrMinted"].ID:
-		return _BurnFromMintTokenPool.ParseReleasedOrMinted(log)
-	case _BurnFromMintTokenPool.abi.Events["RemotePoolAdded"].ID:
-		return _BurnFromMintTokenPool.ParseRemotePoolAdded(log)
-	case _BurnFromMintTokenPool.abi.Events["RemotePoolRemoved"].ID:
-		return _BurnFromMintTokenPool.ParseRemotePoolRemoved(log)
-	case _BurnFromMintTokenPool.abi.Events["RouterUpdated"].ID:
-		return _BurnFromMintTokenPool.ParseRouterUpdated(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (BurnFromMintTokenPoolAllowListAdd) Topic() common.Hash {
 	return common.HexToHash("0x2640d4d76caf8bf478aabfa982fa4e1c4eb71a37f93cd15e80dbc657911546d8")
 }
@@ -3014,8 +2972,6 @@ type BurnFromMintTokenPoolInterface interface {
 	WatchRouterUpdated(opts *bind.WatchOpts, sink chan<- *BurnFromMintTokenPoolRouterUpdated) (event.Subscription, error)
 
 	ParseRouterUpdated(log types.Log) (*BurnFromMintTokenPoolRouterUpdated, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/burn_mint_token_pool/burn_mint_token_pool.go
+++ b/chains/evm/gobindings/generated/latest/burn_mint_token_pool/burn_mint_token_pool.go
@@ -5,7 +5,6 @@ package burn_mint_token_pool
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -2750,46 +2748,6 @@ func (_BurnMintTokenPool *BurnMintTokenPoolFilterer) ParseRouterUpdated(log type
 	return event, nil
 }
 
-func (_BurnMintTokenPool *BurnMintTokenPool) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _BurnMintTokenPool.abi.Events["AllowListAdd"].ID:
-		return _BurnMintTokenPool.ParseAllowListAdd(log)
-	case _BurnMintTokenPool.abi.Events["AllowListRemove"].ID:
-		return _BurnMintTokenPool.ParseAllowListRemove(log)
-	case _BurnMintTokenPool.abi.Events["ChainAdded"].ID:
-		return _BurnMintTokenPool.ParseChainAdded(log)
-	case _BurnMintTokenPool.abi.Events["ChainConfigured"].ID:
-		return _BurnMintTokenPool.ParseChainConfigured(log)
-	case _BurnMintTokenPool.abi.Events["ChainRemoved"].ID:
-		return _BurnMintTokenPool.ParseChainRemoved(log)
-	case _BurnMintTokenPool.abi.Events["ConfigChanged"].ID:
-		return _BurnMintTokenPool.ParseConfigChanged(log)
-	case _BurnMintTokenPool.abi.Events["InboundRateLimitConsumed"].ID:
-		return _BurnMintTokenPool.ParseInboundRateLimitConsumed(log)
-	case _BurnMintTokenPool.abi.Events["LockedOrBurned"].ID:
-		return _BurnMintTokenPool.ParseLockedOrBurned(log)
-	case _BurnMintTokenPool.abi.Events["OutboundRateLimitConsumed"].ID:
-		return _BurnMintTokenPool.ParseOutboundRateLimitConsumed(log)
-	case _BurnMintTokenPool.abi.Events["OwnershipTransferRequested"].ID:
-		return _BurnMintTokenPool.ParseOwnershipTransferRequested(log)
-	case _BurnMintTokenPool.abi.Events["OwnershipTransferred"].ID:
-		return _BurnMintTokenPool.ParseOwnershipTransferred(log)
-	case _BurnMintTokenPool.abi.Events["RateLimitAdminSet"].ID:
-		return _BurnMintTokenPool.ParseRateLimitAdminSet(log)
-	case _BurnMintTokenPool.abi.Events["ReleasedOrMinted"].ID:
-		return _BurnMintTokenPool.ParseReleasedOrMinted(log)
-	case _BurnMintTokenPool.abi.Events["RemotePoolAdded"].ID:
-		return _BurnMintTokenPool.ParseRemotePoolAdded(log)
-	case _BurnMintTokenPool.abi.Events["RemotePoolRemoved"].ID:
-		return _BurnMintTokenPool.ParseRemotePoolRemoved(log)
-	case _BurnMintTokenPool.abi.Events["RouterUpdated"].ID:
-		return _BurnMintTokenPool.ParseRouterUpdated(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (BurnMintTokenPoolAllowListAdd) Topic() common.Hash {
 	return common.HexToHash("0x2640d4d76caf8bf478aabfa982fa4e1c4eb71a37f93cd15e80dbc657911546d8")
 }
@@ -3014,8 +2972,6 @@ type BurnMintTokenPoolInterface interface {
 	WatchRouterUpdated(opts *bind.WatchOpts, sink chan<- *BurnMintTokenPoolRouterUpdated) (event.Subscription, error)
 
 	ParseRouterUpdated(log types.Log) (*BurnMintTokenPoolRouterUpdated, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/burn_to_address_mint_token_pool/burn_to_address_mint_token_pool.go
+++ b/chains/evm/gobindings/generated/latest/burn_to_address_mint_token_pool/burn_to_address_mint_token_pool.go
@@ -5,7 +5,6 @@ package burn_to_address_mint_token_pool
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -2794,46 +2792,6 @@ func (_BurnToAddressMintTokenPool *BurnToAddressMintTokenPoolFilterer) ParseRout
 	return event, nil
 }
 
-func (_BurnToAddressMintTokenPool *BurnToAddressMintTokenPool) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _BurnToAddressMintTokenPool.abi.Events["AllowListAdd"].ID:
-		return _BurnToAddressMintTokenPool.ParseAllowListAdd(log)
-	case _BurnToAddressMintTokenPool.abi.Events["AllowListRemove"].ID:
-		return _BurnToAddressMintTokenPool.ParseAllowListRemove(log)
-	case _BurnToAddressMintTokenPool.abi.Events["ChainAdded"].ID:
-		return _BurnToAddressMintTokenPool.ParseChainAdded(log)
-	case _BurnToAddressMintTokenPool.abi.Events["ChainConfigured"].ID:
-		return _BurnToAddressMintTokenPool.ParseChainConfigured(log)
-	case _BurnToAddressMintTokenPool.abi.Events["ChainRemoved"].ID:
-		return _BurnToAddressMintTokenPool.ParseChainRemoved(log)
-	case _BurnToAddressMintTokenPool.abi.Events["ConfigChanged"].ID:
-		return _BurnToAddressMintTokenPool.ParseConfigChanged(log)
-	case _BurnToAddressMintTokenPool.abi.Events["InboundRateLimitConsumed"].ID:
-		return _BurnToAddressMintTokenPool.ParseInboundRateLimitConsumed(log)
-	case _BurnToAddressMintTokenPool.abi.Events["LockedOrBurned"].ID:
-		return _BurnToAddressMintTokenPool.ParseLockedOrBurned(log)
-	case _BurnToAddressMintTokenPool.abi.Events["OutboundRateLimitConsumed"].ID:
-		return _BurnToAddressMintTokenPool.ParseOutboundRateLimitConsumed(log)
-	case _BurnToAddressMintTokenPool.abi.Events["OwnershipTransferRequested"].ID:
-		return _BurnToAddressMintTokenPool.ParseOwnershipTransferRequested(log)
-	case _BurnToAddressMintTokenPool.abi.Events["OwnershipTransferred"].ID:
-		return _BurnToAddressMintTokenPool.ParseOwnershipTransferred(log)
-	case _BurnToAddressMintTokenPool.abi.Events["RateLimitAdminSet"].ID:
-		return _BurnToAddressMintTokenPool.ParseRateLimitAdminSet(log)
-	case _BurnToAddressMintTokenPool.abi.Events["ReleasedOrMinted"].ID:
-		return _BurnToAddressMintTokenPool.ParseReleasedOrMinted(log)
-	case _BurnToAddressMintTokenPool.abi.Events["RemotePoolAdded"].ID:
-		return _BurnToAddressMintTokenPool.ParseRemotePoolAdded(log)
-	case _BurnToAddressMintTokenPool.abi.Events["RemotePoolRemoved"].ID:
-		return _BurnToAddressMintTokenPool.ParseRemotePoolRemoved(log)
-	case _BurnToAddressMintTokenPool.abi.Events["RouterUpdated"].ID:
-		return _BurnToAddressMintTokenPool.ParseRouterUpdated(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (BurnToAddressMintTokenPoolAllowListAdd) Topic() common.Hash {
 	return common.HexToHash("0x2640d4d76caf8bf478aabfa982fa4e1c4eb71a37f93cd15e80dbc657911546d8")
 }
@@ -3062,8 +3020,6 @@ type BurnToAddressMintTokenPoolInterface interface {
 	WatchRouterUpdated(opts *bind.WatchOpts, sink chan<- *BurnToAddressMintTokenPoolRouterUpdated) (event.Subscription, error)
 
 	ParseRouterUpdated(log types.Log) (*BurnToAddressMintTokenPoolRouterUpdated, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/burn_with_from_mint_token_pool/burn_with_from_mint_token_pool.go
+++ b/chains/evm/gobindings/generated/latest/burn_with_from_mint_token_pool/burn_with_from_mint_token_pool.go
@@ -5,7 +5,6 @@ package burn_with_from_mint_token_pool
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -2750,46 +2748,6 @@ func (_BurnWithFromMintTokenPool *BurnWithFromMintTokenPoolFilterer) ParseRouter
 	return event, nil
 }
 
-func (_BurnWithFromMintTokenPool *BurnWithFromMintTokenPool) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _BurnWithFromMintTokenPool.abi.Events["AllowListAdd"].ID:
-		return _BurnWithFromMintTokenPool.ParseAllowListAdd(log)
-	case _BurnWithFromMintTokenPool.abi.Events["AllowListRemove"].ID:
-		return _BurnWithFromMintTokenPool.ParseAllowListRemove(log)
-	case _BurnWithFromMintTokenPool.abi.Events["ChainAdded"].ID:
-		return _BurnWithFromMintTokenPool.ParseChainAdded(log)
-	case _BurnWithFromMintTokenPool.abi.Events["ChainConfigured"].ID:
-		return _BurnWithFromMintTokenPool.ParseChainConfigured(log)
-	case _BurnWithFromMintTokenPool.abi.Events["ChainRemoved"].ID:
-		return _BurnWithFromMintTokenPool.ParseChainRemoved(log)
-	case _BurnWithFromMintTokenPool.abi.Events["ConfigChanged"].ID:
-		return _BurnWithFromMintTokenPool.ParseConfigChanged(log)
-	case _BurnWithFromMintTokenPool.abi.Events["InboundRateLimitConsumed"].ID:
-		return _BurnWithFromMintTokenPool.ParseInboundRateLimitConsumed(log)
-	case _BurnWithFromMintTokenPool.abi.Events["LockedOrBurned"].ID:
-		return _BurnWithFromMintTokenPool.ParseLockedOrBurned(log)
-	case _BurnWithFromMintTokenPool.abi.Events["OutboundRateLimitConsumed"].ID:
-		return _BurnWithFromMintTokenPool.ParseOutboundRateLimitConsumed(log)
-	case _BurnWithFromMintTokenPool.abi.Events["OwnershipTransferRequested"].ID:
-		return _BurnWithFromMintTokenPool.ParseOwnershipTransferRequested(log)
-	case _BurnWithFromMintTokenPool.abi.Events["OwnershipTransferred"].ID:
-		return _BurnWithFromMintTokenPool.ParseOwnershipTransferred(log)
-	case _BurnWithFromMintTokenPool.abi.Events["RateLimitAdminSet"].ID:
-		return _BurnWithFromMintTokenPool.ParseRateLimitAdminSet(log)
-	case _BurnWithFromMintTokenPool.abi.Events["ReleasedOrMinted"].ID:
-		return _BurnWithFromMintTokenPool.ParseReleasedOrMinted(log)
-	case _BurnWithFromMintTokenPool.abi.Events["RemotePoolAdded"].ID:
-		return _BurnWithFromMintTokenPool.ParseRemotePoolAdded(log)
-	case _BurnWithFromMintTokenPool.abi.Events["RemotePoolRemoved"].ID:
-		return _BurnWithFromMintTokenPool.ParseRemotePoolRemoved(log)
-	case _BurnWithFromMintTokenPool.abi.Events["RouterUpdated"].ID:
-		return _BurnWithFromMintTokenPool.ParseRouterUpdated(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (BurnWithFromMintTokenPoolAllowListAdd) Topic() common.Hash {
 	return common.HexToHash("0x2640d4d76caf8bf478aabfa982fa4e1c4eb71a37f93cd15e80dbc657911546d8")
 }
@@ -3014,8 +2972,6 @@ type BurnWithFromMintTokenPoolInterface interface {
 	WatchRouterUpdated(opts *bind.WatchOpts, sink chan<- *BurnWithFromMintTokenPoolRouterUpdated) (event.Subscription, error)
 
 	ParseRouterUpdated(log types.Log) (*BurnWithFromMintTokenPoolRouterUpdated, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/ccip_home/ccip_home.go
+++ b/chains/evm/gobindings/generated/latest/ccip_home/ccip_home.go
@@ -5,7 +5,6 @@ package ccip_home
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -1745,32 +1743,6 @@ type GetConfigDigests struct {
 	CandidateConfigDigest [32]byte
 }
 
-func (_CCIPHome *CCIPHome) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _CCIPHome.abi.Events["ActiveConfigRevoked"].ID:
-		return _CCIPHome.ParseActiveConfigRevoked(log)
-	case _CCIPHome.abi.Events["CandidateConfigRevoked"].ID:
-		return _CCIPHome.ParseCandidateConfigRevoked(log)
-	case _CCIPHome.abi.Events["CapabilityConfigurationSet"].ID:
-		return _CCIPHome.ParseCapabilityConfigurationSet(log)
-	case _CCIPHome.abi.Events["ChainConfigRemoved"].ID:
-		return _CCIPHome.ParseChainConfigRemoved(log)
-	case _CCIPHome.abi.Events["ChainConfigSet"].ID:
-		return _CCIPHome.ParseChainConfigSet(log)
-	case _CCIPHome.abi.Events["ConfigPromoted"].ID:
-		return _CCIPHome.ParseConfigPromoted(log)
-	case _CCIPHome.abi.Events["ConfigSet"].ID:
-		return _CCIPHome.ParseConfigSet(log)
-	case _CCIPHome.abi.Events["OwnershipTransferRequested"].ID:
-		return _CCIPHome.ParseOwnershipTransferRequested(log)
-	case _CCIPHome.abi.Events["OwnershipTransferred"].ID:
-		return _CCIPHome.ParseOwnershipTransferred(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (CCIPHomeActiveConfigRevoked) Topic() common.Hash {
 	return common.HexToHash("0x0b31c0055e2d464bef7781994b98c4ff9ef4ae0d05f59feb6a68c42de5e201b8")
 }
@@ -1911,8 +1883,6 @@ type CCIPHomeInterface interface {
 	WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *CCIPHomeOwnershipTransferred, from []common.Address, to []common.Address) (event.Subscription, error)
 
 	ParseOwnershipTransferred(log types.Log) (*CCIPHomeOwnershipTransferred, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/ccip_reader_tester/ccip_reader_tester.go
+++ b/chains/evm/gobindings/generated/latest/ccip_reader_tester/ccip_reader_tester.go
@@ -5,7 +5,6 @@ package ccip_reader_tester
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -819,20 +817,6 @@ func (_CCIPReaderTester *CCIPReaderTesterFilterer) ParseExecutionStateChanged(lo
 	return event, nil
 }
 
-func (_CCIPReaderTester *CCIPReaderTester) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _CCIPReaderTester.abi.Events["CCIPMessageSent"].ID:
-		return _CCIPReaderTester.ParseCCIPMessageSent(log)
-	case _CCIPReaderTester.abi.Events["CommitReportAccepted"].ID:
-		return _CCIPReaderTester.ParseCommitReportAccepted(log)
-	case _CCIPReaderTester.abi.Events["ExecutionStateChanged"].ID:
-		return _CCIPReaderTester.ParseExecutionStateChanged(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (CCIPReaderTesterCCIPMessageSent) Topic() common.Hash {
 	return common.HexToHash("0x192442a2b2adb6a7948f097023cb6b57d29d3a7a5dd33e6666d33c39cc456f32")
 }
@@ -889,8 +873,6 @@ type CCIPReaderTesterInterface interface {
 	WatchExecutionStateChanged(opts *bind.WatchOpts, sink chan<- *CCIPReaderTesterExecutionStateChanged, sourceChainSelector []uint64, sequenceNumber []uint64, messageId [][32]byte) (event.Subscription, error)
 
 	ParseExecutionStateChanged(log types.Log) (*CCIPReaderTesterExecutionStateChanged, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/cctp_message_transmitter_proxy/cctp_message_transmitter_proxy.go
+++ b/chains/evm/gobindings/generated/latest/cctp_message_transmitter_proxy/cctp_message_transmitter_proxy.go
@@ -5,7 +5,6 @@ package cctp_message_transmitter_proxy
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -860,22 +858,6 @@ func (_CCTPMessageTransmitterProxy *CCTPMessageTransmitterProxyFilterer) ParseOw
 	return event, nil
 }
 
-func (_CCTPMessageTransmitterProxy *CCTPMessageTransmitterProxy) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _CCTPMessageTransmitterProxy.abi.Events["AllowedCallerAdded"].ID:
-		return _CCTPMessageTransmitterProxy.ParseAllowedCallerAdded(log)
-	case _CCTPMessageTransmitterProxy.abi.Events["AllowedCallerRemoved"].ID:
-		return _CCTPMessageTransmitterProxy.ParseAllowedCallerRemoved(log)
-	case _CCTPMessageTransmitterProxy.abi.Events["OwnershipTransferRequested"].ID:
-		return _CCTPMessageTransmitterProxy.ParseOwnershipTransferRequested(log)
-	case _CCTPMessageTransmitterProxy.abi.Events["OwnershipTransferred"].ID:
-		return _CCTPMessageTransmitterProxy.ParseOwnershipTransferred(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (CCTPMessageTransmitterProxyAllowedCallerAdded) Topic() common.Hash {
 	return common.HexToHash("0x663c7e9ed36d9138863ef4306bbfcf01f60e1e7ca69b370c53d3094369e2cb02")
 }
@@ -938,8 +920,6 @@ type CCTPMessageTransmitterProxyInterface interface {
 	WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *CCTPMessageTransmitterProxyOwnershipTransferred, from []common.Address, to []common.Address) (event.Subscription, error)
 
 	ParseOwnershipTransferred(log types.Log) (*CCTPMessageTransmitterProxyOwnershipTransferred, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/ccv_aggregator/ccv_aggregator.go
+++ b/chains/evm/gobindings/generated/latest/ccv_aggregator/ccv_aggregator.go
@@ -5,7 +5,6 @@ package ccv_aggregator
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -1081,24 +1079,6 @@ func (_CCVAggregator *CCVAggregatorFilterer) ParseStaticConfigSet(log types.Log)
 	return event, nil
 }
 
-func (_CCVAggregator *CCVAggregator) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _CCVAggregator.abi.Events["ExecutionStateChanged"].ID:
-		return _CCVAggregator.ParseExecutionStateChanged(log)
-	case _CCVAggregator.abi.Events["OwnershipTransferRequested"].ID:
-		return _CCVAggregator.ParseOwnershipTransferRequested(log)
-	case _CCVAggregator.abi.Events["OwnershipTransferred"].ID:
-		return _CCVAggregator.ParseOwnershipTransferred(log)
-	case _CCVAggregator.abi.Events["SourceChainConfigSet"].ID:
-		return _CCVAggregator.ParseSourceChainConfigSet(log)
-	case _CCVAggregator.abi.Events["StaticConfigSet"].ID:
-		return _CCVAggregator.ParseStaticConfigSet(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (CCVAggregatorExecutionStateChanged) Topic() common.Hash {
 	return common.HexToHash("0x8c324ce1367b83031769f6a813e3bb4c117aba2185789d66b98b791405be6df2")
 }
@@ -1175,8 +1155,6 @@ type CCVAggregatorInterface interface {
 	WatchStaticConfigSet(opts *bind.WatchOpts, sink chan<- *CCVAggregatorStaticConfigSet) (event.Subscription, error)
 
 	ParseStaticConfigSet(log types.Log) (*CCVAggregatorStaticConfigSet, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/ccv_proxy/ccv_proxy.go
+++ b/chains/evm/gobindings/generated/latest/ccv_proxy/ccv_proxy.go
@@ -5,7 +5,6 @@ package ccv_proxy
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -1317,26 +1315,6 @@ type GetDestChainConfig struct {
 	Router         common.Address
 }
 
-func (_CCVProxy *CCVProxy) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _CCVProxy.abi.Events["CCIPMessageSent"].ID:
-		return _CCVProxy.ParseCCIPMessageSent(log)
-	case _CCVProxy.abi.Events["ConfigSet"].ID:
-		return _CCVProxy.ParseConfigSet(log)
-	case _CCVProxy.abi.Events["DestChainConfigSet"].ID:
-		return _CCVProxy.ParseDestChainConfigSet(log)
-	case _CCVProxy.abi.Events["FeeTokenWithdrawn"].ID:
-		return _CCVProxy.ParseFeeTokenWithdrawn(log)
-	case _CCVProxy.abi.Events["OwnershipTransferRequested"].ID:
-		return _CCVProxy.ParseOwnershipTransferRequested(log)
-	case _CCVProxy.abi.Events["OwnershipTransferred"].ID:
-		return _CCVProxy.ParseOwnershipTransferred(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (CCVProxyCCIPMessageSent) Topic() common.Hash {
 	return common.HexToHash("0xa816f7e08da08b1aa0143155f28f728327e40df7f707f612cb3566ab91229820")
 }
@@ -1433,8 +1411,6 @@ type CCVProxyInterface interface {
 	WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *CCVProxyOwnershipTransferred, from []common.Address, to []common.Address) (event.Subscription, error)
 
 	ParseOwnershipTransferred(log types.Log) (*CCVProxyOwnershipTransferred, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/commit_offramp/commit_offramp.go
+++ b/chains/evm/gobindings/generated/latest/commit_offramp/commit_offramp.go
@@ -5,7 +5,6 @@ package commit_offramp
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -898,22 +896,6 @@ func (_CommitOffRamp *CommitOffRampFilterer) ParseOwnershipTransferred(log types
 	return event, nil
 }
 
-func (_CommitOffRamp *CommitOffRamp) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _CommitOffRamp.abi.Events["ConfigRevoked"].ID:
-		return _CommitOffRamp.ParseConfigRevoked(log)
-	case _CommitOffRamp.abi.Events["ConfigSet"].ID:
-		return _CommitOffRamp.ParseConfigSet(log)
-	case _CommitOffRamp.abi.Events["OwnershipTransferRequested"].ID:
-		return _CommitOffRamp.ParseOwnershipTransferRequested(log)
-	case _CommitOffRamp.abi.Events["OwnershipTransferred"].ID:
-		return _CommitOffRamp.ParseOwnershipTransferred(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (CommitOffRampConfigRevoked) Topic() common.Hash {
 	return common.HexToHash("0xfdde4bfc1a9ef28a2e3dbe34a4ccc65b0ad588f6b0406e492637aeaa73342160")
 }
@@ -978,8 +960,6 @@ type CommitOffRampInterface interface {
 	WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *CommitOffRampOwnershipTransferred, from []common.Address, to []common.Address) (event.Subscription, error)
 
 	ParseOwnershipTransferred(log types.Log) (*CommitOffRampOwnershipTransferred, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/commit_onramp/commit_onramp.go
+++ b/chains/evm/gobindings/generated/latest/commit_onramp/commit_onramp.go
@@ -5,7 +5,6 @@ package commit_onramp
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -1351,28 +1349,6 @@ type GetDestChainConfig struct {
 	AllowedSendersList []common.Address
 }
 
-func (_CommitOnRamp *CommitOnRamp) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _CommitOnRamp.abi.Events["AllowListSendersAdded"].ID:
-		return _CommitOnRamp.ParseAllowListSendersAdded(log)
-	case _CommitOnRamp.abi.Events["AllowListSendersRemoved"].ID:
-		return _CommitOnRamp.ParseAllowListSendersRemoved(log)
-	case _CommitOnRamp.abi.Events["ConfigSet"].ID:
-		return _CommitOnRamp.ParseConfigSet(log)
-	case _CommitOnRamp.abi.Events["DestChainConfigSet"].ID:
-		return _CommitOnRamp.ParseDestChainConfigSet(log)
-	case _CommitOnRamp.abi.Events["FeeTokenWithdrawn"].ID:
-		return _CommitOnRamp.ParseFeeTokenWithdrawn(log)
-	case _CommitOnRamp.abi.Events["OwnershipTransferRequested"].ID:
-		return _CommitOnRamp.ParseOwnershipTransferRequested(log)
-	case _CommitOnRamp.abi.Events["OwnershipTransferred"].ID:
-		return _CommitOnRamp.ParseOwnershipTransferred(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (CommitOnRampAllowListSendersAdded) Topic() common.Hash {
 	return common.HexToHash("0x330939f6eafe8bb516716892fe962ff19770570838686e6579dbc1cc51fc3281")
 }
@@ -1475,8 +1451,6 @@ type CommitOnRampInterface interface {
 	WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *CommitOnRampOwnershipTransferred, from []common.Address, to []common.Address) (event.Subscription, error)
 
 	ParseOwnershipTransferred(log types.Log) (*CommitOnRampOwnershipTransferred, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/erc20_lock_box/erc20_lock_box.go
+++ b/chains/evm/gobindings/generated/latest/erc20_lock_box/erc20_lock_box.go
@@ -5,7 +5,6 @@ package erc20_lock_box
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -690,20 +688,6 @@ func (_ERC20LockBox *ERC20LockBoxFilterer) ParseWithdrawal(log types.Log) (*ERC2
 	return event, nil
 }
 
-func (_ERC20LockBox *ERC20LockBox) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _ERC20LockBox.abi.Events["AllowedCallerUpdated"].ID:
-		return _ERC20LockBox.ParseAllowedCallerUpdated(log)
-	case _ERC20LockBox.abi.Events["Deposit"].ID:
-		return _ERC20LockBox.ParseDeposit(log)
-	case _ERC20LockBox.abi.Events["Withdrawal"].ID:
-		return _ERC20LockBox.ParseWithdrawal(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (ERC20LockBoxAllowedCallerUpdated) Topic() common.Hash {
 	return common.HexToHash("0xb2cc4dde7f9044ba1999f7843e2f9cd1e4ce506f8cc2e16de26ce982bf113fa6")
 }
@@ -750,8 +734,6 @@ type ERC20LockBoxInterface interface {
 	WatchWithdrawal(opts *bind.WatchOpts, sink chan<- *ERC20LockBoxWithdrawal, token []common.Address, recipient []common.Address) (event.Subscription, error)
 
 	ParseWithdrawal(log types.Log) (*ERC20LockBoxWithdrawal, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/factory_burn_mint_erc20/factory_burn_mint_erc20.go
+++ b/chains/evm/gobindings/generated/latest/factory_burn_mint_erc20/factory_burn_mint_erc20.go
@@ -5,7 +5,6 @@ package factory_burn_mint_erc20
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -2018,34 +2016,6 @@ func (_FactoryBurnMintERC20 *FactoryBurnMintERC20Filterer) ParseTransfer(log typ
 	return event, nil
 }
 
-func (_FactoryBurnMintERC20 *FactoryBurnMintERC20) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _FactoryBurnMintERC20.abi.Events["Approval"].ID:
-		return _FactoryBurnMintERC20.ParseApproval(log)
-	case _FactoryBurnMintERC20.abi.Events["BurnAccessGranted"].ID:
-		return _FactoryBurnMintERC20.ParseBurnAccessGranted(log)
-	case _FactoryBurnMintERC20.abi.Events["BurnAccessRevoked"].ID:
-		return _FactoryBurnMintERC20.ParseBurnAccessRevoked(log)
-	case _FactoryBurnMintERC20.abi.Events["CCIPAdminTransferred"].ID:
-		return _FactoryBurnMintERC20.ParseCCIPAdminTransferred(log)
-	case _FactoryBurnMintERC20.abi.Events["HyperEVMLinkerSet"].ID:
-		return _FactoryBurnMintERC20.ParseHyperEVMLinkerSet(log)
-	case _FactoryBurnMintERC20.abi.Events["MintAccessGranted"].ID:
-		return _FactoryBurnMintERC20.ParseMintAccessGranted(log)
-	case _FactoryBurnMintERC20.abi.Events["MintAccessRevoked"].ID:
-		return _FactoryBurnMintERC20.ParseMintAccessRevoked(log)
-	case _FactoryBurnMintERC20.abi.Events["OwnershipTransferRequested"].ID:
-		return _FactoryBurnMintERC20.ParseOwnershipTransferRequested(log)
-	case _FactoryBurnMintERC20.abi.Events["OwnershipTransferred"].ID:
-		return _FactoryBurnMintERC20.ParseOwnershipTransferred(log)
-	case _FactoryBurnMintERC20.abi.Events["Transfer"].ID:
-		return _FactoryBurnMintERC20.ParseTransfer(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (FactoryBurnMintERC20Approval) Topic() common.Hash {
 	return common.HexToHash("0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925")
 }
@@ -2220,8 +2190,6 @@ type FactoryBurnMintERC20Interface interface {
 	WatchTransfer(opts *bind.WatchOpts, sink chan<- *FactoryBurnMintERC20Transfer, from []common.Address, to []common.Address) (event.Subscription, error)
 
 	ParseTransfer(log types.Log) (*FactoryBurnMintERC20Transfer, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/fast_transfer_token_pool/fast_transfer_token_pool.go
+++ b/chains/evm/gobindings/generated/latest/fast_transfer_token_pool/fast_transfer_token_pool.go
@@ -5,7 +5,6 @@ package fast_transfer_token_pool
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -4004,60 +4002,6 @@ type GetCCVs struct {
 	OptionalThreshold uint8
 }
 
-func (_BurnMintFastTransferTokenPool *BurnMintFastTransferTokenPool) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _BurnMintFastTransferTokenPool.abi.Events["AllowListAdd"].ID:
-		return _BurnMintFastTransferTokenPool.ParseAllowListAdd(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["AllowListRemove"].ID:
-		return _BurnMintFastTransferTokenPool.ParseAllowListRemove(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["ChainAdded"].ID:
-		return _BurnMintFastTransferTokenPool.ParseChainAdded(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["ChainConfigured"].ID:
-		return _BurnMintFastTransferTokenPool.ParseChainConfigured(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["ChainRemoved"].ID:
-		return _BurnMintFastTransferTokenPool.ParseChainRemoved(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["ConfigChanged"].ID:
-		return _BurnMintFastTransferTokenPool.ParseConfigChanged(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["DestChainConfigUpdated"].ID:
-		return _BurnMintFastTransferTokenPool.ParseDestChainConfigUpdated(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["DestinationPoolUpdated"].ID:
-		return _BurnMintFastTransferTokenPool.ParseDestinationPoolUpdated(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["FastTransferFilled"].ID:
-		return _BurnMintFastTransferTokenPool.ParseFastTransferFilled(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["FastTransferRequested"].ID:
-		return _BurnMintFastTransferTokenPool.ParseFastTransferRequested(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["FastTransferSettled"].ID:
-		return _BurnMintFastTransferTokenPool.ParseFastTransferSettled(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["FillerAllowListUpdated"].ID:
-		return _BurnMintFastTransferTokenPool.ParseFillerAllowListUpdated(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["InboundRateLimitConsumed"].ID:
-		return _BurnMintFastTransferTokenPool.ParseInboundRateLimitConsumed(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["LockedOrBurned"].ID:
-		return _BurnMintFastTransferTokenPool.ParseLockedOrBurned(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["OutboundRateLimitConsumed"].ID:
-		return _BurnMintFastTransferTokenPool.ParseOutboundRateLimitConsumed(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["OwnershipTransferRequested"].ID:
-		return _BurnMintFastTransferTokenPool.ParseOwnershipTransferRequested(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["OwnershipTransferred"].ID:
-		return _BurnMintFastTransferTokenPool.ParseOwnershipTransferred(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["PoolFeeWithdrawn"].ID:
-		return _BurnMintFastTransferTokenPool.ParsePoolFeeWithdrawn(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["RateLimitAdminSet"].ID:
-		return _BurnMintFastTransferTokenPool.ParseRateLimitAdminSet(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["ReleasedOrMinted"].ID:
-		return _BurnMintFastTransferTokenPool.ParseReleasedOrMinted(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["RemotePoolAdded"].ID:
-		return _BurnMintFastTransferTokenPool.ParseRemotePoolAdded(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["RemotePoolRemoved"].ID:
-		return _BurnMintFastTransferTokenPool.ParseRemotePoolRemoved(log)
-	case _BurnMintFastTransferTokenPool.abi.Events["RouterUpdated"].ID:
-		return _BurnMintFastTransferTokenPool.ParseRouterUpdated(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (BurnMintFastTransferTokenPoolAllowListAdd) Topic() common.Hash {
 	return common.HexToHash("0x2640d4d76caf8bf478aabfa982fa4e1c4eb71a37f93cd15e80dbc657911546d8")
 }
@@ -4382,8 +4326,6 @@ type BurnMintFastTransferTokenPoolInterface interface {
 	WatchRouterUpdated(opts *bind.WatchOpts, sink chan<- *BurnMintFastTransferTokenPoolRouterUpdated) (event.Subscription, error)
 
 	ParseRouterUpdated(log types.Log) (*BurnMintFastTransferTokenPoolRouterUpdated, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/fee_quoter/fee_quoter.go
+++ b/chains/evm/gobindings/generated/latest/fee_quoter/fee_quoter.go
@@ -5,7 +5,6 @@ package fee_quoter
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -2852,44 +2850,6 @@ type ProcessMessageArgs struct {
 	TokenReceiver         []byte
 }
 
-func (_FeeQuoter *FeeQuoter) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _FeeQuoter.abi.Events["AuthorizedCallerAdded"].ID:
-		return _FeeQuoter.ParseAuthorizedCallerAdded(log)
-	case _FeeQuoter.abi.Events["AuthorizedCallerRemoved"].ID:
-		return _FeeQuoter.ParseAuthorizedCallerRemoved(log)
-	case _FeeQuoter.abi.Events["DestChainAdded"].ID:
-		return _FeeQuoter.ParseDestChainAdded(log)
-	case _FeeQuoter.abi.Events["DestChainConfigUpdated"].ID:
-		return _FeeQuoter.ParseDestChainConfigUpdated(log)
-	case _FeeQuoter.abi.Events["FeeTokenAdded"].ID:
-		return _FeeQuoter.ParseFeeTokenAdded(log)
-	case _FeeQuoter.abi.Events["FeeTokenRemoved"].ID:
-		return _FeeQuoter.ParseFeeTokenRemoved(log)
-	case _FeeQuoter.abi.Events["OwnershipTransferRequested"].ID:
-		return _FeeQuoter.ParseOwnershipTransferRequested(log)
-	case _FeeQuoter.abi.Events["OwnershipTransferred"].ID:
-		return _FeeQuoter.ParseOwnershipTransferred(log)
-	case _FeeQuoter.abi.Events["PremiumMultiplierWeiPerEthUpdated"].ID:
-		return _FeeQuoter.ParsePremiumMultiplierWeiPerEthUpdated(log)
-	case _FeeQuoter.abi.Events["PriceFeedPerTokenUpdated"].ID:
-		return _FeeQuoter.ParsePriceFeedPerTokenUpdated(log)
-	case _FeeQuoter.abi.Events["ReportPermissionSet"].ID:
-		return _FeeQuoter.ParseReportPermissionSet(log)
-	case _FeeQuoter.abi.Events["TokenTransferFeeConfigDeleted"].ID:
-		return _FeeQuoter.ParseTokenTransferFeeConfigDeleted(log)
-	case _FeeQuoter.abi.Events["TokenTransferFeeConfigUpdated"].ID:
-		return _FeeQuoter.ParseTokenTransferFeeConfigUpdated(log)
-	case _FeeQuoter.abi.Events["UsdPerTokenUpdated"].ID:
-		return _FeeQuoter.ParseUsdPerTokenUpdated(log)
-	case _FeeQuoter.abi.Events["UsdPerUnitGasUpdated"].ID:
-		return _FeeQuoter.ParseUsdPerUnitGasUpdated(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (FeeQuoterAuthorizedCallerAdded) Topic() common.Hash {
 	return common.HexToHash("0xeb1b9b92e50b7f88f9ff25d56765095ac6e91540eee214906f4036a908ffbdef")
 }
@@ -3112,8 +3072,6 @@ type FeeQuoterInterface interface {
 	WatchUsdPerUnitGasUpdated(opts *bind.WatchOpts, sink chan<- *FeeQuoterUsdPerUnitGasUpdated, destChain []uint64) (event.Subscription, error)
 
 	ParseUsdPerUnitGasUpdated(log types.Log) (*FeeQuoterUsdPerUnitGasUpdated, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/fee_quoter_v2/fee_quoter_v2.go
+++ b/chains/evm/gobindings/generated/latest/fee_quoter_v2/fee_quoter_v2.go
@@ -5,7 +5,6 @@ package fee_quoter_v2
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -2912,44 +2910,6 @@ type ProcessMessageArgs struct {
 	TokenReceiver         []byte
 }
 
-func (_FeeQuoterV2 *FeeQuoterV2) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _FeeQuoterV2.abi.Events["AuthorizedCallerAdded"].ID:
-		return _FeeQuoterV2.ParseAuthorizedCallerAdded(log)
-	case _FeeQuoterV2.abi.Events["AuthorizedCallerRemoved"].ID:
-		return _FeeQuoterV2.ParseAuthorizedCallerRemoved(log)
-	case _FeeQuoterV2.abi.Events["DestChainAdded"].ID:
-		return _FeeQuoterV2.ParseDestChainAdded(log)
-	case _FeeQuoterV2.abi.Events["DestChainConfigUpdated"].ID:
-		return _FeeQuoterV2.ParseDestChainConfigUpdated(log)
-	case _FeeQuoterV2.abi.Events["FeeTokenAdded"].ID:
-		return _FeeQuoterV2.ParseFeeTokenAdded(log)
-	case _FeeQuoterV2.abi.Events["FeeTokenRemoved"].ID:
-		return _FeeQuoterV2.ParseFeeTokenRemoved(log)
-	case _FeeQuoterV2.abi.Events["OwnershipTransferRequested"].ID:
-		return _FeeQuoterV2.ParseOwnershipTransferRequested(log)
-	case _FeeQuoterV2.abi.Events["OwnershipTransferred"].ID:
-		return _FeeQuoterV2.ParseOwnershipTransferred(log)
-	case _FeeQuoterV2.abi.Events["PremiumMultiplierWeiPerEthUpdated"].ID:
-		return _FeeQuoterV2.ParsePremiumMultiplierWeiPerEthUpdated(log)
-	case _FeeQuoterV2.abi.Events["PriceFeedPerTokenUpdated"].ID:
-		return _FeeQuoterV2.ParsePriceFeedPerTokenUpdated(log)
-	case _FeeQuoterV2.abi.Events["ReportPermissionSet"].ID:
-		return _FeeQuoterV2.ParseReportPermissionSet(log)
-	case _FeeQuoterV2.abi.Events["TokenTransferFeeConfigDeleted"].ID:
-		return _FeeQuoterV2.ParseTokenTransferFeeConfigDeleted(log)
-	case _FeeQuoterV2.abi.Events["TokenTransferFeeConfigUpdated"].ID:
-		return _FeeQuoterV2.ParseTokenTransferFeeConfigUpdated(log)
-	case _FeeQuoterV2.abi.Events["UsdPerTokenUpdated"].ID:
-		return _FeeQuoterV2.ParseUsdPerTokenUpdated(log)
-	case _FeeQuoterV2.abi.Events["UsdPerUnitGasUpdated"].ID:
-		return _FeeQuoterV2.ParseUsdPerUnitGasUpdated(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (FeeQuoterV2AuthorizedCallerAdded) Topic() common.Hash {
 	return common.HexToHash("0xeb1b9b92e50b7f88f9ff25d56765095ac6e91540eee214906f4036a908ffbdef")
 }
@@ -3176,8 +3136,6 @@ type FeeQuoterV2Interface interface {
 	WatchUsdPerUnitGasUpdated(opts *bind.WatchOpts, sink chan<- *FeeQuoterV2UsdPerUnitGasUpdated, destChain []uint64) (event.Subscription, error)
 
 	ParseUsdPerUnitGasUpdated(log types.Log) (*FeeQuoterV2UsdPerUnitGasUpdated, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/lock_release_token_pool/lock_release_token_pool.go
+++ b/chains/evm/gobindings/generated/latest/lock_release_token_pool/lock_release_token_pool.go
@@ -5,7 +5,6 @@ package lock_release_token_pool
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -3338,54 +3336,6 @@ func (_LockReleaseTokenPool *LockReleaseTokenPoolFilterer) ParseRouterUpdated(lo
 	return event, nil
 }
 
-func (_LockReleaseTokenPool *LockReleaseTokenPool) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _LockReleaseTokenPool.abi.Events["AllowListAdd"].ID:
-		return _LockReleaseTokenPool.ParseAllowListAdd(log)
-	case _LockReleaseTokenPool.abi.Events["AllowListRemove"].ID:
-		return _LockReleaseTokenPool.ParseAllowListRemove(log)
-	case _LockReleaseTokenPool.abi.Events["ChainAdded"].ID:
-		return _LockReleaseTokenPool.ParseChainAdded(log)
-	case _LockReleaseTokenPool.abi.Events["ChainConfigured"].ID:
-		return _LockReleaseTokenPool.ParseChainConfigured(log)
-	case _LockReleaseTokenPool.abi.Events["ChainRemoved"].ID:
-		return _LockReleaseTokenPool.ParseChainRemoved(log)
-	case _LockReleaseTokenPool.abi.Events["ConfigChanged"].ID:
-		return _LockReleaseTokenPool.ParseConfigChanged(log)
-	case _LockReleaseTokenPool.abi.Events["InboundRateLimitConsumed"].ID:
-		return _LockReleaseTokenPool.ParseInboundRateLimitConsumed(log)
-	case _LockReleaseTokenPool.abi.Events["LiquidityAdded"].ID:
-		return _LockReleaseTokenPool.ParseLiquidityAdded(log)
-	case _LockReleaseTokenPool.abi.Events["LiquidityRemoved"].ID:
-		return _LockReleaseTokenPool.ParseLiquidityRemoved(log)
-	case _LockReleaseTokenPool.abi.Events["LiquidityTransferred"].ID:
-		return _LockReleaseTokenPool.ParseLiquidityTransferred(log)
-	case _LockReleaseTokenPool.abi.Events["LockedOrBurned"].ID:
-		return _LockReleaseTokenPool.ParseLockedOrBurned(log)
-	case _LockReleaseTokenPool.abi.Events["OutboundRateLimitConsumed"].ID:
-		return _LockReleaseTokenPool.ParseOutboundRateLimitConsumed(log)
-	case _LockReleaseTokenPool.abi.Events["OwnershipTransferRequested"].ID:
-		return _LockReleaseTokenPool.ParseOwnershipTransferRequested(log)
-	case _LockReleaseTokenPool.abi.Events["OwnershipTransferred"].ID:
-		return _LockReleaseTokenPool.ParseOwnershipTransferred(log)
-	case _LockReleaseTokenPool.abi.Events["RateLimitAdminSet"].ID:
-		return _LockReleaseTokenPool.ParseRateLimitAdminSet(log)
-	case _LockReleaseTokenPool.abi.Events["RebalancerSet"].ID:
-		return _LockReleaseTokenPool.ParseRebalancerSet(log)
-	case _LockReleaseTokenPool.abi.Events["ReleasedOrMinted"].ID:
-		return _LockReleaseTokenPool.ParseReleasedOrMinted(log)
-	case _LockReleaseTokenPool.abi.Events["RemotePoolAdded"].ID:
-		return _LockReleaseTokenPool.ParseRemotePoolAdded(log)
-	case _LockReleaseTokenPool.abi.Events["RemotePoolRemoved"].ID:
-		return _LockReleaseTokenPool.ParseRemotePoolRemoved(log)
-	case _LockReleaseTokenPool.abi.Events["RouterUpdated"].ID:
-		return _LockReleaseTokenPool.ParseRouterUpdated(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (LockReleaseTokenPoolAllowListAdd) Topic() common.Hash {
 	return common.HexToHash("0x2640d4d76caf8bf478aabfa982fa4e1c4eb71a37f93cd15e80dbc657911546d8")
 }
@@ -3660,8 +3610,6 @@ type LockReleaseTokenPoolInterface interface {
 	WatchRouterUpdated(opts *bind.WatchOpts, sink chan<- *LockReleaseTokenPoolRouterUpdated) (event.Subscription, error)
 
 	ParseRouterUpdated(log types.Log) (*LockReleaseTokenPoolRouterUpdated, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/log_message_data_receiver/log_message_data_receiver.go
+++ b/chains/evm/gobindings/generated/latest/log_message_data_receiver/log_message_data_receiver.go
@@ -5,7 +5,6 @@ package log_message_data_receiver
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -357,16 +355,6 @@ func (_LogMessageDataReceiver *LogMessageDataReceiverFilterer) ParseMessageRecei
 	return event, nil
 }
 
-func (_LogMessageDataReceiver *LogMessageDataReceiver) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _LogMessageDataReceiver.abi.Events["MessageReceived"].ID:
-		return _LogMessageDataReceiver.ParseMessageReceived(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (LogMessageDataReceiverMessageReceived) Topic() common.Hash {
 	return common.HexToHash("0x4b3be2c5d6fcecc68e42c0268adeed4f145b0b4a6cbd5960dcdd39867bef682f")
 }
@@ -387,8 +375,6 @@ type LogMessageDataReceiverInterface interface {
 	WatchMessageReceived(opts *bind.WatchOpts, sink chan<- *LogMessageDataReceiverMessageReceived) (event.Subscription, error)
 
 	ParseMessageReceived(log types.Log) (*LogMessageDataReceiverMessageReceived, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/maybe_revert_message_receiver/maybe_revert_message_receiver.go
+++ b/chains/evm/gobindings/generated/latest/maybe_revert_message_receiver/maybe_revert_message_receiver.go
@@ -5,7 +5,6 @@ package maybe_revert_message_receiver
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -825,22 +823,6 @@ func (_MaybeRevertMessageReceiver *MaybeRevertMessageReceiverFilterer) ParseValu
 	return event, nil
 }
 
-func (_MaybeRevertMessageReceiver *MaybeRevertMessageReceiver) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _MaybeRevertMessageReceiver.abi.Events["MessageReceived"].ID:
-		return _MaybeRevertMessageReceiver.ParseMessageReceived(log)
-	case _MaybeRevertMessageReceiver.abi.Events["NativeFundsWithdrawn"].ID:
-		return _MaybeRevertMessageReceiver.ParseNativeFundsWithdrawn(log)
-	case _MaybeRevertMessageReceiver.abi.Events["TokensWithdrawn"].ID:
-		return _MaybeRevertMessageReceiver.ParseTokensWithdrawn(log)
-	case _MaybeRevertMessageReceiver.abi.Events["ValueReceived"].ID:
-		return _MaybeRevertMessageReceiver.ParseValueReceived(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (MaybeRevertMessageReceiverMessageReceived) Topic() common.Hash {
 	return common.HexToHash("0x707732b700184c0ab3b799f43f03de9b3606a144cfb367f98291044e71972cdc")
 }
@@ -903,8 +885,6 @@ type MaybeRevertMessageReceiverInterface interface {
 	WatchValueReceived(opts *bind.WatchOpts, sink chan<- *MaybeRevertMessageReceiverValueReceived) (event.Subscription, error)
 
 	ParseValueReceived(log types.Log) (*MaybeRevertMessageReceiverValueReceived, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/mock_lbtc_token_pool/mock_lbtc_token_pool.go
+++ b/chains/evm/gobindings/generated/latest/mock_lbtc_token_pool/mock_lbtc_token_pool.go
@@ -5,7 +5,6 @@ package mock_lbtc_token_pool
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -2772,46 +2770,6 @@ func (_MockE2ELBTCTokenPool *MockE2ELBTCTokenPoolFilterer) ParseRouterUpdated(lo
 	return event, nil
 }
 
-func (_MockE2ELBTCTokenPool *MockE2ELBTCTokenPool) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _MockE2ELBTCTokenPool.abi.Events["AllowListAdd"].ID:
-		return _MockE2ELBTCTokenPool.ParseAllowListAdd(log)
-	case _MockE2ELBTCTokenPool.abi.Events["AllowListRemove"].ID:
-		return _MockE2ELBTCTokenPool.ParseAllowListRemove(log)
-	case _MockE2ELBTCTokenPool.abi.Events["ChainAdded"].ID:
-		return _MockE2ELBTCTokenPool.ParseChainAdded(log)
-	case _MockE2ELBTCTokenPool.abi.Events["ChainConfigured"].ID:
-		return _MockE2ELBTCTokenPool.ParseChainConfigured(log)
-	case _MockE2ELBTCTokenPool.abi.Events["ChainRemoved"].ID:
-		return _MockE2ELBTCTokenPool.ParseChainRemoved(log)
-	case _MockE2ELBTCTokenPool.abi.Events["ConfigChanged"].ID:
-		return _MockE2ELBTCTokenPool.ParseConfigChanged(log)
-	case _MockE2ELBTCTokenPool.abi.Events["InboundRateLimitConsumed"].ID:
-		return _MockE2ELBTCTokenPool.ParseInboundRateLimitConsumed(log)
-	case _MockE2ELBTCTokenPool.abi.Events["LockedOrBurned"].ID:
-		return _MockE2ELBTCTokenPool.ParseLockedOrBurned(log)
-	case _MockE2ELBTCTokenPool.abi.Events["OutboundRateLimitConsumed"].ID:
-		return _MockE2ELBTCTokenPool.ParseOutboundRateLimitConsumed(log)
-	case _MockE2ELBTCTokenPool.abi.Events["OwnershipTransferRequested"].ID:
-		return _MockE2ELBTCTokenPool.ParseOwnershipTransferRequested(log)
-	case _MockE2ELBTCTokenPool.abi.Events["OwnershipTransferred"].ID:
-		return _MockE2ELBTCTokenPool.ParseOwnershipTransferred(log)
-	case _MockE2ELBTCTokenPool.abi.Events["RateLimitAdminSet"].ID:
-		return _MockE2ELBTCTokenPool.ParseRateLimitAdminSet(log)
-	case _MockE2ELBTCTokenPool.abi.Events["ReleasedOrMinted"].ID:
-		return _MockE2ELBTCTokenPool.ParseReleasedOrMinted(log)
-	case _MockE2ELBTCTokenPool.abi.Events["RemotePoolAdded"].ID:
-		return _MockE2ELBTCTokenPool.ParseRemotePoolAdded(log)
-	case _MockE2ELBTCTokenPool.abi.Events["RemotePoolRemoved"].ID:
-		return _MockE2ELBTCTokenPool.ParseRemotePoolRemoved(log)
-	case _MockE2ELBTCTokenPool.abi.Events["RouterUpdated"].ID:
-		return _MockE2ELBTCTokenPool.ParseRouterUpdated(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (MockE2ELBTCTokenPoolAllowListAdd) Topic() common.Hash {
 	return common.HexToHash("0x2640d4d76caf8bf478aabfa982fa4e1c4eb71a37f93cd15e80dbc657911546d8")
 }
@@ -3038,8 +2996,6 @@ type MockE2ELBTCTokenPoolInterface interface {
 	WatchRouterUpdated(opts *bind.WatchOpts, sink chan<- *MockE2ELBTCTokenPoolRouterUpdated) (event.Subscription, error)
 
 	ParseRouterUpdated(log types.Log) (*MockE2ELBTCTokenPoolRouterUpdated, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/mock_usdc_token_messenger/mock_usdc_token_messenger.go
+++ b/chains/evm/gobindings/generated/latest/mock_usdc_token_messenger/mock_usdc_token_messenger.go
@@ -5,7 +5,6 @@ package mock_usdc_token_messenger
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -613,18 +611,6 @@ func (_MockE2EUSDCTokenMessenger *MockE2EUSDCTokenMessengerFilterer) ParseDeposi
 	return event, nil
 }
 
-func (_MockE2EUSDCTokenMessenger *MockE2EUSDCTokenMessenger) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _MockE2EUSDCTokenMessenger.abi.Events["DepositForBurn"].ID:
-		return _MockE2EUSDCTokenMessenger.ParseDepositForBurn(log)
-	case _MockE2EUSDCTokenMessenger.abi.Events["DepositForBurn0"].ID:
-		return _MockE2EUSDCTokenMessenger.ParseDepositForBurn0(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (MockE2EUSDCTokenMessengerDepositForBurn) Topic() common.Hash {
 	return common.HexToHash("0x2fa9ca894982930190727e75500a97d8dc500233a5065e0f3126c48fbe0343c0")
 }
@@ -663,8 +649,6 @@ type MockE2EUSDCTokenMessengerInterface interface {
 	WatchDepositForBurn0(opts *bind.WatchOpts, sink chan<- *MockE2EUSDCTokenMessengerDepositForBurn0, burnToken []common.Address, depositor []common.Address, minFinalityThreshold []uint32) (event.Subscription, error)
 
 	ParseDepositForBurn0(log types.Log) (*MockE2EUSDCTokenMessengerDepositForBurn0, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/mock_usdc_token_transmitter/mock_usdc_token_transmitter.go
+++ b/chains/evm/gobindings/generated/latest/mock_usdc_token_transmitter/mock_usdc_token_transmitter.go
@@ -5,7 +5,6 @@ package mock_usdc_token_transmitter
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -424,16 +422,6 @@ func (_MockE2EUSDCTransmitter *MockE2EUSDCTransmitterFilterer) ParseMessageSent(
 	return event, nil
 }
 
-func (_MockE2EUSDCTransmitter *MockE2EUSDCTransmitter) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _MockE2EUSDCTransmitter.abi.Events["MessageSent"].ID:
-		return _MockE2EUSDCTransmitter.ParseMessageSent(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (MockE2EUSDCTransmitterMessageSent) Topic() common.Hash {
 	return common.HexToHash("0x8c5261668696ce22758910d05bab8f186d6eb247ceac2af2e82c7dc17669b036")
 }
@@ -464,8 +452,6 @@ type MockE2EUSDCTransmitterInterface interface {
 	WatchMessageSent(opts *bind.WatchOpts, sink chan<- *MockE2EUSDCTransmitterMessageSent) (event.Subscription, error)
 
 	ParseMessageSent(log types.Log) (*MockE2EUSDCTransmitterMessageSent, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/multi_ocr3_helper/multi_ocr3_helper.go
+++ b/chains/evm/gobindings/generated/latest/multi_ocr3_helper/multi_ocr3_helper.go
@@ -5,7 +5,6 @@ package multi_ocr3_helper
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -997,24 +995,6 @@ func (_MultiOCR3Helper *MultiOCR3HelperFilterer) ParseTransmitted(log types.Log)
 	return event, nil
 }
 
-func (_MultiOCR3Helper *MultiOCR3Helper) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _MultiOCR3Helper.abi.Events["AfterConfigSet"].ID:
-		return _MultiOCR3Helper.ParseAfterConfigSet(log)
-	case _MultiOCR3Helper.abi.Events["ConfigSet"].ID:
-		return _MultiOCR3Helper.ParseConfigSet(log)
-	case _MultiOCR3Helper.abi.Events["OwnershipTransferRequested"].ID:
-		return _MultiOCR3Helper.ParseOwnershipTransferRequested(log)
-	case _MultiOCR3Helper.abi.Events["OwnershipTransferred"].ID:
-		return _MultiOCR3Helper.ParseOwnershipTransferred(log)
-	case _MultiOCR3Helper.abi.Events["Transmitted"].ID:
-		return _MultiOCR3Helper.ParseTransmitted(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (MultiOCR3HelperAfterConfigSet) Topic() common.Hash {
 	return common.HexToHash("0x897ac1b2c12867721b284f3eb147bd4ab046d4eef1cf31c1d8988bfcfb962b53")
 }
@@ -1089,8 +1069,6 @@ type MultiOCR3HelperInterface interface {
 	WatchTransmitted(opts *bind.WatchOpts, sink chan<- *MultiOCR3HelperTransmitted, ocrPluginType []uint8) (event.Subscription, error)
 
 	ParseTransmitted(log types.Log) (*MultiOCR3HelperTransmitted, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/nonce_manager/nonce_manager.go
+++ b/chains/evm/gobindings/generated/latest/nonce_manager/nonce_manager.go
@@ -5,7 +5,6 @@ package nonce_manager
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -1144,26 +1142,6 @@ func (_NonceManager *NonceManagerFilterer) ParseSkippedIncorrectNonce(log types.
 	return event, nil
 }
 
-func (_NonceManager *NonceManager) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _NonceManager.abi.Events["AuthorizedCallerAdded"].ID:
-		return _NonceManager.ParseAuthorizedCallerAdded(log)
-	case _NonceManager.abi.Events["AuthorizedCallerRemoved"].ID:
-		return _NonceManager.ParseAuthorizedCallerRemoved(log)
-	case _NonceManager.abi.Events["OwnershipTransferRequested"].ID:
-		return _NonceManager.ParseOwnershipTransferRequested(log)
-	case _NonceManager.abi.Events["OwnershipTransferred"].ID:
-		return _NonceManager.ParseOwnershipTransferred(log)
-	case _NonceManager.abi.Events["PreviousRampsUpdated"].ID:
-		return _NonceManager.ParsePreviousRampsUpdated(log)
-	case _NonceManager.abi.Events["SkippedIncorrectNonce"].ID:
-		return _NonceManager.ParseSkippedIncorrectNonce(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (NonceManagerAuthorizedCallerAdded) Topic() common.Hash {
 	return common.HexToHash("0xeb1b9b92e50b7f88f9ff25d56765095ac6e91540eee214906f4036a908ffbdef")
 }
@@ -1252,8 +1230,6 @@ type NonceManagerInterface interface {
 	WatchSkippedIncorrectNonce(opts *bind.WatchOpts, sink chan<- *NonceManagerSkippedIncorrectNonce) (event.Subscription, error)
 
 	ParseSkippedIncorrectNonce(log types.Log) (*NonceManagerSkippedIncorrectNonce, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/offramp/offramp.go
+++ b/chains/evm/gobindings/generated/latest/offramp/offramp.go
@@ -5,7 +5,6 @@ package offramp
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -2385,42 +2383,6 @@ func (_OffRamp *OffRampFilterer) ParseTransmitted(log types.Log) (*OffRampTransm
 	return event, nil
 }
 
-func (_OffRamp *OffRamp) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _OffRamp.abi.Events["AlreadyAttempted"].ID:
-		return _OffRamp.ParseAlreadyAttempted(log)
-	case _OffRamp.abi.Events["CommitReportAccepted"].ID:
-		return _OffRamp.ParseCommitReportAccepted(log)
-	case _OffRamp.abi.Events["ConfigSet"].ID:
-		return _OffRamp.ParseConfigSet(log)
-	case _OffRamp.abi.Events["DynamicConfigSet"].ID:
-		return _OffRamp.ParseDynamicConfigSet(log)
-	case _OffRamp.abi.Events["ExecutionStateChanged"].ID:
-		return _OffRamp.ParseExecutionStateChanged(log)
-	case _OffRamp.abi.Events["OwnershipTransferRequested"].ID:
-		return _OffRamp.ParseOwnershipTransferRequested(log)
-	case _OffRamp.abi.Events["OwnershipTransferred"].ID:
-		return _OffRamp.ParseOwnershipTransferred(log)
-	case _OffRamp.abi.Events["RootRemoved"].ID:
-		return _OffRamp.ParseRootRemoved(log)
-	case _OffRamp.abi.Events["SkippedAlreadyExecutedMessage"].ID:
-		return _OffRamp.ParseSkippedAlreadyExecutedMessage(log)
-	case _OffRamp.abi.Events["SkippedReportExecution"].ID:
-		return _OffRamp.ParseSkippedReportExecution(log)
-	case _OffRamp.abi.Events["SourceChainConfigSet"].ID:
-		return _OffRamp.ParseSourceChainConfigSet(log)
-	case _OffRamp.abi.Events["SourceChainSelectorAdded"].ID:
-		return _OffRamp.ParseSourceChainSelectorAdded(log)
-	case _OffRamp.abi.Events["StaticConfigSet"].ID:
-		return _OffRamp.ParseStaticConfigSet(log)
-	case _OffRamp.abi.Events["Transmitted"].ID:
-		return _OffRamp.ParseTransmitted(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (OffRampAlreadyAttempted) Topic() common.Hash {
 	return common.HexToHash("0x3ef2a99c550a751d4b0b261268f05a803dfb049ab43616a1ffb388f61fe65120")
 }
@@ -2605,8 +2567,6 @@ type OffRampInterface interface {
 	WatchTransmitted(opts *bind.WatchOpts, sink chan<- *OffRampTransmitted, ocrPluginType []uint8) (event.Subscription, error)
 
 	ParseTransmitted(log types.Log) (*OffRampTransmitted, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/offramp_over_superchain_interop/offramp_over_superchain_interop.go
+++ b/chains/evm/gobindings/generated/latest/offramp_over_superchain_interop/offramp_over_superchain_interop.go
@@ -5,7 +5,6 @@ package offramp_over_superchain_interop
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -2726,46 +2724,6 @@ func (_OffRampOverSuperchainInterop *OffRampOverSuperchainInteropFilterer) Parse
 	return event, nil
 }
 
-func (_OffRampOverSuperchainInterop *OffRampOverSuperchainInterop) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _OffRampOverSuperchainInterop.abi.Events["AlreadyAttempted"].ID:
-		return _OffRampOverSuperchainInterop.ParseAlreadyAttempted(log)
-	case _OffRampOverSuperchainInterop.abi.Events["ChainSelectorToChainIdConfigRemoved"].ID:
-		return _OffRampOverSuperchainInterop.ParseChainSelectorToChainIdConfigRemoved(log)
-	case _OffRampOverSuperchainInterop.abi.Events["ChainSelectorToChainIdConfigUpdated"].ID:
-		return _OffRampOverSuperchainInterop.ParseChainSelectorToChainIdConfigUpdated(log)
-	case _OffRampOverSuperchainInterop.abi.Events["CommitReportAccepted"].ID:
-		return _OffRampOverSuperchainInterop.ParseCommitReportAccepted(log)
-	case _OffRampOverSuperchainInterop.abi.Events["ConfigSet"].ID:
-		return _OffRampOverSuperchainInterop.ParseConfigSet(log)
-	case _OffRampOverSuperchainInterop.abi.Events["DynamicConfigSet"].ID:
-		return _OffRampOverSuperchainInterop.ParseDynamicConfigSet(log)
-	case _OffRampOverSuperchainInterop.abi.Events["ExecutionStateChanged"].ID:
-		return _OffRampOverSuperchainInterop.ParseExecutionStateChanged(log)
-	case _OffRampOverSuperchainInterop.abi.Events["OwnershipTransferRequested"].ID:
-		return _OffRampOverSuperchainInterop.ParseOwnershipTransferRequested(log)
-	case _OffRampOverSuperchainInterop.abi.Events["OwnershipTransferred"].ID:
-		return _OffRampOverSuperchainInterop.ParseOwnershipTransferred(log)
-	case _OffRampOverSuperchainInterop.abi.Events["RootRemoved"].ID:
-		return _OffRampOverSuperchainInterop.ParseRootRemoved(log)
-	case _OffRampOverSuperchainInterop.abi.Events["SkippedAlreadyExecutedMessage"].ID:
-		return _OffRampOverSuperchainInterop.ParseSkippedAlreadyExecutedMessage(log)
-	case _OffRampOverSuperchainInterop.abi.Events["SkippedReportExecution"].ID:
-		return _OffRampOverSuperchainInterop.ParseSkippedReportExecution(log)
-	case _OffRampOverSuperchainInterop.abi.Events["SourceChainConfigSet"].ID:
-		return _OffRampOverSuperchainInterop.ParseSourceChainConfigSet(log)
-	case _OffRampOverSuperchainInterop.abi.Events["SourceChainSelectorAdded"].ID:
-		return _OffRampOverSuperchainInterop.ParseSourceChainSelectorAdded(log)
-	case _OffRampOverSuperchainInterop.abi.Events["StaticConfigSet"].ID:
-		return _OffRampOverSuperchainInterop.ParseStaticConfigSet(log)
-	case _OffRampOverSuperchainInterop.abi.Events["Transmitted"].ID:
-		return _OffRampOverSuperchainInterop.ParseTransmitted(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (OffRampOverSuperchainInteropAlreadyAttempted) Topic() common.Hash {
 	return common.HexToHash("0x3ef2a99c550a751d4b0b261268f05a803dfb049ab43616a1ffb388f61fe65120")
 }
@@ -2976,8 +2934,6 @@ type OffRampOverSuperchainInteropInterface interface {
 	WatchTransmitted(opts *bind.WatchOpts, sink chan<- *OffRampOverSuperchainInteropTransmitted, ocrPluginType []uint8) (event.Subscription, error)
 
 	ParseTransmitted(log types.Log) (*OffRampOverSuperchainInteropTransmitted, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/offramp_with_message_transformer/offramp_with_message_transformer.go
+++ b/chains/evm/gobindings/generated/latest/offramp_with_message_transformer/offramp_with_message_transformer.go
@@ -5,7 +5,6 @@ package offramp_with_message_transformer
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -2419,42 +2417,6 @@ func (_OffRampWithMessageTransformer *OffRampWithMessageTransformerFilterer) Par
 	return event, nil
 }
 
-func (_OffRampWithMessageTransformer *OffRampWithMessageTransformer) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _OffRampWithMessageTransformer.abi.Events["AlreadyAttempted"].ID:
-		return _OffRampWithMessageTransformer.ParseAlreadyAttempted(log)
-	case _OffRampWithMessageTransformer.abi.Events["CommitReportAccepted"].ID:
-		return _OffRampWithMessageTransformer.ParseCommitReportAccepted(log)
-	case _OffRampWithMessageTransformer.abi.Events["ConfigSet"].ID:
-		return _OffRampWithMessageTransformer.ParseConfigSet(log)
-	case _OffRampWithMessageTransformer.abi.Events["DynamicConfigSet"].ID:
-		return _OffRampWithMessageTransformer.ParseDynamicConfigSet(log)
-	case _OffRampWithMessageTransformer.abi.Events["ExecutionStateChanged"].ID:
-		return _OffRampWithMessageTransformer.ParseExecutionStateChanged(log)
-	case _OffRampWithMessageTransformer.abi.Events["OwnershipTransferRequested"].ID:
-		return _OffRampWithMessageTransformer.ParseOwnershipTransferRequested(log)
-	case _OffRampWithMessageTransformer.abi.Events["OwnershipTransferred"].ID:
-		return _OffRampWithMessageTransformer.ParseOwnershipTransferred(log)
-	case _OffRampWithMessageTransformer.abi.Events["RootRemoved"].ID:
-		return _OffRampWithMessageTransformer.ParseRootRemoved(log)
-	case _OffRampWithMessageTransformer.abi.Events["SkippedAlreadyExecutedMessage"].ID:
-		return _OffRampWithMessageTransformer.ParseSkippedAlreadyExecutedMessage(log)
-	case _OffRampWithMessageTransformer.abi.Events["SkippedReportExecution"].ID:
-		return _OffRampWithMessageTransformer.ParseSkippedReportExecution(log)
-	case _OffRampWithMessageTransformer.abi.Events["SourceChainConfigSet"].ID:
-		return _OffRampWithMessageTransformer.ParseSourceChainConfigSet(log)
-	case _OffRampWithMessageTransformer.abi.Events["SourceChainSelectorAdded"].ID:
-		return _OffRampWithMessageTransformer.ParseSourceChainSelectorAdded(log)
-	case _OffRampWithMessageTransformer.abi.Events["StaticConfigSet"].ID:
-		return _OffRampWithMessageTransformer.ParseStaticConfigSet(log)
-	case _OffRampWithMessageTransformer.abi.Events["Transmitted"].ID:
-		return _OffRampWithMessageTransformer.ParseTransmitted(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (OffRampWithMessageTransformerAlreadyAttempted) Topic() common.Hash {
 	return common.HexToHash("0x3ef2a99c550a751d4b0b261268f05a803dfb049ab43616a1ffb388f61fe65120")
 }
@@ -2643,8 +2605,6 @@ type OffRampWithMessageTransformerInterface interface {
 	WatchTransmitted(opts *bind.WatchOpts, sink chan<- *OffRampWithMessageTransformerTransmitted, ocrPluginType []uint8) (event.Subscription, error)
 
 	ParseTransmitted(log types.Log) (*OffRampWithMessageTransformerTransmitted, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/onramp/onramp.go
+++ b/chains/evm/gobindings/generated/latest/onramp/onramp.go
@@ -5,7 +5,6 @@ package onramp
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -1770,32 +1768,6 @@ type GetDestChainConfig struct {
 	Router           common.Address
 }
 
-func (_OnRamp *OnRamp) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _OnRamp.abi.Events["AllowListAdminSet"].ID:
-		return _OnRamp.ParseAllowListAdminSet(log)
-	case _OnRamp.abi.Events["AllowListSendersAdded"].ID:
-		return _OnRamp.ParseAllowListSendersAdded(log)
-	case _OnRamp.abi.Events["AllowListSendersRemoved"].ID:
-		return _OnRamp.ParseAllowListSendersRemoved(log)
-	case _OnRamp.abi.Events["CCIPMessageSent"].ID:
-		return _OnRamp.ParseCCIPMessageSent(log)
-	case _OnRamp.abi.Events["ConfigSet"].ID:
-		return _OnRamp.ParseConfigSet(log)
-	case _OnRamp.abi.Events["DestChainConfigSet"].ID:
-		return _OnRamp.ParseDestChainConfigSet(log)
-	case _OnRamp.abi.Events["FeeTokenWithdrawn"].ID:
-		return _OnRamp.ParseFeeTokenWithdrawn(log)
-	case _OnRamp.abi.Events["OwnershipTransferRequested"].ID:
-		return _OnRamp.ParseOwnershipTransferRequested(log)
-	case _OnRamp.abi.Events["OwnershipTransferred"].ID:
-		return _OnRamp.ParseOwnershipTransferred(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (OnRampAllowListAdminSet) Topic() common.Hash {
 	return common.HexToHash("0xb8c9b44ae5b5e3afb195f67391d9ff50cb904f9c0fa5fd520e497a97c1aa5a1e")
 }
@@ -1930,8 +1902,6 @@ type OnRampInterface interface {
 	WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *OnRampOwnershipTransferred, from []common.Address, to []common.Address) (event.Subscription, error)
 
 	ParseOwnershipTransferred(log types.Log) (*OnRampOwnershipTransferred, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/onramp_over_superchain_interop/onramp_over_superchain_interop.go
+++ b/chains/evm/gobindings/generated/latest/onramp_over_superchain_interop/onramp_over_superchain_interop.go
@@ -5,7 +5,6 @@ package onramp_over_superchain_interop
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -1958,34 +1956,6 @@ type GetDestChainConfig struct {
 	Router           common.Address
 }
 
-func (_OnRampOverSuperchainInterop *OnRampOverSuperchainInterop) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _OnRampOverSuperchainInterop.abi.Events["AllowListAdminSet"].ID:
-		return _OnRampOverSuperchainInterop.ParseAllowListAdminSet(log)
-	case _OnRampOverSuperchainInterop.abi.Events["AllowListSendersAdded"].ID:
-		return _OnRampOverSuperchainInterop.ParseAllowListSendersAdded(log)
-	case _OnRampOverSuperchainInterop.abi.Events["AllowListSendersRemoved"].ID:
-		return _OnRampOverSuperchainInterop.ParseAllowListSendersRemoved(log)
-	case _OnRampOverSuperchainInterop.abi.Events["CCIPMessageSent"].ID:
-		return _OnRampOverSuperchainInterop.ParseCCIPMessageSent(log)
-	case _OnRampOverSuperchainInterop.abi.Events["CCIPSuperchainMessageSent"].ID:
-		return _OnRampOverSuperchainInterop.ParseCCIPSuperchainMessageSent(log)
-	case _OnRampOverSuperchainInterop.abi.Events["ConfigSet"].ID:
-		return _OnRampOverSuperchainInterop.ParseConfigSet(log)
-	case _OnRampOverSuperchainInterop.abi.Events["DestChainConfigSet"].ID:
-		return _OnRampOverSuperchainInterop.ParseDestChainConfigSet(log)
-	case _OnRampOverSuperchainInterop.abi.Events["FeeTokenWithdrawn"].ID:
-		return _OnRampOverSuperchainInterop.ParseFeeTokenWithdrawn(log)
-	case _OnRampOverSuperchainInterop.abi.Events["OwnershipTransferRequested"].ID:
-		return _OnRampOverSuperchainInterop.ParseOwnershipTransferRequested(log)
-	case _OnRampOverSuperchainInterop.abi.Events["OwnershipTransferred"].ID:
-		return _OnRampOverSuperchainInterop.ParseOwnershipTransferred(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (OnRampOverSuperchainInteropAllowListAdminSet) Topic() common.Hash {
 	return common.HexToHash("0xb8c9b44ae5b5e3afb195f67391d9ff50cb904f9c0fa5fd520e497a97c1aa5a1e")
 }
@@ -2134,8 +2104,6 @@ type OnRampOverSuperchainInteropInterface interface {
 	WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *OnRampOverSuperchainInteropOwnershipTransferred, from []common.Address, to []common.Address) (event.Subscription, error)
 
 	ParseOwnershipTransferred(log types.Log) (*OnRampOverSuperchainInteropOwnershipTransferred, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/onramp_with_message_transformer/onramp_with_message_transformer.go
+++ b/chains/evm/gobindings/generated/latest/onramp_with_message_transformer/onramp_with_message_transformer.go
@@ -5,7 +5,6 @@ package onramp_with_message_transformer
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -1804,32 +1802,6 @@ type GetDestChainConfig struct {
 	Router           common.Address
 }
 
-func (_OnRampWithMessageTransformer *OnRampWithMessageTransformer) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _OnRampWithMessageTransformer.abi.Events["AllowListAdminSet"].ID:
-		return _OnRampWithMessageTransformer.ParseAllowListAdminSet(log)
-	case _OnRampWithMessageTransformer.abi.Events["AllowListSendersAdded"].ID:
-		return _OnRampWithMessageTransformer.ParseAllowListSendersAdded(log)
-	case _OnRampWithMessageTransformer.abi.Events["AllowListSendersRemoved"].ID:
-		return _OnRampWithMessageTransformer.ParseAllowListSendersRemoved(log)
-	case _OnRampWithMessageTransformer.abi.Events["CCIPMessageSent"].ID:
-		return _OnRampWithMessageTransformer.ParseCCIPMessageSent(log)
-	case _OnRampWithMessageTransformer.abi.Events["ConfigSet"].ID:
-		return _OnRampWithMessageTransformer.ParseConfigSet(log)
-	case _OnRampWithMessageTransformer.abi.Events["DestChainConfigSet"].ID:
-		return _OnRampWithMessageTransformer.ParseDestChainConfigSet(log)
-	case _OnRampWithMessageTransformer.abi.Events["FeeTokenWithdrawn"].ID:
-		return _OnRampWithMessageTransformer.ParseFeeTokenWithdrawn(log)
-	case _OnRampWithMessageTransformer.abi.Events["OwnershipTransferRequested"].ID:
-		return _OnRampWithMessageTransformer.ParseOwnershipTransferRequested(log)
-	case _OnRampWithMessageTransformer.abi.Events["OwnershipTransferred"].ID:
-		return _OnRampWithMessageTransformer.ParseOwnershipTransferred(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (OnRampWithMessageTransformerAllowListAdminSet) Topic() common.Hash {
 	return common.HexToHash("0xb8c9b44ae5b5e3afb195f67391d9ff50cb904f9c0fa5fd520e497a97c1aa5a1e")
 }
@@ -1968,8 +1940,6 @@ type OnRampWithMessageTransformerInterface interface {
 	WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *OnRampWithMessageTransformerOwnershipTransferred, from []common.Address, to []common.Address) (event.Subscription, error)
 
 	ParseOwnershipTransferred(log types.Log) (*OnRampWithMessageTransformerOwnershipTransferred, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/ping_pong_demo/ping_pong_demo.go
+++ b/chains/evm/gobindings/generated/latest/ping_pong_demo/ping_pong_demo.go
@@ -5,7 +5,6 @@ package ping_pong_demo
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -1150,24 +1148,6 @@ type GetCCVs struct {
 	OptionalThreshold uint8
 }
 
-func (_PingPongDemo *PingPongDemo) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _PingPongDemo.abi.Events["OutOfOrderExecutionChange"].ID:
-		return _PingPongDemo.ParseOutOfOrderExecutionChange(log)
-	case _PingPongDemo.abi.Events["OwnershipTransferRequested"].ID:
-		return _PingPongDemo.ParseOwnershipTransferRequested(log)
-	case _PingPongDemo.abi.Events["OwnershipTransferred"].ID:
-		return _PingPongDemo.ParseOwnershipTransferred(log)
-	case _PingPongDemo.abi.Events["Ping"].ID:
-		return _PingPongDemo.ParsePing(log)
-	case _PingPongDemo.abi.Events["Pong"].ID:
-		return _PingPongDemo.ParsePong(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (PingPongDemoOutOfOrderExecutionChange) Topic() common.Hash {
 	return common.HexToHash("0x05a3fef9935c9013a24c6193df2240d34fcf6b0ebf8786b85efe8401d696cdd9")
 }
@@ -1262,8 +1242,6 @@ type PingPongDemoInterface interface {
 	WatchPong(opts *bind.WatchOpts, sink chan<- *PingPongDemoPong) (event.Subscription, error)
 
 	ParsePong(log types.Log) (*PingPongDemoPong, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/registry_module_owner_custom/registry_module_owner_custom.go
+++ b/chains/evm/gobindings/generated/latest/registry_module_owner_custom/registry_module_owner_custom.go
@@ -5,7 +5,6 @@ package registry_module_owner_custom
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -365,16 +363,6 @@ func (_RegistryModuleOwnerCustom *RegistryModuleOwnerCustomFilterer) ParseAdmini
 	return event, nil
 }
 
-func (_RegistryModuleOwnerCustom *RegistryModuleOwnerCustom) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _RegistryModuleOwnerCustom.abi.Events["AdministratorRegistered"].ID:
-		return _RegistryModuleOwnerCustom.ParseAdministratorRegistered(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (RegistryModuleOwnerCustomAdministratorRegistered) Topic() common.Hash {
 	return common.HexToHash("0x09590fb70af4b833346363965e043a9339e8c7d378b8a2b903c75c277faec4f9")
 }
@@ -397,8 +385,6 @@ type RegistryModuleOwnerCustomInterface interface {
 	WatchAdministratorRegistered(opts *bind.WatchOpts, sink chan<- *RegistryModuleOwnerCustomAdministratorRegistered, token []common.Address, administrator []common.Address) (event.Subscription, error)
 
 	ParseAdministratorRegistered(log types.Log) (*RegistryModuleOwnerCustomAdministratorRegistered, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/report_codec/report_codec.go
+++ b/chains/evm/gobindings/generated/latest/report_codec/report_codec.go
@@ -5,7 +5,6 @@ package report_codec
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -517,18 +515,6 @@ func (_ReportCodec *ReportCodecFilterer) ParseExecuteReportDecoded(log types.Log
 	return event, nil
 }
 
-func (_ReportCodec *ReportCodec) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _ReportCodec.abi.Events["CommitReportDecoded"].ID:
-		return _ReportCodec.ParseCommitReportDecoded(log)
-	case _ReportCodec.abi.Events["ExecuteReportDecoded"].ID:
-		return _ReportCodec.ParseExecuteReportDecoded(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (ReportCodecCommitReportDecoded) Topic() common.Hash {
 	return common.HexToHash("0x58a603662478f1f3f18b8fc8006e127dc1ef28117b04eb2d89cc22849068dcd8")
 }
@@ -557,8 +543,6 @@ type ReportCodecInterface interface {
 	WatchExecuteReportDecoded(opts *bind.WatchOpts, sink chan<- *ReportCodecExecuteReportDecoded) (event.Subscription, error)
 
 	ParseExecuteReportDecoded(log types.Log) (*ReportCodecExecuteReportDecoded, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/rmn_home/rmn_home.go
+++ b/chains/evm/gobindings/generated/latest/rmn_home/rmn_home.go
@@ -5,7 +5,6 @@ package rmn_home
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -1373,28 +1371,6 @@ type GetConfigDigests struct {
 	CandidateConfigDigest [32]byte
 }
 
-func (_RMNHome *RMNHome) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _RMNHome.abi.Events["ActiveConfigRevoked"].ID:
-		return _RMNHome.ParseActiveConfigRevoked(log)
-	case _RMNHome.abi.Events["CandidateConfigRevoked"].ID:
-		return _RMNHome.ParseCandidateConfigRevoked(log)
-	case _RMNHome.abi.Events["ConfigPromoted"].ID:
-		return _RMNHome.ParseConfigPromoted(log)
-	case _RMNHome.abi.Events["ConfigSet"].ID:
-		return _RMNHome.ParseConfigSet(log)
-	case _RMNHome.abi.Events["DynamicConfigSet"].ID:
-		return _RMNHome.ParseDynamicConfigSet(log)
-	case _RMNHome.abi.Events["OwnershipTransferRequested"].ID:
-		return _RMNHome.ParseOwnershipTransferRequested(log)
-	case _RMNHome.abi.Events["OwnershipTransferred"].ID:
-		return _RMNHome.ParseOwnershipTransferred(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (RMNHomeActiveConfigRevoked) Topic() common.Hash {
 	return common.HexToHash("0x0b31c0055e2d464bef7781994b98c4ff9ef4ae0d05f59feb6a68c42de5e201b8")
 }
@@ -1501,8 +1477,6 @@ type RMNHomeInterface interface {
 	WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *RMNHomeOwnershipTransferred, from []common.Address, to []common.Address) (event.Subscription, error)
 
 	ParseOwnershipTransferred(log types.Log) (*RMNHomeOwnershipTransferred, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/rmn_proxy_contract/rmn_proxy_contract.go
+++ b/chains/evm/gobindings/generated/latest/rmn_proxy_contract/rmn_proxy_contract.go
@@ -5,7 +5,6 @@ package rmn_proxy_contract
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -674,20 +672,6 @@ func (_RMNProxy *RMNProxyFilterer) ParseOwnershipTransferred(log types.Log) (*RM
 	return event, nil
 }
 
-func (_RMNProxy *RMNProxy) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _RMNProxy.abi.Events["ARMSet"].ID:
-		return _RMNProxy.ParseARMSet(log)
-	case _RMNProxy.abi.Events["OwnershipTransferRequested"].ID:
-		return _RMNProxy.ParseOwnershipTransferRequested(log)
-	case _RMNProxy.abi.Events["OwnershipTransferred"].ID:
-		return _RMNProxy.ParseOwnershipTransferred(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (RMNProxyARMSet) Topic() common.Hash {
 	return common.HexToHash("0xef31f568d741a833c6a9dc85a6e1c65e06fa772740d5dc94d1da21827a4e0cab")
 }
@@ -736,8 +720,6 @@ type RMNProxyInterface interface {
 	WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *RMNProxyOwnershipTransferred, from []common.Address, to []common.Address) (event.Subscription, error)
 
 	ParseOwnershipTransferred(log types.Log) (*RMNProxyOwnershipTransferred, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/rmn_remote/rmn_remote.go
+++ b/chains/evm/gobindings/generated/latest/rmn_remote/rmn_remote.go
@@ -5,7 +5,6 @@ package rmn_remote
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -1149,24 +1147,6 @@ type GetVersionedConfig struct {
 	Config  RMNRemoteConfig
 }
 
-func (_RMNRemote *RMNRemote) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _RMNRemote.abi.Events["ConfigSet"].ID:
-		return _RMNRemote.ParseConfigSet(log)
-	case _RMNRemote.abi.Events["Cursed"].ID:
-		return _RMNRemote.ParseCursed(log)
-	case _RMNRemote.abi.Events["OwnershipTransferRequested"].ID:
-		return _RMNRemote.ParseOwnershipTransferRequested(log)
-	case _RMNRemote.abi.Events["OwnershipTransferred"].ID:
-		return _RMNRemote.ParseOwnershipTransferred(log)
-	case _RMNRemote.abi.Events["Uncursed"].ID:
-		return _RMNRemote.ParseUncursed(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (RMNRemoteConfigSet) Topic() common.Hash {
 	return common.HexToHash("0x7f22bf988149dbe8de8fb879c6b97a4e56e68b2bd57421ce1a4e79d4ef6b496c")
 }
@@ -1257,8 +1237,6 @@ type RMNRemoteInterface interface {
 	WatchUncursed(opts *bind.WatchOpts, sink chan<- *RMNRemoteUncursed) (event.Subscription, error)
 
 	ParseUncursed(log types.Log) (*RMNRemoteUncursed, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/router/router.go
+++ b/chains/evm/gobindings/generated/latest/router/router.go
@@ -5,7 +5,6 @@ package router
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -1304,26 +1302,6 @@ func (_Router *RouterFilterer) ParseOwnershipTransferred(log types.Log) (*Router
 	return event, nil
 }
 
-func (_Router *Router) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _Router.abi.Events["MessageExecuted"].ID:
-		return _Router.ParseMessageExecuted(log)
-	case _Router.abi.Events["OffRampAdded"].ID:
-		return _Router.ParseOffRampAdded(log)
-	case _Router.abi.Events["OffRampRemoved"].ID:
-		return _Router.ParseOffRampRemoved(log)
-	case _Router.abi.Events["OnRampSet"].ID:
-		return _Router.ParseOnRampSet(log)
-	case _Router.abi.Events["OwnershipTransferRequested"].ID:
-		return _Router.ParseOwnershipTransferRequested(log)
-	case _Router.abi.Events["OwnershipTransferred"].ID:
-		return _Router.ParseOwnershipTransferred(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (RouterMessageExecuted) Topic() common.Hash {
 	return common.HexToHash("0x9b877de93ea9895756e337442c657f95a34fc68e7eb988bdfa693d5be83016b6")
 }
@@ -1424,8 +1402,6 @@ type RouterInterface interface {
 	WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *RouterOwnershipTransferred, from []common.Address, to []common.Address) (event.Subscription, error)
 
 	ParseOwnershipTransferred(log types.Log) (*RouterOwnershipTransferred, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/siloed_lock_release_token_pool/siloed_lock_release_token_pool.go
+++ b/chains/evm/gobindings/generated/latest/siloed_lock_release_token_pool/siloed_lock_release_token_pool.go
@@ -5,7 +5,6 @@ package siloed_lock_release_token_pool
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -3690,58 +3688,6 @@ func (_SiloedLockReleaseTokenPool *SiloedLockReleaseTokenPoolFilterer) ParseUnsi
 	return event, nil
 }
 
-func (_SiloedLockReleaseTokenPool *SiloedLockReleaseTokenPool) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _SiloedLockReleaseTokenPool.abi.Events["AllowListAdd"].ID:
-		return _SiloedLockReleaseTokenPool.ParseAllowListAdd(log)
-	case _SiloedLockReleaseTokenPool.abi.Events["AllowListRemove"].ID:
-		return _SiloedLockReleaseTokenPool.ParseAllowListRemove(log)
-	case _SiloedLockReleaseTokenPool.abi.Events["ChainAdded"].ID:
-		return _SiloedLockReleaseTokenPool.ParseChainAdded(log)
-	case _SiloedLockReleaseTokenPool.abi.Events["ChainConfigured"].ID:
-		return _SiloedLockReleaseTokenPool.ParseChainConfigured(log)
-	case _SiloedLockReleaseTokenPool.abi.Events["ChainRemoved"].ID:
-		return _SiloedLockReleaseTokenPool.ParseChainRemoved(log)
-	case _SiloedLockReleaseTokenPool.abi.Events["ChainSiloed"].ID:
-		return _SiloedLockReleaseTokenPool.ParseChainSiloed(log)
-	case _SiloedLockReleaseTokenPool.abi.Events["ChainUnsiloed"].ID:
-		return _SiloedLockReleaseTokenPool.ParseChainUnsiloed(log)
-	case _SiloedLockReleaseTokenPool.abi.Events["ConfigChanged"].ID:
-		return _SiloedLockReleaseTokenPool.ParseConfigChanged(log)
-	case _SiloedLockReleaseTokenPool.abi.Events["InboundRateLimitConsumed"].ID:
-		return _SiloedLockReleaseTokenPool.ParseInboundRateLimitConsumed(log)
-	case _SiloedLockReleaseTokenPool.abi.Events["LiquidityAdded"].ID:
-		return _SiloedLockReleaseTokenPool.ParseLiquidityAdded(log)
-	case _SiloedLockReleaseTokenPool.abi.Events["LiquidityRemoved"].ID:
-		return _SiloedLockReleaseTokenPool.ParseLiquidityRemoved(log)
-	case _SiloedLockReleaseTokenPool.abi.Events["LockedOrBurned"].ID:
-		return _SiloedLockReleaseTokenPool.ParseLockedOrBurned(log)
-	case _SiloedLockReleaseTokenPool.abi.Events["OutboundRateLimitConsumed"].ID:
-		return _SiloedLockReleaseTokenPool.ParseOutboundRateLimitConsumed(log)
-	case _SiloedLockReleaseTokenPool.abi.Events["OwnershipTransferRequested"].ID:
-		return _SiloedLockReleaseTokenPool.ParseOwnershipTransferRequested(log)
-	case _SiloedLockReleaseTokenPool.abi.Events["OwnershipTransferred"].ID:
-		return _SiloedLockReleaseTokenPool.ParseOwnershipTransferred(log)
-	case _SiloedLockReleaseTokenPool.abi.Events["RateLimitAdminSet"].ID:
-		return _SiloedLockReleaseTokenPool.ParseRateLimitAdminSet(log)
-	case _SiloedLockReleaseTokenPool.abi.Events["ReleasedOrMinted"].ID:
-		return _SiloedLockReleaseTokenPool.ParseReleasedOrMinted(log)
-	case _SiloedLockReleaseTokenPool.abi.Events["RemotePoolAdded"].ID:
-		return _SiloedLockReleaseTokenPool.ParseRemotePoolAdded(log)
-	case _SiloedLockReleaseTokenPool.abi.Events["RemotePoolRemoved"].ID:
-		return _SiloedLockReleaseTokenPool.ParseRemotePoolRemoved(log)
-	case _SiloedLockReleaseTokenPool.abi.Events["RouterUpdated"].ID:
-		return _SiloedLockReleaseTokenPool.ParseRouterUpdated(log)
-	case _SiloedLockReleaseTokenPool.abi.Events["SiloRebalancerSet"].ID:
-		return _SiloedLockReleaseTokenPool.ParseSiloRebalancerSet(log)
-	case _SiloedLockReleaseTokenPool.abi.Events["UnsiloedRebalancerSet"].ID:
-		return _SiloedLockReleaseTokenPool.ParseUnsiloedRebalancerSet(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (SiloedLockReleaseTokenPoolAllowListAdd) Topic() common.Hash {
 	return common.HexToHash("0x2640d4d76caf8bf478aabfa982fa4e1c4eb71a37f93cd15e80dbc657911546d8")
 }
@@ -4050,8 +3996,6 @@ type SiloedLockReleaseTokenPoolInterface interface {
 	WatchUnsiloedRebalancerSet(opts *bind.WatchOpts, sink chan<- *SiloedLockReleaseTokenPoolUnsiloedRebalancerSet) (event.Subscription, error)
 
 	ParseUnsiloedRebalancerSet(log types.Log) (*SiloedLockReleaseTokenPoolUnsiloedRebalancerSet, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/siloed_usdc_token_pool/siloed_usdc_token_pool.go
+++ b/chains/evm/gobindings/generated/latest/siloed_usdc_token_pool/siloed_usdc_token_pool.go
@@ -5,7 +5,6 @@ package siloed_usdc_token_pool
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -4665,72 +4663,6 @@ func (_SiloedUSDCTokenPool *SiloedUSDCTokenPoolFilterer) ParseUnsiloedRebalancer
 	return event, nil
 }
 
-func (_SiloedUSDCTokenPool *SiloedUSDCTokenPool) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _SiloedUSDCTokenPool.abi.Events["AllowListAdd"].ID:
-		return _SiloedUSDCTokenPool.ParseAllowListAdd(log)
-	case _SiloedUSDCTokenPool.abi.Events["AllowListRemove"].ID:
-		return _SiloedUSDCTokenPool.ParseAllowListRemove(log)
-	case _SiloedUSDCTokenPool.abi.Events["AuthorizedCallerAdded"].ID:
-		return _SiloedUSDCTokenPool.ParseAuthorizedCallerAdded(log)
-	case _SiloedUSDCTokenPool.abi.Events["AuthorizedCallerRemoved"].ID:
-		return _SiloedUSDCTokenPool.ParseAuthorizedCallerRemoved(log)
-	case _SiloedUSDCTokenPool.abi.Events["CCTPMigrationCancelled"].ID:
-		return _SiloedUSDCTokenPool.ParseCCTPMigrationCancelled(log)
-	case _SiloedUSDCTokenPool.abi.Events["CCTPMigrationExecuted"].ID:
-		return _SiloedUSDCTokenPool.ParseCCTPMigrationExecuted(log)
-	case _SiloedUSDCTokenPool.abi.Events["CCTPMigrationProposed"].ID:
-		return _SiloedUSDCTokenPool.ParseCCTPMigrationProposed(log)
-	case _SiloedUSDCTokenPool.abi.Events["ChainAdded"].ID:
-		return _SiloedUSDCTokenPool.ParseChainAdded(log)
-	case _SiloedUSDCTokenPool.abi.Events["ChainConfigured"].ID:
-		return _SiloedUSDCTokenPool.ParseChainConfigured(log)
-	case _SiloedUSDCTokenPool.abi.Events["ChainRemoved"].ID:
-		return _SiloedUSDCTokenPool.ParseChainRemoved(log)
-	case _SiloedUSDCTokenPool.abi.Events["ChainSiloed"].ID:
-		return _SiloedUSDCTokenPool.ParseChainSiloed(log)
-	case _SiloedUSDCTokenPool.abi.Events["ChainUnsiloed"].ID:
-		return _SiloedUSDCTokenPool.ParseChainUnsiloed(log)
-	case _SiloedUSDCTokenPool.abi.Events["CircleMigratorAddressSet"].ID:
-		return _SiloedUSDCTokenPool.ParseCircleMigratorAddressSet(log)
-	case _SiloedUSDCTokenPool.abi.Events["ConfigChanged"].ID:
-		return _SiloedUSDCTokenPool.ParseConfigChanged(log)
-	case _SiloedUSDCTokenPool.abi.Events["InboundRateLimitConsumed"].ID:
-		return _SiloedUSDCTokenPool.ParseInboundRateLimitConsumed(log)
-	case _SiloedUSDCTokenPool.abi.Events["LiquidityAdded"].ID:
-		return _SiloedUSDCTokenPool.ParseLiquidityAdded(log)
-	case _SiloedUSDCTokenPool.abi.Events["LiquidityRemoved"].ID:
-		return _SiloedUSDCTokenPool.ParseLiquidityRemoved(log)
-	case _SiloedUSDCTokenPool.abi.Events["LockedOrBurned"].ID:
-		return _SiloedUSDCTokenPool.ParseLockedOrBurned(log)
-	case _SiloedUSDCTokenPool.abi.Events["OutboundRateLimitConsumed"].ID:
-		return _SiloedUSDCTokenPool.ParseOutboundRateLimitConsumed(log)
-	case _SiloedUSDCTokenPool.abi.Events["OwnershipTransferRequested"].ID:
-		return _SiloedUSDCTokenPool.ParseOwnershipTransferRequested(log)
-	case _SiloedUSDCTokenPool.abi.Events["OwnershipTransferred"].ID:
-		return _SiloedUSDCTokenPool.ParseOwnershipTransferred(log)
-	case _SiloedUSDCTokenPool.abi.Events["RateLimitAdminSet"].ID:
-		return _SiloedUSDCTokenPool.ParseRateLimitAdminSet(log)
-	case _SiloedUSDCTokenPool.abi.Events["ReleasedOrMinted"].ID:
-		return _SiloedUSDCTokenPool.ParseReleasedOrMinted(log)
-	case _SiloedUSDCTokenPool.abi.Events["RemotePoolAdded"].ID:
-		return _SiloedUSDCTokenPool.ParseRemotePoolAdded(log)
-	case _SiloedUSDCTokenPool.abi.Events["RemotePoolRemoved"].ID:
-		return _SiloedUSDCTokenPool.ParseRemotePoolRemoved(log)
-	case _SiloedUSDCTokenPool.abi.Events["RouterUpdated"].ID:
-		return _SiloedUSDCTokenPool.ParseRouterUpdated(log)
-	case _SiloedUSDCTokenPool.abi.Events["SiloRebalancerSet"].ID:
-		return _SiloedUSDCTokenPool.ParseSiloRebalancerSet(log)
-	case _SiloedUSDCTokenPool.abi.Events["TokensExcludedFromBurn"].ID:
-		return _SiloedUSDCTokenPool.ParseTokensExcludedFromBurn(log)
-	case _SiloedUSDCTokenPool.abi.Events["UnsiloedRebalancerSet"].ID:
-		return _SiloedUSDCTokenPool.ParseUnsiloedRebalancerSet(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (SiloedUSDCTokenPoolAllowListAdd) Topic() common.Hash {
 	return common.HexToHash("0x2640d4d76caf8bf478aabfa982fa4e1c4eb71a37f93cd15e80dbc657911546d8")
 }
@@ -5127,8 +5059,6 @@ type SiloedUSDCTokenPoolInterface interface {
 	WatchUnsiloedRebalancerSet(opts *bind.WatchOpts, sink chan<- *SiloedUSDCTokenPoolUnsiloedRebalancerSet) (event.Subscription, error)
 
 	ParseUnsiloedRebalancerSet(log types.Log) (*SiloedUSDCTokenPoolUnsiloedRebalancerSet, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/token_admin_registry/token_admin_registry.go
+++ b/chains/evm/gobindings/generated/latest/token_admin_registry/token_admin_registry.go
@@ -5,7 +5,6 @@ package token_admin_registry
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -1391,28 +1389,6 @@ func (_TokenAdminRegistry *TokenAdminRegistryFilterer) ParseRegistryModuleRemove
 	return event, nil
 }
 
-func (_TokenAdminRegistry *TokenAdminRegistry) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _TokenAdminRegistry.abi.Events["AdministratorTransferRequested"].ID:
-		return _TokenAdminRegistry.ParseAdministratorTransferRequested(log)
-	case _TokenAdminRegistry.abi.Events["AdministratorTransferred"].ID:
-		return _TokenAdminRegistry.ParseAdministratorTransferred(log)
-	case _TokenAdminRegistry.abi.Events["OwnershipTransferRequested"].ID:
-		return _TokenAdminRegistry.ParseOwnershipTransferRequested(log)
-	case _TokenAdminRegistry.abi.Events["OwnershipTransferred"].ID:
-		return _TokenAdminRegistry.ParseOwnershipTransferred(log)
-	case _TokenAdminRegistry.abi.Events["PoolSet"].ID:
-		return _TokenAdminRegistry.ParsePoolSet(log)
-	case _TokenAdminRegistry.abi.Events["RegistryModuleAdded"].ID:
-		return _TokenAdminRegistry.ParseRegistryModuleAdded(log)
-	case _TokenAdminRegistry.abi.Events["RegistryModuleRemoved"].ID:
-		return _TokenAdminRegistry.ParseRegistryModuleRemoved(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (TokenAdminRegistryAdministratorTransferRequested) Topic() common.Hash {
 	return common.HexToHash("0xc54c3051ff16e63bb9203214432372aca006c589e3653619b577a3265675b716")
 }
@@ -1519,8 +1495,6 @@ type TokenAdminRegistryInterface interface {
 	WatchRegistryModuleRemoved(opts *bind.WatchOpts, sink chan<- *TokenAdminRegistryRegistryModuleRemoved, module []common.Address) (event.Subscription, error)
 
 	ParseRegistryModuleRemoved(log types.Log) (*TokenAdminRegistryRegistryModuleRemoved, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/token_pool/token_pool.go
+++ b/chains/evm/gobindings/generated/latest/token_pool/token_pool.go
@@ -5,7 +5,6 @@ package token_pool
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -2709,46 +2707,6 @@ func (_TokenPool *TokenPoolFilterer) ParseRouterUpdated(log types.Log) (*TokenPo
 	return event, nil
 }
 
-func (_TokenPool *TokenPool) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _TokenPool.abi.Events["AllowListAdd"].ID:
-		return _TokenPool.ParseAllowListAdd(log)
-	case _TokenPool.abi.Events["AllowListRemove"].ID:
-		return _TokenPool.ParseAllowListRemove(log)
-	case _TokenPool.abi.Events["ChainAdded"].ID:
-		return _TokenPool.ParseChainAdded(log)
-	case _TokenPool.abi.Events["ChainConfigured"].ID:
-		return _TokenPool.ParseChainConfigured(log)
-	case _TokenPool.abi.Events["ChainRemoved"].ID:
-		return _TokenPool.ParseChainRemoved(log)
-	case _TokenPool.abi.Events["ConfigChanged"].ID:
-		return _TokenPool.ParseConfigChanged(log)
-	case _TokenPool.abi.Events["InboundRateLimitConsumed"].ID:
-		return _TokenPool.ParseInboundRateLimitConsumed(log)
-	case _TokenPool.abi.Events["LockedOrBurned"].ID:
-		return _TokenPool.ParseLockedOrBurned(log)
-	case _TokenPool.abi.Events["OutboundRateLimitConsumed"].ID:
-		return _TokenPool.ParseOutboundRateLimitConsumed(log)
-	case _TokenPool.abi.Events["OwnershipTransferRequested"].ID:
-		return _TokenPool.ParseOwnershipTransferRequested(log)
-	case _TokenPool.abi.Events["OwnershipTransferred"].ID:
-		return _TokenPool.ParseOwnershipTransferred(log)
-	case _TokenPool.abi.Events["RateLimitAdminSet"].ID:
-		return _TokenPool.ParseRateLimitAdminSet(log)
-	case _TokenPool.abi.Events["ReleasedOrMinted"].ID:
-		return _TokenPool.ParseReleasedOrMinted(log)
-	case _TokenPool.abi.Events["RemotePoolAdded"].ID:
-		return _TokenPool.ParseRemotePoolAdded(log)
-	case _TokenPool.abi.Events["RemotePoolRemoved"].ID:
-		return _TokenPool.ParseRemotePoolRemoved(log)
-	case _TokenPool.abi.Events["RouterUpdated"].ID:
-		return _TokenPool.ParseRouterUpdated(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (TokenPoolAllowListAdd) Topic() common.Hash {
 	return common.HexToHash("0x2640d4d76caf8bf478aabfa982fa4e1c4eb71a37f93cd15e80dbc657911546d8")
 }
@@ -2971,8 +2929,6 @@ type TokenPoolInterface interface {
 	WatchRouterUpdated(opts *bind.WatchOpts, sink chan<- *TokenPoolRouterUpdated) (event.Subscription, error)
 
 	ParseRouterUpdated(log types.Log) (*TokenPoolRouterUpdated, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/token_pool_factory/token_pool_factory.go
+++ b/chains/evm/gobindings/generated/latest/token_pool_factory/token_pool_factory.go
@@ -5,7 +5,6 @@ package token_pool_factory
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -369,16 +367,6 @@ func (_TokenPoolFactory *TokenPoolFactoryFilterer) ParseRemoteChainConfigUpdated
 	return event, nil
 }
 
-func (_TokenPoolFactory *TokenPoolFactory) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _TokenPoolFactory.abi.Events["RemoteChainConfigUpdated"].ID:
-		return _TokenPoolFactory.ParseRemoteChainConfigUpdated(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (TokenPoolFactoryRemoteChainConfigUpdated) Topic() common.Hash {
 	return common.HexToHash("0xe3606343290c8e3853a7f92686979dfe24a0f29594186b61177236cb145126f0")
 }
@@ -399,8 +387,6 @@ type TokenPoolFactoryInterface interface {
 	WatchRemoteChainConfigUpdated(opts *bind.WatchOpts, sink chan<- *TokenPoolFactoryRemoteChainConfigUpdated, remoteChainSelector []uint64) (event.Subscription, error)
 
 	ParseRemoteChainConfigUpdated(log types.Log) (*TokenPoolFactoryRemoteChainConfigUpdated, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/usdc_reader_tester/usdc_reader_tester.go
+++ b/chains/evm/gobindings/generated/latest/usdc_reader_tester/usdc_reader_tester.go
@@ -5,7 +5,6 @@ package usdc_reader_tester
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -300,16 +298,6 @@ func (_USDCReaderTester *USDCReaderTesterFilterer) ParseMessageSent(log types.Lo
 	return event, nil
 }
 
-func (_USDCReaderTester *USDCReaderTester) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _USDCReaderTester.abi.Events["MessageSent"].ID:
-		return _USDCReaderTester.ParseMessageSent(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (USDCReaderTesterMessageSent) Topic() common.Hash {
 	return common.HexToHash("0x8c5261668696ce22758910d05bab8f186d6eb247ceac2af2e82c7dc17669b036")
 }
@@ -326,8 +314,6 @@ type USDCReaderTesterInterface interface {
 	WatchMessageSent(opts *bind.WatchOpts, sink chan<- *USDCReaderTesterMessageSent) (event.Subscription, error)
 
 	ParseMessageSent(log types.Log) (*USDCReaderTesterMessageSent, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/usdc_token_pool/usdc_token_pool.go
+++ b/chains/evm/gobindings/generated/latest/usdc_token_pool/usdc_token_pool.go
@@ -5,7 +5,6 @@ package usdc_token_pool
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -3394,54 +3392,6 @@ func (_USDCTokenPool *USDCTokenPoolFilterer) ParseRouterUpdated(log types.Log) (
 	return event, nil
 }
 
-func (_USDCTokenPool *USDCTokenPool) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _USDCTokenPool.abi.Events["AllowListAdd"].ID:
-		return _USDCTokenPool.ParseAllowListAdd(log)
-	case _USDCTokenPool.abi.Events["AllowListRemove"].ID:
-		return _USDCTokenPool.ParseAllowListRemove(log)
-	case _USDCTokenPool.abi.Events["AuthorizedCallerAdded"].ID:
-		return _USDCTokenPool.ParseAuthorizedCallerAdded(log)
-	case _USDCTokenPool.abi.Events["AuthorizedCallerRemoved"].ID:
-		return _USDCTokenPool.ParseAuthorizedCallerRemoved(log)
-	case _USDCTokenPool.abi.Events["ChainAdded"].ID:
-		return _USDCTokenPool.ParseChainAdded(log)
-	case _USDCTokenPool.abi.Events["ChainConfigured"].ID:
-		return _USDCTokenPool.ParseChainConfigured(log)
-	case _USDCTokenPool.abi.Events["ChainRemoved"].ID:
-		return _USDCTokenPool.ParseChainRemoved(log)
-	case _USDCTokenPool.abi.Events["ConfigChanged"].ID:
-		return _USDCTokenPool.ParseConfigChanged(log)
-	case _USDCTokenPool.abi.Events["ConfigSet"].ID:
-		return _USDCTokenPool.ParseConfigSet(log)
-	case _USDCTokenPool.abi.Events["DomainsSet"].ID:
-		return _USDCTokenPool.ParseDomainsSet(log)
-	case _USDCTokenPool.abi.Events["InboundRateLimitConsumed"].ID:
-		return _USDCTokenPool.ParseInboundRateLimitConsumed(log)
-	case _USDCTokenPool.abi.Events["LockedOrBurned"].ID:
-		return _USDCTokenPool.ParseLockedOrBurned(log)
-	case _USDCTokenPool.abi.Events["OutboundRateLimitConsumed"].ID:
-		return _USDCTokenPool.ParseOutboundRateLimitConsumed(log)
-	case _USDCTokenPool.abi.Events["OwnershipTransferRequested"].ID:
-		return _USDCTokenPool.ParseOwnershipTransferRequested(log)
-	case _USDCTokenPool.abi.Events["OwnershipTransferred"].ID:
-		return _USDCTokenPool.ParseOwnershipTransferred(log)
-	case _USDCTokenPool.abi.Events["RateLimitAdminSet"].ID:
-		return _USDCTokenPool.ParseRateLimitAdminSet(log)
-	case _USDCTokenPool.abi.Events["ReleasedOrMinted"].ID:
-		return _USDCTokenPool.ParseReleasedOrMinted(log)
-	case _USDCTokenPool.abi.Events["RemotePoolAdded"].ID:
-		return _USDCTokenPool.ParseRemotePoolAdded(log)
-	case _USDCTokenPool.abi.Events["RemotePoolRemoved"].ID:
-		return _USDCTokenPool.ParseRemotePoolRemoved(log)
-	case _USDCTokenPool.abi.Events["RouterUpdated"].ID:
-		return _USDCTokenPool.ParseRouterUpdated(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (USDCTokenPoolAllowListAdd) Topic() common.Hash {
 	return common.HexToHash("0x2640d4d76caf8bf478aabfa982fa4e1c4eb71a37f93cd15e80dbc657911546d8")
 }
@@ -3722,8 +3672,6 @@ type USDCTokenPoolInterface interface {
 	WatchRouterUpdated(opts *bind.WatchOpts, sink chan<- *USDCTokenPoolRouterUpdated) (event.Subscription, error)
 
 	ParseRouterUpdated(log types.Log) (*USDCTokenPoolRouterUpdated, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/chains/evm/gobindings/generated/latest/usdc_token_pool_cctp_v2/usdc_token_pool_cctp_v2.go
+++ b/chains/evm/gobindings/generated/latest/usdc_token_pool_cctp_v2/usdc_token_pool_cctp_v2.go
@@ -5,7 +5,6 @@ package usdc_token_pool_cctp_v2
 
 import (
 	"errors"
-	"fmt"
 	"math/big"
 	"strings"
 
@@ -15,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated"
 )
 
 var (
@@ -3438,54 +3436,6 @@ func (_USDCTokenPoolCCTPV2 *USDCTokenPoolCCTPV2Filterer) ParseRouterUpdated(log 
 	return event, nil
 }
 
-func (_USDCTokenPoolCCTPV2 *USDCTokenPoolCCTPV2) ParseLog(log types.Log) (generated.AbigenLog, error) {
-	switch log.Topics[0] {
-	case _USDCTokenPoolCCTPV2.abi.Events["AllowListAdd"].ID:
-		return _USDCTokenPoolCCTPV2.ParseAllowListAdd(log)
-	case _USDCTokenPoolCCTPV2.abi.Events["AllowListRemove"].ID:
-		return _USDCTokenPoolCCTPV2.ParseAllowListRemove(log)
-	case _USDCTokenPoolCCTPV2.abi.Events["AuthorizedCallerAdded"].ID:
-		return _USDCTokenPoolCCTPV2.ParseAuthorizedCallerAdded(log)
-	case _USDCTokenPoolCCTPV2.abi.Events["AuthorizedCallerRemoved"].ID:
-		return _USDCTokenPoolCCTPV2.ParseAuthorizedCallerRemoved(log)
-	case _USDCTokenPoolCCTPV2.abi.Events["ChainAdded"].ID:
-		return _USDCTokenPoolCCTPV2.ParseChainAdded(log)
-	case _USDCTokenPoolCCTPV2.abi.Events["ChainConfigured"].ID:
-		return _USDCTokenPoolCCTPV2.ParseChainConfigured(log)
-	case _USDCTokenPoolCCTPV2.abi.Events["ChainRemoved"].ID:
-		return _USDCTokenPoolCCTPV2.ParseChainRemoved(log)
-	case _USDCTokenPoolCCTPV2.abi.Events["ConfigChanged"].ID:
-		return _USDCTokenPoolCCTPV2.ParseConfigChanged(log)
-	case _USDCTokenPoolCCTPV2.abi.Events["ConfigSet"].ID:
-		return _USDCTokenPoolCCTPV2.ParseConfigSet(log)
-	case _USDCTokenPoolCCTPV2.abi.Events["DomainsSet"].ID:
-		return _USDCTokenPoolCCTPV2.ParseDomainsSet(log)
-	case _USDCTokenPoolCCTPV2.abi.Events["InboundRateLimitConsumed"].ID:
-		return _USDCTokenPoolCCTPV2.ParseInboundRateLimitConsumed(log)
-	case _USDCTokenPoolCCTPV2.abi.Events["LockedOrBurned"].ID:
-		return _USDCTokenPoolCCTPV2.ParseLockedOrBurned(log)
-	case _USDCTokenPoolCCTPV2.abi.Events["OutboundRateLimitConsumed"].ID:
-		return _USDCTokenPoolCCTPV2.ParseOutboundRateLimitConsumed(log)
-	case _USDCTokenPoolCCTPV2.abi.Events["OwnershipTransferRequested"].ID:
-		return _USDCTokenPoolCCTPV2.ParseOwnershipTransferRequested(log)
-	case _USDCTokenPoolCCTPV2.abi.Events["OwnershipTransferred"].ID:
-		return _USDCTokenPoolCCTPV2.ParseOwnershipTransferred(log)
-	case _USDCTokenPoolCCTPV2.abi.Events["RateLimitAdminSet"].ID:
-		return _USDCTokenPoolCCTPV2.ParseRateLimitAdminSet(log)
-	case _USDCTokenPoolCCTPV2.abi.Events["ReleasedOrMinted"].ID:
-		return _USDCTokenPoolCCTPV2.ParseReleasedOrMinted(log)
-	case _USDCTokenPoolCCTPV2.abi.Events["RemotePoolAdded"].ID:
-		return _USDCTokenPoolCCTPV2.ParseRemotePoolAdded(log)
-	case _USDCTokenPoolCCTPV2.abi.Events["RemotePoolRemoved"].ID:
-		return _USDCTokenPoolCCTPV2.ParseRemotePoolRemoved(log)
-	case _USDCTokenPoolCCTPV2.abi.Events["RouterUpdated"].ID:
-		return _USDCTokenPoolCCTPV2.ParseRouterUpdated(log)
-
-	default:
-		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
-	}
-}
-
 func (USDCTokenPoolCCTPV2AllowListAdd) Topic() common.Hash {
 	return common.HexToHash("0x2640d4d76caf8bf478aabfa982fa4e1c4eb71a37f93cd15e80dbc657911546d8")
 }
@@ -3770,8 +3720,6 @@ type USDCTokenPoolCCTPV2Interface interface {
 	WatchRouterUpdated(opts *bind.WatchOpts, sink chan<- *USDCTokenPoolCCTPV2RouterUpdated) (event.Subscription, error)
 
 	ParseRouterUpdated(log types.Log) (*USDCTokenPoolCCTPV2RouterUpdated, error)
-
-	ParseLog(log types.Log) (generated.AbigenLog, error)
 
 	Address() common.Address
 }

--- a/devenv/ccipv1_7/go.mod
+++ b/devenv/ccipv1_7/go.mod
@@ -10,10 +10,10 @@ require (
 	github.com/ethereum/go-ethereum v1.15.11
 	github.com/pelletier/go-toml/v2 v2.2.4
 	github.com/rs/zerolog v1.34.0
-	github.com/smartcontractkit/chain-selectors v1.0.62
+	github.com/smartcontractkit/chain-selectors v1.0.67
 	github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment v0.0.0-20250827115115-f07e2780040c
 	github.com/smartcontractkit/chainlink-common v0.9.1-0.20250815142532-64e0a7965958
-	github.com/smartcontractkit/chainlink-deployments-framework v0.34.0
+	github.com/smartcontractkit/chainlink-deployments-framework v0.37.1
 	github.com/smartcontractkit/chainlink-testing-framework/framework v0.10.15
 	github.com/smartcontractkit/chainlink-testing-framework/framework/components/fake v0.10.1-0.20250711120409-5078050f9db4
 	github.com/spf13/cobra v1.9.1
@@ -39,12 +39,12 @@ require (
 	github.com/avast/retry-go/v4 v4.6.1 // indirect
 	github.com/awalterschulze/gographviz v2.0.3+incompatible // indirect
 	github.com/aws/aws-sdk-go v1.55.7 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.32.7 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.38.1 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.28.6 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.47 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.21 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.26 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.26 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.4 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.4 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.7 // indirect
@@ -52,7 +52,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.24.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.2 // indirect
-	github.com/aws/smithy-go v1.22.1 // indirect
+	github.com/aws/smithy-go v1.22.5 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/benbjohnson/clock v1.3.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -230,7 +230,7 @@ require (
 	github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0 // indirect
 	github.com/smartcontractkit/chainlink-testing-framework/seth v1.51.2 // indirect
 	github.com/smartcontractkit/chainlink-tron/relayer v0.0.11-0.20250815105909-75499abc4335 // indirect
-	github.com/smartcontractkit/freeport v0.1.1 // indirect
+	github.com/smartcontractkit/freeport v0.1.2 // indirect
 	github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 // indirect
 	github.com/smartcontractkit/libocr v0.0.0-20250408131511-c90716988ee0 // indirect
 	github.com/smartcontractkit/mcms v0.21.1 // indirect

--- a/devenv/ccipv1_7/go.sum
+++ b/devenv/ccipv1_7/go.sum
@@ -41,6 +41,7 @@ github.com/aws/aws-sdk-go v1.55.7 h1:UJrkFq7es5CShfBwlWAC8DA077vp8PyVbQd3lqLiztE
 github.com/aws/aws-sdk-go v1.55.7/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go-v2 v1.32.7 h1:ky5o35oENWi0JYWUZkB7WYvVPP+bcRF5/Iq7JWSb5Rw=
 github.com/aws/aws-sdk-go-v2 v1.32.7/go.mod h1:P5WJBrYqqbWVaOxgH0X/FYYD47/nooaPOZPlQdmiN2U=
+github.com/aws/aws-sdk-go-v2 v1.38.1/go.mod h1:9Q0OoGQoboYIAJyslFyF1f5K1Ryddop8gqMhWx/n4Wg=
 github.com/aws/aws-sdk-go-v2/config v1.28.6 h1:D89IKtGrs/I3QXOLNTH93NJYtDhm8SYa9Q5CsPShmyo=
 github.com/aws/aws-sdk-go-v2/config v1.28.6/go.mod h1:GDzxJ5wyyFSCoLkS+UhGB0dArhb9mI+Co4dHtoTxbko=
 github.com/aws/aws-sdk-go-v2/credentials v1.17.47 h1:48bA+3/fCdi2yAwVt+3COvmatZ6jUDNkDTIsqDiMUdw=
@@ -49,8 +50,10 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.21 h1:AmoU1pziydclFT/xRV+xXE
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.21/go.mod h1:AjUdLYe4Tgs6kpH4Bv7uMZo7pottoyHMn4eTcIcneaY=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.26 h1:I/5wmGMffY4happ8NOCuIUEWGUvvFp5NSeQcXl9RHcI=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.26/go.mod h1:FR8f4turZtNy6baO0KJ5FJUmXH/cSkI9fOngs0yl6mA=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.4/go.mod h1:l4bdfCD7XyyZA9BolKBo1eLqgaJxl0/x91PL4Yqe0ao=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.26 h1:zXFLuEuMMUOvEARXFUVJdfqZ4bvvSgdGRq/ATcrQxzM=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.26/go.mod h1:3o2Wpy0bogG1kyOPrgkXA8pgIfEEv0+m19O9D5+W8y8=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.4/go.mod h1:yDmJgqOiH4EA8Hndnv4KwAo8jCGTSnM5ASG1nBI+toA=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1 h1:VaRN3TlFdd6KxX1x3ILT5ynH6HvKgqdiXoTxAF4HQcQ=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.1/go.mod h1:FbtygfRFze9usAadmnGJNc8KsP346kEe+y2/oyhGAGc=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.1 h1:iXtILhvDxB6kPvEXgsDhGaZCSC6LQET5ZHSdJozeI0Y=
@@ -67,6 +70,7 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.2 h1:s4074ZO1Hk8qv65GqNXqDjmkf4HS
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.2/go.mod h1:mVggCnIWoM09jP71Wh+ea7+5gAp53q+49wDFs1SW5z8=
 github.com/aws/smithy-go v1.22.1 h1:/HPHZQ0g7f4eUeK6HKglFz8uwVfZKgoI25rb/J+dnro=
 github.com/aws/smithy-go v1.22.1/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/aws/smithy-go v1.22.5/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
 github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df h1:GSoSVRLoBaFpOOds6QyY1L8AX7uoY+Ln3BHc22W40X0=
@@ -703,6 +707,7 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartcontractkit/chain-selectors v1.0.62 h1:KWLEyKQXHxGGHIlUfLrzjYldlB8hBjRZi9GP49WtgYs=
 github.com/smartcontractkit/chain-selectors v1.0.62/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
+github.com/smartcontractkit/chain-selectors v1.0.67/go.mod h1:xsKM0aN3YGcQKTPRPDDtPx2l4mlTN1Djmg0VVXV40b8=
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250414155853-651b4e583ee9 h1:lw8RZ8IR4UX1M7djAB3IuMtcAqFX4Z4bzQczClfb8bs=
 github.com/smartcontractkit/chainlink-aptos v0.0.0-20250414155853-651b4e583ee9/go.mod h1:Sq/ddMOYch6ZuAnW2k5u9V4+TlGKFzuHQnTM8JXEU+g=
 github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20250805210128-7f8a0f403c3a h1:kQ8Zs6OzXizScIK8PEb8THxDUziGttGT9D6tTTAwmZk=
@@ -717,6 +722,7 @@ github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250806152407-15
 github.com/smartcontractkit/chainlink-common/pkg/values v0.0.0-20250806152407-159881c7589c/go.mod h1:U1UAbPhy6D7Qz0wHKGPoQO+dpR0hsYjgUz8xwRrmKwI=
 github.com/smartcontractkit/chainlink-deployments-framework v0.34.0 h1:iYwgKI+cgPulpWhTQRVgUP+N2R9JhLvtBMDjeM59s+c=
 github.com/smartcontractkit/chainlink-deployments-framework v0.34.0/go.mod h1:JOyljUMqJSNH2BE8244Z95u3E9pFiIog+rEnZlpq9Hk=
+github.com/smartcontractkit/chainlink-deployments-framework v0.37.1/go.mod h1:nvsOomMe/u/T4vekY7sd10HEGDbvadEw6bUMEblPDP0=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250826201006-c81344a26fc3 h1:mJP6yJq2woOZchX0KvhLiKxDPaS0Vy4vTDFH4nnFkXs=
 github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20250826201006-c81344a26fc3/go.mod h1:3Lsp38qxen9PABVF+O5eocveQev+hyo9HLAgRodBD4Q=
 github.com/smartcontractkit/chainlink-protos/job-distributor v0.12.0 h1:/bhoALRzNXZkdzxBkNM505pMofNy0K0eW1nCzXw+AUI=
@@ -733,6 +739,7 @@ github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.202505281
 github.com/smartcontractkit/chainlink-tron/relayer/gotron-sdk v0.0.5-0.20250528121202-292529af39df/go.mod h1:4WhGgCA0smBbBud5mK+jnDb2wwndMvoqaWBJ3OV/7Bw=
 github.com/smartcontractkit/freeport v0.1.1 h1:B5fhEtmgomdIhw03uPVbVTP6oPv27fBhZsoZZMSIS8I=
 github.com/smartcontractkit/freeport v0.1.1/go.mod h1:T4zH9R8R8lVWKfU7tUvYz2o2jMv1OpGCdpY2j2QZXzU=
+github.com/smartcontractkit/freeport v0.1.2/go.mod h1:T4zH9R8R8lVWKfU7tUvYz2o2jMv1OpGCdpY2j2QZXzU=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7 h1:12ijqMM9tvYVEm+nR826WsrNi6zCKpwBhuApq127wHs=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20240830132753-a7e17fec5ab7/go.mod h1:FX7/bVdoep147QQhsOPkYsPEXhGZjeYx6lBSaSXtZOA=
 github.com/smartcontractkit/libocr v0.0.0-20250408131511-c90716988ee0 h1:yGD0bRNoIQ9vOILzlYg4AiGKMKpJNqi7eIMpW7QIO9Y=


### PR DESCRIPTION
This ParseLog function introduces a dependency on a local interface, while otherwise no dependency outside of `github.com/ethereum/go-ethereum` or the standard go libs is used. The function appears to be a relic from a long time ago, no longer serving a purpose. This PR removes it from the wrapper gen code as a step towards introducing a go.mod in each versioned wrapper folder. This change allows zero outside imports, making the go.mod creation trivial.