### PR TITLE
feat: token expansion - custom rate limit admin for solana

### DIFF
--- a/chains/solana/deployment/docs/adapter.md
+++ b/chains/solana/deployment/docs/adapter.md
@@ -110,8 +110,8 @@ func init() {
 | `SetTokenPoolRateLimits()` | Sets inbound/outbound rate limits for BurnMint or LockRelease pools |
 | `DeployToken()` | Deploys SPL/SPL2022 token, creates ATAs for senders, optionally uploads metadata |
 | `DeployTokenVerify()` | No-op (returns nil) |
-| `DeployTokenPoolForToken()` | Initializes pool account (BurnMint or LockRelease), creates pool signer ATA, sets mint authority for BurnMint pools |
-| `UpdateAuthorities()` | Transfers token pool ownership to timelock signer PDA, updates rate limit admin |
+| `DeployTokenPoolForToken()` | Initializes pool account (BurnMint or LockRelease), sets rate limit admin to `RateLimitAdmin` or timelock signer PDA, creates pool signer ATA, sets mint authority for BurnMint pools |
+| `UpdateAuthorities()` | Transfers token pool ownership to timelock signer PDA and accepts ownership |
 
 ### TransferOwnershipAdapter Interface
 

--- a/chains/solana/deployment/v1_6_0/sequences/tokens.go
+++ b/chains/solana/deployment/v1_6_0/sequences/tokens.go
@@ -515,7 +515,7 @@ func (a *SolanaAdapter) DeployTokenPoolForToken() *cldf_ops.Sequence[tokenapi.De
 	return operations.NewSequence(
 		"DeployTokenPoolForToken",
 		common_utils.Version_1_6_0,
-		"Configures a token pool for a given token on Solana. Doesn't actually deploy a new token pool contract, as Solana token pools are just accounts.",
+		"Configures a token pool for a given token on Solana (no new program deploy). Initializes the pool, sets rate limit admin to RateLimitAdmin input or timelock signer PDA, then pool signer ATA and mint authority as needed.",
 		func(b operations.Bundle, chains cldf_chain.BlockChains, input tokenapi.DeployTokenPoolInput) (sequences.OnChainOutput, error) {
 			var result sequences.OnChainOutput
 			b.Logger.Info("SVM Deploying token:", input)
@@ -567,6 +567,47 @@ func (a *SolanaAdapter) DeployTokenPoolForToken() *cldf_ops.Sequence[tokenapi.De
 			}
 			result.Addresses = append(result.Addresses, deployOut.Output.Addresses...)
 			result.BatchOps = append(result.BatchOps, deployOut.Output.BatchOps...)
+
+			updateRLOp := tokenpoolops.UpdateRateLimitAdminBurnMint
+			switch input.PoolType {
+			case common_utils.BurnMintTokenPool.String():
+				updateRLOp = tokenpoolops.UpdateRateLimitAdminBurnMint
+			case common_utils.LockReleaseTokenPool.String():
+				updateRLOp = tokenpoolops.UpdateRateLimitAdminLockRelease
+			default:
+				return sequences.OnChainOutput{}, fmt.Errorf("unsupported token pool type '%s' for Solana", input.PoolType)
+			}
+
+			var rlAdmin solana.PublicKey
+			if input.RateLimitAdmin != "" {
+				rlAdmin, err = solana.PublicKeyFromBase58(input.RateLimitAdmin)
+				if err != nil {
+					return sequences.OnChainOutput{}, fmt.Errorf("rate limit admin address %q is not a valid base58 pubkey: %w", input.RateLimitAdmin, err)
+				}
+				if rlAdmin.IsZero() {
+					return sequences.OnChainOutput{}, errors.New("rate limit admin cannot be the zero pubkey")
+				}
+			} else {
+				rlAdmin = utils.GetTimelockSignerPDA(
+					input.ExistingDataStore.Addresses().Filter(),
+					chain.Selector,
+					common_utils.CLLQualifier,
+				)
+				if rlAdmin.IsZero() {
+					return sequences.OnChainOutput{}, fmt.Errorf("failed to resolve timelock signer PDA as rate limit admin for chain %d: ensure MCMS RBACTimelock is in the datastore", chain.Selector)
+				}
+			}
+
+			rlOut, err := operations.ExecuteOperation(b, updateRLOp, chains.SolanaChains()[chain.Selector], tokenpoolops.TokenPoolTransferOwnershipInput{
+				Program:   tokenPool,
+				TokenMint: tokenMint,
+				NewOwner:  rlAdmin,
+			})
+			if err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("failed to set rate limit admin: %w", err)
+			}
+			result.Addresses = append(result.Addresses, rlOut.Output.Addresses...)
+			result.BatchOps = append(result.BatchOps, rlOut.Output.BatchOps...)
 
 			poolSigner, _ := tokens.TokenPoolSignerAddress(tokenMint, tokenPool)
 
@@ -670,28 +711,15 @@ func (a *SolanaAdapter) UpdateAuthorities() *cldf_ops.Sequence[tokenapi.UpdateAu
 
 			transferOwnershipTPOp := tokenpoolops.TransferOwnershipBurnMint
 			acceptOwnershipTPOp := tokenpoolops.AcceptOwnershipBurnMint
-			tprlAdminTPOp := tokenpoolops.UpdateRateLimitAdminBurnMint
 			switch tokenPoolRef.Type.String() {
 			case common_utils.BurnMintTokenPool.String():
 				// Already set to burn mint
 			case common_utils.LockReleaseTokenPool.String():
 				transferOwnershipTPOp = tokenpoolops.TransferOwnershipLockRelease
 				acceptOwnershipTPOp = tokenpoolops.AcceptOwnershipLockRelease
-				tprlAdminTPOp = tokenpoolops.UpdateRateLimitAdminLockRelease
 			default:
 				return sequences.OnChainOutput{}, fmt.Errorf("unsupported token pool type '%s' for Solana", tokenPoolRef.Type)
 			}
-
-			tprlAdminOut, err := operations.ExecuteOperation(b, tprlAdminTPOp, e.BlockChains.SolanaChains()[chain.Selector], tokenpoolops.TokenPoolTransferOwnershipInput{
-				Program:   tokenPool,
-				TokenMint: tokenMint,
-				NewOwner:  timelockSigner,
-			})
-			if err != nil {
-				return sequences.OnChainOutput{}, fmt.Errorf("failed to update TPRL admin: %w", err)
-			}
-			result.Addresses = append(result.Addresses, tprlAdminOut.Output.Addresses...)
-			result.BatchOps = append(result.BatchOps, tprlAdminOut.Output.BatchOps...)
 
 			b.Logger.Infof("Transferring ownership of token pool %s to timelock signer %s", tokenPool.String(), timelockSigner.String())
 			transferOwnershipOut, err := operations.ExecuteOperation(b, transferOwnershipTPOp, e.BlockChains.SolanaChains()[chain.Selector], tokenpoolops.TokenPoolTransferOwnershipInput{

--- a/deployment/docs/changesets.md
+++ b/deployment/docs/changesets.md
@@ -197,7 +197,7 @@ func TokenExpansion() cldf.ChangeSetV2[TokenExpansionInput]
 1. **Deploy tokens** (if `DeployTokenInput` is non-nil): Executes `adapter.DeployToken()`
 2. **Deploy token pools** (if `DeployTokenPoolInput` is non-nil): Executes `adapter.DeployTokenPoolForToken()`
 3. **Configure for transfers** (if `TokenTransferConfig` is non-nil): Calls `processTokenConfigForChain()` which executes `adapter.ConfigureTokenForTransfersSequence()`
-4. **Update authorities** (unless `SkipOwnershipTransfer` is true): Executes `adapter.UpdateAuthorities()` to transfer ownership to the timelock
+4. **Update authorities** (unless `SkipOwnershipTransfer` is true): Executes `adapter.UpdateAuthorities()` to transfer pool ownership to the timelock (Solana: rate limit admin is already set in step 2 via `DeployTokenPoolForToken`; this step only transfers ownership)
 
 ### ConfigureTokensForTransfers
 

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -99,7 +99,8 @@ type DeployTokenPoolInput struct {
 	TokenPoolVersion   *semver.Version       `yaml:"tokenPoolVersion" json:"tokenPoolVersion"`
 	Allowlist          []string              `yaml:"allowlist" json:"allowlist"`
 	// RateLimitAdmin specifies the rate limit admin for the token pool. This field is optional.
-	// If empty, then this remains unconfigured on the token pool (i.e. the zero address).
+	// For Solana: If empty, DeployTokenPoolForToken sets the timelock signer PDA from the datastore;
+	// if non-empty, sets this base58 pubkey. On EVM, empty leaves the pool default (unchanged from contract deploy).
 	RateLimitAdmin string `yaml:"rateLimitAdmin" json:"rateLimitAdmin"`
 	// AcceptLiquidity is used by LockReleaseTokenPool (v1.5.1 only) to indicate
 	// whether the pool should accept liquidity from liquidity providers

--- a/integration-tests/deployment/token_expansion_scenarios_test.go
+++ b/integration-tests/deployment/token_expansion_scenarios_test.go
@@ -1058,6 +1058,14 @@ func TestTokenExpansionScenariosSolana(t *testing.T) {
 		require.Equal(t, solTokenMint, solPoolState.Config.Mint,
 			fmt.Sprintf("Solana pool mint should match token %s", solTokenRef.Address))
 
+		timelockSigner := solanautils.GetTimelockSignerPDA(
+			env.DataStore.Addresses().Filter(),
+			solChainSel,
+			cciputils.CLLQualifier,
+		)
+		require.Equal(t, timelockSigner, solPoolState.Config.RateLimitAdmin,
+			"empty DeployTokenPoolInput.RateLimitAdmin should set RL admin to MCMS timelock signer PDA on Solana")
+
 		// Verify Solana router address is set
 		routerAddr, err := solAdapter.GetRouterAddress(env.DataStore, solChainSel)
 		require.NoError(t, err)

--- a/integration-tests/deployment/tokens_and_token_pools_test.go
+++ b/integration-tests/deployment/tokens_and_token_pools_test.go
@@ -670,36 +670,36 @@ func TestTokensAndTokenPools(t *testing.T) {
 
 				require.Equal(t, 0, preMint.Cmp(big.NewInt(int64(balance))), fmt.Sprintf("expected pre-mint %q to match actual balance %q", preMint.String(), balance))
 
-				if data.RateLimitAdmin == "" {
-					continue
-				}
-				expectedRLA, err := solana.PublicKeyFromBase58(data.RateLimitAdmin)
-				require.NoError(t, err)
+				if data.RateLimitAdmin != "" {
+					expectedRLA, err := solana.PublicKeyFromBase58(data.RateLimitAdmin)
+					require.NoError(t, err)
 
-				tokenPoolRef, err := datastore_utils.FindAndFormatRef(
-					env.DataStore,
-					datastore.AddressRef{
-						ChainSelector: data.Chain.Selector,
-						Qualifier:     data.TokenPoolQualifier,
-						Type:          datastore.ContractType(data.TokenPoolType),
-						Version:       common_utils.Version_1_6_0,
-					},
-					data.Chain.Selector,
-					datastore_utils.FullRef,
-				)
-				require.NoError(t, err)
-				tokenPoolProgramID := solana.MustPublicKeyFromBase58(tokenPoolRef.Address)
-				tokenPoolStatePDA, err := tokens.TokenPoolConfigAddress(tokenAddr, tokenPoolProgramID)
-				require.NoError(t, err)
+					tokenPoolRef, err := datastore_utils.FindAndFormatRef(
+						env.DataStore,
+						datastore.AddressRef{
+							ChainSelector: data.Chain.Selector,
+							Qualifier:     data.TokenPoolQualifier,
+							Type:          datastore.ContractType(data.TokenPoolType),
+							Version:       common_utils.Version_1_6_0,
+						},
+						data.Chain.Selector,
+						datastore_utils.FullRef,
+					)
+					require.NoError(t, err)
 
-				switch data.TokenPoolType {
-				case common_utils.BurnMintTokenPool.String():
-					var poolState burnmint_token_pool.State
-					require.NoError(t, data.Chain.GetAccountDataBorshInto(t.Context(), tokenPoolStatePDA, &poolState))
-					require.Equal(t, expectedRLA, poolState.Config.RateLimitAdmin,
-						"token pool rate limit admin should match DeployTokenPoolInput.RateLimitAdmin")
-				default:
-					t.Fatalf("unexpected TokenPoolType %q with RateLimitAdmin set", data.TokenPoolType)
+					tokenPoolProgramID := solana.MustPublicKeyFromBase58(tokenPoolRef.Address)
+					tokenPoolStatePDA, err := tokens.TokenPoolConfigAddress(tokenAddr, tokenPoolProgramID)
+					require.NoError(t, err)
+
+					switch data.TokenPoolType {
+					case common_utils.BurnMintTokenPool.String():
+						var poolState burnmint_token_pool.State
+						require.NoError(t, data.Chain.GetAccountDataBorshInto(t.Context(), tokenPoolStatePDA, &poolState))
+						require.Equal(t, expectedRLA, poolState.Config.RateLimitAdmin,
+							"token pool rate limit admin should match DeployTokenPoolInput.RateLimitAdmin")
+					default:
+						t.Fatalf("unexpected TokenPoolType %q with RateLimitAdmin set", data.TokenPoolType)
+					}
 				}
 			}
 		})

--- a/integration-tests/deployment/tokens_and_token_pools_test.go
+++ b/integration-tests/deployment/tokens_and_token_pools_test.go
@@ -117,10 +117,13 @@ func TestTokensAndTokenPools(t *testing.T) {
 		Deployer           *solana.PrivateKey
 		Chain              solchain.Chain
 		Deploy             deployapi.ContractDeploymentConfigPerChain
+		// RateLimitAdmin is optional; when set on BurnMint, DeployTokenPoolForToken should set it on-chain.
+		RateLimitAdmin string
 	}{
 		{
 			TokenPoolQualifier: "",
 			TokenPoolType:      cciputils.BurnMintTokenPool.String(),
+			RateLimitAdmin:     solana.NewWallet().PublicKey().String(),
 			Deployer:           solChain.DeployerKey,
 			Chain:              solChain,
 			Deploy:             NewDefaultDeploymentConfigForSolana(v1_6_0),
@@ -278,6 +281,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 			DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
 				TokenPoolQualifier: solbnm.TokenPoolQualifier,
 				PoolType:           solbnm.TokenPoolType,
+				RateLimitAdmin:     solbnm.RateLimitAdmin,
 			},
 			DeployTokenInput: solbnm.Token,
 		}
@@ -312,6 +316,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 			DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
 				TokenPoolQualifier: sollnr.TokenPoolQualifier,
 				PoolType:           sollnr.TokenPoolType,
+				RateLimitAdmin:     sollnr.RateLimitAdmin,
 			},
 			DeployTokenInput: sollnr.Token,
 		}
@@ -664,6 +669,38 @@ func TestTokensAndTokenPools(t *testing.T) {
 				require.NoError(t, err)
 
 				require.Equal(t, 0, preMint.Cmp(big.NewInt(int64(balance))), fmt.Sprintf("expected pre-mint %q to match actual balance %q", preMint.String(), balance))
+
+				if data.RateLimitAdmin == "" {
+					continue
+				}
+				expectedRLA, err := solana.PublicKeyFromBase58(data.RateLimitAdmin)
+				require.NoError(t, err)
+
+				tokenPoolRef, err := datastore_utils.FindAndFormatRef(
+					env.DataStore,
+					datastore.AddressRef{
+						ChainSelector: data.Chain.Selector,
+						Qualifier:     data.TokenPoolQualifier,
+						Type:          datastore.ContractType(data.TokenPoolType),
+						Version:       common_utils.Version_1_6_0,
+					},
+					data.Chain.Selector,
+					datastore_utils.FullRef,
+				)
+				require.NoError(t, err)
+				tokenPoolProgramID := solana.MustPublicKeyFromBase58(tokenPoolRef.Address)
+				tokenPoolStatePDA, err := tokens.TokenPoolConfigAddress(tokenAddr, tokenPoolProgramID)
+				require.NoError(t, err)
+
+				switch data.TokenPoolType {
+				case common_utils.BurnMintTokenPool.String():
+					var poolState burnmint_token_pool.State
+					require.NoError(t, data.Chain.GetAccountDataBorshInto(t.Context(), tokenPoolStatePDA, &poolState))
+					require.Equal(t, expectedRLA, poolState.Config.RateLimitAdmin,
+						"token pool rate limit admin should match DeployTokenPoolInput.RateLimitAdmin")
+				default:
+					t.Fatalf("unexpected TokenPoolType %q with RateLimitAdmin set", data.TokenPoolType)
+				}
 			}
 		})
 
@@ -1021,7 +1058,13 @@ func TestTokensAndTokenPools(t *testing.T) {
 			require.NoError(t, stateErr)
 			require.Equal(t, timelockSigner, tokenPoolStateAccountAfter.Config.Owner)
 			require.Equal(t, tokenMint, tokenPoolStateAccountAfter.Config.Mint)
-			require.Equal(t, timelockSigner, tokenPoolStateAccountAfter.Config.RateLimitAdmin)
+			expectedRLA := timelockSigner
+			if solbnm.RateLimitAdmin != "" {
+				pk, pkErr := solana.PublicKeyFromBase58(solbnm.RateLimitAdmin)
+				require.NoError(t, pkErr)
+				expectedRLA = pk
+			}
+			require.Equal(t, expectedRLA, tokenPoolStateAccountAfter.Config.RateLimitAdmin)
 		})
 	})
 }


### PR DESCRIPTION
## What changed

- **Solana** [`DeployTokenPoolForToken`](chains/solana/deployment/v1_6_0/sequences/tokens.go): After pool initialization, always applies `set_rate_limit_admin` via existing `UpdateRateLimitAdminBurnMint` / `UpdateRateLimitAdminLockRelease` operations.
  - **`DeployTokenPoolInput.RateLimitAdmin` non-empty**: use that base58 pubkey as the new rate limit admin (validated, non-zero).
  - **Empty**: resolve **timelock signer PDA** with `GetTimelockSignerPDA(ExistingDataStore.Addresses().Filter(), chain.Selector, CLLQualifier)` and use that as the rate limit admin; error if the PDA is zero (typically missing MCMS timelock in datastore).
- **Solana** [`UpdateAuthorities`](chains/solana/deployment/v1_6_0/sequences/tokens.go): Removed rate-limit-admin updates. Still performs token pool **transfer ownership** and **accept ownership** to the timelock signer PDA.

## Why

- Aligns Solana with **optional** [`DeployTokenPoolInput.RateLimitAdmin`](deployment/tokens/token_expansion.go) (already used on EVM).
- Ensures a single place defines the pool’s rate limit admin after deploy: avoids a second sequence step overwriting a deploy-time choice.
- Removes conditional flags on [`UpdateAuthoritiesInput`](deployment/tokens/token_expansion.go); that struct is again only chain selector + token + pool refs.

## Contract / on-chain context

- Pool init sets `rate_limit_admin` equal to `owner`. Empty input therefore must **not** mean “leave unset”; default is **timelock signer PDA** when no custom admin is specified.

## Documentation

- [`chains/solana/deployment/docs/adapter.md`](chains/solana/deployment/docs/adapter.md): adapter method descriptions updated.
- [`deployment/docs/changesets.md`](deployment/docs/changesets.md): token expansion step ordering clarified for Solana RL admin vs ownership transfer.
- Deploy input comment for `RateLimitAdmin` updated to describe Solana vs EVM behavior.

## Constraints for callers

`DeployTokenPoolForToken` with empty `RateLimitAdmin` requires **RBACTimelock** (and related MCMS entries) present in `ExistingDataStore` for the chain so the timelock signer PDA can be derived.
