### PR TITLE
Enable loop on solana tests

### DIFF
--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -70,14 +70,17 @@ jobs:
             file: ccip_messaging_test.go
             run: "^Test_CCIPMessaging_EVM2Solana$"
             timeout: 30m
+            installLoopPlugins: true
           - name: "Messaging Test Test_CCIPMessaging_Solana2EVM"
             file: ccip_messaging_test.go
             run: "^Test_CCIPMessaging_Solana2EVM$"
             timeout: 30m
+            installLoopPlugins: true
           - name: "Messaging Test Test_CCIPMessaging_EVM2SolanaMultiExecReports"
             file: ccip_messaging_test.go
             run: "^Test_CCIPMessaging_EVM2SolanaMultiExecReports$"
             timeout: 35m
+            installLoopPlugins: true
           - name: "Batching Test Test_CCIPBatching_MaxBatchSizeEVM"
             file: ccip_batching_test.go
             run: "Test_CCIPBatching_MaxBatchSizeEVM"
@@ -243,6 +246,11 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/chainlink
           go build -o ccip.test .
+      - name: Install LOOP plugins
+        if: matrix.type.installLoopPlugins
+        run: |
+          cd $GITHUB_WORKSPACE/chainlink
+          make install-plugins-public
       - name: Setup DB
         shell: bash
         run: |


### PR DESCRIPTION
## Fix Solana CCIP integration tests by installing LOOP plugins in CI

### Problem

The Solana integration tests (`Test_CCIPMessaging_EVM2Solana`, `Test_CCIPMessaging_Solana2EVM`, `Test_CCIPMessaging_EVM2SolanaMultiExecReports`) started failing after the chainlink dependency was bumped to include [smartcontractkit/chainlink#22139](https://github.com/smartcontractkit/chainlink/pull/22139) ("Disable Solana non-LOOP mode").

That PR removed the in-process Solana relayer fallback — Solana now **always** runs as a LOOP plugin via an external `chainlink-solana` binary. The chainlink-ccip CI workflow was not installing this binary, causing the Chainlink node to fail with:

```
exec: "chainlink-solana": executable file not found in $PATH
```

### Fix

Added a conditional `Install LOOP plugins` step to the CI workflow that runs `make install-plugins-public` (which builds and installs the `chainlink-solana` binary from `plugins/plugins.public.yaml`) **only** for Solana test matrix entries. Non-Solana tests are unaffected.

This matches how the chainlink repo's own CI handles these tests (via `install_plugins_public: true`).

### Changes

- ccip-integration-test.yml:
  - Added `installLoopPlugins: true` to the 3 Solana test matrix entries
  - Added a new conditional step to install LOOP plugins after building the binary