### PR TITLE
feat: add support for TIP20 token

### DIFF
--- a/chains/evm/deployment/v1_0_0/operations/tip20/factory.go
+++ b/chains/evm/deployment/v1_0_0/operations/tip20/factory.go
@@ -1,0 +1,125 @@
+package tip20
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
+	cldf_deployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+)
+
+var FactoryContractType cldf_deployment.ContractType = "TIP20Factory"
+
+// TIP20FactoryABI is a minimal ABI for the Tempo TIP-20 factory precompile (ITIP20Factory).
+const TIP20FactoryABI = `[{"type":"function","name":"createToken","inputs":[{"name":"name","type":"string"},{"name":"symbol","type":"string"},{"name":"currency","type":"string"},{"name":"quoteToken","type":"address"},{"name":"admin","type":"address"},{"name":"salt","type":"bytes32"}],"outputs":[{"name":"","type":"address"}],"stateMutability":"nonpayable"},{"type":"function","name":"getTokenAddress","inputs":[{"name":"sender","type":"address"},{"name":"salt","type":"bytes32"}],"outputs":[{"name":"","type":"address"}],"stateMutability":"pure"},{"type":"function","name":"isTIP20","inputs":[{"name":"token","type":"address"}],"outputs":[{"name":"","type":"bool"}],"stateMutability":"view"}]`
+
+// TIP20Factory binds calls to the on-chain TIP-20 factory precompile.
+type TIP20Factory struct {
+	address  common.Address
+	contract *bind.BoundContract
+}
+
+func NewTIP20Factory(address common.Address, backend bind.ContractBackend) (*TIP20Factory, error) {
+	parsed, err := abi.JSON(strings.NewReader(TIP20FactoryABI))
+	if err != nil {
+		return nil, err
+	}
+	return &TIP20Factory{
+		address:  address,
+		contract: bind.NewBoundContract(address, parsed, backend, backend, backend),
+	}, nil
+}
+
+func (f *TIP20Factory) Address() common.Address {
+	return f.address
+}
+
+func (f *TIP20Factory) CreateToken(opts *bind.TransactOpts, name, symbol, currency string, quoteToken, admin common.Address, salt [32]byte) (*types.Transaction, error) {
+	return f.contract.Transact(opts, "createToken", name, symbol, currency, quoteToken, admin, salt)
+}
+
+func (f *TIP20Factory) GetTokenAddress(opts *bind.CallOpts, sender common.Address, salt [32]byte) (common.Address, error) {
+	var out []any
+	err := f.contract.Call(opts, &out, "getTokenAddress", sender, salt)
+	if err != nil {
+		return common.Address{}, err
+	}
+	return *abi.ConvertType(out[0], new(common.Address)).(*common.Address), nil
+}
+
+func (f *TIP20Factory) IsTIP20(opts *bind.CallOpts, token common.Address) (bool, error) {
+	var out []any
+	err := f.contract.Call(opts, &out, "isTIP20", token)
+	if err != nil {
+		return false, err
+	}
+	return *abi.ConvertType(out[0], new(bool)).(*bool), nil
+}
+
+// CreateTokenArgs are the arguments to TIP20Factory.createToken.
+type CreateTokenArgs struct {
+	Name       string
+	Symbol     string
+	Currency   string
+	QuoteToken common.Address
+	Admin      common.Address
+	Salt       [32]byte
+}
+
+// GetTokenAddressArgs are the arguments to TIP20Factory.getTokenAddress.
+type GetTokenAddressArgs struct {
+	Sender common.Address
+	Salt   [32]byte
+}
+
+var CreateToken = contract.NewWrite(contract.WriteParams[CreateTokenArgs, *TIP20Factory]{
+	Name:            "tip20-factory:create-token",
+	Version:         Version,
+	Description:     "Creates a TIP-20 token via the Tempo TIP-20 factory precompile",
+	ContractType:    FactoryContractType,
+	ContractABI:     TIP20FactoryABI,
+	NewContract:     NewTIP20Factory,
+	IsAllowedCaller: contract.AllCallersAllowed[*TIP20Factory, CreateTokenArgs],
+	Validate: func(args CreateTokenArgs) error {
+		if args.Name == "" {
+			return errors.New("name is required")
+		}
+		if args.Symbol == "" {
+			return errors.New("symbol is required")
+		}
+		if args.Admin == (common.Address{}) {
+			return errors.New("admin is required")
+		}
+		return nil
+	},
+	CallContract: func(f *TIP20Factory, opts *bind.TransactOpts, args CreateTokenArgs) (*types.Transaction, error) {
+		return f.CreateToken(opts, args.Name, args.Symbol, args.Currency, args.QuoteToken, args.Admin, args.Salt)
+	},
+})
+
+var GetTokenAddress = contract.NewRead(contract.ReadParams[GetTokenAddressArgs, common.Address, *TIP20Factory]{
+	Name:         "tip20-factory:get-token-address",
+	Version:      Version,
+	Description:  "Predicts the TIP-20 token address for a sender and salt",
+	ContractType: FactoryContractType,
+	NewContract:  NewTIP20Factory,
+	CallContract: func(f *TIP20Factory, opts *bind.CallOpts, args GetTokenAddressArgs) (common.Address, error) {
+		return f.GetTokenAddress(opts, args.Sender, args.Salt)
+	},
+})
+
+var IsTIP20 = contract.NewRead(contract.ReadParams[common.Address, bool, *TIP20Factory]{
+	Name:         "tip20-factory:is-tip20",
+	Version:      Version,
+	Description:  "Returns whether an address is a valid TIP-20 token",
+	ContractType: FactoryContractType,
+	NewContract:  NewTIP20Factory,
+	CallContract: func(f *TIP20Factory, opts *bind.CallOpts, token common.Address) (bool, error) {
+		return f.IsTIP20(opts, token)
+	},
+})

--- a/chains/evm/deployment/v1_0_0/operations/tip20/factory.go
+++ b/chains/evm/deployment/v1_0_0/operations/tip20/factory.go
@@ -10,10 +10,10 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
-	cldf_deployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 )
 
-var FactoryContractType cldf_deployment.ContractType = "TIP20Factory"
+var FactoryContractType deployment.ContractType = "TIP20Factory"
 
 // TIP20FactoryABI is a minimal ABI for the Tempo TIP-20 factory precompile (ITIP20Factory).
 const TIP20FactoryABI = `[{"type":"function","name":"createToken","inputs":[{"name":"name","type":"string"},{"name":"symbol","type":"string"},{"name":"currency","type":"string"},{"name":"quoteToken","type":"address"},{"name":"admin","type":"address"},{"name":"salt","type":"bytes32"}],"outputs":[{"name":"","type":"address"}],"stateMutability":"nonpayable"},{"type":"function","name":"getTokenAddress","inputs":[{"name":"sender","type":"address"},{"name":"salt","type":"bytes32"}],"outputs":[{"name":"","type":"address"}],"stateMutability":"pure"},{"type":"function","name":"isTIP20","inputs":[{"name":"token","type":"address"}],"outputs":[{"name":"","type":"bool"}],"stateMutability":"view"}]`

--- a/chains/evm/deployment/v1_0_0/operations/tip20/salt.go
+++ b/chains/evm/deployment/v1_0_0/operations/tip20/salt.go
@@ -1,0 +1,36 @@
+package tip20
+
+import (
+	"crypto/rand"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+)
+
+const MaxSaltGenerationAttempts = 10
+
+func generateValidSalt(b operations.Bundle, chain evm.Chain, factoryAddr common.Address, deployer common.Address) ([32]byte, error) {
+	for range MaxSaltGenerationAttempts {
+		var salt [32]byte
+		if _, err := rand.Read(salt[:]); err != nil {
+			return [32]byte{}, fmt.Errorf("failed to generate random salt: %w", err)
+		}
+
+		_, err := operations.ExecuteOperation(b, GetTokenAddress, chain, contract.FunctionInput[GetTokenAddressArgs]{
+			ChainSelector: chain.Selector,
+			Address:       factoryAddr,
+			Args: GetTokenAddressArgs{
+				Sender: deployer,
+				Salt:   salt,
+			},
+		})
+		if err == nil {
+			return salt, nil
+		}
+	}
+
+	return [32]byte{}, fmt.Errorf("could not find a non-reserved salt after %d attempts", MaxSaltGenerationAttempts)
+}

--- a/chains/evm/deployment/v1_0_0/operations/tip20/salt.go
+++ b/chains/evm/deployment/v1_0_0/operations/tip20/salt.go
@@ -19,6 +19,8 @@ func generateValidSalt(b operations.Bundle, chain evm.Chain, factoryAddr common.
 			return [32]byte{}, fmt.Errorf("failed to generate random salt: %w", err)
 		}
 
+		// NOTE: GetTokenAddress will revert if the salt is already used, so we can
+		// use it to check if the salt is valid without actually deploying a token.
 		_, err := operations.ExecuteOperation(b, GetTokenAddress, chain, contract.FunctionInput[GetTokenAddressArgs]{
 			ChainSelector: chain.Selector,
 			Address:       factoryAddr,

--- a/chains/evm/deployment/v1_0_0/operations/tip20/tip20.go
+++ b/chains/evm/deployment/v1_0_0/operations/tip20/tip20.go
@@ -59,7 +59,7 @@ var Deploy = operations.NewSequence(
 	Version,
 	"Deploys a TIP20 token via the TIP20 factory. Only applicable for Tempo testnet / mainnet.",
 	func(b operations.Bundle, chain evm.Chain, input FactoryDeployArgs) (sequences.OnChainOutput, error) {
-		isTempoTestnet := chainsel.TEMPO_TESTNET.Selector == chain.Selector
+		isTempoTestnet := chainsel.TEMPO_TESTNET_MODERATO.Selector == chain.Selector || chainsel.TEMPO_TESTNET.Selector == chain.Selector
 		isTempoMainnet := chainsel.TEMPO_MAINNET.Selector == chain.Selector
 		if !isTempoTestnet && !isTempoMainnet {
 			return sequences.OnChainOutput{}, errors.New("TIP20 token deployment is only supported on Tempo testnet and mainnet")

--- a/chains/evm/deployment/v1_0_0/operations/tip20/tip20.go
+++ b/chains/evm/deployment/v1_0_0/operations/tip20/tip20.go
@@ -1,0 +1,154 @@
+package tip20
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/ethereum/go-ethereum/common"
+	mcms_types "github.com/smartcontractkit/mcms/types"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+)
+
+var (
+	ContractType   deployment.ContractType = "TIP20Token"
+	Version                                = semver.MustParse("1.0.0")
+	TypeAndVersion                         = deployment.NewTypeAndVersion(ContractType, *Version)
+)
+
+const (
+	TokenFactoryAddress = "0x20Fc000000000000000000000000000000000000"
+	TokenThetaUSD       = "0x20c0000000000000000000000000000000000003"
+	TokenBetaUSD        = "0x20c0000000000000000000000000000000000002"
+	TokenAlphaUSD       = "0x20c0000000000000000000000000000000000001"
+	TokenPathUSD        = "0x20c0000000000000000000000000000000000000"
+)
+
+// NOTE: the gas station app in slack uses PathUSD, so we use it as the default for ease of use.
+const DefaultQuoteToken = TokenPathUSD
+
+// NOTE: most pre-deployed TIP20 tokens on Tempo use USD as their currency, so we set it as the default for ease of use.
+const DefaultCurrency = "USD"
+
+type FactoryDeployArgs struct {
+	Currency   string         // The currency of the token. Defaults to "USD" if not provided.
+	Symbol     string         // The Token symbol. This is a required input.
+	Name       string         // The token name. This is a required input.
+	QuoteToken common.Address // Address of a pre-existing TIP20 token to use as the quote token. Defaults to PathUSD if not provided.
+	Admin      common.Address // The admin of the token. Defaults to the deployer address if not provided.
+	Salt       [32]byte       // Optional salt for deterministic deployment. Defaults to a random salt if not provided.
+}
+
+// Deploy deploys the TIP20 token contract with the provided deploy arguments. The TIP20 token is ERC20 compliant and includes additional
+// features as defined in the TIP20 standard: https://www.mintlify.com/tempoxyz/tempo/protocol/tip20/overview#erc-20-compatibility. This
+// sequence is only applicable for Tempo testnet / mainnet. The token is deployed via the factory contract as recommended in the docs. We
+// use sensible defaults for Currency and QuoteToken, so they are not required to be provided by the user when deploying a TIP20 token.
+//
+//	Factory Contract: https://github.com/tempoxyz/tempo/blob/a20e2e46c7cba6164ef95c91bf83d5fc614750f3/tips/ref-impls/src/TIP20Factory.sol#L1
+//	Token Contract: https://github.com/tempoxyz/tempo/blob/a20e2e46c7cba6164ef95c91bf83d5fc614750f3/tips/ref-impls/src/TIP20.sol#L1
+//	Docs: https://www.mintlify.com/tempoxyz/tempo/protocol/tip20/overview
+var Deploy = operations.NewSequence(
+	"tip20:deploy",
+	Version,
+	"Deploys a TIP20 token via the TIP20 factory. Only applicable for Tempo testnet / mainnet.",
+	func(b operations.Bundle, chain evm.Chain, input FactoryDeployArgs) (sequences.OnChainOutput, error) {
+		isTempoTestnet := chainsel.TEMPO_TESTNET.Selector == chain.Selector
+		isTempoMainnet := chainsel.TEMPO_MAINNET.Selector == chain.Selector
+		if !isTempoTestnet && !isTempoMainnet {
+			return sequences.OnChainOutput{}, errors.New("TIP20 token deployment is only supported on Tempo testnet and mainnet")
+		}
+
+		factoryAddr := common.HexToAddress(TokenFactoryAddress)
+		deployerKey := chain.DeployerKey.From
+		if input.Symbol == "" {
+			return sequences.OnChainOutput{}, errors.New("symbol is required")
+		}
+		if input.Name == "" {
+			return sequences.OnChainOutput{}, errors.New("name is required")
+		}
+		if input.QuoteToken == (common.Address{}) {
+			input.QuoteToken = common.HexToAddress(DefaultQuoteToken)
+		}
+		if input.Currency == "" {
+			input.Currency = DefaultCurrency
+		}
+		if input.Admin == (common.Address{}) {
+			input.Admin = deployerKey
+		}
+
+		isQuoteTokenValid, err := operations.ExecuteOperation(b, IsTIP20, chain, contract.FunctionInput[common.Address]{
+			ChainSelector: chain.Selector,
+			Address:       factoryAddr,
+			Args:          input.QuoteToken,
+		})
+		if err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("isTIP20 quote token: %w", err)
+		}
+		if !isQuoteTokenValid.Output {
+			return sequences.OnChainOutput{}, errors.New("quoteToken must be a valid TIP-20 token address")
+		}
+
+		if input.Salt == [32]byte{} {
+			if salt, err := generateValidSalt(b, chain, factoryAddr, deployerKey); err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("failed to produce a valid salt for token deployment: %w", err)
+			} else {
+				input.Salt = salt
+			}
+		}
+
+		createTokenReport, err := operations.ExecuteOperation(b, CreateToken, chain, contract.FunctionInput[CreateTokenArgs]{
+			ChainSelector: chain.Selector,
+			Address:       factoryAddr,
+			Args: CreateTokenArgs{
+				QuoteToken: input.QuoteToken,
+				Currency:   input.Currency,
+				Symbol:     input.Symbol,
+				Admin:      input.Admin,
+				Name:       input.Name,
+				Salt:       input.Salt,
+			},
+		})
+		if err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("createToken: %w", err)
+		}
+
+		tokenAddrReport, err := operations.ExecuteOperation(b, GetTokenAddress, chain, contract.FunctionInput[GetTokenAddressArgs]{
+			ChainSelector: chain.Selector,
+			Address:       factoryAddr,
+			Args: GetTokenAddressArgs{
+				Sender: deployerKey,
+				Salt:   input.Salt,
+			},
+		})
+		if err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("getTokenAddress after deploy: %w", err)
+		}
+
+		batchOp, err := contract.NewBatchOperationFromWrites([]contract.WriteOutput{createTokenReport.Output})
+		if err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("batch operation: %w", err)
+		}
+
+		return sequences.OnChainOutput{
+			Addresses: []datastore.AddressRef{
+				{
+					ChainSelector: chain.Selector,
+					Address:       tokenAddrReport.Output.Hex(),
+					Qualifier:     input.Symbol,
+					Type:          datastore.ContractType(ContractType),
+					Version:       Version,
+				},
+			},
+			BatchOps: []mcms_types.BatchOperation{
+				batchOp,
+			},
+		}, nil
+	},
+)

--- a/chains/evm/deployment/v1_0_0/operations/tip20/tip20.go
+++ b/chains/evm/deployment/v1_0_0/operations/tip20/tip20.go
@@ -94,6 +94,7 @@ var Deploy = operations.NewSequence(
 			}
 		}
 
+		b.Logger.Infof("Validating quote token address: %s", input.QuoteToken.Hex())
 		isQuoteTokenValid, err := operations.ExecuteOperation(b, IsTIP20, chain, contract.FunctionInput[common.Address]{
 			ChainSelector: chain.Selector,
 			Address:       factoryAddr,
@@ -106,6 +107,7 @@ var Deploy = operations.NewSequence(
 			return sequences.OnChainOutput{}, errors.New("quoteToken must be a valid TIP-20 token address")
 		}
 
+		b.Logger.Infof("Deploying TIP20 token: %+v", input)
 		createTokenReport, err := operations.ExecuteOperation(b, CreateToken, chain, contract.FunctionInput[CreateTokenArgs]{
 			ChainSelector: chain.Selector,
 			Address:       factoryAddr,
@@ -122,6 +124,7 @@ var Deploy = operations.NewSequence(
 			return sequences.OnChainOutput{}, fmt.Errorf("createToken: %w", err)
 		}
 
+		b.Logger.Info("Retrieving address of deployed token via factory's getTokenAddress function")
 		tokenAddrReport, err := operations.ExecuteOperation(b, GetTokenAddress, chain, contract.FunctionInput[GetTokenAddressArgs]{
 			ChainSelector: chain.Selector,
 			Address:       factoryAddr,
@@ -134,6 +137,7 @@ var Deploy = operations.NewSequence(
 			return sequences.OnChainOutput{}, fmt.Errorf("getTokenAddress after deploy: %w", err)
 		}
 
+		b.Logger.Infof("Deployed TIP20 token at address: %s", tokenAddrReport.Output.Hex())
 		batchOp, err := contract.NewBatchOperationFromWrites([]contract.WriteOutput{createTokenReport.Output})
 		if err != nil {
 			return sequences.OnChainOutput{}, fmt.Errorf("batch operation: %w", err)

--- a/chains/evm/deployment/v1_0_0/operations/tip20/tip20.go
+++ b/chains/evm/deployment/v1_0_0/operations/tip20/tip20.go
@@ -23,6 +23,7 @@ var (
 	TypeAndVersion                         = deployment.NewTypeAndVersion(ContractType, *Version)
 )
 
+// NOTE: these addresses are the same on both Tempo testnet and mainnet, so we don't need separate constants per environment.
 const (
 	TokenFactoryAddress = "0x20Fc000000000000000000000000000000000000"
 	TokenThetaUSD       = "0x20c0000000000000000000000000000000000003"
@@ -32,24 +33,27 @@ const (
 )
 
 // NOTE: the gas station app in slack uses PathUSD, so we use it as the default for ease of use.
+// If we want to deploy a token with currency USD, then its quote token must also be USD.
 const DefaultQuoteToken = TokenPathUSD
 
-// NOTE: most pre-deployed TIP20 tokens on Tempo use USD as their currency, so we set it as the default for ease of use.
+// NOTE: we chose USD as the default currency since most of the well-known TIP20 tokens on Tempo
+// use USD as their currency (e.g. ThetaUSD, BetaUSD, AlphaUSD, PathUSD).
 const DefaultCurrency = "USD"
 
 type FactoryDeployArgs struct {
-	Currency   string         // The currency of the token. Defaults to "USD" if not provided.
-	Symbol     string         // The Token symbol. This is a required input.
+	Currency   string         // The token currency. Defaults to USD if not provided.
+	Symbol     string         // The token symbol. This is a required input.
 	Name       string         // The token name. This is a required input.
 	QuoteToken common.Address // Address of a pre-existing TIP20 token to use as the quote token. Defaults to PathUSD if not provided.
-	Admin      common.Address // The admin of the token. Defaults to the deployer address if not provided.
+	Admin      common.Address // The token admin. Defaults to the deployer address if not provided.
 	Salt       [32]byte       // Optional salt for deterministic deployment. Defaults to a random salt if not provided.
 }
 
 // Deploy deploys the TIP20 token contract with the provided deploy arguments. The TIP20 token is ERC20 compliant and includes additional
 // features as defined in the TIP20 standard: https://www.mintlify.com/tempoxyz/tempo/protocol/tip20/overview#erc-20-compatibility. This
 // sequence is only applicable for Tempo testnet / mainnet. The token is deployed via the factory contract as recommended in the docs. We
-// use sensible defaults for Currency and QuoteToken, so they are not required to be provided by the user when deploying a TIP20 token.
+// use sensible defaults for QuoteToken, Currency, Admin, and Salt to reduce the configuration burden on the user when deploying a TIP20
+// token.
 //
 //	Factory Contract: https://github.com/tempoxyz/tempo/blob/a20e2e46c7cba6164ef95c91bf83d5fc614750f3/tips/ref-impls/src/TIP20Factory.sol#L1
 //	Token Contract: https://github.com/tempoxyz/tempo/blob/a20e2e46c7cba6164ef95c91bf83d5fc614750f3/tips/ref-impls/src/TIP20.sol#L1
@@ -82,6 +86,13 @@ var Deploy = operations.NewSequence(
 		if input.Admin == (common.Address{}) {
 			input.Admin = deployerKey
 		}
+		if input.Salt == [32]byte{} {
+			if salt, err := generateValidSalt(b, chain, factoryAddr, deployerKey); err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("failed to produce a valid salt for token deployment: %w", err)
+			} else {
+				input.Salt = salt
+			}
+		}
 
 		isQuoteTokenValid, err := operations.ExecuteOperation(b, IsTIP20, chain, contract.FunctionInput[common.Address]{
 			ChainSelector: chain.Selector,
@@ -93,14 +104,6 @@ var Deploy = operations.NewSequence(
 		}
 		if !isQuoteTokenValid.Output {
 			return sequences.OnChainOutput{}, errors.New("quoteToken must be a valid TIP-20 token address")
-		}
-
-		if input.Salt == [32]byte{} {
-			if salt, err := generateValidSalt(b, chain, factoryAddr, deployerKey); err != nil {
-				return sequences.OnChainOutput{}, fmt.Errorf("failed to produce a valid salt for token deployment: %w", err)
-			} else {
-				input.Salt = salt
-			}
 		}
 
 		createTokenReport, err := operations.ExecuteOperation(b, CreateToken, chain, contract.FunctionInput[CreateTokenArgs]{

--- a/chains/evm/deployment/v1_0_0/operations/tip20/tip20_test.go
+++ b/chains/evm/deployment/v1_0_0/operations/tip20/tip20_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
-	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 )
 
 func TestTIP20FactoryABI_Parses(t *testing.T) {
@@ -55,7 +55,7 @@ func TestDeploy_RejectsNonTempoChain(t *testing.T) {
 	chain, ok := e.BlockChains.EVMChains()[evmSel]
 	require.True(t, ok)
 
-	_, err = cldf_ops.ExecuteSequence(e.OperationsBundle, tip20.Deploy, chain, tip20.FactoryDeployArgs{
+	_, err = operations.ExecuteSequence(e.OperationsBundle, tip20.Deploy, chain, tip20.FactoryDeployArgs{
 		QuoteToken: common.Address{}, // defaults to sensible value
 		Currency:   "",               // defaults to sensible value
 		Salt:       [32]byte{},       // generate random salt

--- a/chains/evm/deployment/v1_0_0/operations/tip20/tip20_test.go
+++ b/chains/evm/deployment/v1_0_0/operations/tip20/tip20_test.go
@@ -1,0 +1,68 @@
+package tip20_test
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient/simulated"
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/tip20"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+)
+
+func TestTIP20FactoryABI_Parses(t *testing.T) {
+	t.Parallel()
+
+	_, err := abi.JSON(strings.NewReader(tip20.TIP20FactoryABI))
+	require.NoError(t, err, "TIP20FactoryABI must remain valid JSON ABI")
+}
+
+func TestNewTIP20Factory_Constructs(t *testing.T) {
+	t.Parallel()
+
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	address := crypto.PubkeyToAddress(key.PublicKey)
+	backend := simulated.NewBackend(types.GenesisAlloc{
+		address: {Balance: big.NewInt(1_000_000_000_000_000_000)},
+	})
+	t.Cleanup(func() { backend.Close() })
+
+	factory, err := tip20.NewTIP20Factory(common.HexToAddress(tip20.TokenFactoryAddress), backend.Client())
+	require.NoError(t, err)
+
+	require.Equal(t, common.HexToAddress(tip20.TokenFactoryAddress), factory.Address())
+}
+
+func TestDeploy_RejectsNonTempoChain(t *testing.T) {
+	t.Parallel()
+
+	evmSel := chainsel.ETHEREUM_MAINNET.Selector
+	chains := []uint64{evmSel}
+
+	e, err := environment.New(t.Context(), environment.WithEVMSimulated(t, chains))
+	require.NoError(t, err)
+
+	chain, ok := e.BlockChains.EVMChains()[evmSel]
+	require.True(t, ok)
+
+	_, err = cldf_ops.ExecuteSequence(e.OperationsBundle, tip20.Deploy, chain, tip20.FactoryDeployArgs{
+		QuoteToken: common.Address{}, // defaults to sensible value
+		Currency:   "",               // defaults to sensible value
+		Salt:       [32]byte{},       // generate random salt
+		Name:       "MyTestToken",
+		Symbol:     "MTK",
+		Admin:      chain.DeployerKey.From,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "only supported on Tempo testnet and mainnet")
+}

--- a/chains/evm/deployment/v1_0_0/sequences/token.go
+++ b/chains/evm/deployment/v1_0_0/sequences/token.go
@@ -10,14 +10,15 @@ import (
 
 	mcms_types "github.com/smartcontractkit/mcms/types"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/burn_mint_erc20_with_drip"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/erc20"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/tip20"
 	tokenapi "github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	common_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
@@ -123,6 +124,23 @@ var DeployToken = cldf_ops.NewSequence(
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to deploy BurnMintERC20WithDrip token: %w", err)
 			}
+
+		case tip20.ContractType:
+			report, err := cldf_ops.ExecuteSequence(b, tip20.Deploy, chain, tip20.FactoryDeployArgs{
+				QuoteToken: common.Address{}, // defaults to sensible value
+				Currency:   "",               // defaults to sensible value
+				Salt:       [32]byte{},       // defaults to random salt
+				Symbol:     input.Symbol,
+				Admin:      common.HexToAddress(input.ExternalAdmin),
+				Name:       input.Name,
+			})
+			if err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("failed to deploy TIP20 token via factory: %w", err)
+			}
+			if len(report.Output.Addresses) == 0 {
+				return sequences.OnChainOutput{}, errors.New("no address returned from TIP20 factory deployment")
+			}
+			tokenRef = report.Output.Addresses[0]
 
 		default:
 			return sequences.OnChainOutput{}, fmt.Errorf("unsupported token type: %s", input.Type)

--- a/chains/evm/deployment/v1_0_0/sequences/token.go
+++ b/chains/evm/deployment/v1_0_0/sequences/token.go
@@ -76,6 +76,20 @@ var DeployToken = cldf_ops.NewSequence(
 			preMint = tokenapi.ScaleTokenAmount(new(big.Int).SetUint64(*input.PreMint), input.Decimals)
 		}
 
+		externalAdmin := common.Address{}
+		if input.ExternalAdmin != "" && !common.IsHexAddress(input.ExternalAdmin) {
+			return sequences.OnChainOutput{}, fmt.Errorf("invalid external admin address: %s", input.ExternalAdmin)
+		} else {
+			externalAdmin = common.HexToAddress(input.ExternalAdmin)
+		}
+
+		ccipAdmin := common.Address{}
+		if input.CCIPAdmin != "" && !common.IsHexAddress(input.CCIPAdmin) {
+			return sequences.OnChainOutput{}, fmt.Errorf("invalid CCIP admin address: %s", input.CCIPAdmin)
+		} else {
+			ccipAdmin = common.HexToAddress(input.CCIPAdmin)
+		}
+
 		switch input.Type {
 		case erc20.ContractType:
 			tokenRef, err = contract.MaybeDeployContract(b, erc20.Deploy, chain, contract.DeployInput[erc20.ConstructorArgs]{
@@ -131,7 +145,7 @@ var DeployToken = cldf_ops.NewSequence(
 				Currency:   "",               // defaults to sensible value
 				Salt:       [32]byte{},       // defaults to random salt
 				Symbol:     input.Symbol,
-				Admin:      common.HexToAddress(input.ExternalAdmin),
+				Admin:      externalAdmin,
 				Name:       input.Name,
 			})
 			if err != nil {
@@ -179,7 +193,7 @@ var DeployToken = cldf_ops.NewSequence(
 			setCCIPAdminReport, err := cldf_ops.ExecuteOperation(b, burn_mint_erc20.SetCCIPAdmin, chain, contract.FunctionInput[string]{
 				ChainSelector: chain.Selector,
 				Address:       tokenAddr,
-				Args:          input.CCIPAdmin,
+				Args:          ccipAdmin.Hex(),
 			})
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to set CCIP admin: %w", err)
@@ -202,7 +216,7 @@ var DeployToken = cldf_ops.NewSequence(
 				Address:       tokenAddr,
 				Args: burn_mint_erc20.RoleAssignment{
 					Role: role,
-					To:   common.HexToAddress(input.ExternalAdmin),
+					To:   externalAdmin,
 				},
 			})
 			if err != nil {


### PR DESCRIPTION
## Add Support for TIP-20 Token Deployment for Tempo

## Summary

Updates `TokenExpansion` to include support for deploying TIP-20 tokens on Tempo testnet and mainnet. The TIP-20 token is ERC-20 compliant and includes additional features as defined in the [TIP-20 standard](https://www.mintlify.com/tempoxyz/tempo/protocol/tip20/overview#erc-20-compatibility).

## Details

The token is deployed via the factory contract as [recommended in the docs](https://www.mintlify.com/tempoxyz/tempo/protocol/tip20/overview#factory-deployment). Any attempt to deploy this token outside of Tempo will result in an error. We use sensible defaults for `QuoteToken`, `Currency`, `Admin`, and `Salt`, so they are not required to be provided by the user. In fact, this means that the existing `TokenExpansion` schema can be used as-is and requires no new fields.

## Testing

The PR includes basic unit tests - integration tests will require connecting to Tempo's testnet, which I've intentionally avoided to prevent introducing any testing flakes. Instead, I've performed an E2E test via CLD - results can be found [here](https://github.com/smartcontractkit/chainlink-deployments/compare/main...cd/test-tip20-deploy).

## References

- [TIP-20 Overview](https://www.mintlify.com/tempoxyz/tempo/protocol/tip20/overview)
- [TIP-20 Factory](https://github.com/tempoxyz/tempo/blob/a20e2e46c7cba6164ef95c91bf83d5fc614750f3/tips/ref-impls/src/TIP20Factory.sol)
- [TIP-20 Token](https://github.com/tempoxyz/tempo/blob/main/tips/ref-impls/src/TIP20.sol)