### PR TITLE
update invariants to improve wording

### DIFF
--- a/chains/evm/contracts/invariants/FINALITY_INVARIANTS.md
+++ b/chains/evm/contracts/invariants/FINALITY_INVARIANTS.md
@@ -48,10 +48,9 @@ Finality is a single **`bytes4`** value carried on the wire as `MessageV1.finali
 
 - **INV-FIN-POOL-1**: A pool exposes a configured **allowed finality** (`bytes4`) that bounds which requested modes it accepts. The default `WAIT_FOR_FINALITY_FLAG` means the pool does not support FTF.
 
-### 4.2 Outbound and Inbound Validation
+### 4.2 Pool Allowed-Finality Enforcement
 
-- **INV-FIN-POOL-2**: On both outbound and inbound, the pool validates the requested finality against its allowed finality using the rule in INV-FIN-ENC-3 and reverts otherwise.
-- **INV-FIN-POOL-3**: Legacy `lockOrBurn` / `releaseOrMint` paths that take no finality parameter are treated as `WAIT_FOR_FINALITY_FLAG`.
+- **INV-FIN-POOL-3**: On both outbound and inbound, the pool is able to validate the requested finality. The default pool implementation does not re-verify the finality on inbound, effectively delegating finality enforcement to the source-chain pool. However, a pool implementation can choose to enforce allowed finality on inbound as well, in which case it must apply the same rule as INV-FIN-ENC-3.
 
 ### 4.3 Rate Limiting
 

--- a/chains/evm/contracts/invariants/TOKEN_POOL_INVARIANTS.md
+++ b/chains/evm/contracts/invariants/TOKEN_POOL_INVARIANTS.md
@@ -19,7 +19,7 @@
 ## 3. V1 vs V2 Interface
 
 - **INV-POOL-7**: V1 pools support `lockOrBurn` and `releaseOrMint` without finality or fee parameters. The full token amount is locked/burned and released/minted. V1 is legacy, relevant for v1 CCIP chains migrating to v2.
-- **INV-POOL-8**: V2 pools extend V1 with: `getFee`, `getTokenTransferFeeConfig`, `getRequiredCCVs`, and finality-aware `lockOrBurn`/`releaseOrMint` (receiving `requestedFinalityConfig` and `tokenArgs`).
+- **INV-POOL-8**: V2 pools extend V1 with: `getFee`, `getTokenTransferFeeConfig`, `getRequiredCCVs`, and finality-aware `lockOrBurn`/`releaseOrMint` (receiving `requestedFinalityConfig` and `tokenArgs`). Allowed-finality is enforced on outbound `lockOrBurn` and `getFee`; the default TokenPool implementation inbound `releaseOrMint` uses `requestedFinalityConfig` for rate-limit bucket selection only. It effectively delegates finality enforcement to the source-chain pool. Other pool implementations can explicitly check on the destination chain as well; the interface must support this.
 - **INV-POOL-9**: V1 pools cannot support FTF or custom token args. See FINALITY_INVARIANTS.md (**INV-FIN-SRC-4**, **INV-FIN-POOL-3**).
 
 ---


### PR DESCRIPTION
Improves the wording to properly convey that the default pool does not validate finality config on dest, but pools must get enough params to do this validation if they wanted to.