### PR TITLE
feat: migrate to finality config for `SetTokenPoolTokenTransferFees`

### DIFF
--- a/chains/evm/deployment/v2_0_0/sequences/tokens/set_allowed_finality_config_for_token_pools.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/set_allowed_finality_config_for_token_pools.go
@@ -25,7 +25,7 @@ var SetAllowedFinalityConfigForTokenPools = operations.NewSequence(
 			return sequences.OnChainOutput{}, fmt.Errorf("chain with selector %d not defined", input.Selector)
 		}
 
-		writes := make([]contract.WriteOutput, 0)
+		writes := make([]contract.WriteOutput, 0, len(input.Settings))
 		for pool, finalityConfig := range input.Settings {
 			if err := finalityConfig.Validate(); err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("invalid finality config for pool %s on src %d: %w", pool, chain.Selector, err)

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/set_allowed_finality_config_for_token_pools.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/set_allowed_finality_config_for_token_pools.go
@@ -8,8 +8,8 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	mcms_types "github.com/smartcontractkit/mcms/types"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
@@ -26,7 +26,7 @@ var SetAllowedFinalityConfigForTokenPools = operations.NewSequence(
 		}
 
 		writes := make([]contract.WriteOutput, 0)
-		for pool, minBlockConfirmations := range input.Settings {
+		for pool, finalityConfig := range input.Settings {
 			src := chain.Selector
 			if !common.IsHexAddress(pool) {
 				return sequences.OnChainOutput{}, fmt.Errorf("invalid pool address for src %d: %s", src, pool)
@@ -42,7 +42,7 @@ var SetAllowedFinalityConfigForTokenPools = operations.NewSequence(
 				contract.FunctionInput[[4]byte]{
 					ChainSelector: src,
 					Address:       addr,
-					Args:          minBlockConfirmations,
+					Args:          finalityConfig.Raw(),
 				},
 			)
 			if err != nil {

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/set_allowed_finality_config_for_token_pools.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/set_allowed_finality_config_for_token_pools.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	mcms_types "github.com/smartcontractkit/mcms/types"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
@@ -27,6 +27,10 @@ var SetAllowedFinalityConfigForTokenPools = operations.NewSequence(
 
 		writes := make([]contract.WriteOutput, 0)
 		for pool, finalityConfig := range input.Settings {
+			if err := finalityConfig.Validate(); err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("invalid finality config for pool %s on src %d: %w", pool, chain.Selector, err)
+			}
+
 			src := chain.Selector
 			if !common.IsHexAddress(pool) {
 				return sequences.OnChainOutput{}, fmt.Errorf("invalid pool address for src %d: %s", src, pool)

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/set_token_transfer_fee_config_for_token_pools.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/set_token_transfer_fee_config_for_token_pools.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	mcms_types "github.com/smartcontractkit/mcms/types"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/token_pool"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"

--- a/deployment/tokens/fees.go
+++ b/deployment/tokens/fees.go
@@ -94,6 +94,11 @@ func setTokenTransferFeeVerify() func(deployment.Environment, SetTokenTransferFe
 				if exists := seenPools.Add(trimmed); exists {
 					return fmt.Errorf("duplicate pool address at args[%d].tokenPools[%d] (src=%d): %s", i, j, src.Selector, pool.PoolAddress)
 				}
+				if !pool.AllowedFinalityConfig.IsZero() {
+					if err := pool.AllowedFinalityConfig.Validate(); err != nil {
+						return fmt.Errorf("invalid allowed finality config at args[%d].tokenPools[%d] (src=%d): %w", i, j, src.Selector, err)
+					}
+				}
 
 				seenDests := utils.NewSet[uint64]()
 				for k, dst := range pool.Destinations {

--- a/deployment/tokens/fees.go
+++ b/deployment/tokens/fees.go
@@ -51,7 +51,7 @@ type TokenTransferFeeForDst struct {
 // chain selector. This allows the user to set multiple destination chain configurations for the same token
 // pool address without repeating the pool address for each one.
 type TokenTransferFeeForPool struct {
-	MinBlockConfirmations utils.Optional[uint16]   `json:"minBlockConfirmations" yaml:"minBlockConfirmations"`
+	AllowedFinalityConfig finality.Config          `json:"allowedFinalityConfig" yaml:"allowedFinalityConfig"`
 	Destinations          []TokenTransferFeeForDst `json:"destinations" yaml:"destinations"`
 	PoolAddress           string                   `json:"poolAddress" yaml:"poolAddress"`
 }
@@ -133,10 +133,10 @@ func setTokenTransferFeeApply() func(deployment.Environment, SetTokenTransferFee
 			}
 
 			feeConfigSettings := map[string]map[uint64]*TokenTransferFeeConfig{}
-			minBlocksSettings := map[string][4]byte{}
+			finConfigSettings := map[string]finality.Config{}
 			for _, pool := range src.TokenPools {
-				if minBlockConfirmations, ok := pool.MinBlockConfirmations.Get(); ok {
-					minBlocksSettings[pool.PoolAddress] = finality.Config{BlockDepth: minBlockConfirmations}.Raw()
+				if !pool.AllowedFinalityConfig.IsZero() {
+					finConfigSettings[pool.PoolAddress] = pool.AllowedFinalityConfig
 				}
 				if len(pool.Destinations) > 0 {
 					feeConfigSettings[pool.PoolAddress] = map[uint64]*TokenTransferFeeConfig{}
@@ -150,25 +150,25 @@ func setTokenTransferFeeApply() func(deployment.Environment, SetTokenTransferFee
 				}
 			}
 
-			if len(minBlocksSettings) > 0 {
-				minBlocksReport, err := cldf_ops.ExecuteSequence(
+			if len(finConfigSettings) > 0 {
+				report, err := cldf_ops.ExecuteSequence(
 					e.OperationsBundle,
 					feesAdapter.SetAllowedFinalityConfig(&e),
 					e.BlockChains,
 					SetAllowedFinalityConfigSequenceInput{
 						Selector: src.Selector,
-						Settings: minBlocksSettings,
+						Settings: finConfigSettings,
 					},
 				)
 				if err != nil {
 					return deployment.ChangesetOutput{}, fmt.Errorf("failed to execute SetAllowedFinalityConfig operation for src %d: %w", src.Selector, err)
 				}
-				batchOps = append(batchOps, minBlocksReport.Output.BatchOps...)
-				reports = append(reports, minBlocksReport.ExecutionReports...)
+				batchOps = append(batchOps, report.Output.BatchOps...)
+				reports = append(reports, report.ExecutionReports...)
 			}
 
 			if len(feeConfigSettings) > 0 {
-				feeConfigsReport, err := cldf_ops.ExecuteSequence(
+				report, err := cldf_ops.ExecuteSequence(
 					e.OperationsBundle,
 					feesAdapter.SetTokenTransferFee(&e),
 					e.BlockChains,
@@ -180,8 +180,8 @@ func setTokenTransferFeeApply() func(deployment.Environment, SetTokenTransferFee
 				if err != nil {
 					return deployment.ChangesetOutput{}, fmt.Errorf("failed to execute SetTokenTransferFee operation for src %d: %w", src.Selector, err)
 				}
-				batchOps = append(batchOps, feeConfigsReport.Output.BatchOps...)
-				reports = append(reports, feeConfigsReport.ExecutionReports...)
+				batchOps = append(batchOps, report.Output.BatchOps...)
+				reports = append(reports, report.ExecutionReports...)
 			}
 		}
 

--- a/deployment/tokens/fees.go
+++ b/deployment/tokens/fees.go
@@ -92,7 +92,7 @@ func setTokenTransferFeeVerify() func(deployment.Environment, SetTokenTransferFe
 					return fmt.Errorf("empty pool address at args[%d].tokenPools[%d] (src=%d)", i, j, src.Selector)
 				}
 				if exists := seenPools.Add(trimmed); exists {
-					return fmt.Errorf("duplicate pool address at args[%d].tokenPools[%d] (src=%d): %s", i, j, src.Selector, pool.PoolAddress)
+					return fmt.Errorf("duplicate pool address at args[%d].tokenPools[%d] (src=%d): %s", i, j, src.Selector, trimmed)
 				}
 				if !pool.AllowedFinalityConfig.IsZero() {
 					if err := pool.AllowedFinalityConfig.Validate(); err != nil {
@@ -140,16 +140,17 @@ func setTokenTransferFeeApply() func(deployment.Environment, SetTokenTransferFee
 			feeConfigSettings := map[string]map[uint64]*TokenTransferFeeConfig{}
 			finConfigSettings := map[string]finality.Config{}
 			for _, pool := range src.TokenPools {
+				poolAddress := strings.TrimSpace(pool.PoolAddress)
 				if !pool.AllowedFinalityConfig.IsZero() {
-					finConfigSettings[pool.PoolAddress] = pool.AllowedFinalityConfig
+					finConfigSettings[poolAddress] = pool.AllowedFinalityConfig
 				}
 				if len(pool.Destinations) > 0 {
-					feeConfigSettings[pool.PoolAddress] = map[uint64]*TokenTransferFeeConfig{}
+					feeConfigSettings[poolAddress] = map[uint64]*TokenTransferFeeConfig{}
 					for _, dst := range pool.Destinations {
-						if args, err := inferTokenTransferFeeArgs(feesAdapter, e, pool.PoolAddress, src.Selector, dst.Selector, dst); err != nil {
-							return deployment.ChangesetOutput{}, fmt.Errorf("failed to infer token transfer fee args for src %d, dst %d, and pool %s: %w", src.Selector, dst.Selector, pool.PoolAddress, err)
+						if args, err := inferTokenTransferFeeArgs(feesAdapter, e, poolAddress, src.Selector, dst.Selector, dst); err != nil {
+							return deployment.ChangesetOutput{}, fmt.Errorf("failed to infer token transfer fee args for src %d, dst %d, and pool %s: %w", src.Selector, dst.Selector, poolAddress, err)
 						} else {
-							feeConfigSettings[pool.PoolAddress][dst.Selector] = args
+							feeConfigSettings[poolAddress][dst.Selector] = args
 						}
 					}
 				}

--- a/deployment/tokens/product.go
+++ b/deployment/tokens/product.go
@@ -187,8 +187,8 @@ type ConfigureTokenForTransfersInput struct {
 // SetAllowedFinalityConfigSequenceInput defines the input for setting the allowed finality config on a V2 token pool.
 type SetAllowedFinalityConfigSequenceInput struct {
 	// Settings are provided as a map of pool address to finality config.
-	Settings map[string][4]byte `json:"settings" yaml:"settings"`
-	// Selector is the chain selector for the chain on which to set the minimum block confirmations.
+	Settings map[string]finality.Config `json:"settings" yaml:"settings"`
+	// Selector is the chain selector for the chain on which to set the allowed finality configs.
 	Selector uint64 `json:"selector" yaml:"selector"`
 }
 

--- a/integration-tests/deployment/set_token_transfer_fee_test.go
+++ b/integration-tests/deployment/set_token_transfer_fee_test.go
@@ -596,7 +596,7 @@ func TestSetTokenPoolTokenTransferFeeV2_0_0(t *testing.T) {
 					TokenPools: []tokens.TokenTransferFeeForPool{
 						{
 							PoolAddress:           poolA.Hex(),
-							MinBlockConfirmations: utils.NewOptional(uint16(12)),
+							AllowedFinalityConfig: finality.Config{BlockDepth: 12},
 							Destinations: []tokens.TokenTransferFeeForDst{
 								{
 									IsReset:  false,
@@ -621,7 +621,7 @@ func TestSetTokenPoolTokenTransferFeeV2_0_0(t *testing.T) {
 					TokenPools: []tokens.TokenTransferFeeForPool{
 						{
 							PoolAddress:           poolB.Hex(),
-							MinBlockConfirmations: utils.Optional[uint16]{Value: 12, Valid: false},
+							AllowedFinalityConfig: finality.Config{},
 							Destinations: []tokens.TokenTransferFeeForDst{
 								{
 									IsReset:  false,
@@ -646,7 +646,7 @@ func TestSetTokenPoolTokenTransferFeeV2_0_0(t *testing.T) {
 					TokenPools: []tokens.TokenTransferFeeForPool{
 						{
 							PoolAddress:           poolC.Hex(),
-							MinBlockConfirmations: utils.NewOptional(uint16(0)),
+							AllowedFinalityConfig: finality.Config{WaitForFinality: true},
 							Destinations: []tokens.TokenTransferFeeForDst{
 								{
 									IsReset:  false,


### PR DESCRIPTION
## Summary

Modifies the `SetTokenPoolTokenTransferFee` such that `MinBlockConfirmations` is removed in favor of the new `finality.Config`, which enables support for all three finality modes:

- `WaitForFinality` - wait for chain finality
- `WaitForSafe` - wait for safe block confirmation
- `BlockDepth` - wait for a specific number of block confirmations

This change moves the `[4]byte` encoding (`.Raw()`) to the sequence layer where it belongs, keeping the higher-level API clean and type-safe.

## Changes

- **`TokenTransferFeeForPool`**: Replace `MinBlockConfirmations utils.Optional[uint16]` with `AllowedFinalityConfig finality.Config`
- **`SetAllowedFinalityConfigSequenceInput`**: Change `Settings` type from `map[string][4]byte` to `map[string]finality.Config`
- **`set_allowed_finality_config_for_token_pools.go`**: Call `.Raw()` on the config when passing to the contract operation
- **`fees.go`**: Use `IsZero()` check instead of `Optional.Get()` to determine if config should be applied
- **Tests**: Update test cases to use the new `finality.Config` struct with equivalent semantics
