### PR TITLE
Don't spam config poller cache miss retries

### DIFF
--- a/pkg/chainaccessor/config_processors.go
+++ b/pkg/chainaccessor/config_processors.go
@@ -78,7 +78,7 @@ func processSourceChainConfigResults(
 
 					v, err := sourceChainResults[i].GetResult()
 					if err != nil {
-						lggr.Errorw("Failed to get source chain config from result",
+						lggr.Warnw("Failed to get source chain config from result",
 							"chain", chain,
 							"error", err)
 						continue

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -122,12 +122,15 @@ func newCCIPChainReaderWithConfigPollerInternal(
 		lggr.Errorw("failed to sync contracts", "err", err)
 	}
 
-	// After contracts are synced, start the background polling
+	// After contracts are synced, start the background polling.
+	// The config poller is load-bearing: without the background refresh, transiently
+	// missing source chain configs would only recover via the inline-retry backoff
+	// inside configPollerV2.GetOfframpSourceChainConfigs, which is best-effort. Fail
+	// reader initialization rather than silently degrade.
 	lggr.Info("Starting config background polling")
 	if err := reader.configPoller.Start(ctx); err != nil {
-		// Log the error but don't fail - we can still function without background polling
-		// by fetching configs on demand
 		lggr.Errorw("failed to start config background polling", "err", err)
+		return nil, fmt.Errorf("start config background polling: %w", err)
 	}
 
 	return reader, nil

--- a/pkg/reader/config_poller_v2.go
+++ b/pkg/reader/config_poller_v2.go
@@ -71,6 +71,11 @@ type chainCache struct {
 	sourceChainMu            sync.RWMutex
 	staticSourceChainConfigs map[cciptypes.ChainSelector]StaticSourceChainConfig
 	sourceChainRefresh       time.Time // Single timestamp for all source chain configs
+	// attemptedSourceChains tracks which source chains have been included in at least one
+	// fetch attempt. Chains in this set that are NOT in staticSourceChainConfigs were either
+	// unconfigured on-chain or had an RPC error, either way, re-fetching inline on every
+	// call creates a doom-loop of redundant RPC calls and error log spam.
+	attemptedSourceChains map[cciptypes.ChainSelector]struct{}
 }
 
 // newConfigPollerV2 creates a new instance of configPollerV2 with improved batch fetching capabilities.
@@ -297,16 +302,19 @@ func (c *configPollerV2) GetOfframpSourceChainConfigs(
 		staticSourceChainConfig, exists := destChainCache.staticSourceChainConfigs[chain]
 		if exists {
 			cachedSourceConfigs[chain] = staticSourceChainConfig
-		} else {
-			// This chain isn't in cache yet
+		} else if _, attempted := destChainCache.attemptedSourceChains[chain]; !attempted {
+			// Only treat as missing if we haven't attempted to fetch this chain before.
+			// Chains that were attempted but not returned are either unconfigured on-chain
+			// or had an RPC error. Re-fetching inline on every call creates a doom-loop
+			// of redundant RPC calls and error log spam. The background poller will retry.
 			missingChains = append(missingChains, chain)
 		}
 	}
 
-	// If all chains are in cache, return them immediately
+	// If all chains are in cache or already attempted, return immediately
 	if len(missingChains) == 0 {
 		destChainCache.sourceChainMu.RUnlock()
-		c.lggr.Debugw("All source chain configs found in cache",
+		c.lggr.Debugw("All source chain configs found in cache or already attempted",
 			"destChain", c.destChainSelector,
 			"sourceChains", filteredSourceChains)
 		return cachedSourceConfigs, nil
@@ -354,6 +362,7 @@ func (c *configPollerV2) getOrCreateChainCache(chainSel cciptypes.ChainSelector)
 
 	cache := &chainCache{
 		staticSourceChainConfigs: make(map[cciptypes.ChainSelector]StaticSourceChainConfig),
+		attemptedSourceChains:    make(map[cciptypes.ChainSelector]struct{}),
 	}
 	c.chainCaches[chainSel] = cache
 	return cache
@@ -446,14 +455,21 @@ func (c *configPollerV2) batchRefreshChainAndSourceConfigs(
 	cache.chainConfigMu.Unlock()
 
 	// Acquire StaticSourceChainConfigs lock and update
-	if fetchingForDestChain && len(sourceChainConfigs) > 0 {
+	if fetchingForDestChain {
 		cache.sourceChainMu.Lock()
 		for chain, cfg := range sourceChainConfigs {
 			cache.staticSourceChainConfigs[chain] = staticSourceChainConfigFromSourceChainConfig(cfg)
 		}
+		// Record all source chains that were included in this fetch attempt.
+		// Chains that were attempted but not returned (due to RPC errors or being
+		// unconfigured on-chain) won't trigger inline re-fetches — the background
+		// poller will retry them on its own schedule.
+		for _, chain := range sourceChainSelectors {
+			cache.attemptedSourceChains[chain] = struct{}{}
+		}
 		cache.sourceChainRefresh = time.Now()
 		cache.sourceChainMu.Unlock()
-	} else if !fetchingForDestChain && len(sourceChainConfigs) > 0 {
+	} else if len(sourceChainConfigs) > 0 {
 		c.lggr.Errorw("OffRamp SourceChainConfigs were returned when fetching configs from a source chain, "+
 			"this is not expected",
 			"destChainSelector", c.destChainSelector,

--- a/pkg/reader/config_poller_v2.go
+++ b/pkg/reader/config_poller_v2.go
@@ -71,11 +71,14 @@ type chainCache struct {
 	sourceChainMu            sync.RWMutex
 	staticSourceChainConfigs map[cciptypes.ChainSelector]StaticSourceChainConfig
 	sourceChainRefresh       time.Time // Single timestamp for all source chain configs
-	// attemptedSourceChains tracks which source chains have been included in at least one
-	// fetch attempt. Chains in this set that are NOT in staticSourceChainConfigs were either
-	// unconfigured on-chain or had an RPC error, either way, re-fetching inline on every
-	// call creates a doom-loop of redundant RPC calls and error log spam.
-	attemptedSourceChains map[cciptypes.ChainSelector]struct{}
+	// attemptedSourceChains records the wall-clock time of the most recent fetch attempt
+	// that included each source chain. Chains in this map that are NOT in
+	// staticSourceChainConfigs were either unconfigured on-chain or had an RPC error.
+	// Re-fetching inline on every call creates a doom-loop of redundant RPC calls and
+	// error log spam, so we suppress inline retries when the last attempt was within
+	// configPollerV2.refreshPeriod. After that backoff elapses, inline retries resume so
+	// that recovery does not depend solely on the background poller being healthy.
+	attemptedSourceChains map[cciptypes.ChainSelector]time.Time
 }
 
 // newConfigPollerV2 creates a new instance of configPollerV2 with improved batch fetching capabilities.
@@ -302,19 +305,22 @@ func (c *configPollerV2) GetOfframpSourceChainConfigs(
 		staticSourceChainConfig, exists := destChainCache.staticSourceChainConfigs[chain]
 		if exists {
 			cachedSourceConfigs[chain] = staticSourceChainConfig
-		} else if _, attempted := destChainCache.attemptedSourceChains[chain]; !attempted {
-			// Only treat as missing if we haven't attempted to fetch this chain before.
-			// Chains that were attempted but not returned are either unconfigured on-chain
-			// or had an RPC error. Re-fetching inline on every call creates a doom-loop
-			// of redundant RPC calls and error log spam. The background poller will retry.
+			continue
+		}
+		// Chain isn't in cache. Suppress the inline re-fetch only if we tried to fetch it
+		// recently (within refreshPeriod). After that backoff has elapsed we resume inline
+		// retries so recovery still happens even if the background poller is unhealthy or
+		// has been killed. Chains never attempted always trigger an inline fetch.
+		lastAttempted, attempted := destChainCache.attemptedSourceChains[chain]
+		if !attempted || time.Since(lastAttempted) >= c.refreshPeriod {
 			missingChains = append(missingChains, chain)
 		}
 	}
 
-	// If all chains are in cache or already attempted, return immediately
+	// If all chains are in cache or were attempted within the suppression window, return immediately
 	if len(missingChains) == 0 {
 		destChainCache.sourceChainMu.RUnlock()
-		c.lggr.Debugw("All source chain configs found in cache or already attempted",
+		c.lggr.Debugw("All source chain configs found in cache or attempted within backoff window",
 			"destChain", c.destChainSelector,
 			"sourceChains", filteredSourceChains)
 		return cachedSourceConfigs, nil
@@ -362,7 +368,7 @@ func (c *configPollerV2) getOrCreateChainCache(chainSel cciptypes.ChainSelector)
 
 	cache := &chainCache{
 		staticSourceChainConfigs: make(map[cciptypes.ChainSelector]StaticSourceChainConfig),
-		attemptedSourceChains:    make(map[cciptypes.ChainSelector]struct{}),
+		attemptedSourceChains:    make(map[cciptypes.ChainSelector]time.Time),
 	}
 	c.chainCaches[chainSel] = cache
 	return cache
@@ -456,18 +462,20 @@ func (c *configPollerV2) batchRefreshChainAndSourceConfigs(
 
 	// Acquire StaticSourceChainConfigs lock and update
 	if fetchingForDestChain {
+		now := time.Now()
 		cache.sourceChainMu.Lock()
 		for chain, cfg := range sourceChainConfigs {
 			cache.staticSourceChainConfigs[chain] = staticSourceChainConfigFromSourceChainConfig(cfg)
 		}
-		// Record all source chains that were included in this fetch attempt.
+		// Record the time of this fetch attempt for every source chain we asked about.
 		// Chains that were attempted but not returned (due to RPC errors or being
-		// unconfigured on-chain) won't trigger inline re-fetches — the background
-		// poller will retry them on its own schedule.
+		// unconfigured on-chain) won't trigger inline re-fetches for the next
+		// refreshPeriod, after which inline retries resume so recovery doesn't depend
+		// solely on the background poller.
 		for _, chain := range sourceChainSelectors {
-			cache.attemptedSourceChains[chain] = struct{}{}
+			cache.attemptedSourceChains[chain] = now
 		}
-		cache.sourceChainRefresh = time.Now()
+		cache.sourceChainRefresh = now
 		cache.sourceChainMu.Unlock()
 	} else if len(sourceChainConfigs) > 0 {
 		c.lggr.Errorw("OffRamp SourceChainConfigs were returned when fetching configs from a source chain, "+

--- a/pkg/reader/config_poller_v2_test.go
+++ b/pkg/reader/config_poller_v2_test.go
@@ -910,10 +910,14 @@ func chainSelectorSliceMatcher(expected []cciptypes.ChainSelector) func([]ccipty
 
 // TestConfigPollerV2_FailedSourceChainDoesNotRetriggerInlineFetch verifies that when a source chain
 // config fetch fails (e.g. RPC error), subsequent calls to GetOfframpSourceChainConfigs do NOT
-// trigger another inline batchRefreshChainAndSourceConfigs call. This prevents the "doom-loop"
-// where persistently failing chains cause redundant RPC calls and error log spam on every tick.
+// trigger another inline batchRefreshChainAndSourceConfigs call within the suppression window.
+// This prevents the "doom-loop" where persistently failing chains cause redundant RPC calls
+// and error log spam on every tick.
 func TestConfigPollerV2_FailedSourceChainDoesNotRetriggerInlineFetch(t *testing.T) {
 	cPollerV2, accessors := setupConfigPollerV2(t)
+	// Use a long refresh period so the inline-retry backoff comfortably covers the test
+	// (suppression is `time.Since(lastAttempted) < refreshPeriod`).
+	cPollerV2.refreshPeriod = 30 * time.Second
 	ctx := context.Background()
 
 	sourceChains := []cciptypes.ChainSelector{sourceChain1, sourceChain2}
@@ -1055,9 +1059,11 @@ func TestConfigPollerV2_NewSourceChainStillTriggersInlineFetch(t *testing.T) {
 }
 
 // TestConfigPollerV2_AllSourceChainsFail_NoInlineRetry verifies that when ALL source chains
-// fail on the initial fetch, subsequent calls still don't trigger inline re-fetches.
+// fail on the initial fetch, subsequent calls within the suppression window still don't
+// trigger inline re-fetches.
 func TestConfigPollerV2_AllSourceChainsFail_NoInlineRetry(t *testing.T) {
 	cPollerV2, accessors := setupConfigPollerV2(t)
+	cPollerV2.refreshPeriod = 30 * time.Second
 	ctx := context.Background()
 
 	sourceChains := []cciptypes.ChainSelector{sourceChain1, sourceChain2}
@@ -1085,4 +1091,109 @@ func TestConfigPollerV2_AllSourceChainsFail_NoInlineRetry(t *testing.T) {
 
 	// Verify only one call was made
 	accessors[destChain].AssertNumberOfCalls(t, "GetAllConfigsLegacy", 1)
+}
+
+// TestConfigPollerV2_BatchErrorDoesNotPoisonAttemptedSet verifies that when the top-level
+// GetAllConfigsLegacy call returns an error (as opposed to a successful response with partial
+// per-chain failures), attemptedSourceChains is NOT populated. Inline retries must continue
+// across transient batch failures (e.g., provider RPC unavailable) so we don't get wedged on
+// the first failed call.
+func TestConfigPollerV2_BatchErrorDoesNotPoisonAttemptedSet(t *testing.T) {
+	cPollerV2, accessors := setupConfigPollerV2(t)
+	cPollerV2.refreshPeriod = 30 * time.Second
+	ctx := context.Background()
+
+	sourceChains := []cciptypes.ChainSelector{sourceChain1, sourceChain2}
+	expectedChainConfig := createMockChainConfigSnapshot()
+	fullSourceConfigs := createMockSourceChainConfigs(sourceChains)
+	var nilSourceConfigs map[cciptypes.ChainSelector]cciptypes.SourceChainConfig
+
+	// First call: top-level batch errors (simulates RPC provider unavailable).
+	accessors[destChain].On(
+		"GetAllConfigsLegacy",
+		mock.Anything,
+		destChain,
+		mock.MatchedBy(chainSelectorSliceMatcher(sourceChains))).
+		Return(cciptypes.ChainConfigSnapshot{}, nilSourceConfigs, errors.New("rpc unavailable")).Once()
+
+	_, err := cPollerV2.GetOfframpSourceChainConfigs(ctx, destChain, sourceChains)
+	require.Error(t, err)
+
+	// attemptedSourceChains must remain empty after a batch-level error so the next call
+	// is treated as a true cache miss and triggers another inline fetch.
+	destCache := cPollerV2.getOrCreateChainCache(destChain)
+	require.NotNil(t, destCache)
+	destCache.sourceChainMu.RLock()
+	assert.Empty(t, destCache.attemptedSourceChains,
+		"attemptedSourceChains must not be populated when GetAllConfigsLegacy returns an error")
+	destCache.sourceChainMu.RUnlock()
+
+	// Second call: top-level batch now succeeds for both chains.
+	accessors[destChain].On(
+		"GetAllConfigsLegacy",
+		mock.Anything,
+		destChain,
+		mock.MatchedBy(chainSelectorSliceMatcher(sourceChains))).
+		Return(expectedChainConfig, fullSourceConfigs, nil).Once()
+
+	configs, err := cPollerV2.GetOfframpSourceChainConfigs(ctx, destChain, sourceChains)
+	require.NoError(t, err)
+	assert.Len(t, configs, 2)
+	assert.Contains(t, configs, sourceChain1)
+	assert.Contains(t, configs, sourceChain2)
+
+	// Verify GetAllConfigsLegacy was called exactly twice (one error + one success).
+	accessors[destChain].AssertNumberOfCalls(t, "GetAllConfigsLegacy", 2)
+}
+
+// TestConfigPollerV2_InlineRetryResumesAfterBackoff verifies that once the suppression window
+// elapses, a still-missing source chain triggers another inline fetch. This guards the recovery
+// path used when the background poller is unhealthy or has been killed.
+func TestConfigPollerV2_InlineRetryResumesAfterBackoff(t *testing.T) {
+	cPollerV2, accessors := setupConfigPollerV2(t)
+	// Very short backoff so the test can wait it out without flakiness.
+	cPollerV2.refreshPeriod = 50 * time.Millisecond
+	ctx := context.Background()
+
+	sourceChains := []cciptypes.ChainSelector{sourceChain1, sourceChain2}
+	expectedChainConfig := createMockChainConfigSnapshot()
+
+	// First fetch: sourceChain1 succeeds, sourceChain2 is missing.
+	partialSourceConfigs := createMockSourceChainConfigs([]cciptypes.ChainSelector{sourceChain1})
+	accessors[destChain].On(
+		"GetAllConfigsLegacy",
+		mock.Anything,
+		destChain,
+		mock.MatchedBy(chainSelectorSliceMatcher(sourceChains))).
+		Return(expectedChainConfig, partialSourceConfigs, nil).Once()
+
+	configs, err := cPollerV2.GetOfframpSourceChainConfigs(ctx, destChain, sourceChains)
+	require.NoError(t, err)
+	assert.Len(t, configs, 1)
+	assert.Contains(t, configs, sourceChain1)
+
+	// While the suppression window is open, no additional fetch should fire.
+	configs2, err := cPollerV2.GetOfframpSourceChainConfigs(ctx, destChain, sourceChains)
+	require.NoError(t, err)
+	assert.Len(t, configs2, 1)
+	accessors[destChain].AssertNumberOfCalls(t, "GetAllConfigsLegacy", 1)
+
+	// Wait for the backoff to elapse, then expect an inline retry that recovers sourceChain2.
+	time.Sleep(75 * time.Millisecond)
+
+	fullSourceConfigs := createMockSourceChainConfigs(sourceChains)
+	accessors[destChain].On(
+		"GetAllConfigsLegacy",
+		mock.Anything,
+		destChain,
+		mock.MatchedBy(chainSelectorSliceMatcher(sourceChains))).
+		Return(expectedChainConfig, fullSourceConfigs, nil).Once()
+
+	configs3, err := cPollerV2.GetOfframpSourceChainConfigs(ctx, destChain, sourceChains)
+	require.NoError(t, err)
+	assert.Len(t, configs3, 2)
+	assert.Contains(t, configs3, sourceChain1)
+	assert.Contains(t, configs3, sourceChain2)
+
+	accessors[destChain].AssertNumberOfCalls(t, "GetAllConfigsLegacy", 2)
 }

--- a/pkg/reader/config_poller_v2_test.go
+++ b/pkg/reader/config_poller_v2_test.go
@@ -907,3 +907,182 @@ func chainSelectorSliceMatcher(expected []cciptypes.ChainSelector) func([]ccipty
 		return true
 	}
 }
+
+// TestConfigPollerV2_FailedSourceChainDoesNotRetriggerInlineFetch verifies that when a source chain
+// config fetch fails (e.g. RPC error), subsequent calls to GetOfframpSourceChainConfigs do NOT
+// trigger another inline batchRefreshChainAndSourceConfigs call. This prevents the "doom-loop"
+// where persistently failing chains cause redundant RPC calls and error log spam on every tick.
+func TestConfigPollerV2_FailedSourceChainDoesNotRetriggerInlineFetch(t *testing.T) {
+	cPollerV2, accessors := setupConfigPollerV2(t)
+	ctx := context.Background()
+
+	sourceChains := []cciptypes.ChainSelector{sourceChain1, sourceChain2}
+	expectedChainConfig := createMockChainConfigSnapshot()
+
+	// First fetch: sourceChain1 succeeds, sourceChain2 is missing from the response (simulates RPC failure
+	// where processSourceChainConfigResults skips the chain due to an error).
+	partialSourceConfigs := createMockSourceChainConfigs([]cciptypes.ChainSelector{sourceChain1})
+
+	accessors[destChain].On(
+		"GetAllConfigsLegacy",
+		mock.Anything,
+		destChain,
+		mock.MatchedBy(chainSelectorSliceMatcher(sourceChains))).
+		Return(expectedChainConfig, partialSourceConfigs, nil).Once()
+
+	// First call: triggers inline fetch since nothing is cached
+	configs, err := cPollerV2.GetOfframpSourceChainConfigs(ctx, destChain, sourceChains)
+	require.NoError(t, err)
+	// Only sourceChain1 should be returned (sourceChain2 failed)
+	assert.Len(t, configs, 1)
+	assert.Contains(t, configs, sourceChain1)
+	assert.NotContains(t, configs, sourceChain2)
+
+	// Second call with the SAME chains: should NOT trigger another GetAllConfigsLegacy call
+	// because sourceChain2 was already attempted (it's in attemptedSourceChains).
+	configs2, err := cPollerV2.GetOfframpSourceChainConfigs(ctx, destChain, sourceChains)
+	require.NoError(t, err)
+	// Still only sourceChain1 (sourceChain2 remains failed but no re-fetch happened)
+	assert.Len(t, configs2, 1)
+	assert.Contains(t, configs2, sourceChain1)
+
+	// Verify GetAllConfigsLegacy was only called ONCE total, the second call did not trigger a re-fetch
+	accessors[destChain].AssertNumberOfCalls(t, "GetAllConfigsLegacy", 1)
+}
+
+// TestConfigPollerV2_BackgroundPollerRetriesFailedSourceChains verifies that the background
+// poller successfully retries and recovers source chains that previously failed.
+func TestConfigPollerV2_BackgroundPollerRetriesFailedSourceChains(t *testing.T) {
+	cPollerV2, accessors := setupConfigPollerV2(t)
+	ctx := context.Background()
+
+	sourceChains := []cciptypes.ChainSelector{sourceChain1, sourceChain2}
+	expectedChainConfig := createMockChainConfigSnapshot()
+	emptySourceConfigs := make(map[cciptypes.ChainSelector]cciptypes.SourceChainConfig)
+
+	// First fetch: only sourceChain1 succeeds (sourceChain2 is missing, simulates RPC failure)
+	partialSourceConfigs := createMockSourceChainConfigs([]cciptypes.ChainSelector{sourceChain1})
+
+	accessors[destChain].On(
+		"GetAllConfigsLegacy",
+		mock.Anything,
+		destChain,
+		mock.MatchedBy(chainSelectorSliceMatcher(sourceChains))).
+		Return(expectedChainConfig, partialSourceConfigs, nil).Once()
+
+	// Initial inline fetch
+	configs, err := cPollerV2.GetOfframpSourceChainConfigs(ctx, destChain, sourceChains)
+	require.NoError(t, err)
+	assert.Len(t, configs, 1)
+	assert.Contains(t, configs, sourceChain1)
+
+	// Now simulate the background poller succeeding for both chains on the dest chain refresh
+	fullSourceConfigs := createMockSourceChainConfigs(sourceChains)
+	accessors[destChain].On(
+		"GetAllConfigsLegacy",
+		mock.Anything,
+		destChain,
+		mock.MatchedBy(chainSelectorSliceMatcher(sourceChains))).
+		Return(expectedChainConfig, fullSourceConfigs, nil).Maybe()
+
+	// refreshAllKnownChains also refreshes individual source chains (not just dest),
+	// so we need to mock those too.
+	emptyChains := make([]cciptypes.ChainSelector, 0)
+	for _, chain := range sourceChains {
+		accessors[chain].On(
+			"GetAllConfigsLegacy",
+			mock.Anything,
+			destChain,
+			mock.MatchedBy(chainSelectorSliceMatcher(emptyChains))).
+			Return(createMockChainConfigSnapshot(), emptySourceConfigs, nil).Maybe()
+	}
+
+	// Simulate background poller running
+	cPollerV2.refreshAllKnownChains()
+
+	// Now GetOfframpSourceChainConfigs should return BOTH chains from cache
+	configs2, err := cPollerV2.GetOfframpSourceChainConfigs(ctx, destChain, sourceChains)
+	require.NoError(t, err)
+	assert.Len(t, configs2, 2)
+	assert.Contains(t, configs2, sourceChain1)
+	assert.Contains(t, configs2, sourceChain2)
+}
+
+// TestConfigPollerV2_NewSourceChainStillTriggersInlineFetch verifies that a truly new source
+// chain (never attempted before) still triggers an inline fetch, even if other chains have
+// already been attempted.
+func TestConfigPollerV2_NewSourceChainStillTriggersInlineFetch(t *testing.T) {
+	cPollerV2, accessors := setupConfigPollerV2(t)
+	ctx := context.Background()
+
+	initialChains := []cciptypes.ChainSelector{sourceChain1}
+	expectedChainConfig := createMockChainConfigSnapshot()
+	initialSourceConfigs := createMockSourceChainConfigs(initialChains)
+
+	// First fetch: sourceChain1 only
+	accessors[destChain].On(
+		"GetAllConfigsLegacy",
+		mock.Anything,
+		destChain,
+		mock.MatchedBy(chainSelectorSliceMatcher(initialChains))).
+		Return(expectedChainConfig, initialSourceConfigs, nil).Once()
+
+	configs, err := cPollerV2.GetOfframpSourceChainConfigs(ctx, destChain, initialChains)
+	require.NoError(t, err)
+	assert.Len(t, configs, 1)
+
+	// Now request with a NEW chain (sourceChain3) that was never attempted
+	newChains := []cciptypes.ChainSelector{sourceChain1, sourceChain3}
+	allKnownChains := []cciptypes.ChainSelector{sourceChain1, sourceChain3}
+	allSourceConfigs := createMockSourceChainConfigs(allKnownChains)
+
+	accessors[destChain].On(
+		"GetAllConfigsLegacy",
+		mock.Anything,
+		destChain,
+		mock.MatchedBy(chainSelectorSliceMatcher(allKnownChains))).
+		Return(expectedChainConfig, allSourceConfigs, nil).Once()
+
+	// This should trigger an inline fetch because sourceChain3 was never attempted
+	configs2, err := cPollerV2.GetOfframpSourceChainConfigs(ctx, destChain, newChains)
+	require.NoError(t, err)
+	assert.Len(t, configs2, 2)
+	assert.Contains(t, configs2, sourceChain1)
+	assert.Contains(t, configs2, sourceChain3)
+
+	// Verify GetAllConfigsLegacy was called twice (once for initial, once for new chain)
+	accessors[destChain].AssertNumberOfCalls(t, "GetAllConfigsLegacy", 2)
+}
+
+// TestConfigPollerV2_AllSourceChainsFail_NoInlineRetry verifies that when ALL source chains
+// fail on the initial fetch, subsequent calls still don't trigger inline re-fetches.
+func TestConfigPollerV2_AllSourceChainsFail_NoInlineRetry(t *testing.T) {
+	cPollerV2, accessors := setupConfigPollerV2(t)
+	ctx := context.Background()
+
+	sourceChains := []cciptypes.ChainSelector{sourceChain1, sourceChain2}
+	expectedChainConfig := createMockChainConfigSnapshot()
+
+	// All source chains fail, empty map returned (simulates all RPC calls failing)
+	emptySourceConfigs := make(map[cciptypes.ChainSelector]cciptypes.SourceChainConfig)
+
+	accessors[destChain].On(
+		"GetAllConfigsLegacy",
+		mock.Anything,
+		destChain,
+		mock.MatchedBy(chainSelectorSliceMatcher(sourceChains))).
+		Return(expectedChainConfig, emptySourceConfigs, nil).Once()
+
+	// First call: triggers inline fetch
+	configs, err := cPollerV2.GetOfframpSourceChainConfigs(ctx, destChain, sourceChains)
+	require.NoError(t, err)
+	assert.Empty(t, configs)
+
+	// Second call: should NOT trigger another fetch
+	configs2, err := cPollerV2.GetOfframpSourceChainConfigs(ctx, destChain, sourceChains)
+	require.NoError(t, err)
+	assert.Empty(t, configs2)
+
+	// Verify only one call was made
+	accessors[destChain].AssertNumberOfCalls(t, "GetAllConfigsLegacy", 1)
+}


### PR DESCRIPTION
NOPs reported excessive error log spam from `processSourceChainConfigResults()` when a source chain's `GetSourceChainConfig` RPC call fails persistently (e.g., due to an RPC misconfiguration like gas limit below intrinsic gas).

Root cause: 
- When `GetAllConfigsLegacy` fetches source chain configs and receives some failure, `processSourceChainConfigResults` logs the error and skips that chain and it's never added to the config poller cache. 
- In `configPollerV2.GetOfframpSourceChainConfigs()`, any chain not in the cache is treated as a "cache miss," which triggers an inline call to `batchRefreshChainAndSourceConfigs`. 
- Since the failing chain never gets cached, every subsequent call triggers another full batch fetch, producing the same error logs every time. 
- Two concurrent callers in the merkle root `asyncObserver.sync()` (`ObserveOffRampNextSeqNums` and `ObserveLatestOnRampSeqNums`) both hit this path on every tick, multiplying the log volume.

Fix:
`pkg/reader/config_poller_v2.go`:
- Added `attemptedSourceChains` map to `chainCache` to track which source chains have been included in at least one fetch attempt.
- `GetOfframpSourceChainConfigs`: A chain missing from the cache is only treated as a "cache miss" (triggering an inline fetch) if it has never been attempted. Chains that were previously attempted but failed are not re-fetched inline 
- The background poller (`refreshAllKnownChains`) will still retry them on its regular schedule.
- `batchRefreshChainAndSourceConfigs`: After each fetch, all requested source chain selectors are recorded in `attemptedSourceChains` and sourceChainRefresh is always updated, regardless of whether individual chains succeeded.

`pkg/chainaccessor/config_processors.go`:
- Downgraded the "Failed to get source chain config from result" log from Errorw to Warnw. 
- This is a per-chain partial failure that is retried by the background poller, `Error` level creates excessive noise 