### PR TITLE
Register USDCTokenPoolProxy on legacy v1.6.2 pool for all remotes

### DIFF
--- a/chains/evm/deployment/v2_0_0/sequences/cctp/configure_cctp_chain_for_lanes.go
+++ b/chains/evm/deployment/v2_0_0/sequences/cctp/configure_cctp_chain_for_lanes.go
@@ -1,7 +1,9 @@
 package cctp
 
 import (
+	"bytes"
 	"fmt"
+	"slices"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
@@ -27,6 +29,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/cctp_through_ccv_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/cctp_verifier"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/siloed_usdc_token_pool"
+	evm_token_pool "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/usdc_token_pool_proxy"
 	tokens_sequences "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences/tokens"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/versioned_verifier_resolver"
@@ -38,6 +41,8 @@ const (
 	mechanismLockRelease   = "LOCK_RELEASE"
 	mechanismCCTPV2WithCCV = "CCTP_V2_WITH_CCV"
 )
+
+var v162 = semver.MustParse("1.6.2")
 
 // configureCCTPChainRefs holds resolved address refs for ConfigureCCTPChainForLanes.
 type configureCCTPChainRefs struct {
@@ -178,6 +183,14 @@ var ConfigureCCTPChainForLanes = cldf_ops.NewSequence(
 			}
 			writes = append(writes, w...)
 		}
+
+		// If a legacy USDCTokenPool v1.6.2 exists on this chain, register each supported
+		// remote's USDCTokenPoolProxy on it via usdc_token_pool.AddRemotePool.
+		v162Writes, err := addUSDCTokenPoolProxyAsRemotePoolOnLegacyPool(b, chain, dep, input, remoteChainConfigs)
+		if err != nil {
+			return sequences.OnChainOutput{}, err
+		}
+		writes = append(writes, v162Writes...)
 
 		// Create batch operation from writes
 		if len(writes) > 0 {
@@ -347,6 +360,100 @@ func resolveConfigureCCTPChainRefs(
 		siloedRef = &siloed
 	}
 	return refs, siloedRef, nil
+}
+
+// addUSDCTokenPoolProxyAsRemotePoolOnLegacyPool registers each remote chain's USDCTokenPoolProxy
+// on the legacy USDCTokenPool v1.6.2 via usdc_token_pool.AddRemotePool.
+// Skips when there is no v1.6.2 pool on this chain (net new lane), the remote's registered pool
+// ref is not a USDCTokenPoolProxy, the remote chain is not yet supported on the v1.6.2 pool, or the
+// proxy is already listed as a remote pool.
+func addUSDCTokenPoolProxyAsRemotePoolOnLegacyPool(
+	b cldf_ops.Bundle,
+	chain evm.Chain,
+	dep adapters.ConfigureCCTPChainForLanesDeps,
+	input adapters.ConfigureCCTPChainForLanesInput,
+	remoteChainConfigs map[uint64]tokens_core.RemoteChainConfig[[]byte, string],
+) ([]contract_utils.WriteOutput, error) {
+	refs := dep.DataStore.Addresses().Filter(
+		datastore.AddressRefByChainSelector(input.ChainSelector),
+		datastore.AddressRefByType(datastore.ContractType(usdc_token_pool.ContractType)),
+		datastore.AddressRefByVersion(v162),
+	)
+	if len(refs) == 0 {
+		return nil, nil
+	}
+	if len(refs) > 1 {
+		return nil, fmt.Errorf("expected at most one USDCTokenPool v%s on chain %d, found %d", v162.String(), input.ChainSelector, len(refs))
+	}
+	localV162 := common.HexToAddress(refs[0].Address)
+
+	supportedChainsReport, err := cldf_ops.ExecuteOperation[contract_utils.FunctionInput[struct{}], []uint64, evm.Chain](
+		b, evm_token_pool.GetSupportedChains, chain, contract_utils.FunctionInput[struct{}]{
+			ChainSelector: input.ChainSelector,
+			Address:       localV162,
+		})
+	if err != nil {
+		return nil, fmt.Errorf("getSupportedChains on USDCTokenPool v1.6.2 %s: %w", localV162.Hex(), err)
+	}
+	supportedChains := supportedChainsReport.Output
+
+	var writes []contract_utils.WriteOutput
+	for remoteSel := range input.RemoteChains {
+		poolRef := input.RemoteRegisteredPoolRefs[remoteSel]
+		if poolRef.Type != datastore.ContractType(usdc_token_pool_proxy.ContractType) {
+			continue
+		}
+		cfg, ok := remoteChainConfigs[remoteSel]
+		if !ok {
+			continue
+		}
+		if !slices.Contains(supportedChains, remoteSel) {
+			continue
+		}
+		w, err := maybeAddRemotePoolUSDCTokenPoolV162(b, chain, input.ChainSelector, localV162, remoteSel, cfg.RemotePool)
+		if err != nil {
+			return nil, err
+		}
+		if w.ChainSelector != 0 {
+			writes = append(writes, w)
+		}
+	}
+	return writes, nil
+}
+
+func maybeAddRemotePoolUSDCTokenPoolV162(
+	b cldf_ops.Bundle,
+	chain evm.Chain,
+	chainSelector uint64,
+	localPool common.Address,
+	remoteChainSelector uint64,
+	remotePoolPadded []byte,
+) (contract_utils.WriteOutput, error) {
+	poolsRep, err := cldf_ops.ExecuteOperation[contract_utils.FunctionInput[uint64], [][]byte, evm.Chain](
+		b, evm_token_pool.GetRemotePools, chain, contract_utils.FunctionInput[uint64]{
+			ChainSelector: chainSelector,
+			Address:       localPool,
+			Args:          remoteChainSelector,
+		})
+	if err != nil {
+		return contract_utils.WriteOutput{}, fmt.Errorf("getRemotePools on USDCTokenPool v1.6.2 %s for remote %d: %w", localPool.Hex(), remoteChainSelector, err)
+	}
+	if slices.ContainsFunc(poolsRep.Output, func(p []byte) bool { return bytes.Equal(p, remotePoolPadded) }) {
+		return contract_utils.WriteOutput{}, nil
+	}
+	addRep, err := cldf_ops.ExecuteOperation[contract_utils.FunctionInput[usdc_token_pool.AddRemotePoolArgs], contract_utils.WriteOutput, evm.Chain](
+		b, usdc_token_pool.AddRemotePool, chain, contract_utils.FunctionInput[usdc_token_pool.AddRemotePoolArgs]{
+			ChainSelector: chainSelector,
+			Address:       localPool,
+			Args: usdc_token_pool.AddRemotePoolArgs{
+				RemoteChainSelector: remoteChainSelector,
+				RemotePoolAddress:   remotePoolPadded,
+			},
+		})
+	if err != nil {
+		return contract_utils.WriteOutput{}, fmt.Errorf("addRemotePool on USDCTokenPool v1.6.2 %s for remote %d: %w", localPool.Hex(), remoteChainSelector, err)
+	}
+	return addRep.Output, nil
 }
 
 // buildRemoteChainConfigs builds the remote chain config map used by token pools and configure-token-for-transfers.

--- a/chains/evm/deployment/v2_0_0/sequences/cctp/configure_cctp_chain_for_lanes.go
+++ b/chains/evm/deployment/v2_0_0/sequences/cctp/configure_cctp_chain_for_lanes.go
@@ -411,7 +411,7 @@ func addUSDCTokenPoolProxyAsRemotePoolOnLegacyPool(
 		}
 		cfg, ok := remoteChainConfigs[remoteSel]
 		if !ok {
-			continue
+			return nil, fmt.Errorf("missing remote chain config for remote chain %d on chain %d", remoteSel, input.ChainSelector)
 		}
 		if !slices.Contains(supportedChains, remoteSel) {
 			continue

--- a/chains/evm/deployment/v2_0_0/sequences/cctp/configure_cctp_chain_for_lanes.go
+++ b/chains/evm/deployment/v2_0_0/sequences/cctp/configure_cctp_chain_for_lanes.go
@@ -247,9 +247,15 @@ var ConfigureCCTPChainForLanes = cldf_ops.NewSequence(
 		// Proactively configure the CCTP-through-CCV pool for all CCTP-capable remotes.
 		// This excludes lock-release lanes, but includes V1/V2 remotes so the CCV pool
 		// is ready before proxy routing is switched to CCTP_V2_WITH_CCV.
+		// Non-EVM remotes (e.g. Solana) are excluded: CCIP 2.0 does not support them, so
+		// CCTP_V2_WITH_CCV will never be enabled for them and preconfiguring the CCV pool
+		// would be wasted state.
 		cctpThroughCCVRemoteChainConfigs := make(map[uint64]tokens_core.RemoteChainConfig[[]byte, string])
 		for remoteChainSelector, remoteChainConfig := range remoteChainConfigs {
 			if input.RemoteChains[remoteChainSelector].LockOrBurnMechanism == mechanismLockRelease {
+				continue
+			}
+			if !isEVMRemote(remoteChainSelector) {
 				continue
 			}
 			cctpThroughCCVRemoteChainConfigs[remoteChainSelector] = remoteChainConfig
@@ -479,11 +485,18 @@ func buildRemoteChainConfigs(dep adapters.ConfigureCCTPChainForLanesDeps, input 
 	return configs, nil
 }
 
-// buildVerifierResolverOutboundArgs builds outbound implementation args for the CCTPVerifierResolver (one per remote chain).
+// buildVerifierResolverOutboundArgs builds outbound implementation args for the CCTPVerifierResolver.
+// Includes every CCTP-capable EVM remote (V1, V2, V2_WITH_CCV) and excludes lock-release lanes, matching the
+// set of chains preconfigured on the CCTP-through-CCV pool. This keeps CCTPThroughCCVTokenPool.getTokenTransferFeeConfig
+// from reverting on V1 remotes before proxy routing is switched to CCTP_V2_WITH_CCV.
+// Non-EVM remotes (e.g. Solana) are skipped: CCIP 2.0 does not support them, so the CCV pool will never be used for them.
 func buildVerifierResolverOutboundArgs(input adapters.ConfigureCCTPChainForLanesInput, cctpVerifierAddress common.Address) []versioned_verifier_resolver.OutboundImplementationArgs {
 	out := make([]versioned_verifier_resolver.OutboundImplementationArgs, 0, len(input.RemoteChains))
 	for remoteChainSelector, remoteChain := range input.RemoteChains {
-		if !isV2Mechanism(remoteChain.LockOrBurnMechanism) {
+		if remoteChain.LockOrBurnMechanism == mechanismLockRelease {
+			continue
+		}
+		if !isEVMRemote(remoteChainSelector) {
 			continue
 		}
 		out = append(out, versioned_verifier_resolver.OutboundImplementationArgs{
@@ -492,6 +505,16 @@ func buildVerifierResolverOutboundArgs(input adapters.ConfigureCCTPChainForLanes
 		})
 	}
 	return out
+}
+
+// isEVMRemote reports whether a remote chain selector belongs to the EVM family.
+// Selectors that fail to resolve are treated as non-EVM (skipped by callers).
+func isEVMRemote(remoteChainSelector uint64) bool {
+	family, err := chain_selectors.GetSelectorFamily(remoteChainSelector)
+	if err != nil {
+		return false
+	}
+	return family == chain_selectors.FamilyEVM
 }
 
 // buildUSDCTokenPoolProxyMechanismArgs builds remote chain selectors and lock/burn mechanisms for the USDCTokenPoolProxy.

--- a/chains/evm/deployment/v2_0_0/sequences/cctp/deploy_cctp_chain.go
+++ b/chains/evm/deployment/v2_0_0/sequences/cctp/deploy_cctp_chain.go
@@ -155,14 +155,28 @@ var DeployCCTPChain = cldf_ops.NewSequence(
 		isHomeChain := chain.Selector == chain_selectors.ETHEREUM_MAINNET.Selector || chain.Selector == chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector
 		var siloedLockReleaseTokenPoolRef datastore.AddressRef
 		if isHomeChain {
-			// Only the siloed USDC lock release pool will be deployed here.
-			// Lockboxes are deployed per lane and are therefore deployed during ConfigureCCTPChainForLanes.
+			// Check if SiloedUSDCTokenPool is already present in the datastore,
+			// otherwise the sequence will deploy a fresh pool. Lockboxes are deployed per
+			// lane during ConfigureCCTPChainForLanes, not here.
+			var existingSiloedPoolAddr string
+			existingSiloedRefs := dep.DataStore.Addresses().Filter(
+				datastore.AddressRefByChainSelector(input.ChainSelector),
+				datastore.AddressRefByType(datastore.ContractType(siloed_usdc_token_pool.ContractType)),
+				datastore.AddressRefByVersion(siloed_usdc_token_pool.Version),
+			)
+			if len(existingSiloedRefs) > 1 {
+				return sequences.OnChainOutput{}, fmt.Errorf("expected at most one SiloedUSDCTokenPool v%s on chain %d, found %d", siloed_usdc_token_pool.Version.String(), input.ChainSelector, len(existingSiloedRefs))
+			}
+			if len(existingSiloedRefs) == 1 {
+				existingSiloedPoolAddr = existingSiloedRefs[0].Address
+			}
 			siloedLockReleaseReport, err := cldf_ops.ExecuteSequence(b, DeploySiloedUSDCLockRelease, dep.BlockChains, DeploySiloedUSDCLockReleaseInput{
-				ChainSelector: input.ChainSelector,
-				TokenDecimals: input.TokenDecimals,
-				USDCToken:     input.USDCToken,
-				RMN:           rmnAddress.Hex(),
-				Router:        routerAddress.Hex(),
+				ChainSelector:       input.ChainSelector,
+				TokenDecimals:       input.TokenDecimals,
+				USDCToken:           input.USDCToken,
+				RMN:                 rmnAddress.Hex(),
+				Router:              routerAddress.Hex(),
+				SiloedUSDCTokenPool: existingSiloedPoolAddr,
 			})
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to deploy siloed USDC lock release stack: %w", err)

--- a/deployment/v2_0_0/changesets/deploy_cctp_chains.go
+++ b/deployment/v2_0_0/changesets/deploy_cctp_chains.go
@@ -221,6 +221,11 @@ func makeApplyDeployCCTPChains(cctpChainRegistry *adapters.CCTPChainRegistry, mc
 			}
 			batchOps = append(batchOps, configureCCTPChainForLanesReport.Output.BatchOps...)
 			reports = append(reports, configureCCTPChainForLanesReport.ExecutionReports...)
+			for _, r := range configureCCTPChainForLanesReport.Output.Addresses {
+				if err := newDS.Addresses().Add(r); err != nil {
+					return deployment.ChangesetOutput{}, fmt.Errorf("failed to add %s %s with address %s on chain with selector %d to datastore: %w", r.Type, r.Version, r.Address, r.ChainSelector, err)
+				}
+			}
 		}
 
 		// Return the output.


### PR DESCRIPTION
+ Fixes the following 

- ERC20 Lockbox address were not persisted to datastore
- Skip Solana related config for CCTP v2 flows
- We were not checking if SiloedUSDCTokenPool is already deployed 