### PR TITLE
feat: add support for specifying the TIP-20 token currency

### DIFF
--- a/chains/evm/deployment/v1_0_0/sequences/token.go
+++ b/chains/evm/deployment/v1_0_0/sequences/token.go
@@ -163,7 +163,7 @@ var DeployToken = cldf_ops.NewSequence(
 			// identity pass IsAllowedCaller; ExternalAdmin receives DEFAULT_ADMIN_ROLE in a follow-up grant.
 			report, err := cldf_ops.ExecuteSequence(b, tip20.Deploy, chain, tip20.FactoryDeployArgs{
 				QuoteToken: common.Address{}, // defaults to sensible value
-				Currency:   "",               // defaults to sensible value
+				Currency:   input.Currency,   // defaults to sensible value if empty
 				Salt:       [32]byte{},       // defaults to random salt
 				Symbol:     input.Symbol,
 				Admin:      chain.DeployerKey.From,

--- a/chains/evm/go.mod
+++ b/chains/evm/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/smartcontractkit/ccip-contract-examples/chains/evm v0.0.0-20250826190403-aed7f5f33cde
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0
 	github.com/smartcontractkit/chain-selectors v1.0.98
-	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260430162852-e8daba118223
+	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260501175227-8c02f90e18d9
 	github.com/smartcontractkit/chainlink-ccv v0.0.1
 	github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260428205321-9ce8f4c44d23
 	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260407150650-8115835abd6e

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -48,8 +48,10 @@ type DeployTokenInput struct {
 	// Customer admin who will be granted admin rights on the token
 	// Use string to keep this struct chain-agnostic (EVM uses hex, Solana uses base58, etc.)
 	ExternalAdmin string `yaml:"externalAdmin" json:"externalAdmin"`
-	// Address to be set as the CCIP admin on the token contract, defaults to the timelock address
+	// CCIPAdmin is the address to be set as the CCIP admin on the token contract, defaults to the timelock address. Only applicable for EVM BnM ERC20 tokens.
 	CCIPAdmin string `yaml:"ccipAdmin" json:"ccipAdmin"`
+	// Currency is the TIP20 token currency. This field is only applicable for TIP20 tokens on Tempo. If this field is empty, then a sensible default will be chosen.
+	Currency string `yaml:"currency" json:"currency"`
 	// list of addresses who may need special processing in order to send tokens
 	// e.g. for Solana, addresses that need associated token accounts created
 	Senders []string `yaml:"senders" json:"senders"`

--- a/devenv/go.mod
+++ b/devenv/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment v0.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260312233953-f588f8dc6d7c
-	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260430162852-e8daba118223
+	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260501175227-8c02f90e18d9
 	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260417081611-8bdbd9f45629
 	github.com/smartcontractkit/chainlink-deployments-framework v0.98.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260410162948-2dca02f24e98 // indirect

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment v0.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260312233953-f588f8dc6d7c
-	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260430162852-e8daba118223
+	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260501175227-8c02f90e18d9
 	github.com/smartcontractkit/chainlink-deployments-framework v0.96.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260410162948-2dca02f24e98
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20260119171452-39c98c3b33cd


### PR DESCRIPTION
core ref: 2a52a992df57d88d85e2d6d6aad393950af0944a

Allows operators to specify the `currency` of a TIP-20 tempo token (previously always defaulted to USD)

Testing:
- Managed to deploy a token with custom currency: https://explore.testnet.tempo.xyz/address/0x20C0000000000000000000008CA9A2096d68dd1c?tab=token
- Branch here: https://github.com/smartcontractkit/chainlink-deployments/commit/cde8abdce7fe0ead0cbff488956ab7b9112e539e
