### PR TITLE
feat: add operator-focused JSON unmarshal function for utils.Optional

### DIFF
--- a/deployment/utils/optional.go
+++ b/deployment/utils/optional.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 
 	"gopkg.in/yaml.v3"
@@ -8,9 +10,9 @@ import (
 
 // Optional represents a value that may or may not be explicitly set. This
 // is useful in scenarios where a changeset only needs to partially update
-// a subset of fields in a large configuration struct. In YAML files, it's
+// a subset of fields in a large configuration struct. In YAML & JSON it's
 // not strictly necessary to define both `value` and `valid` keys; instead
-// see optional_test.go for the supported YAML shapes and their semantics.
+// see optional_test.go for the supported shapes and their semantics.
 type Optional[T any] struct {
 	// Valid indicates whether the provided value should be used. If this is
 	// false (the default), then the provided value will be ignored.
@@ -97,6 +99,60 @@ func (o *Optional[T]) UnmarshalYAML(node *yaml.Node) error {
 		o.Valid = true // value present, no valid key → infer true
 	default:
 		o.Valid = false // empty mapping → zero value, Valid stays false
+	}
+
+	return nil
+}
+
+// UnmarshalJSON supports three JSON representations (mirroring UnmarshalYAML):
+//   - Very-Verbose: `{"value": 32, "valid": false}` → backwards-compatible explicit control
+//   - Semi-verbose: `{"value": 32}` → {Value: 32, Valid: true} (inferred)
+//   - Shorthand: `32` → {Value: 32, Valid: true}
+func (o *Optional[T]) UnmarshalJSON(data []byte) error {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return fmt.Errorf("optional: empty json")
+	}
+
+	// Explicit null — omitted equivalent, Valid stays false
+	if bytes.Equal(trimmed, []byte("null")) {
+		return nil
+	}
+
+	// Shorthand: bare scalar — infer value and valid=true
+	if trimmed[0] != '{' {
+		if err := json.Unmarshal(data, &o.Value); err != nil {
+			return err
+		}
+		o.Valid = true
+		return nil
+	}
+
+	// Scan keys present in the object
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	_, hasValid := raw["valid"]
+	_, hasValue := raw["value"]
+
+	// Decode via a local anonymous struct to avoid infinite recursion
+	var decoded struct {
+		Valid bool `json:"valid"`
+		Value T    `json:"value"`
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	o.Value = decoded.Value
+	switch {
+	case hasValid:
+		o.Valid = decoded.Valid // explicit — backwards-compatible
+	case hasValue:
+		o.Valid = true // value present, no valid key → infer true
+	default:
+		o.Valid = false // empty object → zero value, Valid stays false
 	}
 
 	return nil

--- a/deployment/utils/optional_test.go
+++ b/deployment/utils/optional_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -117,6 +118,122 @@ func TestOptionalUnmarshalYAMLWithBool(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var opt Optional[bool]
 			err := yaml.Unmarshal([]byte(tt.yaml), &opt)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantValue, opt.Value)
+			require.Equal(t, tt.wantValid, opt.Valid)
+		})
+	}
+}
+
+func TestOptionalUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name      string
+		json      string
+		wantValue int
+		wantValid bool
+		wantErr   bool
+	}{
+		{name: "verbose: value and valid false", json: `{"value": 50, "valid": false}`, wantValue: 50, wantValid: false},
+		{name: "verbose: value and valid true", json: `{"value": 100, "valid": true}`, wantValue: 100, wantValid: true},
+		{name: "semi-verbose: valid only", json: `{"valid": false}`, wantValue: 0, wantValid: false},
+		{name: "semi-verbose: value only", json: `{"value": 32}`, wantValue: 32, wantValid: true},
+		{name: "shorthand scalar", json: `4`, wantValue: 4, wantValid: true},
+		{name: "empty mapping", json: `{}`, wantValue: 0, wantValid: false},
+		{name: "explicit null", json: `null`, wantValue: 0, wantValid: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opt Optional[int]
+			err := json.Unmarshal([]byte(tt.json), &opt)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.wantValue, opt.Value)
+			require.Equal(t, tt.wantValid, opt.Valid)
+		})
+	}
+}
+
+func TestOptionalUnmarshalJSONWithStruct(t *testing.T) {
+	type config struct {
+		Arg1 Optional[string] `json:"arg1"`
+		Arg2 Optional[int]    `json:"arg2"`
+	}
+
+	var cfg1 config
+	err := json.Unmarshal([]byte(`{"arg1": "hello", "arg2": 42}`), &cfg1)
+	require.NoError(t, err)
+	require.Equal(t, "hello", cfg1.Arg1.Value)
+	require.True(t, cfg1.Arg1.Valid)
+	require.Equal(t, 42, cfg1.Arg2.Value)
+	require.True(t, cfg1.Arg2.Valid)
+
+	var cfg2 config
+	err = json.Unmarshal([]byte(`{"arg1": "world"}`), &cfg2)
+	require.NoError(t, err)
+	require.Equal(t, "world", cfg2.Arg1.Value)
+	require.True(t, cfg2.Arg1.Valid)
+	require.Equal(t, 0, cfg2.Arg2.Value)
+	require.False(t, cfg2.Arg2.Valid)
+
+	var cfg3 config
+	err = json.Unmarshal([]byte(`{"arg2": 100}`), &cfg3)
+	require.NoError(t, err)
+	require.Equal(t, "", cfg3.Arg1.Value)
+	require.False(t, cfg3.Arg1.Valid)
+	require.Equal(t, 100, cfg3.Arg2.Value)
+	require.True(t, cfg3.Arg2.Valid)
+
+	existing := config{Arg1: NewOptional("hi"), Arg2: NewOptional(10)}
+	err = json.Unmarshal([]byte(`{"arg1": "bye"}`), &existing)
+	require.NoError(t, err)
+	require.Equal(t, "bye", existing.Arg1.Value)
+	require.True(t, existing.Arg1.Valid)
+	require.Equal(t, 10, existing.Arg2.Value)
+	require.True(t, existing.Arg2.Valid)
+}
+
+func TestOptionalUnmarshalJSONWithString(t *testing.T) {
+	tests := []struct {
+		name      string
+		json      string
+		wantValue string
+		wantValid bool
+	}{
+		{name: "string semi-verbose", json: `{"value": "world"}`, wantValue: "world", wantValid: true},
+		{name: "string shorthand", json: `"hello"`, wantValue: "hello", wantValid: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opt Optional[string]
+			err := json.Unmarshal([]byte(tt.json), &opt)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantValue, opt.Value)
+			require.Equal(t, tt.wantValid, opt.Valid)
+		})
+	}
+}
+
+func TestOptionalUnmarshalJSONWithBool(t *testing.T) {
+	tests := []struct {
+		name      string
+		json      string
+		wantValue bool
+		wantValid bool
+	}{
+		{name: "bool semi-verbose true", json: `{"value": true}`, wantValue: true, wantValid: true},
+		{name: "bool shorthand false", json: `false`, wantValue: false, wantValid: true},
+		{name: "bool shorthand true", json: `true`, wantValue: true, wantValid: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var opt Optional[bool]
+			err := json.Unmarshal([]byte(tt.json), &opt)
 			require.NoError(t, err)
 			require.Equal(t, tt.wantValue, opt.Value)
 			require.Equal(t, tt.wantValid, opt.Valid)


### PR DESCRIPTION
## Summary

Adds `UnmarshalJSON` to `deployment/utils/Optional[T]` so JSON config payloads accept the same flexible shapes as YAML. This fixes durable-pipeline / config-resolver failures when optional fields use shorthand values (e.g. `destBytesOverhead: 32`) instead of the verbose `{"value": 32, "valid": true}` object form.