### PR TITLE
feat: token api address ref resolvers

### DIFF
--- a/chains/evm/deployment/v1_0_0/adapters/init.go
+++ b/chains/evm/deployment/v1_0_0/adapters/init.go
@@ -16,6 +16,7 @@ func init() {
 	deployapi.GetRegistry().RegisterDeployer(chain_selectors.FamilyEVM, v, &EVMDeployer{})
 	deployapi.GetTransferOwnershipRegistry().RegisterAdapter(chain_selectors.FamilyEVM, v, &EVMTransferOwnershipAdapter{})
 	mcmsreaderapi.GetRegistry().RegisterMCMSReader(chain_selectors.FamilyEVM, &EVMMCMSReader{})
+	tokensapi.GetTokenAdapterRegistry().RegisterTokenRefResolver(chain_selectors.FamilyEVM, &EVMTokenBase{})
 	tokensapi.GetTokenAdapterRegistry().RegisterTokenAdapter(chain_selectors.FamilyEVM, v, &EVMTokenBase{})
 	feesapi.GetRegistry().RegisterFeeResolver(chain_selectors.FamilyEVM, &EVMFeeResolver{})
 	deployapi.GetAddressNormalizerRegistry().RegisterAddressNormalizer(chain_selectors.FamilyEVM, &EVMAddressNormalizer{})

--- a/chains/evm/deployment/v1_0_0/adapters/pool_adapter.go
+++ b/chains/evm/deployment/v1_0_0/adapters/pool_adapter.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/tokens/tokenimpl"
 	datastore_utils_evm "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/datastore"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/erc20"
 	tarops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/operations/token_admin_registry"
 	tarseq "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/sequences"
 	tokensapi "github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
@@ -22,6 +23,11 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+)
+
+var (
+	_ tokensapi.TokenRefResolver = &EVMPoolAdapter{}
+	_ tokensapi.TokenAdapter     = &EVMPoolAdapter{}
 )
 
 // PoolOps abstracts the version-specific token pool contract calls.
@@ -51,57 +57,89 @@ type EVMPoolAdapter struct {
 	DeployTokenPoolSeq *cldf_ops.Sequence[tokensapi.DeployTokenPoolInput, sequences.OnChainOutput, cldf_chain.BlockChains]
 }
 
-func (a *EVMPoolAdapter) DeriveTokenAddress(e deployment.Environment, chainSelector uint64, poolRef datastore.AddressRef) ([]byte, error) {
+func (a *EVMPoolAdapter) DeriveTokenAddress(e deployment.Environment, chainSelector uint64, poolRef datastore.AddressRef) (string, error) {
 	chain, ok := e.BlockChains.EVMChains()[chainSelector]
 	if !ok {
-		return nil, fmt.Errorf("chain with selector %d not defined", chainSelector)
+		return "", fmt.Errorf("chain with selector %d not defined", chainSelector)
 	}
 
-	addrRef, err := datastore_utils.FindAndFormatRef(e.DataStore, poolRef, chainSelector, datastore_utils.FullRef)
+	// If the ref has the pool address already, then skip the datastore lookup altogether
+	if poolRef.Address != "" {
+		tokenPoolAddr := poolRef.Address
+		if !common.IsHexAddress(tokenPoolAddr) {
+			return "", fmt.Errorf("token pool address %q in ref is not a valid hex address", tokenPoolAddr)
+		}
+		tokenAddr, err := a.Ops.GetToken(e.OperationsBundle, chain, common.HexToAddress(tokenPoolAddr))
+		if err != nil {
+			return "", fmt.Errorf("failed to get token address from token pool (%s): %w", datastore_utils.SprintRef(poolRef), err)
+		}
+		return tokenAddr.Hex(), nil
+	}
+
+	// If the pool address isn't in the ref, then look it up in the datastore
+	tokenPoolAddrRef, err := datastore_utils.FindAndFormatRef(e.DataStore, poolRef, chainSelector, datastore_utils.FullRef)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find token pool in datastore using ref (%+v): %w", poolRef, err)
+		return "", fmt.Errorf("failed to find token pool in datastore using ref (%+v): %w", poolRef, err)
 	}
-
-	addrRaw, err := a.AddressRefToBytes(addrRef)
+	tokenPoolAddrBytes, err := a.AddressRefToBytes(tokenPoolAddrRef)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert address ref to bytes: %w", err)
+		return "", fmt.Errorf("failed to convert address ref to bytes: %w", err)
 	}
-
-	tpAddr := common.BytesToAddress(addrRaw)
-	if tpAddr == (common.Address{}) {
-		return nil, errors.New("token pool address is zero address")
+	tokenPoolAddr := common.BytesToAddress(tokenPoolAddrBytes)
+	if tokenPoolAddr == (common.Address{}) {
+		return "", errors.New("token pool address is zero address")
 	}
-
-	tokenAddr, err := a.Ops.GetToken(e.OperationsBundle, chain, tpAddr)
+	tokenAddr, err := a.Ops.GetToken(e.OperationsBundle, chain, tokenPoolAddr)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get token address from token pool ref (%+v): %w", addrRef, err)
+		return "", fmt.Errorf("failed to get token address from token pool ref (%+v): %w", tokenPoolAddrRef, err)
 	}
-
-	return tokenAddr.Bytes(), nil
+	return tokenAddr.Hex(), nil
 }
 
-func (a *EVMPoolAdapter) DeriveTokenDecimals(e deployment.Environment, chainSelector uint64, poolRef datastore.AddressRef, _ []byte) (uint8, error) {
+func (a *EVMPoolAdapter) DeriveTokenDecimals(e deployment.Environment, chainSelector uint64, poolRef datastore.AddressRef, token []byte) (uint8, error) {
 	chain, ok := e.BlockChains.EVMChains()[chainSelector]
 	if !ok {
 		return 0, fmt.Errorf("chain with selector %d not defined", chainSelector)
 	}
 
-	addrRef, err := datastore_utils.FindAndFormatRef(e.DataStore, poolRef, chainSelector, datastore_utils.FullRef)
+	// Optimization: most tokens are ERC20s, so try to get the decimals directly from
+	// the token contract first instead of going through the datastore and token pool
+	// contract.
+	report, err := cldf_ops.ExecuteOperation(
+		e.OperationsBundle, erc20.GetDecimals, chain,
+		evm_contract.FunctionInput[struct{}]{
+			ChainSelector: chainSelector,
+			Address:       common.BytesToAddress(token),
+		},
+	)
+	if err == nil {
+		return report.Output, nil
+	} else {
+		e.Logger.Warnf(
+			"failed to get token decimals directly from token contract at address %s - trying token pool at %s: %v",
+			common.BytesToAddress(token).Hex(), datastore_utils.SprintRef(poolRef), err,
+		)
+	}
+
+	// If we can't source the decimals directly from the token then check if the pool
+	// address is directly available in the ref. If so, we can skip the datastore and
+	// go straight to the pool contract for decimals.
+	if poolRef.Address != "" {
+		if !common.IsHexAddress(poolRef.Address) {
+			return 0, fmt.Errorf("token pool address %q in ref is not a valid hex address", poolRef.Address)
+		} else {
+			return a.Ops.GetTokenDecimals(e.GetContext(), chain, common.HexToAddress(poolRef.Address))
+		}
+	}
+
+	// If the ref doesn't have the pool address, then we need to hit the datastore for
+	// the full pool ref, then get the decimals from the pool contract.
+	poolAddr, err := datastore_utils.FindAndFormatRef(e.DataStore, poolRef, chainSelector, datastore_utils_evm.ToEVMAddress)
 	if err != nil {
-		return 0, fmt.Errorf("failed to find token pool in datastore using ref (%+v): %w", poolRef, err)
+		return 0, fmt.Errorf("failed to find token pool address for ref (%s): %w", datastore_utils.SprintRef(poolRef), err)
+	} else {
+		return a.Ops.GetTokenDecimals(e.GetContext(), chain, poolAddr)
 	}
-
-	addrRaw, err := a.AddressRefToBytes(addrRef)
-	if err != nil {
-		return 0, fmt.Errorf("failed to convert address ref to bytes: %w", err)
-	}
-
-	tpAddr := common.BytesToAddress(addrRaw)
-	if tpAddr == (common.Address{}) {
-		return 0, errors.New("token pool address is zero address")
-	}
-
-	return a.Ops.GetTokenDecimals(e.GetContext(), chain, tpAddr)
 }
 
 func (a *EVMPoolAdapter) SetTokenPoolRateLimits() *cldf_ops.Sequence[tokensapi.TPRLRemotes, sequences.OnChainOutput, cldf_chain.BlockChains] {

--- a/chains/evm/deployment/v1_0_0/adapters/token_adapter.go
+++ b/chains/evm/deployment/v1_0_0/adapters/token_adapter.go
@@ -168,7 +168,7 @@ func (a *EVMTokenBase) DeployTokenPoolForToken() *cldf_ops.Sequence[tokensapi.De
 	return nil
 }
 
-func (a *EVMTokenBase) ResolveTokenPoolRef(b cldf_ops.Bundle, chains cldf_chain.BlockChains, ds datastore.DataStore, chainSelector uint64, address string) (datastore.AddressRef, error) {
+func (a *EVMTokenBase) ResolveTokenPoolRef(b cldf_ops.Bundle, chains cldf_chain.BlockChains, _ datastore.DataStore, chainSelector uint64, address string) (datastore.AddressRef, error) {
 	var poolAddress common.Address
 	if !common.IsHexAddress(address) {
 		return datastore.AddressRef{}, fmt.Errorf("pool address %q is not a valid hex address", address)
@@ -222,7 +222,7 @@ func (a *EVMTokenBase) ResolveTokenPoolRef(b cldf_ops.Bundle, chains cldf_chain.
 	}, nil
 }
 
-func (a *EVMTokenBase) ResolveTokenRef(b cldf_ops.Bundle, chains cldf_chain.BlockChains, ds datastore.DataStore, chainSelector uint64, address string) (datastore.AddressRef, error) {
+func (a *EVMTokenBase) ResolveTokenRef(b cldf_ops.Bundle, chains cldf_chain.BlockChains, _ datastore.DataStore, chainSelector uint64, address string) (datastore.AddressRef, error) {
 	var tokenAddress common.Address
 	if !common.IsHexAddress(address) {
 		return datastore.AddressRef{}, fmt.Errorf("token address %q is not a valid hex address", address)

--- a/chains/evm/deployment/v1_0_0/adapters/token_adapter.go
+++ b/chains/evm/deployment/v1_0_0/adapters/token_adapter.go
@@ -6,7 +6,10 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/erc20"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/type_and_version"
 	v1_0_0_seq "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/sequences"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/operations/token_pool"
 	deployops "github.com/smartcontractkit/chainlink-ccip/deployment/deploy"
 	tokensapi "github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	cciputils "github.com/smartcontractkit/chainlink-ccip/deployment/utils"
@@ -14,12 +17,16 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	evm_contract "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 )
 
-var _ tokensapi.TokenAdapter = &EVMTokenBase{}
+var (
+	_ tokensapi.TokenRefResolver = &EVMTokenBase{}
+	_ tokensapi.TokenAdapter     = &EVMTokenBase{}
+)
 
 // EVMTokenBase provides version-agnostic EVM token adapter methods that are
 // shared across all pool versions (v1.5.1, v1.6.0, v1.6.1, v2.0.0).
@@ -141,8 +148,8 @@ func (a *EVMTokenBase) ConfigureTokenForTransfersSequence() *cldf_ops.Sequence[t
 	return nil
 }
 
-func (a *EVMTokenBase) DeriveTokenAddress(_ deployment.Environment, _ uint64, _ datastore.AddressRef) ([]byte, error) {
-	return nil, fmt.Errorf("DeriveTokenAddress is not implemented on EVMTokenBase; use a pool-version adapter")
+func (a *EVMTokenBase) DeriveTokenAddress(_ deployment.Environment, _ uint64, _ datastore.AddressRef) (string, error) {
+	return "", fmt.Errorf("DeriveTokenAddress is not implemented on EVMTokenBase; use a pool-version adapter")
 }
 
 func (a *EVMTokenBase) DeriveTokenDecimals(_ deployment.Environment, _ uint64, _ datastore.AddressRef, _ []byte) (uint8, error) {
@@ -159,4 +166,94 @@ func (a *EVMTokenBase) ManualRegistration() *cldf_ops.Sequence[tokensapi.ManualR
 
 func (a *EVMTokenBase) DeployTokenPoolForToken() *cldf_ops.Sequence[tokensapi.DeployTokenPoolInput, sequences.OnChainOutput, cldf_chain.BlockChains] {
 	return nil
+}
+
+func (a *EVMTokenBase) ResolveTokenPoolRef(b cldf_ops.Bundle, chains cldf_chain.BlockChains, ds datastore.DataStore, chainSelector uint64, address string) (datastore.AddressRef, error) {
+	var poolAddress common.Address
+	if !common.IsHexAddress(address) {
+		return datastore.AddressRef{}, fmt.Errorf("pool address %q is not a valid hex address", address)
+	} else {
+		poolAddress = common.HexToAddress(address)
+	}
+
+	chain, ok := chains.EVMChains()[chainSelector]
+	if !ok {
+		return datastore.AddressRef{}, fmt.Errorf("chain with selector %d not defined", chainSelector)
+	}
+
+	tv, err := cldf_ops.ExecuteOperation(b,
+		type_and_version.GetTypeAndVersion, chain,
+		evm_contract.FunctionInput[struct{}]{
+			ChainSelector: chainSelector,
+			Address:       poolAddress,
+		},
+	)
+	if err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("failed to get typeAndVersion for pool %s: %w", address, err)
+	}
+
+	// NOTE: for EVM, the token pool qualifier is typically set to the token address
+	// although this is not a hard requirement. We attempt to pull the token address
+	// from the token pool on a best-effort basis, but if this fails for any reason,
+	// then we will fallback to a placeholder qualifier. At the time of this writing
+	// every token pool contract has a getToken( ) function with the same ABI across
+	// all versions (v1.5.x, v1.6.x, v2.x.x) so we use the v1.5.x generated bindings
+	// here for simplicity instead of overcomplicating the code with a switch on the
+	// pool version.
+	qualifier := fmt.Sprintf("%s-%s", poolAddress, tv.Output.Type)
+	if token, err := cldf_ops.ExecuteOperation(b,
+		token_pool.GetToken, chain,
+		evm_contract.FunctionInput[any]{
+			ChainSelector: chainSelector,
+			Address:       poolAddress,
+		},
+	); err != nil {
+		b.Logger.Warnf("failed to get token address from pool at %s: %v; using fallback qualifier %s", poolAddress, err, qualifier)
+	} else {
+		qualifier = token.Output.Hex()
+	}
+
+	return datastore.AddressRef{
+		ChainSelector: chainSelector,
+		Type:          datastore.ContractType(tv.Output.Type),
+		Qualifier:     qualifier,
+		Version:       tv.Output.Version,
+		Address:       poolAddress.Hex(),
+	}, nil
+}
+
+func (a *EVMTokenBase) ResolveTokenRef(b cldf_ops.Bundle, chains cldf_chain.BlockChains, ds datastore.DataStore, chainSelector uint64, address string) (datastore.AddressRef, error) {
+	var tokenAddress common.Address
+	if !common.IsHexAddress(address) {
+		return datastore.AddressRef{}, fmt.Errorf("token address %q is not a valid hex address", address)
+	} else {
+		tokenAddress = common.HexToAddress(address)
+	}
+
+	chain, ok := chains.EVMChains()[chainSelector]
+	if !ok {
+		return datastore.AddressRef{}, fmt.Errorf("chain with selector %d not defined", chainSelector)
+	}
+
+	symbolReport, err := cldf_ops.ExecuteOperation(b,
+		erc20.GetSymbol, chain,
+		evm_contract.FunctionInput[struct{}]{
+			ChainSelector: chainSelector,
+			Address:       tokenAddress,
+		},
+	)
+	if err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("failed to read ERC20 symbol for token %s: %w", address, err)
+	}
+
+	// NOTE: at the moment, there's currently not an easy way to determine the exact
+	// token type. For now, we simply return `ERC20Token` as the type for all tokens
+	// but if needed we can add more specific logic here in the future.
+	return datastore.AddressRef{
+		ChainSelector: chainSelector,
+		Type:          datastore.ContractType(erc20.ContractType),
+		Version:       cciputils.Version_1_0_0,
+		Qualifier:     symbolReport.Output,
+		Address:       tokenAddress.Hex(),
+	}, nil
 }

--- a/chains/evm/deployment/v1_0_0/operations/erc20/erc20.go
+++ b/chains/evm/deployment/v1_0_0/operations/erc20/erc20.go
@@ -8,8 +8,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
 	cldf_deployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/erc20"
 )
@@ -55,5 +55,27 @@ var Transfer = contract.NewWrite(contract.WriteParams[TransferArgs, *erc20.ERC20
 	},
 	CallContract: func(token *erc20.ERC20, opts *bind.TransactOpts, args TransferArgs) (*types.Transaction, error) {
 		return token.Transfer(opts, args.Receiver, args.Amount)
+	},
+})
+
+var GetSymbol = contract.NewRead(contract.ReadParams[struct{}, string, *erc20.ERC20]{
+	Name:         "erc20:get-symbol",
+	Version:      utils.Version_1_0_0,
+	Description:  "Gets the ERC20 token symbol",
+	ContractType: ContractType,
+	NewContract:  erc20.NewERC20,
+	CallContract: func(token *erc20.ERC20, opts *bind.CallOpts, _ struct{}) (string, error) {
+		return token.Symbol(opts)
+	},
+})
+
+var GetDecimals = contract.NewRead(contract.ReadParams[struct{}, uint8, *erc20.ERC20]{
+	Name:         "erc20:get-decimals",
+	Version:      utils.Version_1_0_0,
+	Description:  "Gets the ERC20 token decimals",
+	ContractType: ContractType,
+	NewContract:  erc20.NewERC20,
+	CallContract: func(token *erc20.ERC20, opts *bind.CallOpts, _ struct{}) (uint8, error) {
+		return token.Decimals(opts)
 	},
 })

--- a/chains/evm/go.mod
+++ b/chains/evm/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/smartcontractkit/ccip-contract-examples/chains/evm v0.0.0-20250826190403-aed7f5f33cde
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0
 	github.com/smartcontractkit/chain-selectors v1.0.98
-	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260516222345-f2f143454dbd
+	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260520095735-feac5055dc84
 	github.com/smartcontractkit/chainlink-ccv v0.0.1
 	github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260518113836-b4e2fcbb6799
 	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260417081611-8bdbd9f45629

--- a/chains/evm/go.mod
+++ b/chains/evm/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/smartcontractkit/ccip-contract-examples/chains/evm v0.0.0-20250826190403-aed7f5f33cde
 	github.com/smartcontractkit/ccip-owner-contracts v0.1.0
 	github.com/smartcontractkit/chain-selectors v1.0.98
-	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260520204756-f0fd9c330aac
+	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260520205139-e02dace3eefa
 	github.com/smartcontractkit/chainlink-ccv v0.0.1
 	github.com/smartcontractkit/chainlink-ccv/deployment v0.0.2-0.20260518113836-b4e2fcbb6799
 	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260417081611-8bdbd9f45629

--- a/chains/solana/deployment/utils/utils.go
+++ b/chains/solana/deployment/utils/utils.go
@@ -199,12 +199,13 @@ func GetTokenDecimals(chain cldf_solana.Chain, tokenMint solana.PublicKey) (uint
 }
 
 func FetchTokenProgramID(ctx context.Context, chain cldf_solana.Chain, tokenPubKey solana.PublicKey) (solana.PublicKey, error) {
-	tokenAcctInfo, err := chain.Client.GetAccountInfo(ctx, tokenPubKey)
+	// Fetch the token account info
+	tokenAcctInfo, err := chain.Client.GetAccountInfoWithOpts(ctx, tokenPubKey, &solrpc.GetAccountInfoOpts{Commitment: cldf_solana.SolDefaultCommitment})
 	if err != nil {
 		return solana.PublicKey{}, fmt.Errorf("failed to get account info for token %s: %w", tokenPubKey.String(), err)
 	}
 
-	// Best-effort safeguard: if this truly is a token, then we should be able to fetch its decimals
+	// Safeguard: if this truly is a token, then we should be able to fetch its decimals
 	_, err = GetTokenDecimals(chain, tokenPubKey)
 	if err != nil {
 		return solana.PublicKey{}, fmt.Errorf("failed to get token decimals for token %s: %w", tokenPubKey.String(), err)

--- a/chains/solana/deployment/v1_6_0/sequences/adapter.go
+++ b/chains/solana/deployment/v1_6_0/sequences/adapter.go
@@ -32,7 +32,10 @@ func init() {
 	deployapi.GetTransferOwnershipRegistry().RegisterAdapter(chain_selectors.FamilySolana, v, &SolanaAdapter{})
 	mcmsreaderapi.GetRegistry().RegisterMCMSReader(chain_selectors.FamilySolana, &SolanaAdapter{})
 	tokensapi.GetTokenAdapterRegistry().RegisterTokenAdapter(chain_selectors.FamilySolana, v, &SolanaAdapter{})
+	tokensapi.GetTokenAdapterRegistry().RegisterTokenRefResolver(chain_selectors.FamilySolana, &SolanaAdapter{})
 }
+
+var _ tokensapi.TokenRefResolver = (*SolanaAdapter)(nil)
 
 type SolanaAdapter struct {
 	timelockAddr map[uint64]solana.PublicKey

--- a/chains/solana/deployment/v1_6_0/sequences/tokens.go
+++ b/chains/solana/deployment/v1_6_0/sequences/tokens.go
@@ -1056,8 +1056,12 @@ func (a *SolanaAdapter) getTokenMintAndTokenProgram(b cldf_ops.Bundle, chains cl
 }
 
 func decodeArtificialPoolAddressRef(label string) (solana.PublicKey, bool) {
-	if parts := strings.Split(label, ":"); len(parts) == 2 && parts[0] == tokenapi.ArtificialAddressRefLabel {
-		return solana.MustPublicKeyFromBase58(parts[1]), true
+	if parts := strings.Split(label, ":"); len(parts) >= 2 && parts[0] == tokenapi.ArtificialAddressRefLabel {
+		if pubKey, err := solana.PublicKeyFromBase58(parts[1]); err != nil {
+			return solana.PublicKey{}, false
+		} else {
+			return pubKey, true
+		}
 	} else {
 		return solana.PublicKey{}, false
 	}

--- a/chains/solana/deployment/v1_6_0/sequences/tokens.go
+++ b/chains/solana/deployment/v1_6_0/sequences/tokens.go
@@ -266,6 +266,9 @@ func (a *SolanaAdapter) DeriveTokenAddress(e deployment.Environment, chainSelect
 			break
 		}
 	}
+	if poolPDA.IsZero() {
+		return "", fmt.Errorf("pool PDA could not be derived from pool ref: no valid PDA found in address field or labels")
+	}
 
 	// LockRelease and BurnMint v1.6 pool config accounts share the same state layout, so we
 	// can use the BurnMint config struct to decode the account data for both types of pools

--- a/chains/solana/deployment/v1_6_0/sequences/tokens.go
+++ b/chains/solana/deployment/v1_6_0/sequences/tokens.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"strings"
 
+	bin "github.com/gagliardetto/binary"
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
 
@@ -270,11 +271,25 @@ func (a *SolanaAdapter) DeriveTokenAddress(e deployment.Environment, chainSelect
 		return "", fmt.Errorf("pool PDA could not be derived from pool ref: no valid PDA found in address field or labels")
 	}
 
+	// Optimization: we avoid unnecessary decoding if we weren't actually given the pool
+	// PDA. If the account is executable, then the input address is most likely the pool
+	// program ID and not a PDA.
+	resp, err := chain.Client.GetAccountInfoWithOpts(e.GetContext(), poolPDA, &rpc.GetAccountInfoOpts{Commitment: cldf_solana.SolDefaultCommitment})
+	if err != nil {
+		return "", fmt.Errorf("failed to get account info for %s: %w", poolPDA.String(), err)
+	}
+	if resp == nil || resp.Value == nil {
+		return "", fmt.Errorf("failed to get account info for: %s", poolPDA.String())
+	}
+	if resp.Value.Executable {
+		return "", fmt.Errorf("token derivation is only possible if a pool PDA is provided - got an executable account: %s", poolPDA.String())
+	}
+
 	// LockRelease and BurnMint v1.6 pool config accounts share the same state layout, so we
 	// can use the BurnMint config struct to decode the account data for both types of pools
 	var state burnmint_token_pool.State
-	if err := chain.GetAccountDataBorshInto(e.GetContext(), poolPDA, &state); err != nil {
-		return "", fmt.Errorf("failed to get account data for pool config PDA %s: %w", poolPDA.String(), err)
+	if err = bin.NewBorshDecoder(resp.Value.Data.GetBinary()).Decode(&state); err != nil {
+		return "", fmt.Errorf("failed to decode account data for pool config PDA %s: %w", poolPDA.String(), err)
 	}
 
 	return state.Config.Mint.String(), nil
@@ -941,7 +956,7 @@ func (a *SolanaAdapter) ResolveTokenPoolRef(b cldf_ops.Bundle, chains cldf_chain
 	if err != nil {
 		return datastore.AddressRef{}, fmt.Errorf("get account info for %q: %w", address, err)
 	}
-	if acct.Value == nil {
+	if acct == nil || acct.Value == nil {
 		return datastore.AddressRef{}, fmt.Errorf("account %q not found", address)
 	}
 

--- a/chains/solana/deployment/v1_6_0/sequences/tokens.go
+++ b/chains/solana/deployment/v1_6_0/sequences/tokens.go
@@ -4,13 +4,16 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 
 	"github.com/gagliardetto/solana-go"
+	solrpc "github.com/gagliardetto/solana-go/rpc"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/utils"
 	routerops "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_6_0/operations/router"
 	tokenpoolops "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_6_0/operations/token_pools"
 	tokensops "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_6_0/operations/tokens"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v1_6_0/burnmint_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
 	tokenapi "github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	common_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils"
@@ -44,7 +47,7 @@ func (a *SolanaAdapter) ConfigureTokenForTransfersSequence() *cldf_ops.Sequence[
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to get router address: %w", err)
 			}
 
-			tokenAddr, tokenProgramId, err := getTokenMintAndTokenProgram(input.ExistingDataStore, input.TokenRef, chain)
+			tokenAddr, tokenProgramId, err := a.getTokenMintAndTokenProgram(b, chains, input.ExistingDataStore, chain.Selector, input.TokenRef)
 			if err != nil {
 				return sequences.OnChainOutput{}, err
 			}
@@ -233,8 +236,45 @@ func (a *SolanaAdapter) AddressRefToBytes(ref datastore.AddressRef) ([]byte, err
 	return solana.MustPublicKeyFromBase58(ref.Address).Bytes(), nil
 }
 
-func (a *SolanaAdapter) DeriveTokenAddress(e deployment.Environment, chainSelector uint64, poolRef datastore.AddressRef) ([]byte, error) {
-	return nil, fmt.Errorf("DeriveTokenAddress not implemented for Solana")
+func (a *SolanaAdapter) DeriveTokenAddress(e deployment.Environment, chainSelector uint64, poolRef datastore.AddressRef) (string, error) {
+	chain, ok := e.BlockChains.SolanaChains()[chainSelector]
+	if !ok {
+		return "", fmt.Errorf("chain with selector %d not defined", chainSelector)
+	}
+
+	// Optimization: if there's no artificial pool PDA label present in the input pool ref,
+	// then we can try to see if the Address field of the pool ref is the pool PDA. This is
+	// useful in situations where this function is called with an unresolved pool ref where
+	// the user has intentionally provided the pool PDA in the Address field instead of the
+	// token pool program ID in case they already know it. In this situation we can perform
+	// a token derivation.
+	poolPDA := solana.PublicKey{}
+	if poolRef.Address != "" {
+		if pda, err := solana.PublicKeyFromBase58(poolRef.Address); err != nil {
+			return "", fmt.Errorf("failed to parse pool PDA from address field of pool ref: %w", err)
+		} else {
+			poolPDA = pda
+		}
+	}
+
+	// If the ArtificialAddressRefLabel exists in the labels, then we prefer this over
+	// the Address field in the pool ref since this is a more explicit indication that
+	// the pool PDA is being provided instead of the token pool program ID.
+	for _, label := range poolRef.Labels.List() {
+		if pda, ok := decodeArtificialPoolAddressRef(label); ok {
+			poolPDA = pda
+			break
+		}
+	}
+
+	// LockRelease and BurnMint v1.6 pool config accounts share the same state layout, so we
+	// can use the BurnMint config struct to decode the account data for both types of pools
+	var state burnmint_token_pool.State
+	if err := chain.GetAccountDataBorshInto(e.GetContext(), poolPDA, &state); err != nil {
+		return "", fmt.Errorf("failed to get account data for pool config PDA %s: %w", poolPDA.String(), err)
+	}
+
+	return state.Config.Mint.String(), nil
 }
 
 func (a *SolanaAdapter) DeriveTokenDecimals(e deployment.Environment, chainSelector uint64, poolRef datastore.AddressRef, token []byte) (uint8, error) {
@@ -283,7 +323,7 @@ func (a *SolanaAdapter) ManualRegistration() *cldf_ops.Sequence[tokenapi.ManualR
 			// to proceed.
 			var tokenProg solana.PublicKey
 			var tokenMint solana.PublicKey
-			if tokRef, tokProgramID, err := getTokenMintAndTokenProgram(input.ExistingDataStore, input.TokenRef, chain); err != nil {
+			if tokRef, tokProgramID, err := a.getTokenMintAndTokenProgram(b, chains, input.ExistingDataStore, chain.Selector, input.TokenRef); err != nil {
 				b.Logger.Warnf("Failed to get token mint and program ID from datastore for ref (%s) (err = %v). Falling back to on-chain lookup if possible.", datastore_utils.SprintRef(input.TokenRef), err)
 				if input.TokenRef.Address == "" {
 					return sequences.OnChainOutput{}, errors.New("token information could not be resolved from datastore and token reference does not include an address to attempt on-chain resolution")
@@ -491,7 +531,7 @@ func (a *SolanaAdapter) SetTokenPoolRateLimits() *cldf_ops.Sequence[tokenapi.TPR
 			default:
 				return sequences.OnChainOutput{}, fmt.Errorf("unsupported token pool type '%s' for Solana", input.TokenPoolRef.Type.String())
 			}
-			tokenAddr, tokenProgramId, err := getTokenMintAndTokenProgram(input.ExistingDataStore, input.TokenRef, chain)
+			tokenAddr, tokenProgramId, err := a.getTokenMintAndTokenProgram(b, chains, input.ExistingDataStore, chain.Selector, input.TokenRef)
 			if err != nil {
 				return sequences.OnChainOutput{}, err
 			}
@@ -612,7 +652,7 @@ func (a *SolanaAdapter) DeployTokenPoolForToken() *cldf_ops.Sequence[tokenapi.De
 			default:
 				return sequences.OnChainOutput{}, fmt.Errorf("unsupported token pool type '%s' for Solana", input.PoolType)
 			}
-			tokenAddr, tokenProgramId, err := getTokenMintAndTokenProgram(input.ExistingDataStore, *input.TokenRef, chain)
+			tokenAddr, tokenProgramId, err := a.getTokenMintAndTokenProgram(b, chains, input.ExistingDataStore, chain.Selector, *input.TokenRef)
 			if err != nil {
 				return sequences.OnChainOutput{}, err
 			}
@@ -749,18 +789,6 @@ func (a *SolanaAdapter) DeployTokenPoolForToken() *cldf_ops.Sequence[tokenapi.De
 	)
 }
 
-func getTokenMintAndTokenProgram(store datastore.DataStore, tokenRef datastore.AddressRef, chain cldf_solana.Chain) (datastore.AddressRef, solana.PublicKey, error) {
-	tokenAddr, err := datastore_utils.FindAndFormatRef(store, tokenRef, chain.Selector, datastore_utils.FullRef)
-	if err != nil {
-		return datastore.AddressRef{}, solana.PublicKey{}, fmt.Errorf("failed to find token address for ref '%+v': %w", tokenRef, err)
-	}
-	tokenProgramId, err := utils.GetTokenProgramID(deployment.ContractType(tokenAddr.Type))
-	if err != nil {
-		return datastore.AddressRef{}, solana.PublicKey{}, fmt.Errorf("failed to get token program ID for token type '%s': %w", tokenAddr.Type, err)
-	}
-	return tokenAddr, tokenProgramId, nil
-}
-
 func (a *SolanaAdapter) UpdateAuthorities() *cldf_ops.Sequence[tokenapi.UpdateAuthoritiesInput, sequences.OnChainOutput, *deployment.Environment] {
 	return cldf_ops.NewSequence(
 		"svm-adapter:update-authorities",
@@ -773,7 +801,7 @@ func (a *SolanaAdapter) UpdateAuthorities() *cldf_ops.Sequence[tokenapi.UpdateAu
 				return sequences.OnChainOutput{}, fmt.Errorf("chain with selector %d not defined", input.ChainSelector)
 			}
 			ds := e.DataStore
-			tokenRef, _, err := getTokenMintAndTokenProgram(ds, input.TokenRef, chain)
+			tokenRef, _, err := a.getTokenMintAndTokenProgram(b, e.BlockChains, ds, chain.Selector, input.TokenRef)
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to get token and token program address using the specified reference (%+v): %w", input.TokenRef, err)
 			}
@@ -833,4 +861,152 @@ func (a *SolanaAdapter) UpdateAuthorities() *cldf_ops.Sequence[tokenapi.UpdateAu
 
 func (a *SolanaAdapter) MigrateLockReleasePoolLiquiditySequence() *cldf_ops.Sequence[tokenapi.MigrateLockReleasePoolLiquidityInput, sequences.OnChainOutput, cldf_chain.BlockChains] {
 	return nil
+}
+
+// ResolveTokenPoolRef accepts either the token pool programID or the token pool PDA address
+// and resolves it to the token pool program AddressRef in the datastore. If a PDA is given,
+// then the associated programID is queried from the chain and used to find a matching token
+// pool ref in the datastore. If a programID is provided, then we use it to look up the pool
+// in the datastore. In either case, it returns an error if the token pool can't be found or
+// if on-chain lookups fail.
+func (a *SolanaAdapter) ResolveTokenPoolRef(b cldf_ops.Bundle, chains cldf_chain.BlockChains, ds datastore.DataStore, chainSelector uint64, address string) (datastore.AddressRef, error) {
+	chain, ok := chains.SolanaChains()[chainSelector]
+	if !ok {
+		return datastore.AddressRef{}, fmt.Errorf("chain with selector %d not defined", chainSelector)
+	}
+	pubKey, err := solana.PublicKeyFromBase58(address)
+	if err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("invalid pool address %q: %w", address, err)
+	}
+	acct, err := chain.Client.GetAccountInfoWithOpts(b.GetContext(), pubKey, &solrpc.GetAccountInfoOpts{Commitment: cldf_solana.SolDefaultCommitment})
+	if err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("get account info for %q: %w", address, err)
+	}
+	if acct.Value == nil {
+		return datastore.AddressRef{}, fmt.Errorf("account %q not found", address)
+	}
+
+	var poolProgramID solana.PublicKey
+	var poolPDA *solana.PublicKey
+	if !acct.Value.Executable {
+		// Case 1: the `pubKey` is the pool config PDA - in this case, DeriveTokenAddress
+		// can use the PDA to get the associated mint for the pool
+		poolProgramID = acct.Value.Owner
+		poolPDA = &pubKey
+	} else {
+		// Case 2: the `pubKey` is the pool program ID - in this case, DeriveTokenAddress
+		// doesn't have enough info to derive the associated mint
+		poolProgramID = pubKey
+		poolPDA = nil
+	}
+
+	// If we were given the PDA, then we re-query the datastore with the derived token pool
+	// program ID - if this still fails, then we have no more resolution options to try and
+	// we raise an error
+	poolRef, err := datastore_utils.FindAndFormatRef(ds,
+		datastore.AddressRef{ChainSelector: chainSelector, Address: poolProgramID.String()},
+		chainSelector,
+		datastore_utils.FullRef,
+	)
+	if err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("failed to find token pool program ref for program id %s: %w", poolProgramID.String(), err)
+	}
+
+	// If we have a datastore match and we have the pool PDA, then we encode this info as a
+	// single label so that DeriveTokenAddress can use it
+	if poolPDA != nil {
+		poolRef.Labels.Add(encodeArtificialPoolAddressRefLabel(*poolPDA))
+	}
+
+	return poolRef, nil
+}
+
+// ResolveTokenRef accepts a token mint public key and resolves it to an AddressRef in the
+// datastore. It performs on-chain lookups to determine the token program and token symbol
+// (for qualifier) associated with the mint address. If the token ref can't be resolved or
+// if on-chain lookups fail, it returns an error. The qualifier is set to the token symbol
+// if it can be found on-chain, otherwise a sensible placeholder is used.
+func (a *SolanaAdapter) ResolveTokenRef(b cldf_ops.Bundle, chains cldf_chain.BlockChains, ds datastore.DataStore, chainSelector uint64, address string) (datastore.AddressRef, error) {
+	chain, ok := chains.SolanaChains()[chainSelector]
+	if !ok {
+		return datastore.AddressRef{}, fmt.Errorf("chain with selector %d not defined", chainSelector)
+	}
+	tokenMintPubKey, err := solana.PublicKeyFromBase58(address)
+	if err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("invalid mint address %q: %w", address, err)
+	}
+	tokenProgramID, err := utils.FetchTokenProgramID(b.GetContext(), chain, tokenMintPubKey)
+	if err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("failed to resolve token program for mint %s: %w", address, err)
+	}
+	programType, err := utils.GetTokenProgramType(tokenProgramID)
+	if err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("mint %s: %w", address, err)
+	}
+
+	// NOTE: the token symbol is not strictly required for most Solana operations (some tokens may not have
+	// metadata uploaded via Metaplex). With that in mind, we only perform a best-effort fetch of the token
+	// symbol instead of hard crashing if it isn't on chain. If we can't get this info from the chain, then
+	// we will use a placeholder instead.
+	qualifier := fmt.Sprintf("%s-%s", address, programType)
+	if meta, _, err := tokens.GetTokenMetadata(b.GetContext(), chain.Client, tokenMintPubKey); err != nil {
+		b.Logger.Warnf("failed to get Metaplex token metadata for mint %s falling back to default qualifier (%s): %v", address, qualifier, err)
+	} else {
+		data := tokens.GetTokenDataV2(meta)
+		if symbol := strings.TrimSpace(data.Symbol); symbol == "" {
+			b.Logger.Warnf("token metadata for mint %s does not include a symbol, falling back to default qualifier (%s): %+v", address, qualifier, data)
+		} else {
+			qualifier = symbol
+		}
+	}
+
+	return datastore.AddressRef{
+		ChainSelector: chainSelector,
+		Type:          datastore.ContractType(programType),
+		Version:       common_utils.Version_1_6_0,
+		Qualifier:     qualifier,
+		Address:       tokenMintPubKey.String(),
+	}, nil
+}
+
+func (a *SolanaAdapter) getTokenMintAndTokenProgram(b cldf_ops.Bundle, chains cldf_chain.BlockChains, ds datastore.DataStore, chainSelector uint64, tokenRef datastore.AddressRef) (datastore.AddressRef, solana.PublicKey, error) {
+	chain, ok := chains.SolanaChains()[chainSelector]
+	if !ok {
+		return datastore.AddressRef{}, solana.PublicKey{}, fmt.Errorf("chain with selector %d not defined", chainSelector)
+	}
+
+	// Try to resolve the token ref from the datastore first to avoid RPC
+	// calls and if that fails, then fall back to onchain ref resolution.
+	var resolvedTokenRef datastore.AddressRef
+	if fullTokenRef, err := datastore_utils.FindAndFormatRef(ds, tokenRef, chain.Selector, datastore_utils.FullRef); err == nil {
+		resolvedTokenRef = fullTokenRef
+	} else {
+		if tokenRef.Address == "" {
+			return datastore.AddressRef{}, solana.PublicKey{}, fmt.Errorf("token reference %q could not be resolved from the datastore and does not include an address to attempt on-chain resolution: %w", datastore_utils.SprintRef(tokenRef), err)
+		} else {
+			resolvedTokenRef, err = a.ResolveTokenRef(b, chains, ds, chainSelector, tokenRef.Address)
+			if err != nil {
+				return datastore.AddressRef{}, solana.PublicKey{}, fmt.Errorf("failed to resolve token reference %s on-chain: %w", datastore_utils.SprintRef(tokenRef), err)
+			}
+		}
+	}
+
+	tokenProgramId, err := utils.GetTokenProgramID(deployment.ContractType(resolvedTokenRef.Type))
+	if err != nil {
+		return datastore.AddressRef{}, solana.PublicKey{}, fmt.Errorf("failed to get token program ID for token type '%s': %w", resolvedTokenRef.Type, err)
+	}
+
+	return resolvedTokenRef, tokenProgramId, nil
+}
+
+func decodeArtificialPoolAddressRef(label string) (solana.PublicKey, bool) {
+	if parts := strings.Split(label, ":"); len(parts) == 2 && parts[0] == tokenapi.ArtificialAddressRefLabel {
+		return solana.MustPublicKeyFromBase58(parts[1]), true
+	} else {
+		return solana.PublicKey{}, false
+	}
+}
+
+func encodeArtificialPoolAddressRefLabel(poolPDA solana.PublicKey) string {
+	return tokenapi.ArtificialAddressRefLabel + ":" + poolPDA.String()
 }

--- a/chains/solana/deployment/v1_6_0/sequences/tokens.go
+++ b/chains/solana/deployment/v1_6_0/sequences/tokens.go
@@ -278,7 +278,7 @@ func (a *SolanaAdapter) DeriveTokenAddress(e deployment.Environment, chainSelect
 	if err != nil {
 		return "", fmt.Errorf("failed to get account info for %s: %w", poolPDA.String(), err)
 	}
-	if resp == nil || resp.Value == nil {
+	if resp == nil || resp.Value == nil || resp.Value.Data == nil {
 		return "", fmt.Errorf("failed to get account info for: %s", poolPDA.String())
 	}
 	if resp.Value.Executable {

--- a/chains/solana/deployment/v1_6_0/sequences/tokens.go
+++ b/chains/solana/deployment/v1_6_0/sequences/tokens.go
@@ -985,7 +985,7 @@ func (a *SolanaAdapter) ResolveTokenPoolRef(b cldf_ops.Bundle, chains cldf_chain
 // (for qualifier) associated with the mint address. If the token ref can't be resolved or
 // if on-chain lookups fail, it returns an error. The qualifier is set to the token symbol
 // if it can be found on-chain, otherwise a sensible placeholder is used.
-func (a *SolanaAdapter) ResolveTokenRef(b cldf_ops.Bundle, chains cldf_chain.BlockChains, ds datastore.DataStore, chainSelector uint64, address string) (datastore.AddressRef, error) {
+func (a *SolanaAdapter) ResolveTokenRef(b cldf_ops.Bundle, chains cldf_chain.BlockChains, _ datastore.DataStore, chainSelector uint64, address string) (datastore.AddressRef, error) {
 	chain, ok := chains.SolanaChains()[chainSelector]
 	if !ok {
 		return datastore.AddressRef{}, fmt.Errorf("chain with selector %d not defined", chainSelector)

--- a/deployment/docs/implementing-adapters.md
+++ b/deployment/docs/implementing-adapters.md
@@ -173,7 +173,7 @@ Register a `TokenRefResolver` when callers may supply **partial** token or pool 
 
 **When to implement:** Same chain families that implement `TokenAdapter` and need address inference in changesets (token expansion with inferred refs, configure-for-transfers remote edges, rate limits with address-only pool refs).
 
-**Interface** ([tokens/product.go](../../tokens/product.go)):
+**Interface** ([tokens/product.go](../tokens/product.go)):
 
 ```go
 type TokenRefResolver interface {
@@ -204,7 +204,7 @@ So `TokenRefResolver` answers “what is the full `AddressRef` for this address?
 **Solana-specific notes:**
 
 - Pool refs in the datastore are usually the **token pool program ID**, not the per-mint config PDA. `DeployTokenPoolForToken` initializes state for a mint under an existing program; it does not deploy a new program per token.
-- `ResolveTokenPoolRef` may receive a **config PDA** in user input. The adapter resolves the program ID, re-loads the program ref from the datastore, and can set [`ArtificialAddressRefLabel`](../../tokens/product.go) (`ArtificialAddressRef:<pda>`) so a later `DeriveTokenAddress` can decode mint data from that PDA.
+- `ResolveTokenPoolRef` may receive a **config PDA** in user input. The adapter resolves the program ID, re-loads the program ref from the datastore, and can set [`ArtificialAddressRefLabel`](../tokens/product.go) (`ArtificialAddressRef:<pda>`) so a later `DeriveTokenAddress` can decode mint data from that PDA.
 - `DeriveTokenAddress` must reject **executable** accounts (program IDs) and only decode **pool config** account data.
 
 **EVM-specific notes:**

--- a/deployment/docs/implementing-adapters.md
+++ b/deployment/docs/implementing-adapters.md
@@ -153,7 +153,7 @@ func (a *MyChainAdapter) AddressRefToBytes(ref datastore.AddressRef) ([]byte, er
     // EVM: hex decoding, Solana: base58 decoding
 }
 
-func (a *MyChainAdapter) DeriveTokenAddress(e Environment, chainSelector uint64, poolRef datastore.AddressRef) ([]byte, error) {
+func (a *MyChainAdapter) DeriveTokenAddress(e Environment, chainSelector uint64, poolRef datastore.AddressRef) (string, error) {
     // Read the token address from the pool contract on-chain
 }
 

--- a/deployment/docs/implementing-adapters.md
+++ b/deployment/docs/implementing-adapters.md
@@ -167,6 +167,51 @@ func (a *MyChainAdapter) DeriveTokenPoolCounterpart(e Environment, chainSelector
 }
 ```
 
+#### TokenRefResolver (optional)
+
+Register a `TokenRefResolver` when callers may supply **partial** token or pool refs (address only, or qualifier/type without a datastore row yet). The shared helpers `ResolveTokenPoolRef`, `ResolveTokenRef`, and `ResolveAdapterAndRefs` in `deployment/tokens` call into this interface after a datastore miss.
+
+**When to implement:** Same chain families that implement `TokenAdapter` and need address inference in changesets (token expansion with inferred refs, configure-for-transfers remote edges, rate limits with address-only pool refs).
+
+**Interface** ([tokens/product.go](../../tokens/product.go)):
+
+```go
+type TokenRefResolver interface {
+    ResolveTokenPoolRef(b Bundle, chains BlockChains, ds DataStore, chainSelector uint64, address string) (AddressRef, error)
+    ResolveTokenRef(b Bundle, chains BlockChains, ds DataStore, chainSelector uint64, address string) (AddressRef, error)
+}
+```
+
+**Registration** (same `init()` as `RegisterTokenAdapter`; keyed by **chain family only**):
+
+```go
+tokensapi.GetTokenAdapterRegistry().RegisterTokenRefResolver(chain_selectors.FamilyMyChain, &MyChainAdapter{})
+```
+
+Often the same struct implements both `TokenAdapter` and `TokenRefResolver` (see EVM `EVMTokenBase`, Solana `SolanaAdapter`).
+
+**How it interacts with `DeriveTokenAddress`:**
+
+`ResolveAdapterAndRefs` (used by several token changesets) does the following:
+
+1. Resolve the pool ref (datastore → else `ResolveTokenPoolRef`).
+2. Load the versioned `TokenAdapter`.
+3. Call `DeriveTokenAddress` on the **resolved** pool ref (on-chain mint/token address when the pool stores it).
+4. If derivation fails, fall back to `ResolveTokenRef` on the user’s token ref.
+
+So `TokenRefResolver` answers “what is the full `AddressRef` for this address?” while `DeriveTokenAddress` answers “what token does this **already resolved** pool point at?” Implement both when your pools expose token addresses on-chain.
+
+**Solana-specific notes:**
+
+- Pool refs in the datastore are usually the **token pool program ID**, not the per-mint config PDA. `DeployTokenPoolForToken` initializes state for a mint under an existing program; it does not deploy a new program per token.
+- `ResolveTokenPoolRef` may receive a **config PDA** in user input. The adapter resolves the program ID, re-loads the program ref from the datastore, and can set [`ArtificialAddressRefLabel`](../../tokens/product.go) (`ArtificialAddressRef:<pda>`) so a later `DeriveTokenAddress` can decode mint data from that PDA.
+- `DeriveTokenAddress` must reject **executable** accounts (program IDs) and only decode **pool config** account data.
+
+**EVM-specific notes:**
+
+- `ResolveTokenPoolRef` / `ResolveTokenRef` use RPC (`typeAndVersion`, `getToken`, ERC20 `symbol`) to build refs that are not in the datastore yet.
+- Reconstructed refs are suitable for subsequent datastore lookups and for `DeriveTokenAddress` when the pool contract implements `getToken()`.
+
 #### AddressNormalizer (config and datastore addresses)
 
 Some changesets normalize user-supplied address strings before datastore lookups. That logic lives on **`deploy.AddressNormalizer`** in **`deployment/deploy`**, registered on **`deploy.GetAddressNormalizerRegistry()`** and keyed **only by chain family** (not by token adapter semver).
@@ -251,6 +296,7 @@ func init() {
     deployapi.GetTransferOwnershipRegistry().RegisterAdapter(chain_selectors.FamilyMyChain, v, &MyChainAdapter{})
     mcmsreaderapi.GetRegistry().RegisterMCMSReader(chain_selectors.FamilyMyChain, &MyChainAdapter{})
     tokensapi.GetTokenAdapterRegistry().RegisterTokenAdapter(chain_selectors.FamilyMyChain, v, &MyChainAdapter{})
+    tokensapi.GetTokenAdapterRegistry().RegisterTokenRefResolver(chain_selectors.FamilyMyChain, &MyChainAdapter{})
 }
 ```
 

--- a/deployment/docs/interfaces.md
+++ b/deployment/docs/interfaces.md
@@ -146,7 +146,7 @@ type TokenAdapter interface {
 
     // DeriveTokenAddress derives the token address from a token pool reference.
     // Used when the token address is stored on the pool contract.
-    DeriveTokenAddress(e Environment, chainSelector uint64, poolRef datastore.AddressRef) ([]byte, error)
+    DeriveTokenAddress(e Environment, chainSelector uint64, poolRef datastore.AddressRef) (string, error)
 
     // DeriveTokenDecimals derives the token's decimal count from a pool reference.
     DeriveTokenDecimals(e Environment, chainSelector uint64, poolRef datastore.AddressRef, token []byte) (uint8, error)

--- a/deployment/docs/interfaces.md
+++ b/deployment/docs/interfaces.md
@@ -34,6 +34,7 @@ These interfaces are optional depending on what the chain family supports:
 
 | Interface | Registry | Purpose | Source |
 |-----------|----------|---------|--------|
+| [TokenRefResolver](#tokenrefresolver) | `TokenAdapterRegistry` | Resolve token/pool refs from datastore or on-chain | [tokens/product.go](../tokens/product.go) |
 | [TokenPriceProvider](#tokenpriceprovider) | None (embedded) | Provide default fee token prices | [lanes/product.go](../lanes/product.go) |
 | [PingPongAdapter](#pingpongadapter) | `PingPongAdapterRegistry` | PingPong demo contract support | [lanes/pingpong.go](../lanes/pingpong.go) |
 | [ConfigImporter](#configimporter) | None | Import config from existing deployments | [deploy/product.go](../deploy/product.go) |
@@ -380,6 +381,56 @@ fastcurse.GetCurseRegistry().RegisterNewCurse(fastcurse.CurseRegistryInput{
 
 ## Optional Interfaces
 
+### TokenRefResolver
+
+Reconstructs `datastore.AddressRef` values for tokens and token pools when a changeset input only provides a partial ref (for example, an address string) or when the ref is not yet present in the environment datastore. Used by `ResolveTokenPoolRef`, `ResolveTokenRef`, and `ResolveAdapterAndRefs` in [tokens/token_expansion.go](../tokens/token_expansion.go).
+
+**Source:** [tokens/product.go](../tokens/product.go)
+**Registry:** `TokenAdapterRegistry` via `tokens.GetTokenAdapterRegistry()`
+**Key:** `chainFamily` only (version-agnostic — one resolver per chain family)
+
+```go
+type TokenRefResolver interface {
+    // ResolveTokenPoolRef reconstructs a token pool AddressRef from an on-chain address.
+    // Implementations typically read type/version (and related metadata) from chain state.
+    ResolveTokenPoolRef(b Bundle, chains BlockChains, ds DataStore, chainSelector uint64, address string) (AddressRef, error)
+
+    // ResolveTokenRef reconstructs a token AddressRef from an on-chain address (for example, a mint or ERC20).
+    ResolveTokenRef(b Bundle, chains BlockChains, ds DataStore, chainSelector uint64, address string) (AddressRef, error)
+}
+```
+
+**Registration** (alongside `RegisterTokenAdapter` in the same `init()`):
+
+```go
+tokensapi.GetTokenAdapterRegistry().RegisterTokenRefResolver(chain_selectors.FamilyEVM, &EVMTokenBase{})
+tokensapi.GetTokenAdapterRegistry().RegisterTokenRefResolver(chain_selectors.FamilySolana, &SolanaAdapter{})
+```
+
+First registration wins; a second `RegisterTokenRefResolver` for the same family is ignored.
+
+**Resolution order** (package helpers, not part of the interface):
+
+1. `TryNormalizeAddressRef` canonicalizes `ref.Address` when set (via `deploy.AddressNormalizer` for the chain family).
+2. Datastore lookup with `AddressRefToFilters` — exactly one match returns that row; zero matches fall through to the resolver; more than one match is an error.
+3. If no datastore row and `address` is set, `TokenRefResolver.ResolveTokenPoolRef` / `ResolveTokenRef` rebuild the ref from chain state.
+
+**`ResolveAdapterAndRefs`** (used by token expansion, configure-for-transfers, rate limits):
+
+1. `ResolveTokenPoolRef` → pick `TokenAdapter` from the resolved pool’s version.
+2. `DeriveTokenAddress` on the resolved pool ref when the token address is stored on the pool (preferred).
+3. If derivation fails, `ResolveTokenRef` on the input token ref (datastore, then resolver).
+
+**Semantics by chain family:**
+
+- **EVM:** Resolver reads pool `typeAndVersion` and token `symbol` via RPC. Reconstructed pool refs use the token address as `Qualifier` when `getToken()` succeeds.
+- **Solana:** `ResolveTokenPoolRef` accepts either the **pool program ID** or the **pool config PDA**. For a PDA, the adapter loads the program ID from chain state, looks up the program in the datastore, and may attach an [`ArtificialAddressRefLabel`](../tokens/product.go) label so `DeriveTokenAddress` can read the mint from that PDA. `ResolveTokenRef` reads the mint’s token program and symbol (or a `{mint}-{programType}` placeholder qualifier).
+- **`ArtificialAddressRefLabel`:** Optional label format `ArtificialAddressRef:<poolPDA>` on pool refs. Not required for all adapters; Solana uses it when resolving from a config PDA.
+
+Implement `TokenRefResolver` on the same struct as `TokenAdapter` when the family should support address-only inputs (EVM and Solana in this repo register both on one adapter type).
+
+---
+
 ### TokenPriceProvider
 
 An optional interface that `LaneAdapter` implementations can also satisfy to provide default fee token prices. Primarily used by EVM chains.
@@ -548,7 +599,7 @@ type TestAdapterFactory = func(env *Environment, selector uint64) TestAdapter
 | `TransferOwnershipAdapterRegistry` | `deploy.GetTransferOwnershipRegistry()` | `chainFamily-version` |
 | `LaneAdapterRegistry` | `lanes.GetLaneAdapterRegistry()` | `chainFamily-version` |
 | `PingPongAdapterRegistry` | `lanes.GetPingPongAdapterRegistry()` | `chainFamily-version` |
-| `TokenAdapterRegistry` | `tokens.GetTokenAdapterRegistry()` | `chainFamily-version` |
+| `TokenAdapterRegistry` | `tokens.GetTokenAdapterRegistry()` | `chainFamily-version` (adapters); `chainFamily` (`TokenRefResolver`) |
 | `FeeAdapterRegistry` | `fees.GetRegistry()` | `chainFamily-version` |
 | `FeeAggregatorAdapterRegistry` | `fees.GetFeeAggregatorRegistry()` | `chainFamily-version` |
 | `MCMSReaderRegistry` | `changesets.GetRegistry()` | `chainFamily` |

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -238,6 +238,7 @@ func convertRemoteChainConfig(
 		derivedTokenAddr, deriveErr := remoteAdapter.DeriveTokenAddress(e, remoteChainSelector, fullRemotePoolRef)
 		switch {
 		case deriveErr == nil:
+			e.Logger.Infof("Successfully derived remote token address %s for remote chain selector %d from remote pool ref %s", derivedTokenAddr, remoteChainSelector, datastore_utils.SprintRef(*inCfg.RemotePool))
 			resolvedRef, err := ResolveTokenRef(e, tokenAdapterRegistry, remoteChainSelector, datastore.AddressRef{ChainSelector: remoteChainSelector, Address: derivedTokenAddr})
 			if err != nil {
 				return outCfg, fmt.Errorf("failed to resolve remote token after derivation %s: %w", derivedTokenAddr, err)
@@ -247,6 +248,7 @@ func convertRemoteChainConfig(
 				return outCfg, fmt.Errorf("failed to convert resolved remote token to bytes %s: %w", derivedTokenAddr, err)
 			}
 		case inCfg.RemoteToken != nil:
+			e.Logger.Infof("Derivation of remote token address failed for remote chain selector %d (%s). Falling back to resolving remote token from provided token ref %s", remoteChainSelector, deriveErr.Error(), datastore_utils.SprintRef(*inCfg.RemoteToken))
 			resolvedRef, err := ResolveTokenRef(e, tokenAdapterRegistry, remoteChainSelector, *inCfg.RemoteToken)
 			if err != nil {
 				return outCfg, fmt.Errorf("failed to resolve remote token ref %s: %w", datastore_utils.SprintRef(*inCfg.RemoteToken), err)
@@ -256,7 +258,7 @@ func convertRemoteChainConfig(
 				return outCfg, fmt.Errorf("failed to convert remote token ref %s to bytes: %w", datastore_utils.SprintRef(*inCfg.RemoteToken), err)
 			}
 		default:
-			return outCfg, fmt.Errorf("failed to derive remote token address and no remote token ref provided for remote chain selector %d", remoteChainSelector)
+			return outCfg, fmt.Errorf("failed to derive remote token address and no remote token ref provided for remote chain selector %d: %w", remoteChainSelector, deriveErr)
 		}
 
 		outCfg.RemoteToken = common.LeftPadBytes(outCfg.RemoteToken, 32)

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -238,7 +238,7 @@ func convertRemoteChainConfig(
 		derivedTokenAddr, deriveErr := remoteAdapter.DeriveTokenAddress(e, remoteChainSelector, fullRemotePoolRef)
 		switch {
 		case deriveErr == nil:
-			e.Logger.Infof("Successfully derived remote token address %s for remote chain selector %d from remote pool ref %s", derivedTokenAddr, remoteChainSelector, datastore_utils.SprintRef(*inCfg.RemotePool))
+			e.Logger.Infof("Successfully derived remote token address %s for remote chain selector %d from remote pool ref %s", derivedTokenAddr, remoteChainSelector, datastore_utils.SprintRef(fullRemotePoolRef))
 			resolvedRef, err := ResolveTokenRef(e, tokenAdapterRegistry, remoteChainSelector, datastore.AddressRef{ChainSelector: remoteChainSelector, Address: derivedTokenAddr})
 			if err != nil {
 				return outCfg, fmt.Errorf("failed to resolve remote token after derivation %s: %w", derivedTokenAddr, err)

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
 
-	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -97,24 +95,11 @@ func processTokenConfigForChain(e deployment.Environment, mcmsRegistry *changese
 
 	var err error
 	for selector, token := range cfg {
-		token.TokenPoolRef, err = TryNormalizeAddressRef(selector, token.TokenPoolRef)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to normalize token pool ref address for chain selector %d: %w", selector, err)
-		}
-		token.TokenRef, err = TryNormalizeAddressRef(selector, token.TokenRef)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to normalize token ref address for chain selector %d: %w", selector, err)
-		}
 		token.RegistryRef, err = TryNormalizeAddressRef(selector, token.RegistryRef)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to normalize registry ref address for chain selector %d: %w", selector, err)
 		}
 		cfg[selector] = token
-
-		tokenPool, err := datastore_utils.FindAndFormatRef(e.DataStore, token.TokenPoolRef, selector, datastore_utils.FullRef)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to resolve token pool ref on chain with selector %d: %w", selector, err)
-		}
 
 		var registryAddr string
 		if datastore_utils.IsAddressRefEmpty(token.RegistryRef) {
@@ -127,9 +112,9 @@ func processTokenConfigForChain(e deployment.Environment, mcmsRegistry *changese
 			}
 		}
 
-		adapter, family, err := ResolveAdapter(tokenRegistry, selector, tokenPool.Version)
+		adapter, family, tokenPool, fullTokenRef, err := ResolveAdapterAndRefs(e, tokenRegistry, selector, token.TokenPoolRef, token.TokenRef)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to resolve adapter for chain selector %d: %w", selector, err)
+			return nil, nil, nil, fmt.Errorf("failed to resolve adapter and refs for chain selector %d: %w", selector, err)
 		}
 
 		remoteChains := make(map[uint64]RemoteChainConfig[[]byte, string], len(token.RemoteChains))
@@ -175,7 +160,7 @@ func processTokenConfigForChain(e deployment.Environment, mcmsRegistry *changese
 			RemoteChains:                  remoteChains,
 			ExternalAdmin:                 token.ExternalAdmin,
 			RegistryAddress:               registryAddr,
-			TokenRef:                      token.TokenRef,
+			TokenRef:                      fullTokenRef,
 			PoolType:                      tokenPool.Type.String(),
 			ExistingDataStore:             e.DataStore,
 			AllowedFinalityConfig:         token.AllowedFinalityConfig,
@@ -234,11 +219,7 @@ func convertRemoteChainConfig(
 	}
 
 	if inCfg.RemotePool != nil {
-		remotePoolRef, err := TryNormalizeAddressRef(remoteChainSelector, *inCfg.RemotePool)
-		if err != nil {
-			return outCfg, fmt.Errorf("failed to normalize remote pool ref address for remote chain selector %d: %w", remoteChainSelector, err)
-		}
-		fullRemotePoolRef, err := datastore_utils.FindAndFormatRef(e.DataStore, remotePoolRef, remoteChainSelector, datastore_utils.FullRef)
+		fullRemotePoolRef, err := ResolveTokenPoolRef(e, tokenAdapterRegistry, remoteChainSelector, *inCfg.RemotePool)
 		if err != nil {
 			return outCfg, fmt.Errorf("failed to resolve remote pool ref %s: %w", datastore_utils.SprintRef(*inCfg.RemotePool), err)
 		}
@@ -250,26 +231,34 @@ func convertRemoteChainConfig(
 		if err != nil {
 			return outCfg, fmt.Errorf("failed to convert remote pool ref %s to bytes: %w", datastore_utils.SprintRef(*inCfg.RemotePool), err)
 		}
-		// Can either provide the token reference directly or derive it from the pool reference.
-		if inCfg.RemoteToken != nil {
-			remoteTokenRef, normErr := TryNormalizeAddressRef(remoteChainSelector, *inCfg.RemoteToken)
-			if normErr != nil {
-				return outCfg, fmt.Errorf("failed to normalize remote token ref address for remote chain selector %d: %w", remoteChainSelector, normErr)
-			}
-			outCfg.RemoteToken, err = datastore_utils.FindAndFormatRef(e.DataStore, remoteTokenRef, remoteChainSelector, remoteAdapter.AddressRefToBytes)
+
+		// If DeriveTokenAddress succeeds, then this has higher precedence than the token ref provided in the input since it is
+		// derived from on chain data (and hence more reliable). If it fails, then we fall back to using the token ref provided
+		// in the input and try to resolve it from the datastore first (to avoid RPC calls) then fall back to on chain data.
+		derivedTokenAddr, deriveErr := remoteAdapter.DeriveTokenAddress(e, remoteChainSelector, fullRemotePoolRef)
+		switch {
+		case deriveErr == nil:
+			resolvedRef, err := ResolveTokenRef(e, tokenAdapterRegistry, remoteChainSelector, datastore.AddressRef{ChainSelector: remoteChainSelector, Address: derivedTokenAddr})
 			if err != nil {
-				e.Logger.Warnf("failed to resolve remote token ref %s: %v. Will attempt to derive remote token address from pool reference", datastore_utils.SprintRef(*inCfg.RemoteToken), err)
-				outCfg.RemoteToken, err = remoteAdapter.DeriveTokenAddress(e, remoteChainSelector, fullRemotePoolRef)
-				if err != nil {
-					return outCfg, fmt.Errorf("failed to resolve remote token ref via pool ref (%s) for remote chain selector %d: %w", datastore_utils.SprintRef(*inCfg.RemotePool), remoteChainSelector, err)
-				}
+				return outCfg, fmt.Errorf("failed to resolve remote token after derivation %s: %w", derivedTokenAddr, err)
 			}
-		} else {
-			outCfg.RemoteToken, err = remoteAdapter.DeriveTokenAddress(e, remoteChainSelector, fullRemotePoolRef)
+			outCfg.RemoteToken, err = remoteAdapter.AddressRefToBytes(resolvedRef)
 			if err != nil {
-				return outCfg, fmt.Errorf("failed to get remote token address via pool ref (%s) for remote chain selector %d: %w", datastore_utils.SprintRef(*inCfg.RemotePool), remoteChainSelector, err)
+				return outCfg, fmt.Errorf("failed to convert resolved remote token to bytes %s: %w", derivedTokenAddr, err)
 			}
+		case inCfg.RemoteToken != nil:
+			resolvedRef, err := ResolveTokenRef(e, tokenAdapterRegistry, remoteChainSelector, *inCfg.RemoteToken)
+			if err != nil {
+				return outCfg, fmt.Errorf("failed to resolve remote token ref %s: %w", datastore_utils.SprintRef(*inCfg.RemoteToken), err)
+			}
+			outCfg.RemoteToken, err = remoteAdapter.AddressRefToBytes(resolvedRef)
+			if err != nil {
+				return outCfg, fmt.Errorf("failed to convert remote token ref %s to bytes: %w", datastore_utils.SprintRef(*inCfg.RemoteToken), err)
+			}
+		default:
+			return outCfg, fmt.Errorf("failed to derive remote token address and no remote token ref provided for remote chain selector %d", remoteChainSelector)
 		}
+
 		outCfg.RemoteToken = common.LeftPadBytes(outCfg.RemoteToken, 32)
 		outCfg.RemoteDecimals, err = remoteAdapter.DeriveTokenDecimals(e, remoteChainSelector, fullRemotePoolRef, outCfg.RemoteToken)
 		if err != nil {
@@ -325,17 +314,4 @@ func convertRemoteChainConfig(
 		outCfg.InboundCCVsToAddAboveThreshold = append(outCfg.InboundCCVsToAddAboveThreshold, fullCCVRef.Address)
 	}
 	return outCfg, nil
-}
-
-func ResolveAdapter(registry *TokenAdapterRegistry, selector uint64, tokenPoolVersion *semver.Version) (TokenAdapter, string, error) {
-	family, err := chain_selectors.GetSelectorFamily(selector)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to get chain family for remote chain selector %d: %w", selector, err)
-	}
-	adapter, ok := registry.GetTokenAdapter(family, tokenPoolVersion)
-	if !ok {
-		return nil, "", fmt.Errorf("no token adapter registered for chain family '%s' and version '%s'", family, tokenPoolVersion.String())
-	}
-
-	return adapter, family, nil
 }

--- a/deployment/tokens/configure_tokens_for_transfers_test.go
+++ b/deployment/tokens/configure_tokens_for_transfers_test.go
@@ -111,16 +111,16 @@ func (ma *transfersTest_MockTokenAdapter) ConfigureTokenForTransfersSequence() *
 	)
 }
 
-func (ma *transfersTest_MockTokenAdapter) DeriveTokenAddress(e deployment.Environment, chainSelector uint64, poolRef datastore.AddressRef) ([]byte, error) {
+func (ma *transfersTest_MockTokenAdapter) DeriveTokenAddress(e deployment.Environment, chainSelector uint64, poolRef datastore.AddressRef) (string, error) {
 	if poolRef.Address == "" {
 		// Address in pool ref MUST be populated before this adapter method gets called.
 		// Most implementations will require the pool address in order to fetch the token address.
-		return nil, errors.New("pool ref address is empty")
+		return "", errors.New("pool ref address is empty")
 	}
 	if ma.deriveTokenErrorMsg != "" {
-		return nil, errors.New(ma.deriveTokenErrorMsg)
+		return "", errors.New(ma.deriveTokenErrorMsg)
 	}
-	return []byte("mocked-remote-token-address"), nil
+	return "0x1111111111111111111111111111111111111111", nil
 }
 
 func (ma *transfersTest_MockTokenAdapter) DeriveTokenDecimals(e deployment.Environment, chainSelector uint64, poolRef datastore.AddressRef, token []byte) (uint8, error) {

--- a/deployment/tokens/configure_tokens_for_transfers_test.go
+++ b/deployment/tokens/configure_tokens_for_transfers_test.go
@@ -54,8 +54,9 @@ func (m *MockReader) GetMCMSRef(_ deployment.Environment, selector uint64, _ mcm
 var transfersTest_NewTokenAdapterRegistry = tokens.GetTokenAdapterRegistry()
 
 type transfersTest_MockTokenAdapter struct {
-	deriveTokenErrorMsg string
-	sequenceErrorMsg    string
+	deriveTokenErrorMsg  string
+	sequenceErrorMsg     string
+	deriveFailQualifiers map[string]struct{}
 }
 
 func (ma *transfersTest_MockTokenAdapter) AddressRefToBytes(ref datastore.AddressRef) ([]byte, error) {
@@ -111,15 +112,40 @@ func (ma *transfersTest_MockTokenAdapter) ConfigureTokenForTransfersSequence() *
 	)
 }
 
+func (r *transfersTest_MockTokenAdapter) ResolveTokenPoolRef(_ cldf_ops.Bundle, _ cldf_chain.BlockChains, _ datastore.DataStore, _ uint64, _ string) (datastore.AddressRef, error) {
+	return datastore.AddressRef{}, errors.New("unexpected pool resolve in transfers test")
+}
+
+func (r *transfersTest_MockTokenAdapter) ResolveTokenRef(_ cldf_ops.Bundle, _ cldf_chain.BlockChains, _ datastore.DataStore, chainSelector uint64, address string) (datastore.AddressRef, error) {
+	const derived = "0x1111111111111111111111111111111111111111"
+
+	if address == derived {
+		return datastore.AddressRef{
+			ChainSelector: chainSelector,
+			Address:       address,
+			Type:          datastore.ContractType("Token"),
+			Version:       semver.MustParse("1.0.0"),
+		}, nil
+	}
+
+	return datastore.AddressRef{}, fmt.Errorf("unexpected address: %s", address)
+}
+
 func (ma *transfersTest_MockTokenAdapter) DeriveTokenAddress(e deployment.Environment, chainSelector uint64, poolRef datastore.AddressRef) (string, error) {
-	if poolRef.Address == "" {
-		// Address in pool ref MUST be populated before this adapter method gets called.
-		// Most implementations will require the pool address in order to fetch the token address.
-		return "", errors.New("pool ref address is empty")
+	if len(ma.deriveFailQualifiers) > 0 {
+		if _, blocked := ma.deriveFailQualifiers[poolRef.Qualifier]; blocked {
+			msg := ma.deriveTokenErrorMsg
+			if msg == "" {
+				msg = "failed to derive remote token address"
+			}
+			return "", errors.New(msg)
+		}
+		return "0x1111111111111111111111111111111111111111", nil
 	}
 	if ma.deriveTokenErrorMsg != "" {
 		return "", errors.New(ma.deriveTokenErrorMsg)
 	}
+
 	return "0x1111111111111111111111111111111111111111", nil
 }
 
@@ -175,6 +201,7 @@ func makeBaseDataStore(t *testing.T, chains []uint64) *datastore.MemoryDataStore
 			Address:       fmt.Sprintf("%d-token-pool", chain),
 			Type:          datastore.ContractType("TokenPool"),
 			Version:       semver.MustParse("1.0.0"),
+			Qualifier:     "default",
 		})
 		require.NoError(t, err)
 		ds.Addresses().Add(datastore.AddressRef{
@@ -209,6 +236,28 @@ func makeBaseDataStore(t *testing.T, chains []uint64) *datastore.MemoryDataStore
 	return ds
 }
 
+// makeTwoChainDSWithRemoteEdgePools is like makeBaseDataStore for the two standard test chains but adds
+// a second TokenPool per chain (Address "%d-remote-token-pool", Qualifier "remote-edge").
+func makeTwoChainDSWithRemoteEdgePools(t *testing.T) *datastore.MemoryDataStore {
+	t.Helper()
+	const (
+		chainA = 5009297550715157269
+		chainB = 15971525489660198786
+	)
+	ds := makeBaseDataStore(t, []uint64{chainA, chainB})
+	for _, chain := range []uint64{chainA, chainB} {
+		err := ds.Addresses().Add(datastore.AddressRef{
+			ChainSelector: chain,
+			Address:       fmt.Sprintf("%d-remote-token-pool", chain),
+			Type:          datastore.ContractType("TokenPool"),
+			Version:       semver.MustParse("1.0.0"),
+			Qualifier:     "remote-edge",
+		})
+		require.NoError(t, err)
+	}
+	return ds
+}
+
 func TestConfigureTokensForTransfers_Apply(t *testing.T) {
 	tests := []struct {
 		desc                            string
@@ -217,11 +266,12 @@ func TestConfigureTokensForTransfers_Apply(t *testing.T) {
 		shouldDeriveToken               bool
 		expectedSequenceErrorMsg        string
 		expectedTokenDerivationErrorMsg string
+		tokenPoolDeriveFailQualifiers   map[string]struct{}
 	}{
 		{
 			desc: "success - inputted remote token",
 			makeDataStore: func(t *testing.T) *datastore.MemoryDataStore {
-				return makeBaseDataStore(t, []uint64{5009297550715157269, 15971525489660198786})
+				return makeTwoChainDSWithRemoteEdgePools(t)
 			},
 			cfg: tokens.ConfigureTokensForTransfersConfig{
 				Tokens: []tokens.TokenTransferConfig{
@@ -231,6 +281,7 @@ func TestConfigureTokensForTransfers_Apply(t *testing.T) {
 							Type:          "TokenPool",
 							Version:       semver.MustParse("1.0.0"),
 							ChainSelector: 5009297550715157269,
+							Qualifier:     "default",
 						},
 						RegistryRef: datastore.AddressRef{
 							Type:          "Registry",
@@ -248,6 +299,8 @@ func TestConfigureTokensForTransfers_Apply(t *testing.T) {
 									Type:          "TokenPool",
 									Version:       semver.MustParse("1.0.0"),
 									ChainSelector: 15971525489660198786,
+									Address:       "15971525489660198786-remote-token-pool",
+									Qualifier:     "remote-edge",
 								},
 								OutboundRateLimiterConfig: &tokens.RateLimiterConfigFloatInput{
 									IsEnabled: true,
@@ -263,6 +316,7 @@ func TestConfigureTokensForTransfers_Apply(t *testing.T) {
 							Type:          "TokenPool",
 							Version:       semver.MustParse("1.0.0"),
 							ChainSelector: 15971525489660198786,
+							Qualifier:     "default",
 						},
 						RegistryRef: datastore.AddressRef{
 							Type:          "Registry",
@@ -280,6 +334,8 @@ func TestConfigureTokensForTransfers_Apply(t *testing.T) {
 									Type:          "TokenPool",
 									Version:       semver.MustParse("1.0.0"),
 									ChainSelector: 5009297550715157269,
+									Address:       "5009297550715157269-remote-token-pool",
+									Qualifier:     "remote-edge",
 								},
 								OutboundRateLimiterConfig: &tokens.RateLimiterConfigFloatInput{
 									IsEnabled: true,
@@ -292,6 +348,7 @@ func TestConfigureTokensForTransfers_Apply(t *testing.T) {
 				},
 				MCMS: basicMCMSInput,
 			},
+			tokenPoolDeriveFailQualifiers: map[string]struct{}{"remote-edge": {}},
 		},
 		{
 			desc: "success - derived remote token",
@@ -595,12 +652,12 @@ func TestConfigureTokensForTransfers_Apply(t *testing.T) {
 				},
 				MCMS: basicMCMSInput,
 			},
-			expectedSequenceErrorMsg: "failed to resolve remote token ref",
+			expectedSequenceErrorMsg: "failed to resolve remote token after derivation",
 		},
 		{
 			desc: "failure to derive remote token address",
 			makeDataStore: func(t *testing.T) *datastore.MemoryDataStore {
-				return makeBaseDataStore(t, []uint64{5009297550715157269, 15971525489660198786})
+				return makeTwoChainDSWithRemoteEdgePools(t)
 			},
 			cfg: tokens.ConfigureTokensForTransfersConfig{
 				Tokens: []tokens.TokenTransferConfig{
@@ -610,6 +667,7 @@ func TestConfigureTokensForTransfers_Apply(t *testing.T) {
 							Type:          "TokenPool",
 							Version:       semver.MustParse("1.0.0"),
 							ChainSelector: 5009297550715157269,
+							Qualifier:     "default",
 						},
 						RegistryRef: datastore.AddressRef{
 							Type:          "Registry",
@@ -623,6 +681,8 @@ func TestConfigureTokensForTransfers_Apply(t *testing.T) {
 									Type:          "TokenPool",
 									Version:       semver.MustParse("1.0.0"),
 									ChainSelector: 15971525489660198786,
+									Address:       "15971525489660198786-remote-token-pool",
+									Qualifier:     "remote-edge",
 								},
 								OutboundRateLimiterConfig: &tokens.RateLimiterConfigFloatInput{IsEnabled: false},
 							},
@@ -634,6 +694,7 @@ func TestConfigureTokensForTransfers_Apply(t *testing.T) {
 							Type:          "TokenPool",
 							Version:       semver.MustParse("1.0.0"),
 							ChainSelector: 15971525489660198786,
+							Qualifier:     "default",
 						},
 						RegistryRef: datastore.AddressRef{
 							Type:          "Registry",
@@ -647,6 +708,8 @@ func TestConfigureTokensForTransfers_Apply(t *testing.T) {
 									Type:          "TokenPool",
 									Version:       semver.MustParse("1.0.0"),
 									ChainSelector: 5009297550715157269,
+									Address:       "5009297550715157269-remote-token-pool",
+									Qualifier:     "remote-edge",
 								},
 								OutboundRateLimiterConfig: &tokens.RateLimiterConfigFloatInput{IsEnabled: false},
 							},
@@ -656,6 +719,7 @@ func TestConfigureTokensForTransfers_Apply(t *testing.T) {
 				MCMS: basicMCMSInput,
 			},
 			expectedTokenDerivationErrorMsg: "failed to derive remote token address",
+			tokenPoolDeriveFailQualifiers:   map[string]struct{}{"remote-edge": {}},
 		},
 		{
 			desc: "failure to execute sequence",
@@ -732,6 +796,7 @@ func TestConfigureTokensForTransfers_Apply(t *testing.T) {
 	tokenAdapterRegistry := tokens.GetTokenAdapterRegistry()
 	mockAdapter := &transfersTest_MockTokenAdapter{}
 	tokenAdapterRegistry.RegisterTokenAdapter("evm", semver.MustParse("1.0.0"), mockAdapter)
+	tokenAdapterRegistry.RegisterTokenRefResolver("evm", mockAdapter)
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
@@ -740,6 +805,7 @@ func TestConfigureTokensForTransfers_Apply(t *testing.T) {
 			// Set error conditions for specific test cases
 			mockAdapter.deriveTokenErrorMsg = tt.expectedTokenDerivationErrorMsg
 			mockAdapter.sequenceErrorMsg = tt.expectedSequenceErrorMsg
+			mockAdapter.deriveFailQualifiers = tt.tokenPoolDeriveFailQualifiers
 
 			// Create environment with datastore
 			ds := tt.makeDataStore(t)
@@ -782,11 +848,15 @@ func TestConfigureTokensForTransfers_Apply(t *testing.T) {
 				for _, op := range proposal.Operations {
 					// For derived remote token test, expect mocked address
 					if tt.shouldDeriveToken {
-						require.Equal(t, common.LeftPadBytes([]byte("mocked-remote-token-address"), 32), op.Transactions[0].Data)
+						require.Equal(t, []byte("0x1111111111111111111111111111111111111111"), op.Transactions[0].Data)
 					} else {
 						require.Equal(t, common.LeftPadBytes([]byte(fmt.Sprintf("%d-token", op.ChainSelector)), 32), op.Transactions[0].Data)
 					}
-					require.Equal(t, fmt.Sprintf("%d-token-pool", op.ChainSelector), op.Transactions[0].To)
+					if len(tt.tokenPoolDeriveFailQualifiers) > 0 {
+						require.Equal(t, fmt.Sprintf("%d-remote-token-pool", op.ChainSelector), op.Transactions[0].To)
+					} else {
+						require.Equal(t, fmt.Sprintf("%d-token-pool", op.ChainSelector), op.Transactions[0].To)
+					}
 				}
 			}
 		})

--- a/deployment/tokens/configure_tokens_for_transfers_test.go
+++ b/deployment/tokens/configure_tokens_for_transfers_test.go
@@ -117,7 +117,7 @@ func (r *transfersTest_MockTokenAdapter) ResolveTokenPoolRef(_ cldf_ops.Bundle, 
 }
 
 func (r *transfersTest_MockTokenAdapter) ResolveTokenRef(_ cldf_ops.Bundle, _ cldf_chain.BlockChains, _ datastore.DataStore, chainSelector uint64, address string) (datastore.AddressRef, error) {
-	const derived = "0x1111111111111111111111111111111111111111"
+	const derived = "mocked-remote-token-address"
 
 	if address == derived {
 		return datastore.AddressRef{
@@ -132,6 +132,8 @@ func (r *transfersTest_MockTokenAdapter) ResolveTokenRef(_ cldf_ops.Bundle, _ cl
 }
 
 func (ma *transfersTest_MockTokenAdapter) DeriveTokenAddress(e deployment.Environment, chainSelector uint64, poolRef datastore.AddressRef) (string, error) {
+	const derived = "mocked-remote-token-address"
+
 	if len(ma.deriveFailQualifiers) > 0 {
 		if _, blocked := ma.deriveFailQualifiers[poolRef.Qualifier]; blocked {
 			msg := ma.deriveTokenErrorMsg
@@ -140,13 +142,13 @@ func (ma *transfersTest_MockTokenAdapter) DeriveTokenAddress(e deployment.Enviro
 			}
 			return "", errors.New(msg)
 		}
-		return "0x1111111111111111111111111111111111111111", nil
+		return derived, nil
 	}
 	if ma.deriveTokenErrorMsg != "" {
 		return "", errors.New(ma.deriveTokenErrorMsg)
 	}
 
-	return "0x1111111111111111111111111111111111111111", nil
+	return derived, nil
 }
 
 func (ma *transfersTest_MockTokenAdapter) DeriveTokenDecimals(e deployment.Environment, chainSelector uint64, poolRef datastore.AddressRef, token []byte) (uint8, error) {
@@ -848,7 +850,7 @@ func TestConfigureTokensForTransfers_Apply(t *testing.T) {
 				for _, op := range proposal.Operations {
 					// For derived remote token test, expect mocked address
 					if tt.shouldDeriveToken {
-						require.Equal(t, []byte("0x1111111111111111111111111111111111111111"), op.Transactions[0].Data)
+						require.Equal(t, common.LeftPadBytes([]byte("mocked-remote-token-address"), 32), op.Transactions[0].Data)
 					} else {
 						require.Equal(t, common.LeftPadBytes([]byte(fmt.Sprintf("%d-token", op.ChainSelector)), 32), op.Transactions[0].Data)
 					}

--- a/deployment/tokens/manual_registration.go
+++ b/deployment/tokens/manual_registration.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gagliardetto/solana-go"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
-	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -108,17 +107,8 @@ func manualRegistrationApply() func(cldf.Environment, ManualRegistrationInput) (
 				return cldf.ChangesetOutput{}, fmt.Errorf("chain selector mismatch in TokenRef for registration index %d: expected %d, got %d", i, registration.ChainSelector, registration.TokenRef.ChainSelector)
 			}
 
-			registration.TokenPoolRef, err = TryNormalizeAddressRef(registration.ChainSelector, registration.TokenPoolRef)
-			if err != nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("failed to normalize token pool ref for registration index %d: %w", i, err)
-			}
-			registration.TokenRef, err = TryNormalizeAddressRef(registration.ChainSelector, registration.TokenRef)
-			if err != nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("failed to normalize token ref for registration index %d: %w", i, err)
-			}
-
 			var adapterVersion *semver.Version
-			fullPool, findErr := datastore_utils.FindAndFormatRef(ds.Seal(), registration.TokenPoolRef, registration.ChainSelector, datastore_utils.FullRef)
+			fullPool, findErr := ResolveTokenPoolRef(e, tokenPoolRegistry, registration.ChainSelector, registration.TokenPoolRef)
 			if findErr == nil {
 				adapterVersion = fullPool.Version
 			}

--- a/deployment/tokens/manual_registration.go
+++ b/deployment/tokens/manual_registration.go
@@ -148,6 +148,9 @@ func manualRegistrationApply() func(cldf.Environment, ManualRegistrationInput) (
 					return cldf.ChangesetOutput{}, fmt.Errorf("failed to add address ref (%+v) from report output to datastore for registration index %d, address index %d: %w", addrRef, i, j, err)
 				}
 			}
+
+			// update environment datastore with new addresses for next iteration to use
+			e.DataStore = ds.Seal()
 		}
 
 		return changesets.NewOutputBuilder(e, mcmsRegistry).

--- a/deployment/tokens/migrate_lock_release_pool_liquidity.go
+++ b/deployment/tokens/migrate_lock_release_pool_liquidity.go
@@ -66,20 +66,11 @@ func makeMigrationApply(_ *TokenAdapterRegistry, mcmsRegistry *changesets.MCMSRe
 				return cldf.ChangesetOutput{}, fmt.Errorf("migration[%d]: failed to get chain family for selector %d: %w", i, migration.ChainSelector, err)
 			}
 
-			oldRef, err := TryNormalizeAddressRef(migration.ChainSelector, migration.OldPoolRef)
-			if err != nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("migration[%d]: failed to normalize old pool ref address: %w", i, err)
-			}
-			newRef, err := TryNormalizeAddressRef(migration.ChainSelector, migration.NewPoolRef)
-			if err != nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("migration[%d]: failed to normalize new pool ref address: %w", i, err)
-			}
-
-			oldPoolRef, err := datastore_utils.FindAndFormatRef(e.DataStore, oldRef, migration.ChainSelector, datastore_utils.FullRef)
+			oldPoolRef, err := ResolveTokenPoolRef(e, tokenRegistry, migration.ChainSelector, migration.OldPoolRef)
 			if err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("migration[%d]: failed to resolve old pool ref: %w", i, err)
 			}
-			newPoolRef, err := datastore_utils.FindAndFormatRef(e.DataStore, newRef, migration.ChainSelector, datastore_utils.FullRef)
+			newPoolRef, err := ResolveTokenPoolRef(e, tokenRegistry, migration.ChainSelector, migration.NewPoolRef)
 			if err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("migration[%d]: failed to resolve new pool ref: %w", i, err)
 			}
@@ -110,15 +101,11 @@ func makeMigrationApply(_ *TokenAdapterRegistry, mcmsRegistry *changesets.MCMSRe
 				if err != nil {
 					return cldf.ChangesetOutput{}, fmt.Errorf("migration[%d]: failed to normalize registry ref address: %w", i, err)
 				}
-				tokRef, err := TryNormalizeAddressRef(migration.ChainSelector, *migration.TokenRef)
-				if err != nil {
-					return cldf.ChangesetOutput{}, fmt.Errorf("migration[%d]: failed to normalize token ref address for setPool: %w", i, err)
-				}
 				registryRef, err := datastore_utils.FindAndFormatRef(e.DataStore, regRef, migration.ChainSelector, datastore_utils.FullRef)
 				if err != nil {
 					return cldf.ChangesetOutput{}, fmt.Errorf("migration[%d]: failed to resolve registry ref: %w", i, err)
 				}
-				tokenRef, err := datastore_utils.FindAndFormatRef(e.DataStore, tokRef, migration.ChainSelector, datastore_utils.FullRef)
+				tokenRef, err := ResolveTokenRef(e, tokenRegistry, migration.ChainSelector, *migration.TokenRef)
 				if err != nil {
 					return cldf.ChangesetOutput{}, fmt.Errorf("migration[%d]: failed to resolve token ref: %w", i, err)
 				}

--- a/deployment/tokens/product.go
+++ b/deployment/tokens/product.go
@@ -19,8 +19,9 @@ import (
 
 // ArtificialAddressRefLabel is a special label that can be used by adapters that implement
 // TokenRefResolver. Adapters can add this label to reconstructed `AddressRefs` to indicate
-// that the ref is artifical. It is not required to use this label - if there is no need to
-// mark these types of AddressRefs in adapter logic, then this label can be ignored.
+// that the ref is artificial. It's not required to use this label - if there is no need to
+// distinguish between artificial AddressRefs and datastore AddressRefs in the adapter then
+// this label can be ignored.
 const ArtificialAddressRefLabel = "ArtificialAddressRef"
 
 type tokenAdapterID string

--- a/deployment/tokens/product.go
+++ b/deployment/tokens/product.go
@@ -17,6 +17,12 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
 )
 
+// ArtificialAddressRefLabel is a special label used by adapters that implement TokenRefResolver.
+// It allows adapters to mark reconstructed AddressRefs. The use of this is optional: if there is
+// no need to distinguish between these two types of AddressRefs in adapter logic, then feel free
+// to ignore this label.
+const ArtificialAddressRefLabel = "ArtificialAddressRef"
+
 type tokenAdapterID string
 
 // TokenFeeAdapter is an optional interface that can be implemented by TokenAdapters to support setting token transfer fee configurations.
@@ -25,6 +31,14 @@ type TokenFeeAdapter interface {
 	SetTokenTransferFee(e *deployment.Environment) *cldf_ops.Sequence[SetTokenTransferFeeSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains]
 	GetOnchainTokenTransferFeeConfig(e deployment.Environment, poolAddress string, src uint64, dst uint64) (TokenTransferFeeConfig, error)
 	GetDefaultTokenTransferFeeConfig(src uint64, dst uint64) TokenTransferFeeConfig
+}
+
+// TokenRefResolver is an optional interface that can be implemented by TokenAdapters. It acts as a form of middleware that allows token
+// and pool references to be resolved in a particular way before they are passed into the adapter logic. For example, a ref resolver can
+// reconstruct refs from onchain data, normalize addresses, apply transformations on the raw input ref, etc.
+type TokenRefResolver interface {
+	ResolveTokenPoolRef(b cldf_ops.Bundle, chains cldf_chain.BlockChains, ds datastore.DataStore, chainSelector uint64, address string) (datastore.AddressRef, error)
+	ResolveTokenRef(b cldf_ops.Bundle, chains cldf_chain.BlockChains, ds datastore.DataStore, chainSelector uint64, address string) (datastore.AddressRef, error)
 }
 
 // TokenAdapter defines the interface that each chain family + token pool version combo must implement to support cross-chain token configuration.
@@ -36,9 +50,9 @@ type TokenAdapter interface {
 	// AddressRefToBytes converts an AddressRef to a byte slice representing the address.
 	// Each chain family has their own way of serializing addresses from strings and needs to specify this logic.
 	AddressRefToBytes(ref datastore.AddressRef) ([]byte, error)
-	// DeriveTokenAddress derives the token address (in bytes) from the given token pool reference.
+	// DeriveTokenAddress derives the token address (as a string) from the given token pool reference.
 	// For example, if this address is stored on the pool, this method should fetch it.
-	DeriveTokenAddress(e deployment.Environment, chainSelector uint64, poolRef datastore.AddressRef) ([]byte, error)
+	DeriveTokenAddress(e deployment.Environment, chainSelector uint64, poolRef datastore.AddressRef) (string, error)
 	// DeriveTokenDecimals derives the token decimals from the given token pool reference.
 	DeriveTokenDecimals(e deployment.Environment, chainSelector uint64, poolRef datastore.AddressRef, token []byte) (uint8, error)
 	// For some chains, the token pool address is not the deployed address and must be derived from the token reference.
@@ -261,14 +275,34 @@ type SetTokenTransferFeeSequenceInput struct {
 
 // TokenAdapterRegistry maintains a registry of TokenAdapters.
 type TokenAdapterRegistry struct {
-	mu sync.Mutex
-	m  map[tokenAdapterID]TokenAdapter
+	tokenRefResolverReg map[string]TokenRefResolver
+	tokenAdapterReg     map[tokenAdapterID]TokenAdapter
+	tokenRefResolverMu  sync.Mutex
+	tokenAdapterMu      sync.Mutex
 }
 
 func newTokenAdapterRegistry() *TokenAdapterRegistry {
 	return &TokenAdapterRegistry{
-		m: make(map[tokenAdapterID]TokenAdapter),
+		tokenRefResolverReg: make(map[string]TokenRefResolver),
+		tokenAdapterReg:     make(map[tokenAdapterID]TokenAdapter),
 	}
+}
+
+// Given a chain family, RegisterTokenRefResolver registers a TokenRefResolver that can resolve token and pool references for that chain family.
+func (r *TokenAdapterRegistry) RegisterTokenRefResolver(chainFamily string, resolver TokenRefResolver) {
+	r.tokenRefResolverMu.Lock()
+	defer r.tokenRefResolverMu.Unlock()
+	if _, exists := r.tokenRefResolverReg[chainFamily]; !exists {
+		r.tokenRefResolverReg[chainFamily] = resolver
+	}
+}
+
+// GetTokenRefResolver retrieves a registered TokenRefResolver for the given chain family.
+func (r *TokenAdapterRegistry) GetTokenRefResolver(chainFamily string) (TokenRefResolver, bool) {
+	r.tokenRefResolverMu.Lock()
+	defer r.tokenRefResolverMu.Unlock()
+	resolver, ok := r.tokenRefResolverReg[chainFamily]
+	return resolver, ok
 }
 
 // RegisterTokenAdapter allows chains to register their changeset logic.
@@ -278,10 +312,10 @@ func newTokenAdapterRegistry() *TokenAdapterRegistry {
 // Thus each version of a token pool on a chain family should have its own adapter implementation.
 func (r *TokenAdapterRegistry) RegisterTokenAdapter(chainFamily string, version *semver.Version, adapter TokenAdapter) {
 	id := newTokenAdapterID(chainFamily, version)
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if _, exists := r.m[id]; !exists {
-		r.m[id] = adapter
+	r.tokenAdapterMu.Lock()
+	defer r.tokenAdapterMu.Unlock()
+	if _, exists := r.tokenAdapterReg[id]; !exists {
+		r.tokenAdapterReg[id] = adapter
 	}
 }
 
@@ -293,9 +327,9 @@ func (r *TokenAdapterRegistry) GetTokenAdapter(chainFamily string, version *semv
 		return nil, false
 	}
 	id := newTokenAdapterID(chainFamily, version)
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	adapter, ok := r.m[id]
+	r.tokenAdapterMu.Lock()
+	defer r.tokenAdapterMu.Unlock()
+	adapter, ok := r.tokenAdapterReg[id]
 	return adapter, ok
 }
 

--- a/deployment/tokens/product.go
+++ b/deployment/tokens/product.go
@@ -17,10 +17,10 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
 )
 
-// ArtificialAddressRefLabel is a special label used by adapters that implement TokenRefResolver.
-// It allows adapters to mark reconstructed AddressRefs. The use of this is optional: if there is
-// no need to distinguish between these two types of AddressRefs in adapter logic, then feel free
-// to ignore this label.
+// ArtificialAddressRefLabel is a special label that can be used by adapters that implement
+// TokenRefResolver. Adapters can add this label to reconstructed `AddressRefs` to indicate
+// that the ref is artifical. It is not required to use this label - if there is no need to
+// mark these types of AddressRefs in adapter logic, then this label can be ignored.
 const ArtificialAddressRefLabel = "ArtificialAddressRef"
 
 type tokenAdapterID string

--- a/deployment/tokens/product_test.go
+++ b/deployment/tokens/product_test.go
@@ -24,8 +24,8 @@ func (ma *productTest_MockTokenAdapter) ConfigureTokenForTransfersSequence() *cl
 	return &cldf_ops.Sequence[tokens.ConfigureTokenForTransfersInput, sequences.OnChainOutput, cldf_chain.BlockChains]{}
 }
 
-func (ma *productTest_MockTokenAdapter) DeriveTokenAddress(e deployment.Environment, chainSelector uint64, poolRef datastore.AddressRef) ([]byte, error) {
-	return []byte{}, nil
+func (ma *productTest_MockTokenAdapter) DeriveTokenAddress(e deployment.Environment, chainSelector uint64, poolRef datastore.AddressRef) (string, error) {
+	return "", nil
 }
 
 func (ma *productTest_MockTokenAdapter) DeriveTokenDecimals(e deployment.Environment, chainSelector uint64, poolRef datastore.AddressRef, token []byte) (uint8, error) {

--- a/deployment/tokens/rate_limits.go
+++ b/deployment/tokens/rate_limits.go
@@ -272,18 +272,7 @@ func setTokenPoolRateLimitsApply() func(cldf.Environment, TPRLInput) (cldf.Chang
 				if !ok {
 					return cldf.ChangesetOutput{}, fmt.Errorf("no config provided for remote chain with selector %d", remoteSelector)
 				}
-
-				counterpartFamily, err := chain_selectors.GetSelectorFamily(remoteSelector)
-				if err != nil {
-					return cldf.ChangesetOutput{}, err
-				}
-
-				counterpart.TokenPoolRef, err = TryNormalizeAddressRef(remoteSelector, counterpart.TokenPoolRef)
-				if err != nil {
-					return cldf.ChangesetOutput{}, fmt.Errorf("failed to normalize token pool ref on chain with selector %d: %w", remoteSelector, err)
-				}
-
-				counterPartAdapter, _, remoteTokenPool, remoteToken, err := ResolveAdapterAndRefs(e, tokenPoolRegistry, remoteSelector, counterpart.TokenPoolRef, counterpart.TokenRef)
+				counterPartAdapter, counterpartFamily, remoteTokenPool, remoteToken, err := ResolveAdapterAndRefs(e, tokenPoolRegistry, remoteSelector, counterpart.TokenPoolRef, counterpart.TokenRef)
 				if err != nil {
 					return cldf.ChangesetOutput{}, fmt.Errorf("failed to resolve token pool and token refs on chain with selector %d: %w", remoteSelector, err)
 				}

--- a/deployment/tokens/rate_limits.go
+++ b/deployment/tokens/rate_limits.go
@@ -347,7 +347,7 @@ func setTokenPoolRateLimitsApply() func(cldf.Environment, TPRLInput) (cldf.Chang
 						counterPartAdapter,
 						counterpartFamily,
 						remoteTokenPool,
-						counterpart.TokenRef,
+						remoteToken,
 						remoteSelector,
 						remoteDecimals,
 						selector,

--- a/deployment/tokens/rate_limits.go
+++ b/deployment/tokens/rate_limits.go
@@ -9,7 +9,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/deployment/finality"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
-	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -218,32 +217,11 @@ func setTokenPoolRateLimitsApply() func(cldf.Environment, TPRLInput) (cldf.Chang
 		mcmsRegistry := changesets.GetRegistry()
 
 		for selector, config := range cfg.Configs {
-			family, err := chain_selectors.GetSelectorFamily(selector)
+			tokenPoolAdapter, family, tokenPool, tokenFull, err := ResolveAdapterAndRefs(e, tokenPoolRegistry, selector, config.TokenPoolRef, config.TokenRef)
 			if err != nil {
-				return cldf.ChangesetOutput{}, err
+				return cldf.ChangesetOutput{}, fmt.Errorf("failed to resolve token pool and token refs on chain with selector %d: %w", selector, err)
 			}
-
-			config.TokenPoolRef, err = TryNormalizeAddressRef(selector, config.TokenPoolRef)
-			if err != nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("failed to normalize token pool ref address on chain selector %d: %w", selector, err)
-			}
-			config.TokenRef, err = TryNormalizeAddressRef(selector, config.TokenRef)
-			if err != nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("failed to normalize token ref address on chain selector %d: %w", selector, err)
-			}
-			tokenPool, err := datastore_utils.FindAndFormatRef(e.DataStore, config.TokenPoolRef, selector, datastore_utils.FullRef)
-			if err != nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("failed to resolve token pool ref on chain with selector %d: %w", selector, err)
-			}
-			tokenFull, err := datastore_utils.FindAndFormatRef(e.DataStore, config.TokenRef, selector, datastore_utils.FullRef)
-			if err != nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("failed to resolve token ref on chain with selector %d: %w", selector, err)
-			}
-			tokenPoolAdapter, exists := tokenPoolRegistry.GetTokenAdapter(family, tokenPool.Version)
-			if !exists {
-				return cldf.ChangesetOutput{}, fmt.Errorf("no TokenPoolAdapter registered for chain family '%s' and version '%v'", family, tokenPool.Version)
-			}
-			tokenBytes, err := datastore_utils.FindAndFormatRef(e.DataStore, config.TokenRef, selector, tokenPoolAdapter.AddressRefToBytes)
+			tokenBytes, err := tokenPoolAdapter.AddressRefToBytes(tokenFull)
 			if err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to resolve token ref on chain with selector %d: %w", selector, err)
 			}
@@ -269,33 +247,15 @@ func setTokenPoolRateLimitsApply() func(cldf.Environment, TPRLInput) (cldf.Chang
 				if !ok {
 					return cldf.ChangesetOutput{}, fmt.Errorf("no config provided for remote chain with selector %d", remoteSelector)
 				}
-				counterpartFamily, err := chain_selectors.GetSelectorFamily(remoteSelector)
-				if err != nil {
-					return cldf.ChangesetOutput{}, err
-				}
 				remoteInputs, ok := counterpart.RemoteOutbounds[selector]
 				if !ok {
 					return cldf.ChangesetOutput{}, fmt.Errorf("no inputs provided for remote chain with selector %d to chain with selector %d", selector, remoteSelector)
 				}
-
-				counterpart.TokenPoolRef, err = TryNormalizeAddressRef(remoteSelector, counterpart.TokenPoolRef)
+				counterPartAdapter, _, remoteTokenPool, remoteToken, err := ResolveAdapterAndRefs(e, tokenPoolRegistry, remoteSelector, counterpart.TokenPoolRef, counterpart.TokenRef)
 				if err != nil {
-					return cldf.ChangesetOutput{}, fmt.Errorf("failed to normalize counterpart token pool ref address on chain selector %d: %w", remoteSelector, err)
+					return cldf.ChangesetOutput{}, fmt.Errorf("failed to resolve token pool and token refs on chain with selector %d: %w", remoteSelector, err)
 				}
-				counterpart.TokenRef, err = TryNormalizeAddressRef(remoteSelector, counterpart.TokenRef)
-				if err != nil {
-					return cldf.ChangesetOutput{}, fmt.Errorf("failed to normalize counterpart token ref address on chain selector %d: %w", remoteSelector, err)
-				}
-
-				remoteTokenPool, err := datastore_utils.FindAndFormatRef(e.DataStore, counterpart.TokenPoolRef, remoteSelector, datastore_utils.FullRef)
-				if err != nil {
-					return cldf.ChangesetOutput{}, fmt.Errorf("failed to resolve token pool ref on chain with selector %d: %w", remoteSelector, err)
-				}
-				counterPartAdapter, exists := tokenPoolRegistry.GetTokenAdapter(counterpartFamily, remoteTokenPool.Version)
-				if !exists {
-					return cldf.ChangesetOutput{}, fmt.Errorf("no TokenPoolAdapter registered for chain family '%s' and version '%v'", counterpartFamily, remoteTokenPool.Version)
-				}
-				remoteTokenBytes, err := datastore_utils.FindAndFormatRef(e.DataStore, counterpart.TokenRef, remoteSelector, counterPartAdapter.AddressRefToBytes)
+				remoteTokenBytes, err := counterPartAdapter.AddressRefToBytes(remoteToken)
 				if err != nil {
 					return cldf.ChangesetOutput{}, fmt.Errorf("failed to resolve token ref on chain with selector %d: %w", remoteSelector, err)
 				}

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -562,6 +562,10 @@ func ResolveTokenRef(e cldf.Environment, reg *TokenAdapterRegistry, sel uint64, 
 
 // ResolveAdapter resolves the token adapter for the given chain selector and token pool version.
 func ResolveAdapter(reg *TokenAdapterRegistry, sel uint64, tokenPoolVersion *semver.Version) (TokenAdapter, string, error) {
+	if tokenPoolVersion == nil {
+		return nil, "", fmt.Errorf("token pool version is required to resolve adapter for chain selector %d", sel)
+	}
+
 	family, err := chain_selectors.GetSelectorFamily(sel)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to get chain family for remote chain selector %d: %w", sel, err)

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -437,7 +437,11 @@ func ScaleTokenAmount(amount *big.Int, decimals uint8) *big.Int {
 
 // TryNormalizeAddressRef looks up AddressNormalizer registered for selector's chain family and canonicalizes ref.Address when set.
 func TryNormalizeAddressRef(chainSelector uint64, ref datastore.AddressRef) (datastore.AddressRef, error) {
-	ref.ChainSelector = chainSelector
+	if datastore_utils.IsAddressRefEmpty(ref) {
+		return ref, nil
+	} else {
+		ref.ChainSelector = chainSelector
+	}
 
 	normalized := ref.Clone()
 	if normalized.Address == "" {

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -5,7 +5,6 @@ import (
 	"math/big"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/ethereum/go-ethereum/common"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	mcms_types "github.com/smartcontractkit/mcms/types"
@@ -402,44 +401,9 @@ func tokenExpansionApply() func(cldf.Environment, TokenExpansionInput) (cldf.Cha
 
 		// finally, we update the authorities on the tokens if necessary
 		for selector, tokenConfig := range allTokenConfigs {
-			family, err := chain_selectors.GetSelectorFamily(selector)
+			tokenPoolAdapter, _, fullPoolRef, fullTokenRef, err := ResolveAdapterAndRefs(e, tokenPoolRegistry, selector, tokenConfig.TokenPoolRef, tokenConfig.TokenRef)
 			if err != nil {
-				return cldf.ChangesetOutput{}, err
-			}
-			adapterVersion := cfg.TokenExpansionInputPerChain[selector].TokenPoolVersion
-			if adapterVersion == nil {
-				adapterVersion = cfg.ChainAdapterVersion
-			}
-			tokenPoolAdapter, exists := tokenPoolRegistry.GetTokenAdapter(family, adapterVersion)
-			if !exists {
-				return cldf.ChangesetOutput{}, fmt.Errorf("no TokenPoolAdapter registered for chain family '%s' and version '%s'", family, adapterVersion)
-			}
-			tokenConfig.TokenPoolRef, err = TryNormalizeAddressRef(selector, tokenConfig.TokenPoolRef)
-			if err != nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("failed to normalize token pool ref address for chain selector %d: %w", selector, err)
-			}
-			tokenConfig.TokenRef, err = TryNormalizeAddressRef(selector, tokenConfig.TokenRef)
-			if err != nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("failed to normalize token ref address for chain selector %d: %w", selector, err)
-			}
-			fullPoolRef, err := datastore_utils.FindAndFormatRef(e.DataStore, tokenConfig.TokenPoolRef, selector, datastore_utils.FullRef)
-			if err != nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("failed to find full token pool ref for chain selector %d: %w", selector, err)
-			}
-			fullTokenRef, err := datastore_utils.FindAndFormatRef(e.DataStore, tokenConfig.TokenRef, selector, datastore_utils.FullRef)
-			if err != nil {
-				e.Logger.Warnf("failed to find full token ref for chain selector %d, will try to derive it: %v", selector, err)
-				tokenBytes, err := tokenPoolAdapter.DeriveTokenAddress(e, selector, tokenConfig.TokenPoolRef)
-				if err != nil {
-					return cldf.ChangesetOutput{}, fmt.Errorf("failed to derive token address for chain selector %d: %w", selector, err)
-				}
-				fullTokenRef = datastore.AddressRef{
-					ChainSelector: selector,
-					Type:          tokenConfig.TokenRef.Type,
-					Version:       tokenConfig.TokenRef.Version,
-					Qualifier:     tokenConfig.TokenRef.Qualifier,
-					Address:       common.Bytes2Hex(tokenBytes),
-				}
+				return cldf.ChangesetOutput{}, fmt.Errorf("failed to resolve adapter and refs for chain selector %d: %w", selector, err)
 			}
 			if cfg.TokenExpansionInputPerChain[selector].SkipOwnershipTransfer {
 				e.Logger.Infof("skipping ownership transfer for token pool %s on chain with selector %d", fullPoolRef, selector)
@@ -466,6 +430,7 @@ func tokenExpansionApply() func(cldf.Environment, TokenExpansionInput) (cldf.Cha
 	}
 }
 
+// ScaleTokenAmount scales the given amount by 10^decimals and returns the result as a *big.Int
 func ScaleTokenAmount(amount *big.Int, decimals uint8) *big.Int {
 	return new(big.Int).Mul(amount, new(big.Int).Exp(big.NewInt(10), new(big.Int).SetUint64(uint64(decimals)), nil))
 }
@@ -493,4 +458,119 @@ func TryNormalizeAddressRef(chainSelector uint64, ref datastore.AddressRef) (dat
 	}
 
 	return normalized, nil
+}
+
+// ResolveAdapterAndRefs resolves the token adapter, token pool ref, and token ref for the given
+// chain selector and input refs. It first resolves the token pool ref, then uses that to resolve
+// the adapter, and finally uses the adapter to derive the token address and resolve the token ref.
+// If deriving the token address fails, it falls back to resolving the token ref from the input.
+func ResolveAdapterAndRefs(e cldf.Environment, reg *TokenAdapterRegistry, sel uint64, poolRef, tokenRef datastore.AddressRef) (TokenAdapter, string, datastore.AddressRef, datastore.AddressRef, error) {
+	fullPoolRef, err := ResolveTokenPoolRef(e, reg, sel, poolRef)
+	if err != nil {
+		return nil, "", datastore.AddressRef{}, datastore.AddressRef{}, fmt.Errorf("failed to resolve token pool ref: %w", err)
+	}
+
+	adapter, family, err := ResolveAdapter(reg, sel, fullPoolRef.Version)
+	if err != nil {
+		return nil, "", datastore.AddressRef{}, datastore.AddressRef{}, fmt.Errorf("failed to resolve adapter: %w", err)
+	}
+
+	// If DeriveTokenAddress succeeds, then this has higher precedence than the token ref provided in the input since it is
+	// derived from on chain data (and hence more reliable). If it fails, then we fall back to using the token ref provided
+	// in the input and try to resolve it from the datastore first (to avoid RPC calls) then fall back to on chain data.
+	var fullTokenRef datastore.AddressRef
+	if derivedTokenAddr, deriveErr := adapter.DeriveTokenAddress(e, sel, fullPoolRef); deriveErr != nil {
+		fullTokenRef, err = ResolveTokenRef(e, reg, sel, tokenRef)
+		if err != nil {
+			return nil, "", datastore.AddressRef{}, datastore.AddressRef{}, fmt.Errorf("failed to resolve token ref for chain selector %d: %w", sel, err)
+		}
+	} else {
+		fullTokenRef, err = ResolveTokenRef(e, reg, sel, datastore.AddressRef{ChainSelector: sel, Address: derivedTokenAddr})
+		if err != nil {
+			return nil, "", datastore.AddressRef{}, datastore.AddressRef{}, fmt.Errorf("failed to resolve token ref for chain selector %d: %w", sel, err)
+		}
+	}
+
+	return adapter, family, fullPoolRef, fullTokenRef, nil
+}
+
+// ResolveTokenPoolRef resolves the token pool reference from the datastore, then on chain data if possible.
+func ResolveTokenPoolRef(e cldf.Environment, reg *TokenAdapterRegistry, sel uint64, ref datastore.AddressRef) (datastore.AddressRef, error) {
+	family, err := chain_selectors.GetSelectorFamily(sel)
+	if err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("invalid chain selector %d: %w", sel, err)
+	}
+
+	// Check the cache first (i.e. datastore)
+	maybeNormalized, err := TryNormalizeAddressRef(sel, ref)
+	if err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("failed to normalize address ref (%s) for chain selector %d: %w", datastore_utils.SprintRef(ref), sel, err)
+	}
+	if cached, err := datastore_utils.FindAndFormatRef(e.DataStore, maybeNormalized, sel, datastore_utils.FullRef); err == nil {
+		return cached, nil
+	}
+
+	// If the cache had no hits, then check if we have the capability to retrieve this info from the chain
+	resolver, ok := reg.GetTokenRefResolver(family)
+	if !ok {
+		return datastore.AddressRef{}, fmt.Errorf("failed to resolve token pool ref for chain selector %d: datastore lookup failed for ref %s and no ref resolver registered for chain family '%s'", sel, datastore_utils.SprintRef(maybeNormalized), family)
+	}
+	if maybeNormalized.Address == "" {
+		return datastore.AddressRef{}, fmt.Errorf("failed to resolve token pool ref for chain selector %d: datastore lookup failed for ref %s and no address found in token pool ref", sel, datastore_utils.SprintRef(maybeNormalized))
+	}
+
+	// If the chain has all the data, then reconstruct the ref (otherwise hard error since we're out of options)
+	if tokenPoolRef, err := resolver.ResolveTokenPoolRef(e.OperationsBundle, e.BlockChains, e.DataStore, sel, maybeNormalized.Address); err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("failed to resolve token pool ref (%s) for chain %d: %w", datastore_utils.SprintRef(maybeNormalized), sel, err)
+	} else {
+		return tokenPoolRef, nil
+	}
+}
+
+// ResolveTokenRef resolves the token reference from the datastore, then on chain data if possible.
+func ResolveTokenRef(e cldf.Environment, reg *TokenAdapterRegistry, sel uint64, ref datastore.AddressRef) (datastore.AddressRef, error) {
+	family, err := chain_selectors.GetSelectorFamily(sel)
+	if err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("invalid chain selector %d: %w", sel, err)
+	}
+
+	// Check the cache first (i.e. datastore)
+	maybeNormalized, err := TryNormalizeAddressRef(sel, ref)
+	if err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("failed to normalize address ref (%s) for chain selector %d: %w", datastore_utils.SprintRef(ref), sel, err)
+	}
+	if cached, err := datastore_utils.FindAndFormatRef(e.DataStore, maybeNormalized, sel, datastore_utils.FullRef); err == nil {
+		return cached, nil
+	}
+
+	// If the cache had no hits, then check if we have the capability to retrieve this info from the chain
+	resolver, ok := reg.GetTokenRefResolver(family)
+	if !ok {
+		return datastore.AddressRef{}, fmt.Errorf("failed to resolve token ref for chain selector %d: datastore lookup failed for ref %s and no ref resolver registered for chain family '%s'", sel, datastore_utils.SprintRef(maybeNormalized), family)
+	}
+	if maybeNormalized.Address == "" {
+		return datastore.AddressRef{}, fmt.Errorf("failed to resolve token ref for chain selector %d: datastore lookup failed for ref %s and no address found in token ref", sel, datastore_utils.SprintRef(maybeNormalized))
+	}
+
+	// If the chain has all the data, then reconstruct the ref (otherwise hard error since we're out of options)
+	if tokenRef, err := resolver.ResolveTokenRef(e.OperationsBundle, e.BlockChains, e.DataStore, sel, maybeNormalized.Address); err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("failed to resolve token ref (%s) for chain %d: %w", datastore_utils.SprintRef(maybeNormalized), sel, err)
+	} else {
+		return tokenRef, nil
+	}
+}
+
+// ResolveAdapter resolves the token adapter for the given chain selector and token pool version.
+func ResolveAdapter(reg *TokenAdapterRegistry, sel uint64, tokenPoolVersion *semver.Version) (TokenAdapter, string, error) {
+	family, err := chain_selectors.GetSelectorFamily(sel)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get chain family for remote chain selector %d: %w", sel, err)
+	}
+
+	adapter, ok := reg.GetTokenAdapter(family, tokenPoolVersion)
+	if !ok {
+		return nil, "", fmt.Errorf("no token adapter registered for chain family '%s' and version '%s'", family, tokenPoolVersion.String())
+	}
+
+	return adapter, family, nil
 }

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -398,6 +398,10 @@ func tokenExpansionApply() func(cldf.Environment, TokenExpansionInput) (cldf.Cha
 		batchOps = append(batchOps, transferOps...)
 		reports = append(reports, transferReports...)
 		ds.Merge(tokends.Seal())
+		mergedDS := datastore.NewMemoryDataStore()
+		mergedDS.Merge(e.DataStore)
+		mergedDS.Merge(ds.Seal())
+		e.DataStore = mergedDS.Seal()
 
 		// finally, we update the authorities on the tokens if necessary
 		for selector, tokenConfig := range allTokenConfigs {

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -437,8 +437,10 @@ func ScaleTokenAmount(amount *big.Int, decimals uint8) *big.Int {
 
 // TryNormalizeAddressRef looks up AddressNormalizer registered for selector's chain family and canonicalizes ref.Address when set.
 func TryNormalizeAddressRef(chainSelector uint64, ref datastore.AddressRef) (datastore.AddressRef, error) {
+	ref.ChainSelector = chainSelector
+
 	normalized := ref.Clone()
-	if ref.Address == "" {
+	if normalized.Address == "" {
 		return normalized, nil
 	}
 
@@ -506,8 +508,12 @@ func ResolveTokenPoolRef(e cldf.Environment, reg *TokenAdapterRegistry, sel uint
 	if err != nil {
 		return datastore.AddressRef{}, fmt.Errorf("failed to normalize address ref (%s) for chain selector %d: %w", datastore_utils.SprintRef(ref), sel, err)
 	}
-	if cached, err := datastore_utils.FindAndFormatRef(e.DataStore, maybeNormalized, sel, datastore_utils.FullRef); err == nil {
-		return cached, nil
+	results := e.DataStore.Addresses().Filter(datastore_utils.AddressRefToFilters(maybeNormalized)...)
+	if len(results) > 1 {
+		return datastore.AddressRef{}, fmt.Errorf("multiple refs found in datastore for ref %s and chain selector %d: %v", datastore_utils.SprintRef(maybeNormalized), sel, results)
+	}
+	if len(results) == 1 {
+		return results[0], nil
 	}
 
 	// If the cache had no hits, then check if we have the capability to retrieve this info from the chain
@@ -539,8 +545,12 @@ func ResolveTokenRef(e cldf.Environment, reg *TokenAdapterRegistry, sel uint64, 
 	if err != nil {
 		return datastore.AddressRef{}, fmt.Errorf("failed to normalize address ref (%s) for chain selector %d: %w", datastore_utils.SprintRef(ref), sel, err)
 	}
-	if cached, err := datastore_utils.FindAndFormatRef(e.DataStore, maybeNormalized, sel, datastore_utils.FullRef); err == nil {
-		return cached, nil
+	results := e.DataStore.Addresses().Filter(datastore_utils.AddressRefToFilters(maybeNormalized)...)
+	if len(results) > 1 {
+		return datastore.AddressRef{}, fmt.Errorf("multiple refs found in datastore for ref %s and chain selector %d: %v", datastore_utils.SprintRef(maybeNormalized), sel, results)
+	}
+	if len(results) == 1 {
+		return results[0], nil
 	}
 
 	// If the cache had no hits, then check if we have the capability to retrieve this info from the chain

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -444,6 +444,8 @@ func TryNormalizeAddressRef(chainSelector uint64, ref datastore.AddressRef) (dat
 	if datastore_utils.IsAddressRefEmpty(ref) {
 		return ref, nil
 	} else {
+		// NOTE: `ref.ChainSelector` is intentionally ignored in favor of `chainSelector`
+		// which comes from the keys of `TokenExpansionInput.TokenExpansionInputPerChain`
 		ref.ChainSelector = chainSelector
 	}
 

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -492,7 +492,7 @@ func ResolveAdapterAndRefs(e cldf.Environment, reg *TokenAdapterRegistry, sel ui
 	if derivedTokenAddr, deriveErr := adapter.DeriveTokenAddress(e, sel, fullPoolRef); deriveErr != nil {
 		fullTokenRef, err = ResolveTokenRef(e, reg, sel, tokenRef)
 		if err != nil {
-			return nil, "", datastore.AddressRef{}, datastore.AddressRef{}, fmt.Errorf("failed to resolve token ref for chain selector %d: %w", sel, err)
+			return nil, "", datastore.AddressRef{}, datastore.AddressRef{}, fmt.Errorf("token derivation failed (%w) and fallback token ref resolution was unsuccessful for chain selector %d: %w", deriveErr, sel, err)
 		}
 	} else {
 		fullTokenRef, err = ResolveTokenRef(e, reg, sel, datastore.AddressRef{ChainSelector: sel, Address: derivedTokenAddr})

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -507,11 +507,16 @@ func ResolveTokenPoolRef(e cldf.Environment, reg *TokenAdapterRegistry, sel uint
 		return datastore.AddressRef{}, fmt.Errorf("invalid chain selector %d: %w", sel, err)
 	}
 
-	// Check the cache first (i.e. datastore)
+	// Try to normalize ref.Address before doing any lookups
 	maybeNormalized, err := TryNormalizeAddressRef(sel, ref)
 	if err != nil {
 		return datastore.AddressRef{}, fmt.Errorf("failed to normalize address ref (%s) for chain selector %d: %w", datastore_utils.SprintRef(ref), sel, err)
 	}
+	if datastore_utils.IsAddressRefEmpty(maybeNormalized) {
+		return datastore.AddressRef{}, fmt.Errorf("empty token pool ref provided for chain selector %d", sel)
+	}
+
+	// Check the cache first (i.e. datastore)
 	results := e.DataStore.Addresses().Filter(datastore_utils.AddressRefToFilters(maybeNormalized)...)
 	if len(results) > 1 {
 		return datastore.AddressRef{}, fmt.Errorf("multiple refs found in datastore for ref %s and chain selector %d: %v", datastore_utils.SprintRef(maybeNormalized), sel, results)
@@ -544,11 +549,16 @@ func ResolveTokenRef(e cldf.Environment, reg *TokenAdapterRegistry, sel uint64, 
 		return datastore.AddressRef{}, fmt.Errorf("invalid chain selector %d: %w", sel, err)
 	}
 
-	// Check the cache first (i.e. datastore)
+	// Try to normalize ref.Address before doing any lookups
 	maybeNormalized, err := TryNormalizeAddressRef(sel, ref)
 	if err != nil {
 		return datastore.AddressRef{}, fmt.Errorf("failed to normalize address ref (%s) for chain selector %d: %w", datastore_utils.SprintRef(ref), sel, err)
 	}
+	if datastore_utils.IsAddressRefEmpty(maybeNormalized) {
+		return datastore.AddressRef{}, fmt.Errorf("empty token ref provided for chain selector %d", sel)
+	}
+
+	// Check the cache first (i.e. datastore)
 	results := e.DataStore.Addresses().Filter(datastore_utils.AddressRefToFilters(maybeNormalized)...)
 	if len(results) > 1 {
 		return datastore.AddressRef{}, fmt.Errorf("multiple refs found in datastore for ref %s and chain selector %d: %v", datastore_utils.SprintRef(maybeNormalized), sel, results)

--- a/deployment/utils/datastore/datastore.go
+++ b/deployment/utils/datastore/datastore.go
@@ -314,3 +314,24 @@ func MergeRefs(ref1, ref2 *datastore.AddressRef) (datastore.AddressRef, error) {
 
 	return merged, nil
 }
+
+func AddressRefToFilters(ref datastore.AddressRef) []datastore.FilterFunc[datastore.AddressRefKey, datastore.AddressRef] {
+	filters := []datastore.FilterFunc[datastore.AddressRefKey, datastore.AddressRef]{}
+	if ref.ChainSelector != 0 {
+		filters = append(filters, datastore.AddressRefByChainSelector(ref.ChainSelector))
+	}
+	if ref.Qualifier != "" {
+		filters = append(filters, datastore.AddressRefByQualifier(ref.Qualifier))
+	}
+	if ref.Version != nil {
+		filters = append(filters, datastore.AddressRefByVersion(ref.Version))
+	}
+	if ref.Address != "" {
+		filters = append(filters, datastore.AddressRefByAddress(ref.Address))
+	}
+	if ref.Type != "" {
+		filters = append(filters, datastore.AddressRefByType(ref.Type))
+	}
+
+	return filters
+}

--- a/deployment/utils/datastore/datastore.go
+++ b/deployment/utils/datastore/datastore.go
@@ -299,8 +299,8 @@ func MergeRefs(ref1, ref2 *datastore.AddressRef) (datastore.AddressRef, error) {
 
 func AddressRefToFilters(ref datastore.AddressRef) []datastore.FilterFunc[datastore.AddressRefKey, datastore.AddressRef] {
 	// NOTE: filters are applied sequentially, so it is more efficient to order
-	// to place the more selective filters first so that each subsequent filter
-	// iteration is working with a smaller set of refs.
+	// the more selective filters first so that each subsequent filter operates
+	// on a smaller set of refs.
 	filters := []datastore.FilterFunc[datastore.AddressRefKey, datastore.AddressRef]{}
 	if ref.ChainSelector != 0 {
 		filters = append(filters, datastore.AddressRefByChainSelector(ref.ChainSelector))

--- a/deployment/utils/datastore/datastore.go
+++ b/deployment/utils/datastore/datastore.go
@@ -84,25 +84,7 @@ func SprintRef(ref datastore.AddressRef) string {
 // findRef queries the datastore for an AddressRef matching a subset of fields provided by AddressRef.
 // It enforces that exactly one match is found.
 func findRef(ds datastore.DataStore, ref datastore.AddressRef) (datastore.AddressRef, int, error) {
-	filterFns := make([]datastore.FilterFunc[datastore.AddressRefKey, datastore.AddressRef], 0, 5)
-	// Filter by largest scope (chain) to smallest scope (address)
-	// Address is the smallest scope because there can only be one of each address on a given chain
-	if ref.ChainSelector != 0 {
-		filterFns = append(filterFns, datastore.AddressRefByChainSelector(ref.ChainSelector))
-	}
-	if ref.Type != "" {
-		filterFns = append(filterFns, datastore.AddressRefByType(ref.Type))
-	}
-	if ref.Version != nil {
-		filterFns = append(filterFns, datastore.AddressRefByVersion(ref.Version))
-	}
-	if ref.Qualifier != "" {
-		filterFns = append(filterFns, datastore.AddressRefByQualifier(ref.Qualifier))
-	}
-	if ref.Address != "" {
-		filterFns = append(filterFns, datastore.AddressRefByAddress(ref.Address))
-	}
-	refs := ds.Addresses().Filter(filterFns...)
+	refs := ds.Addresses().Filter(AddressRefToFilters(ref)...)
 	if len(refs) != 1 {
 		return datastore.AddressRef{}, len(refs), fmt.Errorf("expected to find exactly 1 ref with criteria %s, found %d", SprintRef(ref), len(refs))
 	}
@@ -316,18 +298,21 @@ func MergeRefs(ref1, ref2 *datastore.AddressRef) (datastore.AddressRef, error) {
 }
 
 func AddressRefToFilters(ref datastore.AddressRef) []datastore.FilterFunc[datastore.AddressRefKey, datastore.AddressRef] {
+	// NOTE: filters are applied sequentially, so it is more efficient to order
+	// to place the more selective filters first so that each subsequent filter
+	// iteration is working with a smaller set of refs.
 	filters := []datastore.FilterFunc[datastore.AddressRefKey, datastore.AddressRef]{}
 	if ref.ChainSelector != 0 {
 		filters = append(filters, datastore.AddressRefByChainSelector(ref.ChainSelector))
+	}
+	if ref.Address != "" {
+		filters = append(filters, datastore.AddressRefByAddress(ref.Address))
 	}
 	if ref.Qualifier != "" {
 		filters = append(filters, datastore.AddressRefByQualifier(ref.Qualifier))
 	}
 	if ref.Version != nil {
 		filters = append(filters, datastore.AddressRefByVersion(ref.Version))
-	}
-	if ref.Address != "" {
-		filters = append(filters, datastore.AddressRefByAddress(ref.Address))
 	}
 	if ref.Type != "" {
 		filters = append(filters, datastore.AddressRefByType(ref.Type))

--- a/deployment/utils/datastore/datastore.go
+++ b/deployment/utils/datastore/datastore.go
@@ -302,11 +302,11 @@ func AddressRefToFilters(ref datastore.AddressRef) []datastore.FilterFunc[datast
 	// the more selective filters first so that each subsequent filter operates
 	// on a smaller set of refs.
 	filters := []datastore.FilterFunc[datastore.AddressRefKey, datastore.AddressRef]{}
-	if ref.ChainSelector != 0 {
-		filters = append(filters, datastore.AddressRefByChainSelector(ref.ChainSelector))
-	}
 	if ref.Address != "" {
 		filters = append(filters, datastore.AddressRefByAddress(ref.Address))
+	}
+	if ref.ChainSelector != 0 {
+		filters = append(filters, datastore.AddressRefByChainSelector(ref.ChainSelector))
 	}
 	if ref.Qualifier != "" {
 		filters = append(filters, datastore.AddressRefByQualifier(ref.Qualifier))

--- a/devenv/go.mod
+++ b/devenv/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment v0.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260312233953-f588f8dc6d7c
-	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260516222345-f2f143454dbd
+	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260520095735-feac5055dc84
 	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260417081611-8bdbd9f45629
 	github.com/smartcontractkit/chainlink-deployments-framework v0.101.1
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260410162948-2dca02f24e98 // indirect

--- a/devenv/go.mod
+++ b/devenv/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment v0.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260312233953-f588f8dc6d7c
-	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260520204756-f0fd9c330aac
+	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260520205139-e02dace3eefa
 	github.com/smartcontractkit/chainlink-common v0.11.2-0.20260417081611-8bdbd9f45629
 	github.com/smartcontractkit/chainlink-deployments-framework v0.101.1
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260410162948-2dca02f24e98 // indirect

--- a/integration-tests/deployment/token_expansion_scenarios_test.go
+++ b/integration-tests/deployment/token_expansion_scenarios_test.go
@@ -1097,16 +1097,16 @@ func TestTokenExpansionScenariosSolana(t *testing.T) {
 			// discriminator. The decode would silently fail and the function would return a
 			// zero RateLimiterConfig, which in OutboundOnly mode then overwrote the bucket's
 			// InboundRateLimiterConfig with zeros — clobbering a previously-enabled inbound
-			// rate limit on chain. This subtest seeds an enabled inbound (via the symmetric
-			// apply above), runs an OutboundOnly apply on Solana, and verifies the Solana
-			// inbound is preserved by pass-through. Depends on the SetTokenPoolRateLimits
-			// subtest running first so the Solana inbound is in an enabled, non-zero state.
+			// rate limit on chain. Solana's inbound is already enabled and non-zero from the
+			// symmetric OutboundRateLimiterConfig on both sides in TokenExpansion().Apply above
+			// (BasicDeploymentAndConnection). This subtest runs an OutboundOnly apply on Solana
+			// and verifies that inbound is preserved by pass-through.
 			t.Run("SetTokenPoolRateLimits_OutboundOnly_PreservesSolanaInbound", func(t *testing.T) {
 				chainCfgPDA, _, err := tokens.TokenPoolChainConfigPDA(evmChainSel, solTokenMint, solPoolProgramID)
 				require.NoError(t, err)
 
 				// Snapshot Solana's current rate limits — both directions should be enabled with
-				// non-zero values from the previous SetTokenPoolRateLimits subtest.
+				// non-zero values from the TokenExpansion lane setup above.
 				var preCfg lockrelease_token_pool.ChainConfig
 				require.NoError(t, solChain.GetAccountDataBorshInto(t.Context(), chainCfgPDA, &preCfg))
 				require.True(t, preCfg.Base.InboundRateLimit.Cfg.Enabled, "seed: Solana inbound from EVM should be enabled before OutboundOnly apply")
@@ -1114,7 +1114,7 @@ func TestTokenExpansionScenariosSolana(t *testing.T) {
 				require.NotZero(t, preCfg.Base.InboundRateLimit.Cfg.Rate, "seed: Solana inbound rate should be non-zero before OutboundOnly apply")
 
 				// Snapshot EVM rate limits too so we can assert they're untouched without
-				// depending on which specific values the prior subtest left behind.
+				// depending on which specific values the TokenExpansion seed left on-chain.
 				preOutboundEVM, err := evmPool.GetCurrentOutboundRateLimiterState(&bind.CallOpts{Context: t.Context()}, solChainSel)
 				require.NoError(t, err)
 				preInboundEVM, err := evmPool.GetCurrentInboundRateLimiterState(&bind.CallOpts{Context: t.Context()}, solChainSel)
@@ -1122,7 +1122,7 @@ func TestTokenExpansionScenariosSolana(t *testing.T) {
 
 				// Pick a new outbound that's safely below the counterpart's existing inbound
 				// headroom: counterpart inbound (in svmDecimals) >= 1.10 * new_outbound. Use a
-				// small value relative to anything the previous subtests could have set.
+				// small value relative to anything the TokenExpansion seed could have set.
 				newSVMOutbound := tokensapi.RemoteOutbounds{
 					OutboundOnly: true,
 					Outbounds: []tokensapi.RateLimitConfig{{

--- a/integration-tests/deployment/token_expansion_scenarios_test.go
+++ b/integration-tests/deployment/token_expansion_scenarios_test.go
@@ -1091,6 +1091,100 @@ func TestTokenExpansionScenariosSolana(t *testing.T) {
 			routerAddr, err := solAdapter.GetRouterAddress(env.DataStore, solChainSel)
 			require.NoError(t, err)
 			require.NotEmpty(t, routerAddr, "Solana router should be deployed")
+
+			// Regression: SolanaAdapter.GetOnchainInboundRateLimit used to decode the on-chain
+			// ChainConfig PDA into a bare base_token_pool.BaseChain, ignoring the 8-byte Anchor
+			// discriminator. The decode would silently fail and the function would return a
+			// zero RateLimiterConfig, which in OutboundOnly mode then overwrote the bucket's
+			// InboundRateLimiterConfig with zeros — clobbering a previously-enabled inbound
+			// rate limit on chain. This subtest seeds an enabled inbound (via the symmetric
+			// apply above), runs an OutboundOnly apply on Solana, and verifies the Solana
+			// inbound is preserved by pass-through. Depends on the SetTokenPoolRateLimits
+			// subtest running first so the Solana inbound is in an enabled, non-zero state.
+			t.Run("SetTokenPoolRateLimits_OutboundOnly_PreservesSolanaInbound", func(t *testing.T) {
+				chainCfgPDA, _, err := tokens.TokenPoolChainConfigPDA(evmChainSel, solTokenMint, solPoolProgramID)
+				require.NoError(t, err)
+
+				// Snapshot Solana's current rate limits — both directions should be enabled with
+				// non-zero values from the previous SetTokenPoolRateLimits subtest.
+				var preCfg lockrelease_token_pool.ChainConfig
+				require.NoError(t, solChain.GetAccountDataBorshInto(t.Context(), chainCfgPDA, &preCfg))
+				require.True(t, preCfg.Base.InboundRateLimit.Cfg.Enabled, "seed: Solana inbound from EVM should be enabled before OutboundOnly apply")
+				require.NotZero(t, preCfg.Base.InboundRateLimit.Cfg.Capacity, "seed: Solana inbound capacity should be non-zero before OutboundOnly apply")
+				require.NotZero(t, preCfg.Base.InboundRateLimit.Cfg.Rate, "seed: Solana inbound rate should be non-zero before OutboundOnly apply")
+
+				// Snapshot EVM rate limits too so we can assert they're untouched without
+				// depending on which specific values the prior subtest left behind.
+				preOutboundEVM, err := evmPool.GetCurrentOutboundRateLimiterState(&bind.CallOpts{Context: t.Context()}, solChainSel)
+				require.NoError(t, err)
+				preInboundEVM, err := evmPool.GetCurrentInboundRateLimiterState(&bind.CallOpts{Context: t.Context()}, solChainSel)
+				require.NoError(t, err)
+
+				// Pick a new outbound that's safely below the counterpart's existing inbound
+				// headroom: counterpart inbound (in svmDecimals) >= 1.10 * new_outbound. Use a
+				// small value relative to anything the previous subtests could have set.
+				newSVMOutbound := tokensapi.RemoteOutbounds{
+					OutboundOnly: true,
+					Outbounds: []tokensapi.RateLimitConfig{{
+						RateLimit: tokensapi.RateLimiterConfigFloatInput{Capacity: 50, Rate: 5, IsEnabled: true},
+					}},
+				}
+
+				tprlOut, err := tokensapi.SetTokenPoolRateLimits().Apply(*env, tokensapi.TPRLInput{
+					MCMS: NewDefaultInputForMCMS("Scenario 5 TPRL OutboundOnly"),
+					Configs: map[uint64]tokensapi.TPRLConfig{
+						solChainSel: {
+							ChainAdapterVersion: v1_6_0_scenarios,
+							TokenPoolRef:        datastore.AddressRef{Address: solPoolProgramID.String()},
+							TokenRef:            datastore.AddressRef{Address: solTokenMint.String()},
+							RemoteOutbounds: map[uint64]tokensapi.RemoteOutbounds{
+								evmChainSel: newSVMOutbound,
+							},
+						},
+						// Counterpart EVM config is refs-only — no RemoteOutbounds entry — which is
+						// exactly the shape OutboundOnly is designed for.
+						evmChainSel: {
+							ChainAdapterVersion: v1_6_0_scenarios,
+							TokenPoolRef:        datastore.AddressRef{Address: evmPoolAddr.Hex()},
+							TokenRef:            datastore.AddressRef{Address: evmTokAddr.Hex()},
+						},
+					},
+				})
+				require.NoError(t, err)
+				testhelpers.ProcessTimelockProposals(t, *env, tprlOut.MCMSTimelockProposals, false)
+
+				// Re-read Solana's chain config.
+				var postCfg lockrelease_token_pool.ChainConfig
+				require.NoError(t, solChain.GetAccountDataBorshInto(t.Context(), chainCfgPDA, &postCfg))
+
+				// Solana inbound must be preserved bit-for-bit (the OutboundOnly pass-through).
+				// Before the fix, GetOnchainInboundRateLimit silently returned a zero
+				// RateLimiterConfig, the bucket's InboundRateLimiterConfig was overwritten
+				// with zeros, and these three assertions failed.
+				require.Equal(t, preCfg.Base.InboundRateLimit.Cfg.Enabled, postCfg.Base.InboundRateLimit.Cfg.Enabled, "Solana inbound IsEnabled must be unchanged by OutboundOnly apply")
+				require.Equal(t, preCfg.Base.InboundRateLimit.Cfg.Capacity, postCfg.Base.InboundRateLimit.Cfg.Capacity, "Solana inbound capacity must be unchanged by OutboundOnly apply")
+				require.Equal(t, preCfg.Base.InboundRateLimit.Cfg.Rate, postCfg.Base.InboundRateLimit.Cfg.Rate, "Solana inbound rate must be unchanged by OutboundOnly apply")
+
+				// Solana outbound was rewritten to the new value.
+				expOutCap := tokensapi.ScaleFloatToBigInt(newSVMOutbound.Outbounds[0].RateLimit.Capacity, int(svmDecimals), 0)
+				expOutRate := tokensapi.ScaleFloatToBigInt(newSVMOutbound.Outbounds[0].RateLimit.Rate, int(svmDecimals), 0)
+				require.True(t, postCfg.Base.OutboundRateLimit.Cfg.Enabled)
+				require.Equal(t, expOutCap.Uint64(), postCfg.Base.OutboundRateLimit.Cfg.Capacity, "Solana outbound capacity after OutboundOnly apply")
+				require.Equal(t, expOutRate.Uint64(), postCfg.Base.OutboundRateLimit.Cfg.Rate, "Solana outbound rate after OutboundOnly apply")
+
+				// EVM pool was not touched by this OutboundOnly apply (no RemoteOutbounds entry
+				// for solChainSel was provided on the EVM side).
+				postOutboundEVM, err := evmPool.GetCurrentOutboundRateLimiterState(&bind.CallOpts{Context: t.Context()}, solChainSel)
+				require.NoError(t, err)
+				postInboundEVM, err := evmPool.GetCurrentInboundRateLimiterState(&bind.CallOpts{Context: t.Context()}, solChainSel)
+				require.NoError(t, err)
+				require.Equal(t, preOutboundEVM.IsEnabled, postOutboundEVM.IsEnabled, "EVM outbound IsEnabled should be unchanged after OutboundOnly apply on Solana")
+				require.Zero(t, preOutboundEVM.Capacity.Cmp(postOutboundEVM.Capacity), "EVM outbound capacity should be unchanged after OutboundOnly apply on Solana")
+				require.Zero(t, preOutboundEVM.Rate.Cmp(postOutboundEVM.Rate), "EVM outbound rate should be unchanged after OutboundOnly apply on Solana")
+				require.Equal(t, preInboundEVM.IsEnabled, postInboundEVM.IsEnabled, "EVM inbound IsEnabled should be unchanged after OutboundOnly apply on Solana")
+				require.Zero(t, preInboundEVM.Capacity.Cmp(postInboundEVM.Capacity), "EVM inbound capacity should be unchanged after OutboundOnly apply on Solana")
+				require.Zero(t, preInboundEVM.Rate.Cmp(postInboundEVM.Rate), "EVM inbound rate should be unchanged after OutboundOnly apply on Solana")
+			})
 		})
 
 		// Test address ref inference
@@ -1331,100 +1425,6 @@ func TestTokenExpansionScenariosSolana(t *testing.T) {
 				require.True(t, chainCfg.Base.OutboundRateLimit.Cfg.Enabled)
 				require.True(t, chainCfg.Base.InboundRateLimit.Cfg.Enabled)
 			})
-		})
-
-		// Regression: SolanaAdapter.GetOnchainInboundRateLimit used to decode the on-chain
-		// ChainConfig PDA into a bare base_token_pool.BaseChain, ignoring the 8-byte Anchor
-		// discriminator. The decode would silently fail and the function would return a
-		// zero RateLimiterConfig, which in OutboundOnly mode then overwrote the bucket's
-		// InboundRateLimiterConfig with zeros — clobbering a previously-enabled inbound
-		// rate limit on chain. This subtest seeds an enabled inbound (via the symmetric
-		// apply above), runs an OutboundOnly apply on Solana, and verifies the Solana
-		// inbound is preserved by pass-through. Depends on the SetTokenPoolRateLimits
-		// subtest running first so the Solana inbound is in an enabled, non-zero state.
-		t.Run("SetTokenPoolRateLimits_OutboundOnly_PreservesSolanaInbound", func(t *testing.T) {
-			chainCfgPDA, _, err := tokens.TokenPoolChainConfigPDA(evmChainSel, solTokenMint, solPoolProgramID)
-			require.NoError(t, err)
-
-			// Snapshot Solana's current rate limits — both directions should be enabled with
-			// non-zero values from the previous SetTokenPoolRateLimits subtest.
-			var preCfg lockrelease_token_pool.ChainConfig
-			require.NoError(t, solChain.GetAccountDataBorshInto(t.Context(), chainCfgPDA, &preCfg))
-			require.True(t, preCfg.Base.InboundRateLimit.Cfg.Enabled, "seed: Solana inbound from EVM should be enabled before OutboundOnly apply")
-			require.NotZero(t, preCfg.Base.InboundRateLimit.Cfg.Capacity, "seed: Solana inbound capacity should be non-zero before OutboundOnly apply")
-			require.NotZero(t, preCfg.Base.InboundRateLimit.Cfg.Rate, "seed: Solana inbound rate should be non-zero before OutboundOnly apply")
-
-			// Snapshot EVM rate limits too so we can assert they're untouched without
-			// depending on which specific values the prior subtest left behind.
-			preOutboundEVM, err := evmPool.GetCurrentOutboundRateLimiterState(&bind.CallOpts{Context: t.Context()}, solChainSel)
-			require.NoError(t, err)
-			preInboundEVM, err := evmPool.GetCurrentInboundRateLimiterState(&bind.CallOpts{Context: t.Context()}, solChainSel)
-			require.NoError(t, err)
-
-			// Pick a new outbound that's safely below the counterpart's existing inbound
-			// headroom: counterpart inbound (in svmDecimals) >= 1.10 * new_outbound. Use a
-			// small value relative to anything the previous subtests could have set.
-			newSVMOutbound := tokensapi.RemoteOutbounds{
-				OutboundOnly: true,
-				Outbounds: []tokensapi.RateLimitConfig{{
-					RateLimit: tokensapi.RateLimiterConfigFloatInput{Capacity: 50, Rate: 5, IsEnabled: true},
-				}},
-			}
-
-			tprlOut, err := tokensapi.SetTokenPoolRateLimits().Apply(*env, tokensapi.TPRLInput{
-				MCMS: NewDefaultInputForMCMS("Scenario 5 TPRL OutboundOnly"),
-				Configs: map[uint64]tokensapi.TPRLConfig{
-					solChainSel: {
-						ChainAdapterVersion: v1_6_0_scenarios,
-						TokenPoolRef:        datastore.AddressRef{Address: solPoolProgramID.String()},
-						TokenRef:            datastore.AddressRef{Address: solTokenMint.String()},
-						RemoteOutbounds: map[uint64]tokensapi.RemoteOutbounds{
-							evmChainSel: newSVMOutbound,
-						},
-					},
-					// Counterpart EVM config is refs-only — no RemoteOutbounds entry — which is
-					// exactly the shape OutboundOnly is designed for.
-					evmChainSel: {
-						ChainAdapterVersion: v1_6_0_scenarios,
-						TokenPoolRef:        datastore.AddressRef{Address: evmPoolAddr.Hex()},
-						TokenRef:            datastore.AddressRef{Address: evmTokAddr.Hex()},
-					},
-				},
-			})
-			require.NoError(t, err)
-			testhelpers.ProcessTimelockProposals(t, *env, tprlOut.MCMSTimelockProposals, false)
-
-			// Re-read Solana's chain config.
-			var postCfg lockrelease_token_pool.ChainConfig
-			require.NoError(t, solChain.GetAccountDataBorshInto(t.Context(), chainCfgPDA, &postCfg))
-
-			// Solana inbound must be preserved bit-for-bit (the OutboundOnly pass-through).
-			// Before the fix, GetOnchainInboundRateLimit silently returned a zero
-			// RateLimiterConfig, the bucket's InboundRateLimiterConfig was overwritten
-			// with zeros, and these three assertions failed.
-			require.Equal(t, preCfg.Base.InboundRateLimit.Cfg.Enabled, postCfg.Base.InboundRateLimit.Cfg.Enabled, "Solana inbound IsEnabled must be unchanged by OutboundOnly apply")
-			require.Equal(t, preCfg.Base.InboundRateLimit.Cfg.Capacity, postCfg.Base.InboundRateLimit.Cfg.Capacity, "Solana inbound capacity must be unchanged by OutboundOnly apply")
-			require.Equal(t, preCfg.Base.InboundRateLimit.Cfg.Rate, postCfg.Base.InboundRateLimit.Cfg.Rate, "Solana inbound rate must be unchanged by OutboundOnly apply")
-
-			// Solana outbound was rewritten to the new value.
-			expOutCap := tokensapi.ScaleFloatToBigInt(newSVMOutbound.Outbounds[0].RateLimit.Capacity, int(svmDecimals), 0)
-			expOutRate := tokensapi.ScaleFloatToBigInt(newSVMOutbound.Outbounds[0].RateLimit.Rate, int(svmDecimals), 0)
-			require.True(t, postCfg.Base.OutboundRateLimit.Cfg.Enabled)
-			require.Equal(t, expOutCap.Uint64(), postCfg.Base.OutboundRateLimit.Cfg.Capacity, "Solana outbound capacity after OutboundOnly apply")
-			require.Equal(t, expOutRate.Uint64(), postCfg.Base.OutboundRateLimit.Cfg.Rate, "Solana outbound rate after OutboundOnly apply")
-
-			// EVM pool was not touched by this OutboundOnly apply (no RemoteOutbounds entry
-			// for solChainSel was provided on the EVM side).
-			postOutboundEVM, err := evmPool.GetCurrentOutboundRateLimiterState(&bind.CallOpts{Context: t.Context()}, solChainSel)
-			require.NoError(t, err)
-			postInboundEVM, err := evmPool.GetCurrentInboundRateLimiterState(&bind.CallOpts{Context: t.Context()}, solChainSel)
-			require.NoError(t, err)
-			require.Equal(t, preOutboundEVM.IsEnabled, postOutboundEVM.IsEnabled, "EVM outbound IsEnabled should be unchanged after OutboundOnly apply on Solana")
-			require.Zero(t, preOutboundEVM.Capacity.Cmp(postOutboundEVM.Capacity), "EVM outbound capacity should be unchanged after OutboundOnly apply on Solana")
-			require.Zero(t, preOutboundEVM.Rate.Cmp(postOutboundEVM.Rate), "EVM outbound rate should be unchanged after OutboundOnly apply on Solana")
-			require.Equal(t, preInboundEVM.IsEnabled, postInboundEVM.IsEnabled, "EVM inbound IsEnabled should be unchanged after OutboundOnly apply on Solana")
-			require.Zero(t, preInboundEVM.Capacity.Cmp(postInboundEVM.Capacity), "EVM inbound capacity should be unchanged after OutboundOnly apply on Solana")
-			require.Zero(t, preInboundEVM.Rate.Cmp(postInboundEVM.Rate), "EVM inbound rate should be unchanged after OutboundOnly apply on Solana")
 		})
 	})
 }

--- a/integration-tests/deployment/token_expansion_scenarios_test.go
+++ b/integration-tests/deployment/token_expansion_scenarios_test.go
@@ -1242,7 +1242,7 @@ func TestTokenExpansionScenariosSolana(t *testing.T) {
 
 			// Get SVM pool address from environment datastore
 			svmPoolRefs := env.DataStore.Addresses().Filter(datastore.AddressRefByChainSelector(solChainSel), datastore.AddressRefByType(datastore.ContractType(cciputils.BurnMintTokenPool)))
-			require.Len(t, svmPoolRefs, 1, "token expansion output should record the new Solana pool")
+			require.Len(t, svmPoolRefs, 1, "preloaded BurnMint token pool program should exist in env.DataStore on Solana (TokenExpansion registers tokens under existing programs, not new pool programs)")
 			svmPoolAddr := svmPoolRefs[0].Address
 
 			// Get EVM token address from changeset output

--- a/integration-tests/deployment/token_expansion_scenarios_test.go
+++ b/integration-tests/deployment/token_expansion_scenarios_test.go
@@ -17,6 +17,7 @@ import (
 
 	evmadapters "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/adapters"
 	bnmERC20ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/burn_mint_erc20"
+	erc20ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/erc20"
 	evmseqV1_6_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/sequences"
 	bnmpool "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/burn_mint_token_pool"
 	lrpool "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/lock_release_token_pool"
@@ -24,6 +25,7 @@ import (
 	routerops "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_6_0/operations/router"
 	solseqV1_6_0 "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_6_0/sequences"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/ccip_common"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v1_6_0/burnmint_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v1_6_0/lockrelease_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
@@ -43,6 +45,9 @@ import (
 
 	_ "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_1/adapters"
 	_ "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_1/adapters"
+
+	// Registers SolanaAddressNormalizer (v1_6_0 sequences do not import v1_0_0 adapters).
+	_ "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_0_0/adapters"
 )
 
 // ---------------------------------------------------------------------------
@@ -916,6 +921,7 @@ func TestTokenExpansionScenariosEVM(t *testing.T) {
 // --------------------------------------------------------------------------------------------------
 
 func TestTokenExpansionScenariosSolana(t *testing.T) {
+	newChainSel := chainsel.TEST_90000002.Selector
 	evmChainSel := chainsel.TEST_90000001.Selector
 	solChainSel := chainsel.SOLANA_DEVNET.Selector
 
@@ -924,7 +930,7 @@ func TestTokenExpansionScenariosSolana(t *testing.T) {
 
 	env, err := environment.New(t.Context(),
 		environment.WithSolanaContainer(t, []uint64{solChainSel}, programsPath, solanaProgramIDs),
-		environment.WithEVMSimulated(t, []uint64{evmChainSel}),
+		environment.WithEVMSimulated(t, []uint64{evmChainSel, newChainSel}),
 	)
 	require.NoError(t, err)
 	env.DataStore = ds.Seal()
@@ -946,6 +952,7 @@ func TestTokenExpansionScenariosSolana(t *testing.T) {
 
 	// Deploy core contracts
 	deployInput := map[uint64]deployapi.ContractDeploymentConfigPerChain{
+		newChainSel: NewDefaultDeploymentConfigForEVM(v1_6_0_scenarios),
 		evmChainSel: NewDefaultDeploymentConfigForEVM(v1_6_0_scenarios),
 		solChainSel: NewDefaultDeploymentConfigForSolana(v1_6_0_scenarios),
 	}
@@ -953,15 +960,14 @@ func TestTokenExpansionScenariosSolana(t *testing.T) {
 	require.NoError(t, err)
 	MergeAddresses(t, env, output.DataStore)
 
+	DeployMCMS(t, env, newChainSel, []string{cciputils.CLLQualifier})
 	DeployMCMS(t, env, evmChainSel, []string{cciputils.CLLQualifier})
 	DeployMCMS(t, env, solChainSel, []string{cciputils.CLLQualifier})
+	EVMTransferOwnership(t, env, newChainSel)
 	EVMTransferOwnership(t, env, evmChainSel)
 	SolanaTransferOwnership(t, env, solChainSel)
 
 	t.Run("Scenario5_SolanaLRToEVMBM", func(t *testing.T) {
-		evmTokenSymbol := "S5_EVM_TOK"
-		evmPoolQual := "S5_EVM_POOL"
-		solTokenSymbol := "S5_SOL_TOK"
 		defaultMaxSupply := uint64(1e6)
 		defaultPreMint := uint64(1e5)
 		evmDecimals := uint8(18)
@@ -973,183 +979,358 @@ func TestTokenExpansionScenariosSolana(t *testing.T) {
 			IsEnabled: true,
 		}
 
-		output, err = tokensapi.TokenExpansion().Apply(*env, tokensapi.TokenExpansionInput{
-			ChainAdapterVersion: v1_6_0_scenarios,
-			MCMS:                NewDefaultInputForMCMS("Scenario 5"),
-			TokenExpansionInputPerChain: map[uint64]tokensapi.TokenExpansionInputPerChain{
-				evmChainSel: {
-					TokenPoolVersion: v1_5_1_scenarios,
-					DeployTokenInput: &tokensapi.DeployTokenInput{
-						Name: "Scenario5 EVM Token", Symbol: evmTokenSymbol, Decimals: evmDecimals,
-						Type: bnmERC20ops.ContractType, Supply: &defaultMaxSupply, PreMint: &defaultPreMint,
-					},
-					DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
-						TokenPoolQualifier: evmPoolQual,
-						PoolType:           cciputils.BurnMintTokenPool.String(),
-					},
-					TokenTransferConfig: &tokensapi.TokenTransferConfig{
-						RemoteChains: map[uint64]tokensapi.RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
-							solChainSel: {OutboundRateLimiterConfig: &defaultRL},
-						},
-					},
-				},
-				solChainSel: {
-					TokenPoolVersion: v1_6_0_scenarios,
-					DeployTokenInput: &tokensapi.DeployTokenInput{
-						Name: "Scenario5 SOL Token", Symbol: solTokenSymbol, Decimals: svmDecimals,
-						Type:                   solanautils.SPLTokens,
-						ExternalAdmin:          solana.NewWallet().PublicKey().String(),
-						DisableFreezeAuthority: true,
-						Senders:                []string{solChain.DeployerKey.PublicKey().String()},
-						PreMint:                &defaultPreMint,
-					},
-					DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
-						TokenPoolQualifier: "",
-						PoolType:           cciputils.LockReleaseTokenPool.String(),
-					},
-					TokenTransferConfig: &tokensapi.TokenTransferConfig{
-						RemoteChains: map[uint64]tokensapi.RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
-							evmChainSel: {OutboundRateLimiterConfig: &defaultRL},
-						},
-					},
-				},
-			},
-		})
-		require.NoError(t, err)
-		MergeAddresses(t, env, output.DataStore)
-		testhelpers.ProcessTimelockProposals(t, *env, output.MCMSTimelockProposals, false)
+		t.Run("BasicDeploymentAndConnection", func(t *testing.T) {
+			const evmTokenSymbol = "S5_EVM_TOK"
+			const solTokenSymbol = "S5_SOL_TOK"
+			const evmPoolQual = "S5_EVM_POOL"
 
-		// ---- EVM assertions ----
-		evmTokAddr := assertTokenExists(t, env, evmChainSel, evmTokenSymbol, "Scenario5 EVM Token", 18)
-		evmPoolAddr, err := evmAdapter.FindLatestAddressRef(env.DataStore, datastore.AddressRef{
-			ChainSelector: evmChainSel,
-			Qualifier:     evmPoolQual,
-			Type:          datastore.ContractType(cciputils.BurnMintTokenPool),
-		})
-		require.NoError(t, err)
-		evmPool, err := bnmpool.NewBurnMintTokenPool(evmPoolAddr, evmChain.Client)
-		require.NoError(t, err)
-
-		gotTok, err := evmPool.GetToken(&bind.CallOpts{Context: t.Context()})
-		require.NoError(t, err)
-		require.Equal(t, evmTokAddr, gotTok)
-
-		supportedChains, err := evmPool.GetSupportedChains(&bind.CallOpts{Context: t.Context()})
-		require.NoError(t, err)
-		require.Contains(t, supportedChains, solChainSel, "EVM pool should support Solana as remote chain")
-
-		assertBMRateLimitsEnabled(t, evmPool, solChainSel)
-
-		// ---- Solana assertions ----
-		solTokenRef, err := datastore_utils.FindAndFormatRef(
-			env.DataStore,
-			datastore.AddressRef{Qualifier: solTokenSymbol},
-			solChainSel,
-			datastore_utils.FullRef,
-		)
-		require.NoError(t, err)
-		require.NotEmpty(t, solTokenRef.Address, "Solana token should exist in datastore")
-
-		// Find the LockRelease pool program for Solana
-		solPoolRef, err := datastore_utils.FindAndFormatRef(env.DataStore, datastore.AddressRef{
-			ChainSelector: solChainSel,
-			Type:          datastore.ContractType(cciputils.LockReleaseTokenPool),
-			Version:       v1_6_0_scenarios,
-		}, solChainSel, datastore_utils.FullRef)
-		require.NoError(t, err)
-		solPoolProgramID := solana.MustPublicKeyFromBase58(solPoolRef.Address)
-		solTokenMint := solana.MustPublicKeyFromBase58(solTokenRef.Address)
-
-		// Verify Solana pool PDA state
-		tokenPoolStatePDA, _ := tokens.TokenPoolConfigAddress(solTokenMint, solPoolProgramID)
-		var solPoolState lockrelease_token_pool.State
-		err = solChain.GetAccountDataBorshInto(t.Context(), tokenPoolStatePDA, &solPoolState)
-		require.NoError(t, err, "Solana LockRelease pool state PDA should be initialized")
-		require.Equal(t, solTokenMint, solPoolState.Config.Mint,
-			fmt.Sprintf("Solana pool mint should match token %s", solTokenRef.Address))
-
-		timelockSigner := solanautils.GetTimelockSignerPDA(
-			env.DataStore.Addresses().Filter(),
-			solChainSel,
-			cciputils.CLLQualifier,
-		)
-		require.Equal(t, timelockSigner, solPoolState.Config.RateLimitAdmin,
-			"empty DeployTokenPoolInput.RateLimitAdmin should set RL admin to MCMS timelock signer PDA on Solana")
-
-		// Verify Solana router address is set
-		routerAddr, err := solAdapter.GetRouterAddress(env.DataStore, solChainSel)
-		require.NoError(t, err)
-		require.NotEmpty(t, routerAddr, "Solana router should be deployed")
-
-		// Now try updating the rate limits in both directions and verify on-chain state is updated accordingly
-		t.Run("SetTokenPoolRateLimits", func(t *testing.T) {
-			evmTowardSVM := tokensapi.RemoteOutbounds{RateLimit: &tokensapi.RateLimiterConfigFloatInput{Capacity: 111, Rate: 11, IsEnabled: true}}
-			svmTowardEVM := tokensapi.RemoteOutbounds{RateLimit: &tokensapi.RateLimiterConfigFloatInput{Capacity: 222, Rate: 22, IsEnabled: true}}
-			tprlOut, err := tokensapi.SetTokenPoolRateLimits().Apply(*env, tokensapi.TPRLInput{
-				MCMS: NewDefaultInputForMCMS("Scenario 5 TPRL"),
-				Configs: map[uint64]tokensapi.TPRLConfig{
+			output, err = tokensapi.TokenExpansion().Apply(*env, tokensapi.TokenExpansionInput{
+				ChainAdapterVersion: v1_6_0_scenarios,
+				MCMS:                NewDefaultInputForMCMS("Scenario 5"),
+				TokenExpansionInputPerChain: map[uint64]tokensapi.TokenExpansionInputPerChain{
 					evmChainSel: {
-						ChainAdapterVersion: v1_6_0_scenarios,
-						TokenPoolRef:        datastore.AddressRef{Address: evmPoolAddr.Hex()},
-						TokenRef:            datastore.AddressRef{Address: evmTokAddr.Hex()},
-						RemoteOutbounds: map[uint64]tokensapi.RemoteOutbounds{
-							solChainSel: evmTowardSVM,
+						TokenPoolVersion: v1_5_1_scenarios,
+						DeployTokenInput: &tokensapi.DeployTokenInput{
+							Name: "Scenario5 EVM Token", Symbol: evmTokenSymbol, Decimals: evmDecimals,
+							Type: bnmERC20ops.ContractType, Supply: &defaultMaxSupply, PreMint: &defaultPreMint,
+						},
+						DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
+							TokenPoolQualifier: evmPoolQual,
+							PoolType:           cciputils.BurnMintTokenPool.String(),
+						},
+						TokenTransferConfig: &tokensapi.TokenTransferConfig{
+							RemoteChains: map[uint64]tokensapi.RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
+								solChainSel: {OutboundRateLimiterConfig: &defaultRL},
+							},
 						},
 					},
 					solChainSel: {
-						ChainAdapterVersion: v1_6_0_scenarios,
-						TokenPoolRef:        datastore.AddressRef{Address: solPoolProgramID.String()},
-						TokenRef:            datastore.AddressRef{Address: solTokenMint.String()},
-						RemoteOutbounds: map[uint64]tokensapi.RemoteOutbounds{
-							evmChainSel: svmTowardEVM,
+						TokenPoolVersion: v1_6_0_scenarios,
+						DeployTokenInput: &tokensapi.DeployTokenInput{
+							Name: "Scenario5 SOL Token", Symbol: solTokenSymbol, Decimals: svmDecimals,
+							Type:                   solanautils.SPLTokens,
+							ExternalAdmin:          solana.NewWallet().PublicKey().String(),
+							DisableFreezeAuthority: true,
+							Senders:                []string{solChain.DeployerKey.PublicKey().String()},
+							PreMint:                &defaultPreMint,
+						},
+						DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
+							TokenPoolQualifier: "",
+							PoolType:           cciputils.LockReleaseTokenPool.String(),
+						},
+						TokenTransferConfig: &tokensapi.TokenTransferConfig{
+							RemoteChains: map[uint64]tokensapi.RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
+								evmChainSel: {OutboundRateLimiterConfig: &defaultRL},
+							},
 						},
 					},
 				},
 			})
 			require.NoError(t, err)
-			testhelpers.ProcessTimelockProposals(t, *env, tprlOut.MCMSTimelockProposals, false)
+			MergeAddresses(t, env, output.DataStore)
+			testhelpers.ProcessTimelockProposals(t, *env, output.MCMSTimelockProposals, false)
 
-			// Read EVM rate limits from the chain
-			outboundEVM, err := evmPool.GetCurrentOutboundRateLimiterState(&bind.CallOpts{Context: t.Context()}, solChainSel)
+			// ---- EVM assertions ----
+			evmTokAddr := assertTokenExists(t, env, evmChainSel, evmTokenSymbol, "Scenario5 EVM Token", 18)
+			evmPoolAddr, err := evmAdapter.FindLatestAddressRef(env.DataStore, datastore.AddressRef{
+				ChainSelector: evmChainSel,
+				Qualifier:     evmPoolQual,
+				Type:          datastore.ContractType(cciputils.BurnMintTokenPool),
+			})
 			require.NoError(t, err)
-			inboundEVM, err := evmPool.GetCurrentInboundRateLimiterState(&bind.CallOpts{Context: t.Context()}, solChainSel)
+			evmPool, err := bnmpool.NewBurnMintTokenPool(evmPoolAddr, evmChain.Client)
 			require.NoError(t, err)
 
-			// Verify EVM rate limit state matches expected values (with correct scaling for decimals). The
-			// inbound on legacy EVM pools (<v1.6.1 non-external-minter) scales using remote token decimals
-			// (see tokensapi.GenerateTPRLConfigs); counterpart outbound is Solana -> use svmDecimals.
-			expInboundCapEVM := tokensapi.ScaleFloatToBigInt(svmTowardEVM.RateLimit.Capacity, int(svmDecimals), 0.10)
-			expInboundRateEVM := tokensapi.ScaleFloatToBigInt(svmTowardEVM.RateLimit.Rate, int(svmDecimals), 0.10)
-			expOutboundCapEVM := tokensapi.ScaleFloatToBigInt(evmTowardSVM.RateLimit.Capacity, int(evmDecimals), 0)
-			expOutboundRateEVM := tokensapi.ScaleFloatToBigInt(evmTowardSVM.RateLimit.Rate, int(evmDecimals), 0)
-			require.Zero(t, expOutboundCapEVM.Cmp(outboundEVM.Capacity), "EVM outbound capacity toward Solana should match TPRL input after scaling (want %s, got %s)", expOutboundCapEVM.String(), outboundEVM.Capacity.String())
-			require.Zero(t, expOutboundRateEVM.Cmp(outboundEVM.Rate), "EVM outbound rate toward Solana should match TPRL input after scaling (want %s, got %s)", expOutboundRateEVM.String(), outboundEVM.Rate.String())
-			require.Zero(t, expInboundCapEVM.Cmp(inboundEVM.Capacity), "EVM inbound capacity from Solana should match counterpart outbound TPRL input + inbound scaling (want %s, got %s)", expInboundCapEVM.String(), inboundEVM.Capacity.String())
-			require.Zero(t, expInboundRateEVM.Cmp(inboundEVM.Rate), "EVM inbound rate from Solana should match counterpart outbound TPRL input + inbound scaling (want %s, got %s)", expInboundRateEVM.String(), inboundEVM.Rate.String())
-			require.True(t, outboundEVM.IsEnabled)
-			require.True(t, inboundEVM.IsEnabled)
-
-			// Read Solana rate limits from the chain
-			chainCfgPDA, _, err := tokens.TokenPoolChainConfigPDA(evmChainSel, solTokenMint, solPoolProgramID)
+			gotTok, err := evmPool.GetToken(&bind.CallOpts{Context: t.Context()})
 			require.NoError(t, err)
-			var chainCfg lockrelease_token_pool.ChainConfig
-			require.NoError(t, solChain.GetAccountDataBorshInto(t.Context(), chainCfgPDA, &chainCfg))
-			outboundCapSVM := big.NewInt(0).SetUint64(chainCfg.Base.OutboundRateLimit.Cfg.Capacity)
-			outboundRateSVM := big.NewInt(0).SetUint64(chainCfg.Base.OutboundRateLimit.Cfg.Rate)
-			inboundCapSVM := big.NewInt(0).SetUint64(chainCfg.Base.InboundRateLimit.Cfg.Capacity)
-			inboundRateSVM := big.NewInt(0).SetUint64(chainCfg.Base.InboundRateLimit.Cfg.Rate)
+			require.Equal(t, evmTokAddr, gotTok)
 
-			// Verify Solana rate limit state matches expected values (with correct scaling for decimals)
-			expInboundCapSVM := tokensapi.ScaleFloatToBigInt(evmTowardSVM.RateLimit.Capacity, int(svmDecimals), 0.10)
-			expInboundRateSVM := tokensapi.ScaleFloatToBigInt(evmTowardSVM.RateLimit.Rate, int(svmDecimals), 0.10)
-			expOutboundCapSVM := tokensapi.ScaleFloatToBigInt(svmTowardEVM.RateLimit.Capacity, int(svmDecimals), 0)
-			expOutboundRateSVM := tokensapi.ScaleFloatToBigInt(svmTowardEVM.RateLimit.Rate, int(svmDecimals), 0)
-			require.Zero(t, expOutboundCapSVM.Cmp(outboundCapSVM), "Solana outbound capacity toward EVM should match TPRL input after scaling (want %s, got %s)", expOutboundCapSVM.String(), outboundCapSVM.String())
-			require.Zero(t, expOutboundRateSVM.Cmp(outboundRateSVM), "Solana outbound rate toward EVM should match TPRL input after scaling (want %s, got %s)", expOutboundRateSVM.String(), outboundRateSVM.String())
-			require.Zero(t, expInboundCapSVM.Cmp(inboundCapSVM), "Solana inbound capacity from EVM should match counterpart outbound TPRL input + inbound scaling (want %s, got %s)", expInboundCapSVM.String(), inboundCapSVM.String())
-			require.Zero(t, expInboundRateSVM.Cmp(inboundRateSVM), "Solana inbound rate from EVM should match counterpart outbound TPRL input + inbound scaling (want %s, got %s)", expInboundRateSVM.String(), inboundRateSVM.String())
-			require.True(t, chainCfg.Base.OutboundRateLimit.Cfg.Enabled)
-			require.True(t, chainCfg.Base.InboundRateLimit.Cfg.Enabled)
+			supportedChains, err := evmPool.GetSupportedChains(&bind.CallOpts{Context: t.Context()})
+			require.NoError(t, err)
+			require.Contains(t, supportedChains, solChainSel, "EVM pool should support Solana as remote chain")
+
+			assertBMRateLimitsEnabled(t, evmPool, solChainSel)
+
+			// ---- Solana assertions ----
+			solTokenRef, err := datastore_utils.FindAndFormatRef(
+				env.DataStore,
+				datastore.AddressRef{Qualifier: solTokenSymbol},
+				solChainSel,
+				datastore_utils.FullRef,
+			)
+			require.NoError(t, err)
+			require.NotEmpty(t, solTokenRef.Address, "Solana token should exist in datastore")
+
+			// Find the LockRelease pool program for Solana
+			solPoolRef, err := datastore_utils.FindAndFormatRef(env.DataStore, datastore.AddressRef{
+				ChainSelector: solChainSel,
+				Type:          datastore.ContractType(cciputils.LockReleaseTokenPool),
+				Version:       v1_6_0_scenarios,
+			}, solChainSel, datastore_utils.FullRef)
+			require.NoError(t, err)
+			solPoolProgramID := solana.MustPublicKeyFromBase58(solPoolRef.Address)
+			solTokenMint := solana.MustPublicKeyFromBase58(solTokenRef.Address)
+
+			// Verify Solana pool PDA state
+			tokenPoolStatePDA, _ := tokens.TokenPoolConfigAddress(solTokenMint, solPoolProgramID)
+			var solPoolState lockrelease_token_pool.State
+			err = solChain.GetAccountDataBorshInto(t.Context(), tokenPoolStatePDA, &solPoolState)
+			require.NoError(t, err, "Solana LockRelease pool state PDA should be initialized")
+			require.Equal(t, solTokenMint, solPoolState.Config.Mint,
+				fmt.Sprintf("Solana pool mint should match token %s", solTokenRef.Address))
+
+			timelockSigner := solanautils.GetTimelockSignerPDA(
+				env.DataStore.Addresses().Filter(),
+				solChainSel,
+				cciputils.CLLQualifier,
+			)
+			require.Equal(t, timelockSigner, solPoolState.Config.RateLimitAdmin,
+				"empty DeployTokenPoolInput.RateLimitAdmin should set RL admin to MCMS timelock signer PDA on Solana")
+
+			// Verify Solana router address is set
+			routerAddr, err := solAdapter.GetRouterAddress(env.DataStore, solChainSel)
+			require.NoError(t, err)
+			require.NotEmpty(t, routerAddr, "Solana router should be deployed")
+		})
+
+		// Test address ref inference
+		t.Run("TokenRefResolver", func(t *testing.T) {
+			// Helper vars
+			refReader := tokensapi.GetTokenAdapterRegistry()
+			svmSymbol := "S5_TR_SVM"
+			evmSymbol := "S5_TR_EVM"
+
+			// Make sure tokens aren't in the datastore yet
+			refs := env.DataStore.Addresses().Filter(datastore.AddressRefByChainSelector(solChainSel), datastore.AddressRefByQualifier(svmSymbol))
+			require.Empty(t, refs, "SVM token symbol should not exist in env.DataStore before test")
+			refs = env.DataStore.Addresses().Filter(datastore.AddressRefByChainSelector(evmChainSel), datastore.AddressRefByQualifier(evmSymbol))
+			require.Empty(t, refs, "EVM token symbol should not exist in env.DataStore before test")
+
+			// Deploy some tokens and pools
+			acceptLiquidity := true
+			teOut, err := tokensapi.TokenExpansion().Apply(*env, tokensapi.TokenExpansionInput{
+				ChainAdapterVersion: v1_6_0_scenarios,
+				MCMS:                NewDefaultInputForMCMS("Scenario5 AddressRefInference"),
+				TokenExpansionInputPerChain: map[uint64]tokensapi.TokenExpansionInputPerChain{
+					evmChainSel: {
+						TokenPoolVersion: v1_5_1_scenarios,
+						DeployTokenInput: &tokensapi.DeployTokenInput{
+							Name: "Scenario5 try-resolve EVM token", Symbol: evmSymbol, Decimals: 18,
+							Type: bnmERC20ops.ContractType, Supply: &defaultMaxSupply, PreMint: &defaultPreMint,
+						},
+						DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
+							TokenPoolQualifier: "", // use sensible default
+							PoolType:           cciputils.LockReleaseTokenPool.String(),
+							AcceptLiquidity:    &acceptLiquidity,
+						},
+					},
+					solChainSel: {
+						TokenPoolVersion: v1_6_0_scenarios,
+						DeployTokenInput: &tokensapi.DeployTokenInput{
+							Name: "Scenario5 try-resolve SVM token", Symbol: svmSymbol, Decimals: svmDecimals,
+							Type: solanautils.SPLTokens, ExternalAdmin: solana.NewWallet().PublicKey().String(),
+							Senders: []string{solChain.DeployerKey.PublicKey().String()},
+						},
+						DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
+							TokenPoolQualifier: "",
+							PoolType:           cciputils.BurnMintTokenPool.String(),
+						},
+					},
+				},
+			})
+			require.NoError(t, err)
+			testhelpers.ProcessTimelockProposals(t, *env, teOut.MCMSTimelockProposals, false)
+
+			// Get SVM token address from changeset output
+			svmTokRefs := teOut.DataStore.Addresses().Filter(datastore.AddressRefByChainSelector(solChainSel), datastore.AddressRefByQualifier(svmSymbol))
+			require.Len(t, svmTokRefs, 1, "token expansion output should record the new Solana token")
+			svmTokAddr := svmTokRefs[0].Address
+
+			// Get SVM pool address from environment datastore
+			svmPoolRefs := env.DataStore.Addresses().Filter(datastore.AddressRefByChainSelector(solChainSel), datastore.AddressRefByType(datastore.ContractType(cciputils.BurnMintTokenPool)))
+			require.Len(t, svmPoolRefs, 1, "token expansion output should record the new Solana pool")
+			svmPoolAddr := svmPoolRefs[0].Address
+
+			// Get EVM token address from changeset output
+			evmTokRefs := teOut.DataStore.Addresses().Filter(datastore.AddressRefByChainSelector(evmChainSel), datastore.AddressRefByQualifier(evmSymbol))
+			require.Len(t, evmTokRefs, 1, "token expansion output should record the new EVM token")
+			evmTokAddr := evmTokRefs[0].Address
+
+			// Get EVM pool address from changeset output
+			evmPoolRefs := teOut.DataStore.Addresses().Filter(datastore.AddressRefByChainSelector(evmChainSel), datastore.AddressRefByQualifier(evmTokAddr))
+			require.Len(t, evmPoolRefs, 1, "token expansion output should record the new EVM pool")
+			evmPoolAddr := evmPoolRefs[0].Address
+
+			// We did not call MergeAddresses on teOut, so the environment datastore should NOT have the deployed tokens yet
+			refs = env.DataStore.Addresses().Filter(datastore.AddressRefByChainSelector(solChainSel), datastore.AddressRefByQualifier(svmSymbol), datastore.AddressRefByAddress(svmTokAddr))
+			require.Empty(t, refs, "new SVM mint must not be in env.DataStore before ResolveTokenRef")
+			refs = env.DataStore.Addresses().Filter(datastore.AddressRefByChainSelector(evmChainSel), datastore.AddressRefByQualifier(evmSymbol), datastore.AddressRefByAddress(evmTokAddr))
+			require.Empty(t, refs, "new EVM token address must not be in env.DataStore before ResolveTokenRef")
+
+			// Get the Solana pool PDA and verify it exists on chain
+			svmPoolProgID := solana.MustPublicKeyFromBase58(svmPoolAddr)
+			svmMintPubKey := solana.MustPublicKeyFromBase58(svmTokAddr)
+			svmPoolCfgPDA, _ := tokens.TokenPoolConfigAddress(svmMintPubKey, svmPoolProgID)
+			var solPoolStateBnM burnmint_token_pool.State
+			err = solChain.GetAccountDataBorshInto(t.Context(), svmPoolCfgPDA, &solPoolStateBnM)
+			require.NoError(t, err, "Solana BnM pool state PDA should be initialized for the new pool")
+
+			// Check that we can resolve the new pool and token refs even though they are not in the environment datastore
+			t.Run("ResolveRef", func(t *testing.T) {
+				// Token expansion for Solana now supports either the pool program ID or the pool PDA:
+				// (1) if the user provides a pool PDA, then the initial DS look up will fail -> code will check if it's a PDA and resolve its program ID from the chain -> datastore lookup is re-attempted
+				// (2) if the user provides a prog ID, then the ref must be in the datastore (no onchain resolution is possible)
+				resolvedSvmPool, err := tokensapi.ResolveTokenPoolRef(*env, refReader, solChainSel, datastore.AddressRef{Address: svmPoolCfgPDA.String()})
+				require.NoError(t, err)
+				require.Equal(t, datastore.ContractType(cciputils.BurnMintTokenPool), resolvedSvmPool.Type)
+				require.Equal(t, svmPoolProgID.String(), resolvedSvmPool.Address)
+				require.Equal(t, "", resolvedSvmPool.Qualifier)
+				require.True(t, v1_6_0_scenarios.Equal(resolvedSvmPool.Version))
+
+				// Since the SVM token does not exist in the environment datastore yet, ResolveTokenRef will resolve it from on chain data
+				resolvedSvmTok, err := tokensapi.ResolveTokenRef(*env, refReader, solChainSel, datastore.AddressRef{Address: svmTokAddr})
+				require.NoError(t, err)
+				require.Equal(t, svmTokAddr, resolvedSvmTok.Address)
+				require.Equal(t, fmt.Sprintf("%s-%s", svmTokAddr, solanautils.SPLTokens), resolvedSvmTok.Qualifier)
+				require.Equal(t, datastore.ContractType(solanautils.SPLTokens), resolvedSvmTok.Type)
+				require.True(t, v1_6_0_scenarios.Equal(resolvedSvmTok.Version))
+
+				// Since the EVM pool does not exist in the environment datastore yet, ResolveTokenPoolRef will resolve it from on chain data
+				resolvedEvmPool, err := tokensapi.ResolveTokenPoolRef(*env, refReader, evmChainSel, datastore.AddressRef{Address: evmPoolAddr})
+				require.NoError(t, err)
+				require.Equal(t, datastore.ContractType(cciputils.LockReleaseTokenPool), resolvedEvmPool.Type)
+				require.Equal(t, evmPoolAddr, resolvedEvmPool.Address)
+				require.Equal(t, evmTokAddr, resolvedEvmPool.Qualifier)
+				require.True(t, v1_5_1_scenarios.Equal(resolvedEvmPool.Version))
+
+				// Since the EVM token does not exist in the environment datastore yet, ResolveTokenRef will resolve it from on chain data
+				resolvedEvmTok, err := tokensapi.ResolveTokenRef(*env, refReader, evmChainSel, datastore.AddressRef{Address: evmTokAddr})
+				require.NoError(t, err)
+				require.Equal(t, common.HexToAddress(evmTokAddr).Hex(), resolvedEvmTok.Address)
+				require.Equal(t, evmSymbol, resolvedEvmTok.Qualifier)
+				require.Equal(t, datastore.ContractType(erc20ops.ContractType), resolvedEvmTok.Type)
+				require.True(t, cciputils.Version_1_0_0.Equal(resolvedEvmTok.Version))
+			})
+
+			// The deployed tokens are not in the datastore yet so calling TokenExpansion again would normally result in an error.
+			// However, the new TokenRefResolver interface allows us to source tokens and pools from the chain so now we no longer
+			// need to worry about the datastore containing these token/pool refs - the tooling is smart enough to infer them.
+			t.Run("TokenExpansionWithInferredRefs", func(t *testing.T) {
+				teOut, err = tokensapi.TokenExpansion().Apply(*env, tokensapi.TokenExpansionInput{
+					ChainAdapterVersion: v1_6_0_scenarios,
+					MCMS:                NewDefaultInputForMCMS("Scenario5 AddressRefInference"),
+					TokenExpansionInputPerChain: map[uint64]tokensapi.TokenExpansionInputPerChain{
+						newChainSel: {
+							TokenPoolVersion: cciputils.Version_1_6_1,
+							DeployTokenInput: &tokensapi.DeployTokenInput{
+								Name: "Scenario5 try-resolve EVM token", Symbol: evmSymbol, Decimals: 18,
+								Type: bnmERC20ops.ContractType, Supply: &defaultMaxSupply, PreMint: &defaultPreMint,
+							},
+							DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
+								TokenPoolQualifier: "", // use sensible default
+								PoolType:           cciputils.BurnWithFromMintTokenPool.String(),
+							},
+							TokenTransferConfig: &tokensapi.TokenTransferConfig{
+								RemoteChains: map[uint64]tokensapi.RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
+									evmChainSel: {OutboundRateLimiterConfig: &defaultRL},
+									solChainSel: {OutboundRateLimiterConfig: &defaultRL},
+								},
+							},
+						},
+						evmChainSel: {
+							// TokenRef is not needed - DeriveTokenAddress can resolve the whole ref from the chain
+							TokenTransferConfig: &tokensapi.TokenTransferConfig{
+								TokenPoolRef: datastore.AddressRef{Address: evmPoolAddr},
+								RemoteChains: map[uint64]tokensapi.RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
+									newChainSel: {OutboundRateLimiterConfig: &defaultRL},
+									solChainSel: {OutboundRateLimiterConfig: &defaultRL},
+								},
+							},
+						},
+						solChainSel: {
+							// TokenRef is not needed - DeriveTokenAddress can resolve the whole ref from the chain since we're using the pool PDA
+							TokenTransferConfig: &tokensapi.TokenTransferConfig{
+								TokenPoolRef: datastore.AddressRef{Address: svmPoolCfgPDA.String()},
+								RemoteChains: map[uint64]tokensapi.RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
+									newChainSel: {OutboundRateLimiterConfig: &defaultRL},
+									evmChainSel: {OutboundRateLimiterConfig: &defaultRL},
+								},
+							},
+						},
+					},
+				})
+				require.NoError(t, err)
+				testhelpers.ProcessTimelockProposals(t, *env, teOut.MCMSTimelockProposals, false)
+			})
+
+			// Next, we try updating the rate limits in both directions without providing the token refs (the ref resolver should be able to infer them)
+			t.Run("TPRLWithInferredRefs", func(t *testing.T) {
+				evmTowardSVM := tokensapi.RemoteOutbounds{RateLimit: &tokensapi.RateLimiterConfigFloatInput{Capacity: 111, Rate: 11, IsEnabled: true}}
+				svmTowardEVM := tokensapi.RemoteOutbounds{RateLimit: &tokensapi.RateLimiterConfigFloatInput{Capacity: 222, Rate: 22, IsEnabled: true}}
+				tprlOut, err := tokensapi.SetTokenPoolRateLimits().Apply(*env, tokensapi.TPRLInput{
+					MCMS: NewDefaultInputForMCMS("Scenario 5 TPRL"),
+					Configs: map[uint64]tokensapi.TPRLConfig{
+						evmChainSel: {
+							TokenPoolRef: datastore.AddressRef{Address: evmPoolAddr},
+							RemoteOutbounds: map[uint64]tokensapi.RemoteOutbounds{
+								solChainSel: evmTowardSVM,
+							},
+						},
+						solChainSel: {
+							TokenPoolRef: datastore.AddressRef{Address: svmPoolCfgPDA.String()},
+							RemoteOutbounds: map[uint64]tokensapi.RemoteOutbounds{
+								evmChainSel: svmTowardEVM,
+							},
+						},
+					},
+				})
+				require.NoError(t, err)
+				testhelpers.ProcessTimelockProposals(t, *env, tprlOut.MCMSTimelockProposals, false)
+
+				// Read EVM rate limits from the chain
+				evmPool, err := lrpool.NewLockReleaseTokenPool(common.HexToAddress(evmPoolAddr), evmChain.Client)
+				require.NoError(t, err)
+				outboundEVM, err := evmPool.GetCurrentOutboundRateLimiterState(&bind.CallOpts{Context: t.Context()}, solChainSel)
+				require.NoError(t, err)
+				inboundEVM, err := evmPool.GetCurrentInboundRateLimiterState(&bind.CallOpts{Context: t.Context()}, solChainSel)
+				require.NoError(t, err)
+
+				// Verify EVM rate limit state matches expected values (with correct scaling for decimals). The
+				// inbound on legacy EVM pools (<v1.6.1 non-external-minter) scales using remote token decimals
+				// (see tokensapi.GenerateTPRLConfigs); counterpart outbound is Solana -> use svmDecimals.
+				expInboundCapEVM := tokensapi.ScaleFloatToBigInt(svmTowardEVM.RateLimit.Capacity, int(svmDecimals), 0.10)
+				expInboundRateEVM := tokensapi.ScaleFloatToBigInt(svmTowardEVM.RateLimit.Rate, int(svmDecimals), 0.10)
+				expOutboundCapEVM := tokensapi.ScaleFloatToBigInt(evmTowardSVM.RateLimit.Capacity, int(evmDecimals), 0)
+				expOutboundRateEVM := tokensapi.ScaleFloatToBigInt(evmTowardSVM.RateLimit.Rate, int(evmDecimals), 0)
+				require.Zero(t, expOutboundCapEVM.Cmp(outboundEVM.Capacity), "EVM outbound capacity toward Solana should match TPRL input after scaling (want %s, got %s)", expOutboundCapEVM.String(), outboundEVM.Capacity.String())
+				require.Zero(t, expOutboundRateEVM.Cmp(outboundEVM.Rate), "EVM outbound rate toward Solana should match TPRL input after scaling (want %s, got %s)", expOutboundRateEVM.String(), outboundEVM.Rate.String())
+				require.Zero(t, expInboundCapEVM.Cmp(inboundEVM.Capacity), "EVM inbound capacity from Solana should match counterpart outbound TPRL input + inbound scaling (want %s, got %s)", expInboundCapEVM.String(), inboundEVM.Capacity.String())
+				require.Zero(t, expInboundRateEVM.Cmp(inboundEVM.Rate), "EVM inbound rate from Solana should match counterpart outbound TPRL input + inbound scaling (want %s, got %s)", expInboundRateEVM.String(), inboundEVM.Rate.String())
+				require.True(t, outboundEVM.IsEnabled)
+				require.True(t, inboundEVM.IsEnabled)
+
+				// Read Solana rate limits from the chain
+				chainCfgPDA, _, err := tokens.TokenPoolChainConfigPDA(evmChainSel, svmMintPubKey, svmPoolProgID)
+				require.NoError(t, err)
+				var chainCfg lockrelease_token_pool.ChainConfig
+				require.NoError(t, solChain.GetAccountDataBorshInto(t.Context(), chainCfgPDA, &chainCfg))
+				outboundCapSVM := big.NewInt(0).SetUint64(chainCfg.Base.OutboundRateLimit.Cfg.Capacity)
+				outboundRateSVM := big.NewInt(0).SetUint64(chainCfg.Base.OutboundRateLimit.Cfg.Rate)
+				inboundCapSVM := big.NewInt(0).SetUint64(chainCfg.Base.InboundRateLimit.Cfg.Capacity)
+				inboundRateSVM := big.NewInt(0).SetUint64(chainCfg.Base.InboundRateLimit.Cfg.Rate)
+
+				// Verify Solana rate limit state matches expected values (with correct scaling for decimals)
+				expInboundCapSVM := tokensapi.ScaleFloatToBigInt(evmTowardSVM.RateLimit.Capacity, int(svmDecimals), 0.10)
+				expInboundRateSVM := tokensapi.ScaleFloatToBigInt(evmTowardSVM.RateLimit.Rate, int(svmDecimals), 0.10)
+				expOutboundCapSVM := tokensapi.ScaleFloatToBigInt(svmTowardEVM.RateLimit.Capacity, int(svmDecimals), 0)
+				expOutboundRateSVM := tokensapi.ScaleFloatToBigInt(svmTowardEVM.RateLimit.Rate, int(svmDecimals), 0)
+				require.Zero(t, expOutboundCapSVM.Cmp(outboundCapSVM), "Solana outbound capacity toward EVM should match TPRL input after scaling (want %s, got %s)", expOutboundCapSVM.String(), outboundCapSVM.String())
+				require.Zero(t, expOutboundRateSVM.Cmp(outboundRateSVM), "Solana outbound rate toward EVM should match TPRL input after scaling (want %s, got %s)", expOutboundRateSVM.String(), outboundRateSVM.String())
+				require.Zero(t, expInboundCapSVM.Cmp(inboundCapSVM), "Solana inbound capacity from EVM should match counterpart outbound TPRL input + inbound scaling (want %s, got %s)", expInboundCapSVM.String(), inboundCapSVM.String())
+				require.Zero(t, expInboundRateSVM.Cmp(inboundRateSVM), "Solana inbound rate from EVM should match counterpart outbound TPRL input + inbound scaling (want %s, got %s)", expInboundRateSVM.String(), inboundRateSVM.String())
+				require.True(t, chainCfg.Base.OutboundRateLimit.Cfg.Enabled)
+				require.True(t, chainCfg.Base.InboundRateLimit.Cfg.Enabled)
+			})
 		})
 	})
 }

--- a/integration-tests/deployment/tokens_and_token_pools_test.go
+++ b/integration-tests/deployment/tokens_and_token_pools_test.go
@@ -679,8 +679,8 @@ func TestTokensAndTokenPools(t *testing.T) {
 				tokenPoolStatePDA, err := tokens.TokenPoolConfigAddress(tokenAddr, tokenPoolProgramID)
 				require.NoError(t, err)
 
-				// NOTE: BnM and LnR pools have the same pool state format
-				// so we can either type for decoding the pool state here.
+				// NOTE: BnM & LnR pools have the same pool state format so
+				// we can use either type for decoding the pool state here.
 				var poolState burnmint_token_pool.State
 				require.NoError(t, data.Chain.GetAccountDataBorshInto(t.Context(), tokenPoolStatePDA, &poolState))
 

--- a/integration-tests/deployment/tokens_and_token_pools_test.go
+++ b/integration-tests/deployment/tokens_and_token_pools_test.go
@@ -6,7 +6,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
@@ -28,7 +27,6 @@ import (
 	deployapi "github.com/smartcontractkit/chainlink-ccip/deployment/deploy"
 	tokensapi "github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	cciputils "github.com/smartcontractkit/chainlink-ccip/deployment/utils"
-	common_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
 	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
@@ -49,11 +47,6 @@ import (
 )
 
 func TestTokensAndTokenPools(t *testing.T) {
-	v1_6_0, err := semver.NewVersion("1.6.0")
-	require.NoError(t, err)
-	v1_6_1, err := semver.NewVersion("1.6.1")
-	require.NoError(t, err)
-
 	// Define chains
 	evmChainSelA := chainsel.TEST_90000001.Selector
 	evmChainSelB := chainsel.TEST_90000002.Selector
@@ -126,7 +119,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 			RateLimitAdmin:     solana.NewWallet().PublicKey().String(),
 			Deployer:           solChain.DeployerKey,
 			Chain:              solChain,
-			Deploy:             NewDefaultDeploymentConfigForSolana(v1_6_0),
+			Deploy:             NewDefaultDeploymentConfigForSolana(cciputils.Version_1_6_0),
 			Token: &tokensapi.DeployTokenInput{
 				Decimals:               uint8(9),
 				Symbol:                 "SOL_TEST",
@@ -146,7 +139,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 			TokenPoolType:      cciputils.LockReleaseTokenPool.String(),
 			Deployer:           solChain.DeployerKey,
 			Chain:              solChain,
-			Deploy:             NewDefaultDeploymentConfigForSolana(v1_6_0),
+			Deploy:             NewDefaultDeploymentConfigForSolana(cciputils.Version_1_6_0),
 			Token: &tokensapi.DeployTokenInput{
 				Decimals:               uint8(9),
 				Symbol:                 "SOL_TEST2",
@@ -183,7 +176,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 			Deployer:           evmChainA.DeployerKey.From,
 			Chain:              evmChainA,
 			TAR:                nil, // populated later
-			Deploy:             NewDefaultDeploymentConfigForEVM(v1_6_0),
+			Deploy:             NewDefaultDeploymentConfigForEVM(cciputils.Version_1_6_0),
 			Token: &tokensapi.DeployTokenInput{
 				Decimals:               uint8(18),
 				Symbol:                 "EVM_TEST_A",
@@ -204,7 +197,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 			Deployer:           evmChainB.DeployerKey.From,
 			Chain:              evmChainB,
 			TAR:                nil, // populated later
-			Deploy:             NewDefaultDeploymentConfigForEVM(v1_6_0),
+			Deploy:             NewDefaultDeploymentConfigForEVM(cciputils.Version_1_6_0),
 			Token: &tokensapi.DeployTokenInput{
 				Decimals:               uint8(18),
 				Symbol:                 "EVM_TEST_B",
@@ -277,7 +270,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 		input := make(map[uint64]tokensapi.TokenExpansionInputPerChain)
 		// Define token expansion input
 		input[solbnm.Chain.Selector] = tokensapi.TokenExpansionInputPerChain{
-			TokenPoolVersion: v1_6_0,
+			TokenPoolVersion: cciputils.Version_1_6_0,
 			DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
 				TokenPoolQualifier: solbnm.TokenPoolQualifier,
 				PoolType:           solbnm.TokenPoolType,
@@ -289,7 +282,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 		// Add EVM chains to the input
 		for _, data := range evmTestData {
 			input[data.Chain.Selector] = tokensapi.TokenExpansionInputPerChain{
-				TokenPoolVersion: v1_6_1,
+				TokenPoolVersion: cciputils.Version_1_6_1,
 				DeployTokenInput: data.Token,
 				DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
 					TokenPoolQualifier: data.TokenPoolQualifier,
@@ -302,7 +295,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 		// Run token expansion for bnm
 		output, err = tokensapi.TokenExpansion().Apply(*env, tokensapi.TokenExpansionInput{
 			TokenExpansionInputPerChain: input,
-			ChainAdapterVersion:         v1_6_0,
+			ChainAdapterVersion:         cciputils.Version_1_6_0,
 			MCMS:                        NewDefaultInputForMCMS("Token Expansion"),
 		})
 		require.NoError(t, err)
@@ -312,7 +305,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 		input = make(map[uint64]tokensapi.TokenExpansionInputPerChain)
 		// Define token expansion input
 		input[sollnr.Chain.Selector] = tokensapi.TokenExpansionInputPerChain{
-			TokenPoolVersion: v1_6_0,
+			TokenPoolVersion: cciputils.Version_1_6_0,
 			DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
 				TokenPoolQualifier: sollnr.TokenPoolQualifier,
 				PoolType:           sollnr.TokenPoolType,
@@ -322,7 +315,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 		}
 		output, err = tokensapi.TokenExpansion().Apply(*env, tokensapi.TokenExpansionInput{
 			TokenExpansionInputPerChain: input,
-			ChainAdapterVersion:         v1_6_0,
+			ChainAdapterVersion:         cciputils.Version_1_6_0,
 			MCMS:                        NewDefaultInputForMCMS("Token Expansion"),
 		})
 		require.NoError(t, err)
@@ -415,16 +408,16 @@ func TestTokensAndTokenPools(t *testing.T) {
 				require.Equal(t, tokAddress, tok)
 
 				// Verify that DeriveTokenAddress works as expected via token adapter registry
-				evmTokenAdapter, adapterOk := tokensapi.GetTokenAdapterRegistry().GetTokenAdapter(chainsel.FamilyEVM, v1_6_1)
+				evmTokenAdapter, adapterOk := tokensapi.GetTokenAdapterRegistry().GetTokenAdapter(chainsel.FamilyEVM, cciputils.Version_1_6_1)
 				require.True(t, adapterOk, "v1.6.1 EVM token adapter should be registered")
 				derived, err := evmTokenAdapter.DeriveTokenAddress(*env, data.Chain.Selector, datastore.AddressRef{
 					ChainSelector: data.Chain.Selector,
 					Qualifier:     data.TokenPoolQualifier,
 					Type:          datastore.ContractType(evmTokenPoolType),
-					Version:       v1_6_1,
+					Version:       cciputils.Version_1_6_1,
 				})
 				require.NoError(t, err)
-				require.Equal(t, 0, common.BytesToAddress(derived).Cmp(tokAddress))
+				require.Equal(t, 0, common.HexToAddress(derived).Cmp(tokAddress))
 			}
 		})
 
@@ -450,7 +443,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 				output, err = tokensapi.
 					ManualRegistration().
 					Apply(*env, tokensapi.ManualRegistrationInput{
-						ChainAdapterVersion: v1_6_0,
+						ChainAdapterVersion: cciputils.Version_1_6_0,
 						MCMS:                NewDefaultInputForMCMS("Manual Registration EVM"),
 						Registrations: []tokensapi.RegisterTokenConfig{
 							// NOTE: if the input contains registrations for the same chain selector + token
@@ -536,7 +529,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 					TokenExpansionInputPerChain: map[uint64]tokensapi.TokenExpansionInputPerChain{
 						evmA.Chain.Selector: {
 							SkipOwnershipTransfer: true, // https://smartcontract-it.atlassian.net/browse/NONEVM-2902
-							TokenPoolVersion:      v1_6_0,
+							TokenPoolVersion:      cciputils.Version_1_6_0,
 							TokenTransferConfig: &tokensapi.TokenTransferConfig{
 								ChainSelector: evmA.Chain.Selector,
 								TokenPoolRef: datastore.AddressRef{
@@ -557,7 +550,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 											ChainSelector: evmB.Chain.Selector,
 											Qualifier:     evmB.TokenPoolQualifier,
 											Type:          datastore.ContractType(evmTokenPoolType),
-											Version:       v1_6_1,
+											Version:       cciputils.Version_1_6_1,
 										},
 									},
 								},
@@ -565,14 +558,14 @@ func TestTokensAndTokenPools(t *testing.T) {
 						},
 						evmB.Chain.Selector: {
 							SkipOwnershipTransfer: true, // https://smartcontract-it.atlassian.net/browse/NONEVM-2902
-							TokenPoolVersion:      v1_6_0,
+							TokenPoolVersion:      cciputils.Version_1_6_0,
 							TokenTransferConfig: &tokensapi.TokenTransferConfig{
 								ChainSelector: evmB.Chain.Selector,
 								TokenPoolRef: datastore.AddressRef{
 									ChainSelector: evmB.Chain.Selector,
 									Qualifier:     evmB.TokenPoolQualifier,
 									Type:          datastore.ContractType(evmTokenPoolType),
-									Version:       v1_6_1,
+									Version:       cciputils.Version_1_6_1,
 								},
 								RegistryRef: datastore.AddressRef{}, // inferred
 								RemoteChains: map[uint64]tokensapi.RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
@@ -591,7 +584,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 							},
 						},
 					},
-					ChainAdapterVersion: v1_6_0,
+					ChainAdapterVersion: cciputils.Version_1_6_0,
 					MCMS:                NewDefaultInputForMCMS("Deploy token to test"),
 				})
 				require.NoError(t, err)
@@ -667,40 +660,46 @@ func TestTokensAndTokenPools(t *testing.T) {
 
 				_, balance, err := tokens.TokenBalance(t.Context(), data.Chain.Client, deployerATA, solchain.SolDefaultCommitment)
 				require.NoError(t, err)
-
 				require.Equal(t, 0, preMint.Cmp(big.NewInt(int64(balance))), fmt.Sprintf("expected pre-mint %q to match actual balance %d", preMint.String(), balance))
 
+				tokenPoolRef, err := datastore_utils.FindAndFormatRef(
+					env.DataStore,
+					datastore.AddressRef{
+						ChainSelector: data.Chain.Selector,
+						Qualifier:     data.TokenPoolQualifier,
+						Type:          datastore.ContractType(data.TokenPoolType),
+						Version:       cciputils.Version_1_6_0,
+					},
+					data.Chain.Selector,
+					datastore_utils.FullRef,
+				)
+				require.NoError(t, err)
+
+				tokenPoolProgramID := solana.MustPublicKeyFromBase58(tokenPoolRef.Address)
+				tokenPoolStatePDA, err := tokens.TokenPoolConfigAddress(tokenAddr, tokenPoolProgramID)
+				require.NoError(t, err)
+
+				// NOTE: BnM and LnR pools have the same pool state format
+				// so we can either type for decoding the pool state here.
+				var poolState burnmint_token_pool.State
+				require.NoError(t, data.Chain.GetAccountDataBorshInto(t.Context(), tokenPoolStatePDA, &poolState))
+
+				// Verify that the rate limit admin was set correctly on-chain
 				if data.RateLimitAdmin != "" {
 					expectedRLA, err := solana.PublicKeyFromBase58(data.RateLimitAdmin)
 					require.NoError(t, err)
-
-					tokenPoolRef, err := datastore_utils.FindAndFormatRef(
-						env.DataStore,
-						datastore.AddressRef{
-							ChainSelector: data.Chain.Selector,
-							Qualifier:     data.TokenPoolQualifier,
-							Type:          datastore.ContractType(data.TokenPoolType),
-							Version:       common_utils.Version_1_6_0,
-						},
-						data.Chain.Selector,
-						datastore_utils.FullRef,
-					)
-					require.NoError(t, err)
-
-					tokenPoolProgramID := solana.MustPublicKeyFromBase58(tokenPoolRef.Address)
-					tokenPoolStatePDA, err := tokens.TokenPoolConfigAddress(tokenAddr, tokenPoolProgramID)
-					require.NoError(t, err)
-
-					switch data.TokenPoolType {
-					case common_utils.BurnMintTokenPool.String():
-						var poolState burnmint_token_pool.State
-						require.NoError(t, data.Chain.GetAccountDataBorshInto(t.Context(), tokenPoolStatePDA, &poolState))
-						require.Equal(t, expectedRLA, poolState.Config.RateLimitAdmin,
-							"token pool rate limit admin should match DeployTokenPoolInput.RateLimitAdmin")
-					default:
-						t.Fatalf("unexpected TokenPoolType %q with RateLimitAdmin set", data.TokenPoolType)
-					}
+					require.Equal(t, expectedRLA, poolState.Config.RateLimitAdmin, "token pool rate limit admin should match DeployTokenPoolInput.RateLimitAdmin")
 				}
+
+				// Verify that DeriveTokenAddress can derive the token address if it is given the pool PDA instead of the pool program ID
+				svmTokenAdapter, adapterOk := tokensapi.GetTokenAdapterRegistry().GetTokenAdapter(chainsel.FamilySolana, cciputils.Version_1_6_0)
+				require.True(t, adapterOk, "v1.6.0 Solana token adapter should be registered")
+				derived, err := svmTokenAdapter.DeriveTokenAddress(*env,
+					data.Chain.Selector,
+					datastore.AddressRef{Address: tokenPoolStatePDA.String()},
+				)
+				require.NoError(t, err)
+				require.Equal(t, tokenAddr.String(), derived, fmt.Sprintf("expected derived token address %q to match actual token address %q", derived, tokenAddr.String()))
 			}
 		})
 
@@ -726,11 +725,11 @@ func TestTokensAndTokenPools(t *testing.T) {
 			output, err = tokensapi.TokenExpansion().Apply(*env, tokensapi.TokenExpansionInput{
 				TokenExpansionInputPerChain: map[uint64]tokensapi.TokenExpansionInputPerChain{
 					solbnm.Chain.Selector: {
-						TokenPoolVersion: v1_6_0,
+						TokenPoolVersion: cciputils.Version_1_6_0,
 						DeployTokenInput: &deployTokenInput,
 					},
 				},
-				ChainAdapterVersion: v1_6_0,
+				ChainAdapterVersion: cciputils.Version_1_6_0,
 				MCMS:                NewDefaultInputForMCMS("Deploy token to test"),
 			})
 			require.NoError(t, err)
@@ -747,8 +746,8 @@ func TestTokensAndTokenPools(t *testing.T) {
 			require.NoError(t, err)
 			tokenPool, err := datastore_utils.FindAndFormatRef(env.DataStore, datastore.AddressRef{
 				ChainSelector: solbnm.Chain.Selector,
-				Type:          datastore.ContractType(common_utils.BurnMintTokenPool),
-				Version:       common_utils.Version_1_6_0,
+				Type:          datastore.ContractType(cciputils.BurnMintTokenPool),
+				Version:       cciputils.Version_1_6_0,
 			}, solbnm.Chain.Selector, datastore_utils.FullRef)
 			require.NoError(t, err)
 			tokenPoolProgramId := solana.MustPublicKeyFromBase58(tokenPool.Address)
@@ -775,7 +774,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 			output, err = tokensapi.
 				ManualRegistration().
 				Apply(*env, tokensapi.ManualRegistrationInput{
-					ChainAdapterVersion: v1_6_0,
+					ChainAdapterVersion: cciputils.Version_1_6_0,
 					MCMS:                NewDefaultInputForMCMS("Manual Registration Solana"),
 					Registrations: []tokensapi.RegisterTokenConfig{
 						{
@@ -818,7 +817,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 			// Validate the Multisig is stored
 			multisigAdd, err := datastore_utils.FindAndFormatRef(env.DataStore, datastore.AddressRef{
 				ChainSelector: solbnm.Chain.Selector,
-				Version:       common_utils.Version_1_6_0,
+				Version:       cciputils.Version_1_6_0,
 				Qualifier:     tokenSymbol,
 				Type:          "TOKEN_MULTISIG",
 			}, solbnm.Chain.Selector, datastore_utils.FullRef)
@@ -831,7 +830,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 			output, err = tokensapi.
 				ManualRegistration().
 				Apply(*env, tokensapi.ManualRegistrationInput{
-					ChainAdapterVersion: v1_6_0,
+					ChainAdapterVersion: cciputils.Version_1_6_0,
 					MCMS:                NewDefaultInputForMCMS("Manual Registration Solana"),
 					Registrations: []tokensapi.RegisterTokenConfig{
 						{
@@ -891,8 +890,8 @@ func TestTokensAndTokenPools(t *testing.T) {
 			require.NoError(t, err)
 			tokenPool, err := datastore_utils.FindAndFormatRef(env.DataStore, datastore.AddressRef{
 				ChainSelector: solbnm.Chain.Selector,
-				Type:          datastore.ContractType(common_utils.BurnMintTokenPool),
-				Version:       common_utils.Version_1_6_0,
+				Type:          datastore.ContractType(cciputils.BurnMintTokenPool),
+				Version:       cciputils.Version_1_6_0,
 			}, solbnm.Chain.Selector, datastore_utils.FullRef)
 			require.NoError(t, err)
 			tokenPoolProgramId := solana.MustPublicKeyFromBase58(tokenPool.Address)
@@ -919,13 +918,13 @@ func TestTokensAndTokenPools(t *testing.T) {
 			output, err = tokensapi.TokenExpansion().Apply(*env, tokensapi.TokenExpansionInput{
 				TokenExpansionInputPerChain: map[uint64]tokensapi.TokenExpansionInputPerChain{
 					solbnm.Chain.Selector: {
-						TokenPoolVersion: v1_6_0,
+						TokenPoolVersion: cciputils.Version_1_6_0,
 						TokenTransferConfig: &tokensapi.TokenTransferConfig{
 							ChainSelector: solbnm.Chain.Selector,
 							TokenPoolRef: datastore.AddressRef{
 								ChainSelector: solbnm.Chain.Selector,
 								Address:       tokenPool.Address,
-								Version:       v1_6_0,
+								Version:       cciputils.Version_1_6_0,
 							},
 							TokenRef: datastore.AddressRef{
 								ChainSelector: solbnm.Chain.Selector,
@@ -946,7 +945,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 										ChainSelector: evmA.Chain.Selector,
 										Qualifier:     evmA.TokenPoolQualifier,
 										Type:          datastore.ContractType(evmTokenPoolType),
-										Version:       v1_6_1,
+										Version:       cciputils.Version_1_6_1,
 									},
 								},
 								evmB.Chain.Selector: {
@@ -962,7 +961,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 										ChainSelector: evmB.Chain.Selector,
 										Qualifier:     evmB.TokenPoolQualifier,
 										Type:          datastore.ContractType(evmTokenPoolType),
-										Version:       v1_6_1,
+										Version:       cciputils.Version_1_6_1,
 									},
 								},
 							},
@@ -970,14 +969,14 @@ func TestTokensAndTokenPools(t *testing.T) {
 					},
 					evmA.Chain.Selector: {
 						SkipOwnershipTransfer: true, // https://smartcontract-it.atlassian.net/browse/NONEVM-2902
-						TokenPoolVersion:      v1_6_0,
+						TokenPoolVersion:      cciputils.Version_1_6_0,
 						TokenTransferConfig: &tokensapi.TokenTransferConfig{
 							ChainSelector: evmA.Chain.Selector,
 							TokenPoolRef: datastore.AddressRef{
 								ChainSelector: evmA.Chain.Selector,
 								Qualifier:     evmA.TokenPoolQualifier,
 								Type:          datastore.ContractType(evmTokenPoolType),
-								Version:       v1_6_1,
+								Version:       cciputils.Version_1_6_1,
 							},
 							RegistryRef: datastore.AddressRef{}, // inferred
 							RemoteChains: map[uint64]tokensapi.RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
@@ -994,7 +993,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 										ChainSelector: solbnm.Chain.Selector,
 										Qualifier:     solbnm.TokenPoolQualifier,
 										Type:          datastore.ContractType(solbnm.TokenPoolType),
-										Version:       v1_6_0,
+										Version:       cciputils.Version_1_6_0,
 									},
 								},
 							},
@@ -1002,14 +1001,14 @@ func TestTokensAndTokenPools(t *testing.T) {
 					},
 					evmB.Chain.Selector: {
 						SkipOwnershipTransfer: true, // https://smartcontract-it.atlassian.net/browse/NONEVM-2902
-						TokenPoolVersion:      v1_6_0,
+						TokenPoolVersion:      cciputils.Version_1_6_0,
 						TokenTransferConfig: &tokensapi.TokenTransferConfig{
 							ChainSelector: evmB.Chain.Selector,
 							TokenPoolRef: datastore.AddressRef{
 								ChainSelector: evmB.Chain.Selector,
 								Qualifier:     evmB.TokenPoolQualifier,
 								Type:          datastore.ContractType(evmTokenPoolType),
-								Version:       v1_6_1,
+								Version:       cciputils.Version_1_6_1,
 							},
 							RegistryRef: datastore.AddressRef{}, // inferred
 							RemoteChains: map[uint64]tokensapi.RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
@@ -1026,14 +1025,14 @@ func TestTokensAndTokenPools(t *testing.T) {
 										ChainSelector: solbnm.Chain.Selector,
 										Qualifier:     solbnm.TokenPoolQualifier,
 										Type:          datastore.ContractType(solbnm.TokenPoolType),
-										Version:       v1_6_0,
+										Version:       cciputils.Version_1_6_0,
 									},
 								},
 							},
 						},
 					},
 				},
-				ChainAdapterVersion: v1_6_0,
+				ChainAdapterVersion: cciputils.Version_1_6_0,
 				MCMS:                NewDefaultInputForMCMS("Deploy token to test"),
 			})
 			require.NoError(t, err)
@@ -1043,7 +1042,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 			timelockSigner := solanautils.GetTimelockSignerPDA(
 				env.DataStore.Addresses().Filter(),
 				chain.Selector,
-				common_utils.CLLQualifier,
+				cciputils.CLLQualifier,
 			)
 
 			// Verify that a new admin was proposed for the specified token

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment v0.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260312233953-f588f8dc6d7c
-	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260520204756-f0fd9c330aac
+	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260520205139-e02dace3eefa
 	github.com/smartcontractkit/chainlink-deployments-framework v0.100.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260410162948-2dca02f24e98
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20260119171452-39c98c3b33cd

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/smartcontractkit/chainlink-ccip/chains/solana v0.0.0-20260121163256-85accaf3d28d
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment v0.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings v0.0.0-20260312233953-f588f8dc6d7c
-	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260516222345-f2f143454dbd
+	github.com/smartcontractkit/chainlink-ccip/deployment v0.0.0-20260520095735-feac5055dc84
 	github.com/smartcontractkit/chainlink-deployments-framework v0.100.0
 	github.com/smartcontractkit/chainlink-evm v0.3.4-0.20260410162948-2dca02f24e98
 	github.com/smartcontractkit/chainlink-evm/gethwrappers v0.0.0-20260119171452-39c98c3b33cd


### PR DESCRIPTION
## Token / Pool Address Ref Inference + Standardized Address Ref Resolution

### Feature 1: Token and pool address resolvers

A new optional interface has been added to the token adapter registry: **`TokenRefResolver`**. This interface has two methods (**`ResolveTokenPoolRef`** and **`ResolveTokenRef`**) and their purpose is to construct a fully populated address ref given just the token pool address or token address respectively.

This interface has been implemented for both EVM and Solana:

- **Solana resolver:** mint → token program, program type, best-effort Metaplex symbol for qualifier.
- **EVM resolver:** pool address → type & version from contract, getToken for qualifier token hex; token address → ERC20 symbol and a sensible type/version for our datastore conventions.

This allows **`ConfigureTokensForTransfers`**, **`SetTokenPoolRateLimits`**, **manual registration**, **migrations**, etc. to recover when the datastore row isn’t there yet (which happens very often when performing real-world operations).

---

### Feature 2: Solana pool PDA support (so `DeriveTokenAddress` can win)

On Solana, SAs prefer using the **[pool config PDA](https://docs.chain.link/ccip/directory/mainnet/token/USD1)**, not the **token pool program ID**. A pool PDA is more expressive since it contains both the pool program ID and the token mint in its data. 

To accommodate this, the `DeriveTokenAddress` implementation for Solana has been updated as follows: if the input pool ref has a label with the pool PDA or the address itself is the PDA (instead of the token pool program ID), then the function will successfully return the corresponding mint. If the user only provides the token pool program ID, then the behavior of `DeriveTokenAddress` degrades to the current behavior on `main` (i.e. it hard errors since there's not enough info to infer the token).

**Flow (high level):**

```
User passes pool address (base58)
        |
        v
  Is it the PDA or the program ID?
        |
        +--- PDA ----> get owner (program ID) + remember PDA in label
        |
        +--- program ID --> use as-is (can’t derive mint from program ID alone)
        |
        v
  DeriveTokenAddress: read config account @ PDA -> mint string
```

---

### Feature 3: Standardize operation address ref resolution — pool → adapter → token

At the moment, each token API operation resolves refs inconsistently - some of them require you to specify both the pool ref and token ref whereas others do not. This PR fixes that by ensuring all token API operations follow the same standardized address ref resolution flow.

**Flow (high level):**

```mermaid
flowchart TD
    A["poolRef"] --> B["ResolveTokenPoolRef"]
    B --> C["ResolveAdapter (pool version)"]
    C --> D{"DeriveTokenAddress OK?"}
    D -->|yes| E["ResolveTokenRef(derived)"]
    D -->|no| F["ResolveTokenRef(tokenRef)"]
    E --> G["adapter + family + full pool ref + full token ref"]
    F --> G
```

For all operations, **on-chain derivation now has higher precedence than the hand-waved token ref** to reduce misconfigurations. This is a backwards compatible change - you can still pass both the token pool ref and token ref, but if the adapter can get everything it needs from the pool ref + chain, then it will ignore the token ref since it is less reliable.

**Small related cleanups worth knowing:**

- **Remote chain config** path: derive remote token when possible, then resolve; same `ResolveTokenRef` / `AddressRefToBytes` as local.
- **Solana `getTokenMintAndTokenProgram`**: datastore first, then **on-chain resolve** if you have at least the mint address—fixes “chain-only filter matched half the datastore” when token ref was empty.
- **EVM `DeriveTokenAddress`**: can skip datastore when `poolRef.Address` is already the pool contract.
- **EVM `DeriveTokenDecimals`**: try ERC20 **decimals** on the token address first, then fall back to pool path (fewer round-trips when token bytes are known).
- **Solana RPC:** token account info uses explicit **commitment** for more predictable reads.

---

### Testing

This has been tested for both EVM and Solana for TPRL [here](https://github.com/smartcontractkit/chainlink-deployments/compare/main...cd/test-tip20-deploy)

tl;dr: 
- I found a successful TPRL run we did in the past [here](https://github.com/smartcontractkit/chainlink-deployments/pull/14393)
- I copy/pasted the YAML file and edited it such that for EVM I removed the token address, and for SVM I removed the token address + replaced the pool address with the pool PDA
- I ran the durable pipeline and generated the proposal files locally
- I confirmed that with these new changes, the generated proposal [matches the one from the previous TPRL run](https://github.com/smartcontractkit/chainlink-deployments/pull/14394/changes#top)