### PR TITLE
Fix set rate limit for first time

### DIFF
--- a/chains/solana/deployment/v1_6_0/operations/token_pools/burnmint.go
+++ b/chains/solana/deployment/v1_6_0/operations/token_pools/burnmint.go
@@ -373,13 +373,16 @@ var UpsertRateLimitsBurnMint = operations.NewOperation(
 
 		// There is a bug on the token pool contract which does not allow us to set the actual rate limits directly.
 		// We have to setup dummy limits first and then update it.
-		// This workaround is only needed when the rate limits are being set for the first time (uninitialized),
-		// not when updating already-configured limits, to avoid resetting the token bucket.
+		// This workaround is only needed when enabling a rate limit that is currently disabled on-chain,
+		// not when updating already-enabled limits, to avoid resetting that direction's token bucket.
 		var remoteChainConfigAccount base_token_pool.BaseChain
 		err = chain.GetAccountDataBorshInto(b.GetContext(), remoteChainConfigPDA, &remoteChainConfigAccount)
-		rateLimitsUninitialized := err != nil ||
-			(remoteChainConfigAccount.InboundRateLimit.LastUpdated == 0 || remoteChainConfigAccount.OutboundRateLimit.LastUpdated == 0)
-		if (inbound.Enabled || outbound.Enabled) && rateLimitsUninitialized {
+		if err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to read remote chain config account: %w", err)
+		}
+		needsDummy := (inbound.Enabled && !remoteChainConfigAccount.InboundRateLimit.Cfg.Enabled) ||
+			(outbound.Enabled && !remoteChainConfigAccount.OutboundRateLimit.Cfg.Enabled)
+		if needsDummy {
 			ixDummyRates, err := burnmint_token_pool.NewSetChainRateLimitInstruction(
 				input.RemoteSelector,
 				input.TokenMint,

--- a/chains/solana/deployment/v1_6_0/operations/token_pools/burnmint.go
+++ b/chains/solana/deployment/v1_6_0/operations/token_pools/burnmint.go
@@ -369,6 +369,35 @@ var UpsertRateLimitsBurnMint = operations.NewOperation(
 		// check if remote chain config already exists
 		remoteChainConfigPDA, _, _ := tokens.TokenPoolChainConfigPDA(input.RemoteSelector, input.TokenMint, input.TokenPool)
 		batches := make([]types.BatchOperation, 0)
+		var ixns []solana.Instruction
+
+		// There is a bug on the token pool contract which does not allow us to set the actual rate limits directly.
+		// We have to setup dummy limits first and then update it.
+		// If the user is trying to set actual limits (enabled=true), we set dummy limits first and then update.
+		if inbound.Enabled || outbound.Enabled {
+			ixDummyRates, err := burnmint_token_pool.NewSetChainRateLimitInstruction(
+				input.RemoteSelector,
+				input.TokenMint,
+				burnmint_token_pool.RateLimitConfig{
+					Enabled:  false,
+					Capacity: 0,
+					Rate:     0,
+				},
+				burnmint_token_pool.RateLimitConfig{
+					Enabled:  false,
+					Capacity: 0,
+					Rate:     0,
+				},
+				poolConfigPDA,
+				remoteChainConfigPDA,
+				authority,
+			).ValidateAndBuild()
+			if err != nil {
+				return sequences.OnChainOutput{}, err
+			}
+			ixns = append(ixns, ixDummyRates)
+		}
+
 		ixn, err := burnmint_token_pool.NewSetChainRateLimitInstruction(
 			input.RemoteSelector,
 			input.TokenMint,
@@ -381,10 +410,12 @@ var UpsertRateLimitsBurnMint = operations.NewOperation(
 		if err != nil {
 			return sequences.OnChainOutput{}, err
 		}
+		ixns = append(ixns, ixn)
+
 		if authority != chain.DeployerKey.PublicKey() {
 			b, err := utils.BuildMCMSBatchOperation(
 				chain.Selector,
-				[]solana.Instruction{ixn},
+				ixns,
 				input.TokenPool.String(),
 				common_utils.BurnMintTokenPool.String(),
 			)
@@ -394,7 +425,7 @@ var UpsertRateLimitsBurnMint = operations.NewOperation(
 			batches = append(batches, b)
 			return sequences.OnChainOutput{BatchOps: batches}, nil
 		} else {
-			err = chain.Confirm([]solana.Instruction{ixn})
+			err = chain.Confirm(ixns)
 			if err != nil {
 				return sequences.OnChainOutput{}, err
 			}

--- a/chains/solana/deployment/v1_6_0/operations/token_pools/burnmint.go
+++ b/chains/solana/deployment/v1_6_0/operations/token_pools/burnmint.go
@@ -378,7 +378,7 @@ var UpsertRateLimitsBurnMint = operations.NewOperation(
 		var remoteChainConfigAccount base_token_pool.BaseChain
 		err = chain.GetAccountDataBorshInto(b.GetContext(), remoteChainConfigPDA, &remoteChainConfigAccount)
 		rateLimitsUninitialized := err != nil ||
-			(remoteChainConfigAccount.InboundRateLimit.LastUpdated == 0 && remoteChainConfigAccount.OutboundRateLimit.LastUpdated == 0)
+			(remoteChainConfigAccount.InboundRateLimit.LastUpdated == 0 || remoteChainConfigAccount.OutboundRateLimit.LastUpdated == 0)
 		if (inbound.Enabled || outbound.Enabled) && rateLimitsUninitialized {
 			ixDummyRates, err := burnmint_token_pool.NewSetChainRateLimitInstruction(
 				input.RemoteSelector,

--- a/chains/solana/deployment/v1_6_0/operations/token_pools/burnmint.go
+++ b/chains/solana/deployment/v1_6_0/operations/token_pools/burnmint.go
@@ -373,8 +373,13 @@ var UpsertRateLimitsBurnMint = operations.NewOperation(
 
 		// There is a bug on the token pool contract which does not allow us to set the actual rate limits directly.
 		// We have to setup dummy limits first and then update it.
-		// If the user is trying to set actual limits (enabled=true), we set dummy limits first and then update.
-		if inbound.Enabled || outbound.Enabled {
+		// This workaround is only needed when the rate limits are being set for the first time (uninitialized),
+		// not when updating already-configured limits, to avoid resetting the token bucket.
+		var remoteChainConfigAccount base_token_pool.BaseChain
+		err = chain.GetAccountDataBorshInto(b.GetContext(), remoteChainConfigPDA, &remoteChainConfigAccount)
+		rateLimitsUninitialized := err != nil ||
+			(remoteChainConfigAccount.InboundRateLimit.LastUpdated == 0 && remoteChainConfigAccount.OutboundRateLimit.LastUpdated == 0)
+		if (inbound.Enabled || outbound.Enabled) && rateLimitsUninitialized {
 			ixDummyRates, err := burnmint_token_pool.NewSetChainRateLimitInstruction(
 				input.RemoteSelector,
 				input.TokenMint,

--- a/chains/solana/deployment/v1_6_0/operations/token_pools/burnmint.go
+++ b/chains/solana/deployment/v1_6_0/operations/token_pools/burnmint.go
@@ -377,11 +377,16 @@ var UpsertRateLimitsBurnMint = operations.NewOperation(
 		// not when updating already-enabled limits, to avoid resetting that direction's token bucket.
 		var remoteChainConfigAccount base_token_pool.BaseChain
 		err = chain.GetAccountDataBorshInto(b.GetContext(), remoteChainConfigPDA, &remoteChainConfigAccount)
+		// If the account doesn't exist yet (e.g. during token expansion where MCMS batches
+		// init_chain_remote_config and set_chain_rate_limit in a single proposal), we treat
+		// both directions as uninitialized and always prepend the dummy instruction.
+		needsDummy := false
 		if err != nil {
-			return sequences.OnChainOutput{}, fmt.Errorf("failed to read remote chain config account: %w", err)
+			needsDummy = inbound.Enabled || outbound.Enabled
+		} else {
+			needsDummy = (inbound.Enabled && !remoteChainConfigAccount.InboundRateLimit.Cfg.Enabled) ||
+				(outbound.Enabled && !remoteChainConfigAccount.OutboundRateLimit.Cfg.Enabled)
 		}
-		needsDummy := (inbound.Enabled && !remoteChainConfigAccount.InboundRateLimit.Cfg.Enabled) ||
-			(outbound.Enabled && !remoteChainConfigAccount.OutboundRateLimit.Cfg.Enabled)
 		if needsDummy {
 			ixDummyRates, err := burnmint_token_pool.NewSetChainRateLimitInstruction(
 				input.RemoteSelector,

--- a/chains/solana/deployment/v1_6_0/operations/token_pools/lockrelease.go
+++ b/chains/solana/deployment/v1_6_0/operations/token_pools/lockrelease.go
@@ -316,8 +316,13 @@ var UpsertRateLimitsLockRelease = operations.NewOperation(
 
 		// There is a bug on the token pool contract which does not allow us to set the actual rate limits directly.
 		// We have to setup dummy limits first and then update it.
-		// If the user is trying to set actual limits (enabled=true), we set dummy limits first and then update.
-		if inbound.Enabled || outbound.Enabled {
+		// This workaround is only needed when the rate limits are being set for the first time (uninitialized),
+		// not when updating already-configured limits, to avoid resetting the token bucket.
+		var remoteChainConfigAccount base_token_pool.BaseChain
+		err = chain.GetAccountDataBorshInto(b.GetContext(), remoteChainConfigPDA, &remoteChainConfigAccount)
+		rateLimitsUninitialized := err != nil ||
+			(remoteChainConfigAccount.InboundRateLimit.LastUpdated == 0 && remoteChainConfigAccount.OutboundRateLimit.LastUpdated == 0)
+		if (inbound.Enabled || outbound.Enabled) && rateLimitsUninitialized {
 			ixDummyRates, err := lockrelease_token_pool.NewSetChainRateLimitInstruction(
 				input.RemoteSelector,
 				input.TokenMint,

--- a/chains/solana/deployment/v1_6_0/operations/token_pools/lockrelease.go
+++ b/chains/solana/deployment/v1_6_0/operations/token_pools/lockrelease.go
@@ -321,7 +321,7 @@ var UpsertRateLimitsLockRelease = operations.NewOperation(
 		var remoteChainConfigAccount base_token_pool.BaseChain
 		err = chain.GetAccountDataBorshInto(b.GetContext(), remoteChainConfigPDA, &remoteChainConfigAccount)
 		rateLimitsUninitialized := err != nil ||
-			(remoteChainConfigAccount.InboundRateLimit.LastUpdated == 0 && remoteChainConfigAccount.OutboundRateLimit.LastUpdated == 0)
+			(remoteChainConfigAccount.InboundRateLimit.LastUpdated == 0 || remoteChainConfigAccount.OutboundRateLimit.LastUpdated == 0)
 		if (inbound.Enabled || outbound.Enabled) && rateLimitsUninitialized {
 			ixDummyRates, err := lockrelease_token_pool.NewSetChainRateLimitInstruction(
 				input.RemoteSelector,

--- a/chains/solana/deployment/v1_6_0/operations/token_pools/lockrelease.go
+++ b/chains/solana/deployment/v1_6_0/operations/token_pools/lockrelease.go
@@ -312,6 +312,35 @@ var UpsertRateLimitsLockRelease = operations.NewOperation(
 		// check if remote chain config already exists
 		remoteChainConfigPDA, _, _ := tokens.TokenPoolChainConfigPDA(input.RemoteSelector, input.TokenMint, input.TokenPool)
 		batches := make([]types.BatchOperation, 0)
+		var ixns []solana.Instruction
+
+		// There is a bug on the token pool contract which does not allow us to set the actual rate limits directly.
+		// We have to setup dummy limits first and then update it.
+		// If the user is trying to set actual limits (enabled=true), we set dummy limits first and then update.
+		if inbound.Enabled || outbound.Enabled {
+			ixDummyRates, err := lockrelease_token_pool.NewSetChainRateLimitInstruction(
+				input.RemoteSelector,
+				input.TokenMint,
+				lockrelease_token_pool.RateLimitConfig{
+					Enabled:  false,
+					Capacity: 0,
+					Rate:     0,
+				},
+				lockrelease_token_pool.RateLimitConfig{
+					Enabled:  false,
+					Capacity: 0,
+					Rate:     0,
+				},
+				poolConfigPDA,
+				remoteChainConfigPDA,
+				authority,
+			).ValidateAndBuild()
+			if err != nil {
+				return sequences.OnChainOutput{}, err
+			}
+			ixns = append(ixns, ixDummyRates)
+		}
+
 		ixn, err := lockrelease_token_pool.NewSetChainRateLimitInstruction(
 			input.RemoteSelector,
 			input.TokenMint,
@@ -324,10 +353,12 @@ var UpsertRateLimitsLockRelease = operations.NewOperation(
 		if err != nil {
 			return sequences.OnChainOutput{}, err
 		}
+		ixns = append(ixns, ixn)
+
 		if authority != chain.DeployerKey.PublicKey() {
 			b, err := utils.BuildMCMSBatchOperation(
 				chain.Selector,
-				[]solana.Instruction{ixn},
+				ixns,
 				input.TokenPool.String(),
 				common_utils.LockReleaseTokenPool.String(),
 			)
@@ -337,7 +368,7 @@ var UpsertRateLimitsLockRelease = operations.NewOperation(
 			batches = append(batches, b)
 			return sequences.OnChainOutput{BatchOps: batches}, nil
 		} else {
-			err = chain.Confirm([]solana.Instruction{ixn})
+			err = chain.Confirm(ixns)
 			if err != nil {
 				return sequences.OnChainOutput{}, err
 			}

--- a/chains/solana/deployment/v1_6_0/operations/token_pools/lockrelease.go
+++ b/chains/solana/deployment/v1_6_0/operations/token_pools/lockrelease.go
@@ -316,13 +316,16 @@ var UpsertRateLimitsLockRelease = operations.NewOperation(
 
 		// There is a bug on the token pool contract which does not allow us to set the actual rate limits directly.
 		// We have to setup dummy limits first and then update it.
-		// This workaround is only needed when the rate limits are being set for the first time (uninitialized),
-		// not when updating already-configured limits, to avoid resetting the token bucket.
+		// This workaround is only needed when enabling a rate limit that is currently disabled on-chain,
+		// not when updating already-enabled limits, to avoid resetting that direction's token bucket.
 		var remoteChainConfigAccount base_token_pool.BaseChain
 		err = chain.GetAccountDataBorshInto(b.GetContext(), remoteChainConfigPDA, &remoteChainConfigAccount)
-		rateLimitsUninitialized := err != nil ||
-			(remoteChainConfigAccount.InboundRateLimit.LastUpdated == 0 || remoteChainConfigAccount.OutboundRateLimit.LastUpdated == 0)
-		if (inbound.Enabled || outbound.Enabled) && rateLimitsUninitialized {
+		if err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to read remote chain config account: %w", err)
+		}
+		needsDummy := (inbound.Enabled && !remoteChainConfigAccount.InboundRateLimit.Cfg.Enabled) ||
+			(outbound.Enabled && !remoteChainConfigAccount.OutboundRateLimit.Cfg.Enabled)
+		if needsDummy {
 			ixDummyRates, err := lockrelease_token_pool.NewSetChainRateLimitInstruction(
 				input.RemoteSelector,
 				input.TokenMint,

--- a/chains/solana/deployment/v1_6_0/operations/token_pools/lockrelease.go
+++ b/chains/solana/deployment/v1_6_0/operations/token_pools/lockrelease.go
@@ -320,11 +320,16 @@ var UpsertRateLimitsLockRelease = operations.NewOperation(
 		// not when updating already-enabled limits, to avoid resetting that direction's token bucket.
 		var remoteChainConfigAccount base_token_pool.BaseChain
 		err = chain.GetAccountDataBorshInto(b.GetContext(), remoteChainConfigPDA, &remoteChainConfigAccount)
+		// If the account doesn't exist yet (e.g. during token expansion where MCMS batches
+		// init_chain_remote_config and set_chain_rate_limit in a single proposal), we treat
+		// both directions as uninitialized and always prepend the dummy instruction.
+		needsDummy := false
 		if err != nil {
-			return sequences.OnChainOutput{}, fmt.Errorf("failed to read remote chain config account: %w", err)
+			needsDummy = inbound.Enabled || outbound.Enabled
+		} else {
+			needsDummy = (inbound.Enabled && !remoteChainConfigAccount.InboundRateLimit.Cfg.Enabled) ||
+				(outbound.Enabled && !remoteChainConfigAccount.OutboundRateLimit.Cfg.Enabled)
 		}
-		needsDummy := (inbound.Enabled && !remoteChainConfigAccount.InboundRateLimit.Cfg.Enabled) ||
-			(outbound.Enabled && !remoteChainConfigAccount.OutboundRateLimit.Cfg.Enabled)
 		if needsDummy {
 			ixDummyRates, err := lockrelease_token_pool.NewSetChainRateLimitInstruction(
 				input.RemoteSelector,


### PR DESCRIPTION
This pull request addresses a bug in the Solana token pool contracts that prevents setting actual rate limits directly. The solution implements a workaround by first setting dummy (disabled) rate limits before applying the intended configuration. This logic is applied to both the burn/mint and lock/release token pool operations. The changes ensure that the correct sequence of instructions is constructed and executed, improving reliability when updating rate limits.
