### PR TITLE
fix: token decimal scaling for custom USD1 pools

### DIFF
--- a/chains/evm/deployment/v1_5_1/sequences/token_pool/configure_token_pool_for_remote_chains.go
+++ b/chains/evm/deployment/v1_5_1/sequences/token_pool/configure_token_pool_for_remote_chains.go
@@ -28,7 +28,6 @@ type ConfigureTokenPoolForRemoteChainsInput struct {
 
 type ConfigureTokenPoolForRemoteChainInput struct {
 	TokenPoolAddress    common.Address
-	TokenPoolVersion    *semver.Version
 	RemoteChainSelector uint64
 	RemoteChainConfig   tokensapi.RemoteChainConfig[[]byte, string]
 }
@@ -70,7 +69,6 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 				chain,
 				ConfigureTokenPoolForRemoteChainInput{
 					TokenPoolAddress:    tokenPool.Address(),
-					TokenPoolVersion:    input.TokenPoolVersion,
 					RemoteChainSelector: remoteChainSelector,
 					RemoteChainConfig:   remoteChainConfig,
 				},
@@ -111,6 +109,8 @@ var ConfigureTokenPoolForRemoteChain = cldf_ops.NewSequence(
 			return sequences.OnChainOutput{}, fmt.Errorf("failed to get token decimals: %w", err)
 		}
 
+		// A pool's type and version is immutable so we can safely use ExecuteOperation here
+		// without worrying about stale data from the cache.
 		tvReport, err := cldf_ops.ExecuteOperation(b, type_and_version.GetTypeAndVersion, chain, contract.FunctionInput[struct{}]{
 			ChainSelector: chain.Selector,
 			Address:       input.TokenPoolAddress,

--- a/chains/evm/deployment/v1_5_1/sequences/token_pool/configure_token_pool_for_remote_chains.go
+++ b/chains/evm/deployment/v1_5_1/sequences/token_pool/configure_token_pool_for_remote_chains.go
@@ -9,12 +9,13 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/type_and_version"
 	tpops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_1/operations/token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/token_pool"
 	tokensapi "github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	mcms_types "github.com/smartcontractkit/mcms/types"
 )
@@ -110,13 +111,23 @@ var ConfigureTokenPoolForRemoteChain = cldf_ops.NewSequence(
 			return sequences.OnChainOutput{}, fmt.Errorf("failed to get token decimals: %w", err)
 		}
 
+		tvReport, err := cldf_ops.ExecuteOperation(b, type_and_version.GetTypeAndVersion, chain, contract.FunctionInput[struct{}]{
+			ChainSelector: chain.Selector,
+			Address:       input.TokenPoolAddress,
+			Args:          struct{}{},
+		})
+		if err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to get type and version of token pool: %w", err)
+		}
+
 		inputORL, inputIRL := tokensapi.GenerateTPRLConfigs(
 			input.RemoteChainConfig.OutboundRateLimiterConfig,
 			input.RemoteChainConfig.InboundRateLimiterConfig,
 			localDecimals,
 			input.RemoteChainConfig.RemoteDecimals,
 			chain.Family(),
-			input.TokenPoolVersion,
+			tvReport.Output.Version,
+			tvReport.Output.Type.String(),
 		)
 
 		// Token pool remote chain configuration can vary depending on whether the remote

--- a/chains/evm/deployment/v1_6_1/sequences/configure_token_pool_for_remote_chain.go
+++ b/chains/evm/deployment/v1_6_1/sequences/configure_token_pool_for_remote_chain.go
@@ -13,10 +13,11 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
-	evm_contract "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/type_and_version"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_1/operations/token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
+	evm_contract "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
 )
 
 // ConfigureTokenPoolForRemoteChainInput is the input for the ConfigureTokenPoolForRemoteChain sequence.
@@ -65,13 +66,23 @@ var ConfigureTokenPoolForRemoteChain = cldf_ops.NewSequence(
 			return sequences.OnChainOutput{}, fmt.Errorf("failed to get token decimals: %w", err)
 		}
 
+		tvReport, err := cldf_ops.ExecuteOperation(b, type_and_version.GetTypeAndVersion, chain, evm_contract.FunctionInput[struct{}]{
+			ChainSelector: chain.Selector,
+			Address:       input.TokenPoolAddress,
+			Args:          struct{}{},
+		})
+		if err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to get type and version of token pool: %w", err)
+		}
+
 		outboundConfig, inboundConfig := tokens.GenerateTPRLConfigs(
 			input.RemoteChainConfig.OutboundRateLimiterConfig,
 			input.RemoteChainConfig.InboundRateLimiterConfig,
 			localDecimalsReport.Output,
 			input.RemoteChainConfig.RemoteDecimals,
 			chain.Family(),
-			semver.MustParse("1.6.1"),
+			tvReport.Output.Version,
+			tvReport.Output.Type.String(),
 		)
 
 		// If the chain is supported

--- a/chains/evm/deployment/v1_6_1/sequences/token_pool/configure_token_pool_for_remote_chains.go
+++ b/chains/evm/deployment/v1_6_1/sequences/token_pool/configure_token_pool_for_remote_chains.go
@@ -10,12 +10,9 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/type_and_version"
 	tpops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_1/operations/token_pool"
-
-	// NOTE: the token pool contracts for v1.6.1 are still children of the abstract v1.5.1
-	// TokenPool.sol contract so we can still use the 1.5.1 bindings to read onchain state
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/token_pool"
-
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_1/token_pool"
 	tokensapi "github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
@@ -114,13 +111,23 @@ var ConfigureTokenPoolForRemoteChain = cldf_ops.NewSequence(
 			return sequences.OnChainOutput{}, fmt.Errorf("failed to get token decimals: %w", err)
 		}
 
+		tvReport, err := cldf_ops.ExecuteOperation(b, type_and_version.GetTypeAndVersion, chain, contract.FunctionInput[struct{}]{
+			ChainSelector: chain.Selector,
+			Address:       input.TokenPoolAddress,
+			Args:          struct{}{},
+		})
+		if err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to get type and version of token pool: %w", err)
+		}
+
 		inputORL, inputIRL := tokensapi.GenerateTPRLConfigs(
 			input.RemoteChainConfig.OutboundRateLimiterConfig,
 			input.RemoteChainConfig.InboundRateLimiterConfig,
 			localDecimals,
 			input.RemoteChainConfig.RemoteDecimals,
 			chain.Family(),
-			input.TokenPoolVersion,
+			tvReport.Output.Version,
+			tvReport.Output.Type.String(),
 		)
 
 		// Token pool remote chain configuration can vary depending on whether the remote

--- a/chains/evm/deployment/v1_6_1/sequences/token_pool/configure_token_pool_for_remote_chains.go
+++ b/chains/evm/deployment/v1_6_1/sequences/token_pool/configure_token_pool_for_remote_chains.go
@@ -9,13 +9,13 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/type_and_version"
 	tpops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_1/operations/token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_1/token_pool"
 	tokensapi "github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	mcms_types "github.com/smartcontractkit/mcms/types"
 )
@@ -28,7 +28,6 @@ type ConfigureTokenPoolForRemoteChainsInput struct {
 
 type ConfigureTokenPoolForRemoteChainInput struct {
 	TokenPoolAddress    common.Address
-	TokenPoolVersion    *semver.Version
 	RemoteChainSelector uint64
 	RemoteChainConfig   tokensapi.RemoteChainConfig[[]byte, string]
 }
@@ -70,7 +69,6 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 				chain,
 				ConfigureTokenPoolForRemoteChainInput{
 					TokenPoolAddress:    tokenPool.Address(),
-					TokenPoolVersion:    input.TokenPoolVersion,
 					RemoteChainSelector: remoteChainSelector,
 					RemoteChainConfig:   remoteChainConfig,
 				},
@@ -111,6 +109,8 @@ var ConfigureTokenPoolForRemoteChain = cldf_ops.NewSequence(
 			return sequences.OnChainOutput{}, fmt.Errorf("failed to get token decimals: %w", err)
 		}
 
+		// A pool's type and version is immutable so we can safely use ExecuteOperation here
+		// without worrying about stale data from the cache.
 		tvReport, err := cldf_ops.ExecuteOperation(b, type_and_version.GetTypeAndVersion, chain, contract.FunctionInput[struct{}]{
 			ChainSelector: chain.Selector,
 			Address:       input.TokenPoolAddress,

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chain.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chain.go
@@ -105,13 +105,23 @@ var ConfigureTokenPoolForRemoteChain = cldf_ops.NewSequence(
 			return sequences.OnChainOutput{}, fmt.Errorf("failed to get token decimals: %w", err)
 		}
 
+		tvReport, err := cldf_ops.ExecuteOperation(b, type_and_version.GetTypeAndVersion, chain, evm_contract.FunctionInput[struct{}]{
+			ChainSelector: chain.Selector,
+			Address:       input.TokenPoolAddress,
+			Args:          struct{}{},
+		})
+		if err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to get type and version of token pool: %w", err)
+		}
+
 		outboundRateLimiterConfig, inboundRateLimiterConfig := tokens.GenerateTPRLConfigs(
 			input.RemoteChainConfig.OutboundRateLimiterConfig,
 			input.RemoteChainConfig.InboundRateLimiterConfig,
 			localDecimalsReport.Output,
 			input.RemoteChainConfig.RemoteDecimals,
 			chain.Family(),
-			token_pool.Version,
+			tvReport.Output.Version,
+			tvReport.Output.Type.String(),
 		)
 		// If input did not provide rate limits, use imported from active pool when available.
 		if importedDefaultOutbound != nil && !input.RemoteChainConfig.OutboundRateLimiterConfig.IsEnabled {

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chain_test.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chain_test.go
@@ -559,7 +559,6 @@ func TestConfigureTokenPoolForRemoteChainUpgradeImportLegacyInboundDecimals(t *t
 		chain,
 		v1_5_1_token_pool_sequences.ConfigureTokenPoolForRemoteChainInput{
 			TokenPoolAddress:    legacyPoolAddress,
-			TokenPoolVersion:    v1_5_1_burn_mint_token_pool.Version,
 			RemoteChainSelector: remoteChainSel,
 			RemoteChainConfig: tokens_core.RemoteChainConfig[[]byte, string]{
 				RemoteToken:                     remoteToken,

--- a/chains/solana/deployment/v1_6_0/sequences/tokens.go
+++ b/chains/solana/deployment/v1_6_0/sequences/tokens.go
@@ -140,6 +140,7 @@ func (a *SolanaAdapter) ConfigureTokenForTransfersSequence() *cldf_ops.Sequence[
 					remoteChainConfig.RemoteDecimals,
 					chain.Family(),
 					common_utils.Version_1_6_0,
+					input.PoolType,
 				)
 				result.Addresses = append(result.Addresses, upsertOut.Output.Addresses...)
 				result.BatchOps = append(result.BatchOps, upsertOut.Output.BatchOps...)

--- a/deployment/tokens/rate_limits.go
+++ b/deployment/tokens/rate_limits.go
@@ -285,7 +285,8 @@ func GenerateTPRLConfigs(
 			isBurnMintWithExternalMinterTokenPool := tokenPoolType == "HybridWithExternalMinterTokenPool"
 			isHybridWithExternalMinterTokenPool := tokenPoolType == "BurnMintWithExternalMinterTokenPool"
 			if tokenPoolVersion.Equal(utils.Version_1_6_0) && (isBurnMintWithExternalMinterTokenPool || isHybridWithExternalMinterTokenPool) {
-				// pass through - these contracts scale by local decimals: (https://etherscan.io/address/0x36a72eD0096B414521C45E3ddC9ed657d1D9c141#code)
+				// These contracts scale by local decimals: https://etherscan.io/address/0x36a72eD0096B414521C45E3ddC9ed657d1D9c141#code
+				scaleByDecimals = decimals
 			} else {
 				scaleByDecimals = remoteDecimals
 			}

--- a/deployment/tokens/rate_limits.go
+++ b/deployment/tokens/rate_limits.go
@@ -278,7 +278,7 @@ func GenerateTPRLConfigs(
 		scaleByDecimals := localDecimals
 
 		// https://github.com/smartcontractkit/chainlink-deployments/blob/cce886554ca0587492955784381321ce817fb6bb/domains/ccip/shared/tokendefaults.go#L1904
-		// Only old EVM pools need to scale by remote deciamls on inbound. Newer pools and non-EVM pools handle all conversions in local decimals.
+		// Only old EVM pools need to scale by remote decimals on inbound. Newer pools and non-EVM pools handle all conversions in local decimals.
 		// This is a hack. Avoiding it would require refactoring the token pool adapters to handle rate limit configs in a more structured way instead of
 		// just passing them as bytes through the registry, so for now we can live with this special case for old EVM pools since we're moving towards newer versions and non-EVM chains where this isn't an issue.
 		if chainFamily == chain_selectors.FamilyEVM && poolVersion.LessThan(utils.Version_1_6_1) {

--- a/deployment/tokens/rate_limits.go
+++ b/deployment/tokens/rate_limits.go
@@ -249,11 +249,11 @@ func ScaleFloatToBigInt(value float64, decimals int, extraPercent float64) *big.
 func GenerateTPRLConfigs(
 	outboundInput RateLimiterConfigFloatInput,
 	inboundInput RateLimiterConfigFloatInput,
-	decimals uint8,
+	localDecimals uint8,
 	remoteDecimals uint8,
 	chainFamily string,
-	tokenPoolVersion *semver.Version,
-	tokenPoolType string,
+	poolVersion *semver.Version,
+	poolType string,
 ) (RateLimiterConfig, RateLimiterConfig) {
 	outboundConfig := RateLimiterConfig{}
 	inboundConfig := RateLimiterConfig{}
@@ -265,8 +265,8 @@ func GenerateTPRLConfigs(
 		// We scale the rate limiter configs by the token decimals to convert from
 		// human-readable token amounts to the on-chain representation
 		outboundConfig.IsEnabled = true
-		outboundConfig.Capacity = ScaleFloatToBigInt(outboundInput.Capacity, int(decimals), 0)
-		outboundConfig.Rate = ScaleFloatToBigInt(outboundInput.Rate, int(decimals), 0)
+		outboundConfig.Capacity = ScaleFloatToBigInt(outboundInput.Capacity, int(localDecimals), 0)
+		outboundConfig.Rate = ScaleFloatToBigInt(outboundInput.Rate, int(localDecimals), 0)
 	}
 
 	if !inboundInput.IsEnabled {
@@ -275,18 +275,18 @@ func GenerateTPRLConfigs(
 		inboundConfig.Rate = big.NewInt(0)
 	} else {
 		// We set the inbound capacity to be 1.1x the outbound capacity of the counterpart to avoid accidentally hitting the rate limit due to minor timing differences in refilling
-		scaleByDecimals := decimals
+		scaleByDecimals := localDecimals
+
 		// https://github.com/smartcontractkit/chainlink-deployments/blob/cce886554ca0587492955784381321ce817fb6bb/domains/ccip/shared/tokendefaults.go#L1904
 		// Only old EVM pools need to scale by remote deciamls on inbound. Newer pools and non-EVM pools handle all conversions in local decimals.
 		// This is a hack. Avoiding it would require refactoring the token pool adapters to handle rate limit configs in a more structured way instead of
 		// just passing them as bytes through the registry, so for now we can live with this special case for old EVM pools since we're moving towards newer versions and non-EVM chains where this isn't an issue.
-		if chainFamily == chain_selectors.FamilyEVM && tokenPoolVersion.LessThan(utils.Version_1_6_1) {
-			// NOTE: need to hardcode EVM contract types to avoid import cycle
-			isBurnMintWithExternalMinterTokenPool := tokenPoolType == "HybridWithExternalMinterTokenPool"
-			isHybridWithExternalMinterTokenPool := tokenPoolType == "BurnMintWithExternalMinterTokenPool"
-			if tokenPoolVersion.Equal(utils.Version_1_6_0) && (isBurnMintWithExternalMinterTokenPool || isHybridWithExternalMinterTokenPool) {
-				// These contracts scale by local decimals: https://etherscan.io/address/0x36a72eD0096B414521C45E3ddC9ed657d1D9c141#code
-				scaleByDecimals = decimals
+		if chainFamily == chain_selectors.FamilyEVM && poolVersion.LessThan(utils.Version_1_6_1) {
+			// These custom contracts actually scale by local decimals: https://etherscan.io/address/0x36a72eD0096B414521C45E3ddC9ed657d1D9c141#code
+			isBurnMintWithExternalMinterTokenPool := poolType == utils.BurnMintWithExternalMinterTokenPool.String()
+			isHybridWithExternalMinterTokenPool := poolType == utils.HybridWithExternalMinterTokenPool.String()
+			if poolVersion.Equal(utils.Version_1_6_0) && (isBurnMintWithExternalMinterTokenPool || isHybridWithExternalMinterTokenPool) {
+				scaleByDecimals = localDecimals
 			} else {
 				scaleByDecimals = remoteDecimals
 			}

--- a/deployment/tokens/rate_limits.go
+++ b/deployment/tokens/rate_limits.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/finality"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
 	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
@@ -181,7 +182,7 @@ func setTokenPoolRateLimitsApply() func(cldf.Environment, TPRLInput) (cldf.Chang
 				if err != nil {
 					return cldf.ChangesetOutput{}, fmt.Errorf("failed to get token decimals for token on chain with selector %d: %w", remoteSelector, err)
 				}
-				tprlRemote.OutboundRateLimiterConfig, tprlRemote.InboundRateLimiterConfig = GenerateTPRLConfigs(inputs.RateLimit, remoteInputs.RateLimit, decimals, remoteDecimals, family, tokenPool.Version)
+				tprlRemote.OutboundRateLimiterConfig, tprlRemote.InboundRateLimiterConfig = GenerateTPRLConfigs(inputs.RateLimit, remoteInputs.RateLimit, decimals, remoteDecimals, family, tokenPool.Version, tokenPool.Type.String())
 				rateLimitReport, err := cldf_ops.ExecuteSequence(
 					e.OperationsBundle, tokenPoolAdapter.SetTokenPoolRateLimits(), e.BlockChains, tprlRemote)
 				if err != nil {
@@ -252,6 +253,7 @@ func GenerateTPRLConfigs(
 	remoteDecimals uint8,
 	chainFamily string,
 	tokenPoolVersion *semver.Version,
+	tokenPoolType string,
 ) (RateLimiterConfig, RateLimiterConfig) {
 	outboundConfig := RateLimiterConfig{}
 	inboundConfig := RateLimiterConfig{}
@@ -278,8 +280,15 @@ func GenerateTPRLConfigs(
 		// Only old EVM pools need to scale by remote deciamls on inbound. Newer pools and non-EVM pools handle all conversions in local decimals.
 		// This is a hack. Avoiding it would require refactoring the token pool adapters to handle rate limit configs in a more structured way instead of
 		// just passing them as bytes through the registry, so for now we can live with this special case for old EVM pools since we're moving towards newer versions and non-EVM chains where this isn't an issue.
-		if chainFamily == chain_selectors.FamilyEVM && tokenPoolVersion.LessThan(semver.MustParse("1.6.1")) {
-			scaleByDecimals = remoteDecimals
+		if chainFamily == chain_selectors.FamilyEVM && tokenPoolVersion.LessThan(utils.Version_1_6_1) {
+			// NOTE: need to hardcode EVM contract types to avoid import cycle
+			isBurnMintWithExternalMinterTokenPool := tokenPoolType == "HybridWithExternalMinterTokenPool"
+			isHybridWithExternalMinterTokenPool := tokenPoolType == "BurnMintWithExternalMinterTokenPool"
+			if tokenPoolVersion.Equal(utils.Version_1_6_0) && (isBurnMintWithExternalMinterTokenPool || isHybridWithExternalMinterTokenPool) {
+				// pass through - these contracts scale by local decimals: (https://etherscan.io/address/0x36a72eD0096B414521C45E3ddC9ed657d1D9c141#code)
+			} else {
+				scaleByDecimals = remoteDecimals
+			}
 		}
 		inboundConfig.IsEnabled = true
 		inboundConfig.Capacity = ScaleFloatToBigInt(inboundInput.Capacity, int(scaleByDecimals), .10)

--- a/deployment/tokens/rate_limits.go
+++ b/deployment/tokens/rate_limits.go
@@ -282,7 +282,9 @@ func GenerateTPRLConfigs(
 		// This is a hack. Avoiding it would require refactoring the token pool adapters to handle rate limit configs in a more structured way instead of
 		// just passing them as bytes through the registry, so for now we can live with this special case for old EVM pools since we're moving towards newer versions and non-EVM chains where this isn't an issue.
 		if chainFamily == chain_selectors.FamilyEVM && poolVersion.LessThan(utils.Version_1_6_1) {
-			// These custom contracts actually scale by local decimals: https://etherscan.io/address/0x36a72eD0096B414521C45E3ddC9ed657d1D9c141#code
+			// These custom contracts actually scale by local decimals:
+			//   BurnMintWithExternalMinterTokenPool: https://explorer.plume.org/address/0x770318D51052871DeF5Eb5c452F4fd28B7960C4e?tab=contract
+			//   HybridWithExternalMinterTokenPool: https://etherscan.io/address/0x36a72eD0096B414521C45E3ddC9ed657d1D9c141#code
 			isBurnMintWithExternalMinterTokenPool := poolType == utils.BurnMintWithExternalMinterTokenPool.String()
 			isHybridWithExternalMinterTokenPool := poolType == utils.HybridWithExternalMinterTokenPool.String()
 			if poolVersion.Equal(utils.Version_1_6_0) && (isBurnMintWithExternalMinterTokenPool || isHybridWithExternalMinterTokenPool) {


### PR DESCRIPTION
Adds additional edge case handling for TPRL token decimal scaling for `HybridWithExternalMinterTokenPool v1.6.0` and `BurnMintWithExternalMinterTokenPool v1.6.0`

Please note that `ExecuteOperation` caches results by default - so repeated `TypeAndVersion` queries with the same params only incurs one RPC call