### PR TITLE
update npm release action

### DIFF
--- a/.github/workflows/solidity-build-and-publish.yml
+++ b/.github/workflows/solidity-build-and-publish.yml
@@ -171,9 +171,8 @@ jobs:
           pnpm version "${version}" --no-git-tag-version --no-commit-hooks --no-git-checks
 
       - name: Publish to NPM (beta)
-        uses: smartcontractkit/.github/actions/ci-publish-npm@4b0ab756abcb1760cb82e1e87b94ff431905bffc # ci-publish-npm@0.4.0
+        uses: smartcontractkit/.github/actions/ci-publish-npm@ci-publish-npm/v1
         with:
-          npm-token: ${{ secrets.NPM_CHAINLINK_CCIP }}
           create-github-release: false
           publish-command: "pnpm publish-beta --no-git-checks"
           package-json-directory: chains/evm
@@ -228,9 +227,8 @@ jobs:
           fi
 
       - name: Publish to NPM (latest)
-        uses: smartcontractkit/.github/actions/ci-publish-npm@4b0ab756abcb1760cb82e1e87b94ff431905bffc # ci-publish-npm@0.4.0
+        uses: smartcontractkit/.github/actions/ci-publish-npm@ci-publish-npm/v1
         with:
-          npm-token: ${{ secrets.NPM_CHAINLINK_CCIP }}
-          create-github-release: false
+          create-github-release: true
           publish-command: "pnpm publish-prod --no-git-checks"
           package-json-directory: chains/evm


### PR DESCRIPTION
This changes the release action to the new format which doesn't take a token. 

Production releases now also create a Git release. 