### PR TITLE
fix: dual admin role for tip-20 token

### DIFF
--- a/chains/evm/deployment/v1_0_0/operations/tip20/tip20_ops.go
+++ b/chains/evm/deployment/v1_0_0/operations/tip20/tip20_ops.go
@@ -186,3 +186,24 @@ var GrantIssuerRole = contract.NewWrite(contract.WriteParams[common.Address, *TI
 		return token.GrantRole(opts, issuerRole, input)
 	},
 })
+
+var GrantAdminRole = contract.NewWrite(contract.WriteParams[common.Address, *TIP20Token]{
+	Name:         "tip20:grant-admin-role",
+	Version:      Version,
+	Description:  "Grants DEFAULT_ADMIN_ROLE on a TIP-20 token (same role id as TIP20RolesAuth bytes32(0))",
+	ContractType: ContractType,
+	ContractABI:  TIP20TokenABI,
+	NewContract:  NewTIP20Token,
+	IsAllowedCaller: func(token *TIP20Token, opts *bind.CallOpts, caller common.Address, input common.Address) (bool, error) {
+		return token.HasRole(opts, caller, DefaultAdminRole)
+	},
+	Validate: func(address common.Address) error {
+		if address == (common.Address{}) {
+			return errors.New("account address is required")
+		}
+		return nil
+	},
+	CallContract: func(token *TIP20Token, opts *bind.TransactOpts, input common.Address) (*types.Transaction, error) {
+		return token.GrantRole(opts, DefaultAdminRole, input)
+	},
+})

--- a/chains/evm/deployment/v1_0_0/sequences/token.go
+++ b/chains/evm/deployment/v1_0_0/sequences/token.go
@@ -28,7 +28,8 @@ import (
 func tokenSupportsAdminRole(tokenType deployment.ContractType) bool {
 	switch tokenType {
 	case burn_mint_erc20.ContractType,
-		burn_mint_erc20_with_drip.ContractType:
+		burn_mint_erc20_with_drip.ContractType,
+		tip20.ContractType:
 		return true
 	default:
 		return false
@@ -140,12 +141,14 @@ var DeployToken = cldf_ops.NewSequence(
 			}
 
 		case tip20.ContractType:
+			// Initial admin must be the deployer so subsequent ops (e.g. GrantIssuerRole) run as the same
+			// identity pass IsAllowedCaller; ExternalAdmin receives DEFAULT_ADMIN_ROLE in a follow-up grant.
 			report, err := cldf_ops.ExecuteSequence(b, tip20.Deploy, chain, tip20.FactoryDeployArgs{
 				QuoteToken: common.Address{}, // defaults to sensible value
 				Currency:   "",               // defaults to sensible value
 				Salt:       [32]byte{},       // defaults to random salt
 				Symbol:     input.Symbol,
-				Admin:      externalAdmin,
+				Admin:      chain.DeployerKey.From,
 				Name:       input.Name,
 			})
 			if err != nil {
@@ -202,27 +205,44 @@ var DeployToken = cldf_ops.NewSequence(
 		}
 
 		if input.ExternalAdmin != "" && tokenSupportsAdminRole(input.Type) {
-			token, err := bnm_erc20_bindings.NewBurnMintERC20(tokenAddr, chain.Client)
-			if err != nil {
-				return sequences.OnChainOutput{}, fmt.Errorf("failed to instantiate BurnMintERC20 contract: %w", err)
-			}
-			role, err := token.DEFAULTADMINROLE(&bind.CallOpts{Context: b.GetContext()})
-			if err != nil {
-				return sequences.OnChainOutput{}, fmt.Errorf("failed to get default admin role constant: %w", err)
-			}
+			switch input.Type {
+			case burn_mint_erc20.ContractType, burn_mint_erc20_with_drip.ContractType:
+				token, err := bnm_erc20_bindings.NewBurnMintERC20(tokenAddr, chain.Client)
+				if err != nil {
+					return sequences.OnChainOutput{}, fmt.Errorf("failed to instantiate BurnMintERC20 contract: %w", err)
+				}
+				role, err := token.DEFAULTADMINROLE(&bind.CallOpts{Context: b.GetContext()})
+				if err != nil {
+					return sequences.OnChainOutput{}, fmt.Errorf("failed to get default admin role constant: %w", err)
+				}
 
-			grantReport, err := cldf_ops.ExecuteOperation(b, burn_mint_erc20.GrantAdminRole, chain, contract.FunctionInput[burn_mint_erc20.RoleAssignment]{
-				ChainSelector: chain.Selector,
-				Address:       tokenAddr,
-				Args: burn_mint_erc20.RoleAssignment{
-					Role: role,
-					To:   externalAdmin,
-				},
-			})
-			if err != nil {
-				return sequences.OnChainOutput{}, fmt.Errorf("failed to grant admin role to %s: %w", input.ExternalAdmin, err)
+				grantReport, err := cldf_ops.ExecuteOperation(b, burn_mint_erc20.GrantAdminRole, chain, contract.FunctionInput[burn_mint_erc20.RoleAssignment]{
+					ChainSelector: chain.Selector,
+					Address:       tokenAddr,
+					Args: burn_mint_erc20.RoleAssignment{
+						Role: role,
+						To:   externalAdmin,
+					},
+				})
+				if err != nil {
+					return sequences.OnChainOutput{}, fmt.Errorf("failed to grant admin role to %s: %w", input.ExternalAdmin, err)
+				}
+				writes = append(writes, grantReport.Output)
+
+			case tip20.ContractType:
+				grantReport, err := cldf_ops.ExecuteOperation(b, tip20.GrantAdminRole, chain, contract.FunctionInput[common.Address]{
+					ChainSelector: chain.Selector,
+					Address:       tokenAddr,
+					Args:          externalAdmin,
+				})
+				if err != nil {
+					return sequences.OnChainOutput{}, fmt.Errorf("failed to grant admin role to %s: %w", input.ExternalAdmin, err)
+				}
+				writes = append(writes, grantReport.Output)
+
+			default:
+				return sequences.OnChainOutput{}, fmt.Errorf("unsupported token type for admin role grant: %s", input.Type)
 			}
-			writes = append(writes, grantReport.Output)
 		}
 
 		batchOp, err := contract.NewBatchOperationFromWrites(writes)

--- a/chains/evm/deployment/v1_0_0/sequences/token_test.go
+++ b/chains/evm/deployment/v1_0_0/sequences/token_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/burn_mint_erc20"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/burn_mint_erc20_with_drip"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/erc20"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/tip20"
 	bnm_bindings "github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/burn_mint_erc20"
 
 	tokensapi "github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
@@ -229,4 +230,13 @@ func TestEVMTokenDeployments(t *testing.T) {
 			require.True(t, tokenFound, "Token %s should be found in deployed addresses", tc.name)
 		})
 	}
+}
+
+func TestTokenSupportsAdminRole(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, tokenSupportsAdminRole(burn_mint_erc20.ContractType))
+	require.True(t, tokenSupportsAdminRole(burn_mint_erc20_with_drip.ContractType))
+	require.True(t, tokenSupportsAdminRole(tip20.ContractType))
+	require.False(t, tokenSupportsAdminRole(erc20.ContractType))
 }


### PR DESCRIPTION
## PR: TIP-20 deploy admin + external admin grant

### What this fixes

**`DeployToken`** was passing **`ExternalAdmin`** as the TIP-20 factory **`admin`**, so **`DEFAULT_ADMIN_ROLE`** landed only on the external admin. Deployment and follow-up ops (e.g. **`GrantIssuerRole`** when attaching a burn-mint pool) run as the **deployer**, which no longer passed **`IsAllowedCaller`** on the token.

### Behavior

- **TIP-20 factory deploy** now sets **`Admin`** to the **deployer** (`chain.DeployerKey.From`), matching how BurnMint tokens start with the deployer as admin.
- If **`ExternalAdmin`** is set, the sequence enqueues **`tip20.GrantAdminRole`**: **`grantRole(DEFAULT_ADMIN_ROLE, externalAdmin)`**, in line with **`burn_mint_erc20.GrantAdminRole`** for BurnMint types.
- **`tokenSupportsAdminRole`** includes **TIP-20** so that grant runs when an external admin is requested.

After this, the deployer remains a default admin (and the external admin is granted the same role), so later **`GrantIssuerRole`**-style checks that expect the deploying identity to be admin behave as intended.

### Test Results

- Account: https://explore.testnet.tempo.xyz/address/0x5c25312c82791e6cb76dc9efabe2f5fa695d966b
- Branch: https://github.com/smartcontractkit/chainlink-deployments/compare/main...cd/test-tip20-deploy