### PR TITLE
Update Lane Migrator DefaultTokenFeeUSDCents and MaxMsgPerGasLimit

### DIFF
--- a/chains/evm/deployment/v2_0_0/adapters/lanemigrator.go
+++ b/chains/evm/deployment/v2_0_0/adapters/lanemigrator.go
@@ -15,9 +15,6 @@ import (
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	mcms_types "github.com/smartcontractkit/mcms/types"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/committee_verifier"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/executor"
-	seq1_7 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils"
 	evm_datastore_utils "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/datastore"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
@@ -27,6 +24,9 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/operations/token_admin_registry"
 	onrampops_v160 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/operations/onramp"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/operations/rmn_remote"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/committee_verifier"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/executor"
+	seq1_7 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v2_0_0/fee_quoter"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/deploy"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
@@ -39,9 +39,9 @@ import (
 )
 
 const (
-	DefaultTxGasLimit        uint32 = 200_000
-	DefaultMaxPerMsgGasLimit uint32 = 8_000_000
-	DefaultMaxDataBytes      uint32 = 32_000
+	DefaultTxGasLimit       uint32 = 200_000
+	DefaultMaxDataBytes     uint32 = 32_000
+	DefaultTokenFeeUSDCents uint16 = 0
 )
 
 type LaneMigrator struct{}
@@ -399,11 +399,11 @@ func (r *LaneMigrator) UpdateVersionWithRouter() *cldf_ops.Sequence[deploy.RampU
 					DestChainConfig: fqops.DestChainConfig{
 						IsEnabled:                   dstChainCfg.IsEnabled,
 						MaxDataBytes:                DefaultMaxDataBytes,
-						MaxPerMsgGasLimit:           DefaultMaxPerMsgGasLimit,
+						MaxPerMsgGasLimit:           seq1_7.GetMaxMsgPerGasLimit(remoteChainSelector), // differs based on destination chain
 						DestGasOverhead:             dstChainCfg.DestGasOverhead,
 						DestGasPerPayloadByteBase:   dstChainCfg.DestGasPerPayloadByteBase,
 						ChainFamilySelector:         dstChainCfg.ChainFamilySelector,
-						DefaultTokenFeeUSDCents:     dstChainCfg.DefaultTokenFeeUSDCents,
+						DefaultTokenFeeUSDCents:     DefaultTokenFeeUSDCents,
 						DefaultTokenDestGasOverhead: dstChainCfg.DefaultTokenDestGasOverhead,
 						DefaultTxGasLimit:           DefaultTxGasLimit,
 						NetworkFeeUSDCents:          dstChainCfg.NetworkFeeUSDCents,

--- a/chains/evm/deployment/v2_0_0/adapters/lanemigrator_test.go
+++ b/chains/evm/deployment/v2_0_0/adapters/lanemigrator_test.go
@@ -150,7 +150,7 @@ func TestLaneMigrator(t *testing.T) {
 			})
 			require.NoError(t, err)
 			destConfig := opOut.Output
-			require.Equal(t, 15_000_000, destConfig.MaxPerMsgGasLimit) // MaxPerMsgGasLimit should be 15 million for Arbitrum
+			require.Equal(t, uint32(15_000_000), destConfig.MaxPerMsgGasLimit) // MaxPerMsgGasLimit should be 15 million for Arbitrum
 			require.Equal(t, adapters1_7.DefaultMaxDataBytes, destConfig.MaxDataBytes)
 		})
 	}

--- a/chains/evm/deployment/v2_0_0/adapters/lanemigrator_test.go
+++ b/chains/evm/deployment/v2_0_0/adapters/lanemigrator_test.go
@@ -24,6 +24,7 @@ import (
 	adapters1_7 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/adapters"
 	v2_0_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/changesets"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/create2_factory"
+	seq1_7 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/testsetup"
 )
 
@@ -150,7 +151,7 @@ func TestLaneMigrator(t *testing.T) {
 			})
 			require.NoError(t, err)
 			destConfig := opOut.Output
-			require.Equal(t, adapters1_7.DefaultMaxPerMsgGasLimit, destConfig.MaxPerMsgGasLimit)
+			require.Equal(t, seq1_7.GetMaxMsgPerGasLimit(chainB), destConfig.MaxPerMsgGasLimit)
 			require.Equal(t, adapters1_7.DefaultMaxDataBytes, destConfig.MaxDataBytes)
 		})
 	}

--- a/chains/evm/deployment/v2_0_0/adapters/lanemigrator_test.go
+++ b/chains/evm/deployment/v2_0_0/adapters/lanemigrator_test.go
@@ -24,7 +24,6 @@ import (
 	adapters1_7 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/adapters"
 	v2_0_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/changesets"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/create2_factory"
-	seq1_7 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/testsetup"
 )
 
@@ -151,7 +150,7 @@ func TestLaneMigrator(t *testing.T) {
 			})
 			require.NoError(t, err)
 			destConfig := opOut.Output
-			require.Equal(t, seq1_7.GetMaxMsgPerGasLimit(chainB), destConfig.MaxPerMsgGasLimit)
+			require.Equal(t, 15_000_000, destConfig.MaxPerMsgGasLimit) // MaxPerMsgGasLimit should be 15 million for Arbitrum
 			require.Equal(t, adapters1_7.DefaultMaxDataBytes, destConfig.MaxDataBytes)
 		})
 	}

--- a/chains/evm/deployment/v2_0_0/sequences/fee_quoter.go
+++ b/chains/evm/deployment/v2_0_0/sequences/fee_quoter.go
@@ -82,7 +82,7 @@ func getDefaultTokenFeeUSDCents(sourceChain, remoteChain uint64) uint16 {
 	if isEthChain(sourceChain) {
 		return 50
 	}
-	return 0
+	return 25
 }
 
 // GetMaxMsgPerGasLimit returns the max msg per gas limit based on the destination chain.

--- a/chains/evm/deployment/v2_0_0/sequences/fee_quoter.go
+++ b/chains/evm/deployment/v2_0_0/sequences/fee_quoter.go
@@ -82,7 +82,31 @@ func getDefaultTokenFeeUSDCents(sourceChain, remoteChain uint64) uint16 {
 	if isEthChain(sourceChain) {
 		return 50
 	}
-	return 25
+	return 0
+}
+
+// GetMaxMsgPerGasLimit returns the max msg per gas limit based on the destination chain.
+// This function will need to be updated as more defaults are defined.
+func GetMaxMsgPerGasLimit(destinationChain uint64) uint32 {
+	switch destinationChain {
+	case chain_selectors.ETHEREUM_MAINNET.Selector, chain_selectors.ETHEREUM_TESTNET_SEPOLIA.Selector, chain_selectors.ETHEREUM_TESTNET_HOODI.Selector,
+		chain_selectors.AVALANCHE_MAINNET.Selector, chain_selectors.AVALANCHE_TESTNET_FUJI.Selector,
+		chain_selectors.ETHEREUM_MAINNET_ARBITRUM_1.Selector, chain_selectors.ETHEREUM_TESTNET_SEPOLIA_ARBITRUM_1.Selector,
+		chain_selectors.ETHEREUM_MAINNET_BASE_1.Selector, chain_selectors.ETHEREUM_TESTNET_SEPOLIA_BASE_1.Selector,
+		chain_selectors.BINANCE_SMART_CHAIN_MAINNET.Selector, chain_selectors.BINANCE_SMART_CHAIN_TESTNET.Selector,
+		chain_selectors.POLYGON_MAINNET.Selector, chain_selectors.POLYGON_TESTNET_AMOY.Selector,
+		chain_selectors.ETHEREUM_MAINNET_MANTLE_1.Selector, chain_selectors.ETHEREUM_TESTNET_SEPOLIA_MANTLE_1.Selector,
+		chain_selectors.ETHEREUM_MAINNET_INK_1.Selector, chain_selectors.INK_TESTNET_SEPOLIA.Selector,
+		chain_selectors.PLASMA_MAINNET.Selector, chain_selectors.PLASMA_TESTNET.Selector,
+		chain_selectors.HYPERLIQUID_MAINNET.Selector, chain_selectors.HYPERLIQUID_TESTNET.Selector,
+		chain_selectors.TEST_0G_MAINNET.Selector, chain_selectors.ZERO_G_TESTNET_GALILEO.Selector,
+		chain_selectors.PLUME_MAINNET.Selector, chain_selectors.PLUME_TESTNET_SEPOLIA.Selector:
+		return 15_000_000
+	case chain_selectors.ETHEREUM_MAINNET_UNICHAIN_1.Selector, chain_selectors.ETHEREUM_TESTNET_SEPOLIA_UNICHAIN_1.Selector:
+		return 6_000_000
+	default:
+		return 8_000_000
+	}
 }
 
 type FeeQuoterUpdate struct {


### PR DESCRIPTION
### What
- Updates Lane Migrator DefaultTokenFeeUSDCents and MaxMsgPerGasLimit
- Adds function to determine MaxMsgPerGasLimit by dest chain selector

### Why
- This updates values to match what is in the config parameter source of truth: https://docs.google.com/spreadsheets/d/1PeYdK9rm5BHZz9d-m-UGF4Dm8uSaSLDmS0n-Y6kKkHY/edit?gid=325061287#gid=325061287