### PR TITLE
Update changelog

### DIFF
--- a/chains/solana/CHANGELOG.md
+++ b/chains/solana/CHANGELOG.md
@@ -6,6 +6,9 @@ This document describes the changes introduced in the different versions of the 
 
 ## [1.6.2]
 
+- Commit [`9546a59bd0a3cee4ddc8ae4042da533e62225b78`](https://github.com/smartcontractkit/chainlink-ccip/commit/9546a59bd0a3cee4ddc8ae4042da533e62225b78)
+- Git Tag: [solana-v1.6.2](https://github.com/smartcontractkit/chainlink-ccip/releases/tag/solana-v1.6.2)
+
 ### Added
 
 - [BurnMintTokenPool] New `transfer_mint_authority_to_pda_signer` instruction to revert mint authority from a multisig back to the pool signer PDA during migration cleanup


### PR DESCRIPTION
This pull request updates the `chains/solana/CHANGELOG.md` file to document the release of version 1.6.2. The update includes a reference to the relevant commit and git tag, as well as a summary of a new instruction added to the `BurnMintTokenPool` for migration cleanup.

Release documentation:

* Added commit reference and git tag for version 1.6.2 to the changelog.

Feature addition:

* Documented the new `transfer_mint_authority_to_pda_signer` instruction in `BurnMintTokenPool`, which allows reverting mint authority from a multisig back to the pool signer PDA during migration cleanup.