### PR TITLE
fix: omit function fields from JSON + YAML

### DIFF
--- a/deployment/lanes/lane_update.go
+++ b/deployment/lanes/lane_update.go
@@ -25,7 +25,7 @@ type ChainDefinition struct {
 	TokenPrices map[string]*big.Int
 	// FeeQuoterDestChainConfigOverrides is a functional option that mutates a
 	// FeeQuoterDestChainConfig in place. Pass one or more overrides to selectively change default values.
-	FeeQuoterDestChainConfigOverrides *FeeQuoterDestChainConfigOverride
+	FeeQuoterDestChainConfigOverrides *FeeQuoterDestChainConfigOverride `json:"-"`
 	// RMNVerificationEnabled is true if we want the RMN to bless messages FROM this chain.
 	// This is provided by the user
 	// 1.6 only

--- a/deployment/lanes/lane_update.go
+++ b/deployment/lanes/lane_update.go
@@ -25,7 +25,7 @@ type ChainDefinition struct {
 	TokenPrices map[string]*big.Int
 	// FeeQuoterDestChainConfigOverrides is a functional option that mutates a
 	// FeeQuoterDestChainConfig in place. Pass one or more overrides to selectively change default values.
-	FeeQuoterDestChainConfigOverrides *FeeQuoterDestChainConfigOverride `json:"-"`
+	FeeQuoterDestChainConfigOverrides *FeeQuoterDestChainConfigOverride `json:"-" yaml:"-"`
 	// RMNVerificationEnabled is true if we want the RMN to bless messages FROM this chain.
 	// This is provided by the user
 	// 1.6 only
@@ -194,7 +194,7 @@ type ConnectChainsConfig struct {
 	// CommitteePopulator populates CommitteeVerifierInputs into fully configured
 	// CommitteeVerifierConfig values during apply. Required when any ChainDefinition
 	// in Lanes has CommitteeVerifierInputs set. Nil for 1.6-only usage.
-	CommitteePopulator CommitteeConfigPopulator
+	CommitteePopulator CommitteeConfigPopulator `json:"-" yaml:"-"`
 }
 type LaneConfig struct {
 	ChainA       ChainDefinition


### PR DESCRIPTION
This PR omits functional fields from some structs in the lanes API so that we can avoid YAML/JSON marshaling errors such as this:

```
(*Command).ExecuteC\n\tgithub.com/spf13/cobra@v1.10.2/command.go:1148\ngithub.com/spf13/cobra.
(*Command).Execute\n\tgithub.com/spf13/cobra@v1.10.2/command.go:1071\nmain.main\n\tgithub.com/
smartcontractkit/chainlink-deployments/domains/ccip/cmd/main.go:207\nruntime.main\n\truntime/proc.go:290\n
Error: json: unsupported type: lanes.FeeQuoterDestChainConfigOverride\n" prefix=STDERR
```

EDIT: fix has been confirmed via CLD