### PR TITLE
feat: add support for EVM v1.6.2 token adapter

### DIFF
--- a/chains/evm/deployment/v1_6_2/adapters/init.go
+++ b/chains/evm/deployment/v1_6_2/adapters/init.go
@@ -1,0 +1,25 @@
+package adapters
+
+import (
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+
+	tokensapi "github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
+)
+
+// NOTE: v1.6.2 token pool contracts still use the base v1.6.1 token pool bindings
+
+func init() {
+	version := utils.Version_1_6_2
+	adapter := NewTokenAdapter()
+	tokensapi.GetTokenAdapterRegistry().RegisterTokenAdapter(
+		chain_selectors.FamilyEVM,
+		version,
+		adapter,
+	)
+	tokensapi.GetTokenAdapterRegistry().RegisterTokenAdapter(
+		chain_selectors.FamilyEVM,
+		version,
+		adapter,
+	)
+}

--- a/chains/evm/deployment/v1_6_2/adapters/init.go
+++ b/chains/evm/deployment/v1_6_2/adapters/init.go
@@ -3,6 +3,7 @@ package adapters
 import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_1/adapters"
 	tokensapi "github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 )
@@ -10,8 +11,8 @@ import (
 // NOTE: v1.6.2 token pool contracts still use the base v1.6.1 token pool bindings
 
 func init() {
+	adapter := adapters.NewTokenAdapter()
 	version := utils.Version_1_6_2
-	adapter := NewTokenAdapter()
 	tokensapi.GetTokenAdapterRegistry().RegisterTokenAdapter(
 		chain_selectors.FamilyEVM,
 		version,

--- a/chains/evm/deployment/v1_6_2/adapters/init.go
+++ b/chains/evm/deployment/v1_6_2/adapters/init.go
@@ -3,15 +3,14 @@ package adapters
 import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_1/adapters"
+	adaptersV1_6_1 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_1/adapters"
 	tokensapi "github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 )
 
-// NOTE: v1.6.2 token pool contracts still use the base v1.6.1 token pool bindings
-
 func init() {
-	adapter := adapters.NewTokenAdapter()
 	version := utils.Version_1_6_2
-	tokensapi.GetTokenAdapterRegistry().RegisterTokenAdapter(chain_selectors.FamilyEVM, version, adapter)
+
+	// NOTE: v1.6.2 token pool contracts still use the base v1.6.1 token pool bindings
+	tokensapi.GetTokenAdapterRegistry().RegisterTokenAdapter(chain_selectors.FamilyEVM, version, adaptersV1_6_1.NewTokenAdapter())
 }

--- a/chains/evm/deployment/v1_6_2/adapters/init.go
+++ b/chains/evm/deployment/v1_6_2/adapters/init.go
@@ -13,14 +13,5 @@ import (
 func init() {
 	adapter := adapters.NewTokenAdapter()
 	version := utils.Version_1_6_2
-	tokensapi.GetTokenAdapterRegistry().RegisterTokenAdapter(
-		chain_selectors.FamilyEVM,
-		version,
-		adapter,
-	)
-	tokensapi.GetTokenAdapterRegistry().RegisterTokenAdapter(
-		chain_selectors.FamilyEVM,
-		version,
-		adapter,
-	)
+	tokensapi.GetTokenAdapterRegistry().RegisterTokenAdapter(chain_selectors.FamilyEVM, version, adapter)
 }

--- a/deployment/utils/common.go
+++ b/deployment/utils/common.go
@@ -124,6 +124,7 @@ var (
 	Version_1_5_1 = semver.MustParse("1.5.1")
 	Version_1_6_0 = semver.MustParse("1.6.0")
 	Version_1_6_1 = semver.MustParse("1.6.1")
+	Version_1_6_2 = semver.MustParse("1.6.2")
 	Version_1_6_3 = semver.MustParse("1.6.3")
 	Version_2_0_0 = semver.MustParse("2.0.0")
 )


### PR DESCRIPTION
Re-registers the EVM v1.6.1 token adapter under v1.6.2 (v1.6.2 pools use the same base token pool bindings as v1.6.1)