### PR TITLE
fix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,6 @@
 /chains/evm @smartcontractkit/ccip-onchain
 .github/workflows/**solidity** @smartcontractkit/ccip-onchain
 /integration-tests @smartcontractkit/ccip-onchain @smartcontractkit/ccip-tooling
-/ccv/chains/evm @smartcontractkit/ccip-onchain
 
 # solana development ownership
 /chains/solana @smartcontractkit/ccip-onchain-solana
@@ -16,5 +15,5 @@
 # Deployment tooling
 **/deployment @smartcontractkit/ccip-tooling @smartcontractkit/ccip-onchain @smartcontractkit/ccip-offchain
 /devenv @smartcontractkit/ccip-tooling @smartcontractkit/ccip-onchain @smartcontractkit/ccip-offchain
-/chains/evm/deployment @smartcontractkit/ccip-tooling @smartcontractkit/ccip-onchain
+/chains/evm/deployment @smartcontractkit/ccip-onchain
 /chains/solana/deployment @smartcontractkit/ccip-tooling @smartcontractkit/ccip-onchain-solana

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,5 +15,6 @@
 # Deployment tooling
 **/deployment @smartcontractkit/ccip-tooling @smartcontractkit/ccip-onchain @smartcontractkit/ccip-offchain
 /devenv @smartcontractkit/ccip-tooling @smartcontractkit/ccip-onchain @smartcontractkit/ccip-offchain
-/chains/evm/deployment @smartcontractkit/ccip-onchain
+/chains/evm/deployment @smartcontractkit/ccip-onchain @smartcontractkit/ccip-tooling
+/chains/evm/deployment/**/operations @smartcontractkit/ccip-onchain
 /chains/solana/deployment @smartcontractkit/ccip-tooling @smartcontractkit/ccip-onchain-solana

--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -246,8 +246,8 @@ jobs:
       - name: Setup DB
         shell: bash
         run: |
-          go get github.com/smartcontractkit/chainlink/v2/core/store/cmd/preparetest@latest
-          go run github.com/smartcontractkit/chainlink/v2/core/store/cmd/preparetest
+          cd $GITHUB_WORKSPACE/chainlink
+          go run ./core/store/cmd/preparetest
         env:
           CL_DATABASE_URL: ${{ env.DB_URL }}
       - name: Install gotestsum

--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -246,8 +246,7 @@ jobs:
       - name: Setup DB
         shell: bash
         run: |
-          cd $GITHUB_WORKSPACE/chainlink
-          go run ./core/store/cmd/preparetest
+          go -C $GITHUB_WORKSPACE/chainlink run ./core/store/cmd/preparetest
         env:
           CL_DATABASE_URL: ${{ env.DB_URL }}
       - name: Install gotestsum


### PR DESCRIPTION
Remove `ccip-tooling` from the owners of `chains/evm/deployment/operations` as onchain owns this folder


Fixes tests as well