### PR TITLE
Change Minimum Number of NOP Validation to 15

### DIFF
--- a/deployment/v2_0_0/changesets/apply_executor_config_test.go
+++ b/deployment/v2_0_0/changesets/apply_executor_config_test.go
@@ -136,13 +136,13 @@ func TestApplyExecutorConfig_Validation(t *testing.T) {
 			wantErr: "nop_topology is required",
 		},
 		{
-			name: "production topology with fewer than sixteen NOPs returns error",
+			name: "production topology with fewer than fifteen NOPs returns error",
 			env:  deployment.Environment{Name: "prod_mainnet", BlockChains: newExecutorTestBlockChains([]uint64{sel1})},
 			input: changesets.ApplyExecutorConfigInput{
 				Topology:          newMinimalTopology([]string{"nop1"}, "pool1", ""),
 				ExecutorQualifier: "pool1",
 			},
-			wantErr: "requires at least 16 unique NOPs",
+			wantErr: "requires at least 15 unique NOPs",
 		},
 		{
 			name: "missing executor qualifier returns error",
@@ -176,7 +176,7 @@ func TestApplyExecutorConfig_Validation(t *testing.T) {
 			env:  deployment.Environment{Name: "mainnet", BlockChains: newExecutorTestBlockChains([]uint64{sel1})},
 			input: changesets.ApplyExecutorConfigInput{
 				Topology: func() *offchain.EnvironmentTopology {
-					topo := newMinimalTopology(makeTestNOPAliases(16), "pool1", "")
+					topo := newMinimalTopology(makeTestNOPAliases(15), "pool1", "")
 					topo.PyroscopeURL = "http://pyroscope"
 					return topo
 				}(),

--- a/deployment/v2_0_0/offchain/topology.go
+++ b/deployment/v2_0_0/offchain/topology.go
@@ -14,7 +14,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/offchain/shared"
 )
 
-const minProductionChainNOPs = 16
+const minProductionChainNOPs = 15 // this is temporarily 15 while we replace AlphaChain
 
 // EnvironmentTopology holds all environment-specific configuration that cannot be inferred
 // from the datastore. This serves as the single source of truth for the desired state of both off-chain

--- a/deployment/v2_0_0/offchain/topology_test.go
+++ b/deployment/v2_0_0/offchain/topology_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestEnvironmentTopologyValidateForEnvironment_ProductionMinimumNOPs(t *testing.T) {
-	sixteenAliases := testNOPAliases(16)
 	fifteenAliases := testNOPAliases(15)
+	fourteenAliases := testNOPAliases(14)
 
 	tests := []struct {
 		name             string
@@ -22,31 +22,31 @@ func TestEnvironmentTopologyValidateForEnvironment_ProductionMinimumNOPs(t *test
 		{
 			name:             "prod committee chain with fifteen unique NOPs fails",
 			envName:          "prod_mainnet",
-			committeeAliases: fifteenAliases,
-			poolAliases:      sixteenAliases,
-			wantErr:          `committee "default" chain "1" requires at least 16 unique NOPs`,
+			committeeAliases: fourteenAliases,
+			poolAliases:      fifteenAliases,
+			wantErr:          `committee "default" chain "1" requires at least 15 unique NOPs`,
 		},
 		{
-			name:             "prod committee chain with sixteen unique NOPs passes",
+			name:             "prod committee chain with fifteen unique NOPs passes",
 			envName:          "prod_mainnet",
-			committeeAliases: sixteenAliases,
-			poolAliases:      sixteenAliases,
+			committeeAliases: fifteenAliases,
+			poolAliases:      fifteenAliases,
 		},
 		{
 			name:             "prod executor pool chain with fifteen unique NOPs fails",
 			envName:          "prod_testnet",
-			committeeAliases: sixteenAliases,
-			poolAliases:      fifteenAliases,
-			wantErr:          `executor pool "default" chain "1" requires at least 16 unique NOPs`,
+			committeeAliases: fifteenAliases,
+			poolAliases:      fourteenAliases,
+			wantErr:          `executor pool "default" chain "1" requires at least 15 unique NOPs`,
 		},
 		{
-			name:             "prod executor pool chain with sixteen unique NOPs passes",
+			name:             "prod executor pool chain with fifteen unique NOPs passes",
 			envName:          "prod_testnet",
-			committeeAliases: sixteenAliases,
-			poolAliases:      sixteenAliases,
+			committeeAliases: fifteenAliases,
+			poolAliases:      fifteenAliases,
 		},
 		{
-			name:             "non prod chain with fewer than sixteen NOPs passes",
+			name:             "non prod chain with fewer than fifteen NOPs passes",
 			envName:          "test",
 			committeeAliases: []string{"nop-1"},
 			poolAliases:      []string{"nop-1"},
@@ -54,9 +54,9 @@ func TestEnvironmentTopologyValidateForEnvironment_ProductionMinimumNOPs(t *test
 		{
 			name:             "duplicate committee aliases do not count toward minimum",
 			envName:          "prod_mainnet",
-			committeeAliases: append(testNOPAliases(15), "nop-1"),
-			poolAliases:      sixteenAliases,
-			wantErr:          `committee "default" chain "1" requires at least 16 unique NOPs`,
+			committeeAliases: append(testNOPAliases(14), "nop-1"),
+			poolAliases:      fifteenAliases,
+			wantErr:          `committee "default" chain "1" requires at least 15 unique NOPs`,
 		},
 	}
 


### PR DESCRIPTION
### What
- Due to AlphaChain's offboarding, we will have some chains in mainnet for a period of time with 15 NOPs instead of 16