### PR TITLE
fix: use token pool version to get token adapter

### DIFF
--- a/deployment/tokens/manual_registration.go
+++ b/deployment/tokens/manual_registration.go
@@ -118,7 +118,7 @@ func manualRegistrationApply() func(cldf.Environment, ManualRegistrationInput) (
 			}
 
 			var adapterVersion *semver.Version
-			fullPool, findErr := datastore_utils.FindAndFormatRef(e.DataStore, registration.TokenPoolRef, registration.ChainSelector, datastore_utils.FullRef)
+			fullPool, findErr := datastore_utils.FindAndFormatRef(ds.Seal(), registration.TokenPoolRef, registration.ChainSelector, datastore_utils.FullRef)
 			if findErr == nil {
 				adapterVersion = fullPool.Version
 			}
@@ -135,7 +135,7 @@ func manualRegistrationApply() func(cldf.Environment, ManualRegistrationInput) (
 
 			adapter, exists := tokenPoolRegistry.GetTokenAdapter(chainfam, adapterVersion)
 			if !exists {
-				return cldf.ChangesetOutput{}, fmt.Errorf("no TokenPoolAdapter registered for chain family '%s' and version '%s'", chainfam, adapterVersion)
+				return cldf.ChangesetOutput{}, fmt.Errorf("no TokenPoolAdapter registered for chain family '%s' and version '%v'", chainfam, adapterVersion)
 			}
 
 			report, err := cldf_ops.ExecuteSequence(

--- a/deployment/tokens/manual_registration.go
+++ b/deployment/tokens/manual_registration.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gagliardetto/solana-go"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
+	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -99,17 +100,42 @@ func manualRegistrationApply() func(cldf.Environment, ManualRegistrationInput) (
 				return cldf.ChangesetOutput{}, err
 			}
 
-			adapter, exists := tokenPoolRegistry.GetTokenAdapter(chainfam, cfg.ChainAdapterVersion)
-			if !exists {
-				return cldf.ChangesetOutput{}, fmt.Errorf("no TokenPoolAdapter registered for chain family '%s'", chainfam)
-			}
-
 			// Safeguard: always prevent chain selector mismatches
 			if registration.TokenPoolRef.ChainSelector != 0 && registration.TokenPoolRef.ChainSelector != registration.ChainSelector {
 				return cldf.ChangesetOutput{}, fmt.Errorf("chain selector mismatch in TokenPoolRef for registration index %d: expected %d, got %d", i, registration.ChainSelector, registration.TokenPoolRef.ChainSelector)
 			}
 			if registration.TokenRef.ChainSelector != 0 && registration.TokenRef.ChainSelector != registration.ChainSelector {
 				return cldf.ChangesetOutput{}, fmt.Errorf("chain selector mismatch in TokenRef for registration index %d: expected %d, got %d", i, registration.ChainSelector, registration.TokenRef.ChainSelector)
+			}
+
+			registration.TokenPoolRef, err = TryNormalizeAddressRef(registration.ChainSelector, registration.TokenPoolRef)
+			if err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("failed to normalize token pool ref for registration index %d: %w", i, err)
+			}
+			registration.TokenRef, err = TryNormalizeAddressRef(registration.ChainSelector, registration.TokenRef)
+			if err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("failed to normalize token ref for registration index %d: %w", i, err)
+			}
+
+			var adapterVersion *semver.Version
+			fullPool, findErr := datastore_utils.FindAndFormatRef(e.DataStore, registration.TokenPoolRef, registration.ChainSelector, datastore_utils.FullRef)
+			if findErr == nil {
+				adapterVersion = fullPool.Version
+			}
+			if adapterVersion == nil {
+				switch {
+				case registration.TokenPoolRef.Version != nil:
+					adapterVersion = registration.TokenPoolRef.Version
+				case cfg.ChainAdapterVersion != nil:
+					adapterVersion = cfg.ChainAdapterVersion
+				default:
+					return cldf.ChangesetOutput{}, fmt.Errorf("registration[%d]: cannot determine token pool adapter version: pool not found in datastore under tokenPoolRef and neither tokenPoolRef.version nor chainAdapterVersion is set", i)
+				}
+			}
+
+			adapter, exists := tokenPoolRegistry.GetTokenAdapter(chainfam, adapterVersion)
+			if !exists {
+				return cldf.ChangesetOutput{}, fmt.Errorf("no TokenPoolAdapter registered for chain family '%s' and version '%s'", chainfam, adapterVersion)
 			}
 
 			report, err := cldf_ops.ExecuteSequence(

--- a/deployment/tokens/migrate_lock_release_pool_liquidity.go
+++ b/deployment/tokens/migrate_lock_release_pool_liquidity.go
@@ -65,15 +65,6 @@ func makeMigrationApply(_ *TokenAdapterRegistry, mcmsRegistry *changesets.MCMSRe
 			if err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("migration[%d]: failed to get chain family for selector %d: %w", i, migration.ChainSelector, err)
 			}
-			adapter, ok := tokenRegistry.GetTokenAdapter(family, migration.NewPoolRef.Version)
-			if !ok {
-				return cldf.ChangesetOutput{}, fmt.Errorf("migration[%d]: no token adapter registered for chain family '%s' and version '%s'", i, family, migration.NewPoolRef.Version)
-			}
-
-			migrationSeq := adapter.MigrateLockReleasePoolLiquiditySequence()
-			if migrationSeq == nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("migration[%d]: adapter for family '%s' version '%s' does not support liquidity migration", i, family, migration.NewPoolRef.Version)
-			}
 
 			oldRef, err := TryNormalizeAddressRef(migration.ChainSelector, migration.OldPoolRef)
 			if err != nil {
@@ -91,6 +82,16 @@ func makeMigrationApply(_ *TokenAdapterRegistry, mcmsRegistry *changesets.MCMSRe
 			newPoolRef, err := datastore_utils.FindAndFormatRef(e.DataStore, newRef, migration.ChainSelector, datastore_utils.FullRef)
 			if err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("migration[%d]: failed to resolve new pool ref: %w", i, err)
+			}
+
+			adapter, ok := tokenRegistry.GetTokenAdapter(family, newPoolRef.Version)
+			if !ok {
+				return cldf.ChangesetOutput{}, fmt.Errorf("migration[%d]: no token adapter registered for chain family '%s' and version '%s'", i, family, newPoolRef.Version)
+			}
+
+			migrationSeq := adapter.MigrateLockReleasePoolLiquiditySequence()
+			if migrationSeq == nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("migration[%d]: adapter for family '%s' version '%s' does not support liquidity migration", i, family, newPoolRef.Version)
 			}
 
 			// Derive the timelock address from the MCMS config.

--- a/deployment/tokens/migrate_lock_release_pool_liquidity.go
+++ b/deployment/tokens/migrate_lock_release_pool_liquidity.go
@@ -86,12 +86,12 @@ func makeMigrationApply(_ *TokenAdapterRegistry, mcmsRegistry *changesets.MCMSRe
 
 			adapter, ok := tokenRegistry.GetTokenAdapter(family, newPoolRef.Version)
 			if !ok {
-				return cldf.ChangesetOutput{}, fmt.Errorf("migration[%d]: no token adapter registered for chain family '%s' and version '%s'", i, family, newPoolRef.Version)
+				return cldf.ChangesetOutput{}, fmt.Errorf("migration[%d]: no token adapter registered for chain family '%s' and version '%v'", i, family, newPoolRef.Version)
 			}
 
 			migrationSeq := adapter.MigrateLockReleasePoolLiquiditySequence()
 			if migrationSeq == nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("migration[%d]: adapter for family '%s' version '%s' does not support liquidity migration", i, family, newPoolRef.Version)
+				return cldf.ChangesetOutput{}, fmt.Errorf("migration[%d]: adapter for family '%s' version '%v' does not support liquidity migration", i, family, newPoolRef.Version)
 			}
 
 			// Derive the timelock address from the MCMS config.

--- a/deployment/tokens/rate_limits.go
+++ b/deployment/tokens/rate_limits.go
@@ -119,7 +119,7 @@ func setTokenPoolRateLimitsApply() func(cldf.Environment, TPRLInput) (cldf.Chang
 			}
 			tokenPoolAdapter, exists := tokenPoolRegistry.GetTokenAdapter(family, tokenPool.Version)
 			if !exists {
-				return cldf.ChangesetOutput{}, fmt.Errorf("no TokenPoolAdapter registered for chain family '%s' and version '%s'", family, tokenPool.Version)
+				return cldf.ChangesetOutput{}, fmt.Errorf("no TokenPoolAdapter registered for chain family '%s' and version '%v'", family, tokenPool.Version)
 			}
 			tokenBytes, err := datastore_utils.FindAndFormatRef(e.DataStore, config.TokenRef, selector, tokenPoolAdapter.AddressRefToBytes)
 			if err != nil {
@@ -171,7 +171,7 @@ func setTokenPoolRateLimitsApply() func(cldf.Environment, TPRLInput) (cldf.Chang
 				}
 				counterPartAdapter, exists := tokenPoolRegistry.GetTokenAdapter(counterpartFamily, remoteTokenPool.Version)
 				if !exists {
-					return cldf.ChangesetOutput{}, fmt.Errorf("no TokenPoolAdapter registered for chain family '%s' and version '%s'", counterpartFamily, remoteTokenPool.Version)
+					return cldf.ChangesetOutput{}, fmt.Errorf("no TokenPoolAdapter registered for chain family '%s' and version '%v'", counterpartFamily, remoteTokenPool.Version)
 				}
 				remoteTokenBytes, err := datastore_utils.FindAndFormatRef(e.DataStore, counterpart.TokenRef, remoteSelector, counterPartAdapter.AddressRefToBytes)
 				if err != nil {

--- a/deployment/tokens/rate_limits.go
+++ b/deployment/tokens/rate_limits.go
@@ -100,10 +100,7 @@ func setTokenPoolRateLimitsApply() func(cldf.Environment, TPRLInput) (cldf.Chang
 			if err != nil {
 				return cldf.ChangesetOutput{}, err
 			}
-			tokenPoolAdapter, exists := tokenPoolRegistry.GetTokenAdapter(family, config.ChainAdapterVersion)
-			if !exists {
-				return cldf.ChangesetOutput{}, fmt.Errorf("no TokenPoolAdapter registered for chain family '%s'", family)
-			}
+
 			config.TokenPoolRef, err = TryNormalizeAddressRef(selector, config.TokenPoolRef)
 			if err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to normalize token pool ref address on chain selector %d: %w", selector, err)
@@ -119,6 +116,10 @@ func setTokenPoolRateLimitsApply() func(cldf.Environment, TPRLInput) (cldf.Chang
 			tokenFull, err := datastore_utils.FindAndFormatRef(e.DataStore, config.TokenRef, selector, datastore_utils.FullRef)
 			if err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to resolve token ref on chain with selector %d: %w", selector, err)
+			}
+			tokenPoolAdapter, exists := tokenPoolRegistry.GetTokenAdapter(family, tokenPool.Version)
+			if !exists {
+				return cldf.ChangesetOutput{}, fmt.Errorf("no TokenPoolAdapter registered for chain family '%s' and version '%s'", family, tokenPool.Version)
 			}
 			tokenBytes, err := datastore_utils.FindAndFormatRef(e.DataStore, config.TokenRef, selector, tokenPoolAdapter.AddressRefToBytes)
 			if err != nil {
@@ -150,10 +151,6 @@ func setTokenPoolRateLimitsApply() func(cldf.Environment, TPRLInput) (cldf.Chang
 				if err != nil {
 					return cldf.ChangesetOutput{}, err
 				}
-				counterPartAdapter, exists := tokenPoolRegistry.GetTokenAdapter(counterpartFamily, counterpart.ChainAdapterVersion)
-				if !exists {
-					return cldf.ChangesetOutput{}, fmt.Errorf("no TokenPoolAdapter registered for chain family '%s'", counterpartFamily)
-				}
 				remoteInputs, ok := counterpart.RemoteOutbounds[selector]
 				if !ok {
 					return cldf.ChangesetOutput{}, fmt.Errorf("no inputs provided for remote chain with selector %d to chain with selector %d", selector, remoteSelector)
@@ -171,6 +168,10 @@ func setTokenPoolRateLimitsApply() func(cldf.Environment, TPRLInput) (cldf.Chang
 				remoteTokenPool, err := datastore_utils.FindAndFormatRef(e.DataStore, counterpart.TokenPoolRef, remoteSelector, datastore_utils.FullRef)
 				if err != nil {
 					return cldf.ChangesetOutput{}, fmt.Errorf("failed to resolve token pool ref on chain with selector %d: %w", remoteSelector, err)
+				}
+				counterPartAdapter, exists := tokenPoolRegistry.GetTokenAdapter(counterpartFamily, remoteTokenPool.Version)
+				if !exists {
+					return cldf.ChangesetOutput{}, fmt.Errorf("no TokenPoolAdapter registered for chain family '%s' and version '%s'", counterpartFamily, remoteTokenPool.Version)
 				}
 				remoteTokenBytes, err := datastore_utils.FindAndFormatRef(e.DataStore, counterpart.TokenRef, remoteSelector, counterPartAdapter.AddressRefToBytes)
 				if err != nil {


### PR DESCRIPTION
## Summary

Token pool changesets now select the **`TokenAdapter` by the semver on the datastore-resolved token pool ref**, not by `chainAdapterVersion` (or the raw config ref) when a full pool is already known in the environment datastore. This aligns `set_token_pool_rate_limits`, lock-release migration, and manual registration with the same idea as **token expansion**: the pool record in the datastore is the source of truth for which adapter implementation to use.

## Problem

Several paths called `GetTokenAdapter(family, cfg.ChainAdapterVersion)` (or equivalent) **before** resolving the pool through the datastore, or used a version that could diverge from the stored pool metadata. That mismatch can pick the wrong adapter for:

- **Encoding / decoding** addresses (`AddressRefToBytes`) and **decimals** derivation, which are version-specific.
- **Rate limit application** on the local pool and on the **counterpart** chain when inferring remote decimals (cross-family TPRL).

YAML `chainAdapterVersion` can also drift from the pools actually recorded for the environment.

## Approach

- **`deployment/tokens/rate_limits.go`**
  - Resolve and normalize token pool + token refs, then **`GetTokenAdapter(family, tokenPool.Version)`** for the source chain.
  - For each remote counterpart: after **`FindAndFormatRef` → `remoteTokenPool`**, use **`GetTokenAdapter(counterpartFamily, remoteTokenPool.Version)`** instead of `counterpart.ChainAdapterVersion`.
  - Improve “not registered” errors to include the **version** attempted.

- **`deployment/tokens/migrate_lock_release_pool_liquidity.go`**  
  After normalizing and resolving **old** and **new** pools, call **`GetTokenAdapter(family, newPoolRef.Version)`** (Datastore full ref for the **new** pool), then resolve the migration sequence. This matches the deployed new pool’s stored semver rather than `migration.NewPoolRef.Version` alone.

- **`deployment/tokens/manual_registration.go`**  
  Normalize pool and token refs, then **`FindAndFormatRef`** the pool against `e.DataStore`. Adapter version precedence: **`fullPool.Version`** (datastore), else **`tokenPoolRef.Version`**, else **`chainAdapterVersion`**. Fail fast with a clear error if none of these can be determined.
