### PR TITLE
feat: infer CCIP admin for EVM BnM ERC20 tokens

### DIFF
--- a/chains/evm/deployment/v1_0_0/operations/burn_mint_erc20/burn_mint_erc20.go
+++ b/chains/evm/deployment/v1_0_0/operations/burn_mint_erc20/burn_mint_erc20.go
@@ -7,8 +7,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
 	cldf_deployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/burn_mint_erc20"
 )
@@ -49,12 +49,13 @@ var SetCCIPAdmin = contract.NewWrite(contract.WriteParams[string, *burn_mint_erc
 	ContractABI:  burn_mint_erc20.BurnMintERC20ABI,
 	NewContract:  burn_mint_erc20.NewBurnMintERC20,
 	IsAllowedCaller: func(token *burn_mint_erc20.BurnMintERC20, opts *bind.CallOpts, caller common.Address, input string) (bool, error) {
-		// SetCCIPAdmin can only be called by the current CCIP admin
-		currentAdmin, err := token.GetCCIPAdmin(opts)
+		// SetCCIPAdmin requires DEFAULT_ADMIN_ROLE on BurnMintERC20 (not the current ccipAdmin).
+		// https://bscscan.com/address/0x02bcC4C181B83a8c0A342BC003389CbEcb4BC54D#code#F1#L151
+		defaultAdminRole, err := token.DEFAULTADMINROLE(opts)
 		if err != nil {
 			return false, err
 		}
-		return currentAdmin == caller, nil
+		return token.HasRole(opts, defaultAdminRole, caller)
 	},
 	Validate: func(string) error { return nil },
 	CallContract: func(token *burn_mint_erc20.BurnMintERC20, opts *bind.TransactOpts, input string) (*types.Transaction, error) {

--- a/chains/evm/deployment/v1_0_0/sequences/token.go
+++ b/chains/evm/deployment/v1_0_0/sequences/token.go
@@ -28,7 +28,6 @@ var DeployToken = cldf_ops.NewSequence(
 		if !ok {
 			return sequences.OnChainOutput{}, fmt.Errorf("chain with selector %d not found among provided chains", input.ChainSelector)
 		}
-
 		preMint := big.NewInt(0)
 		if input.PreMint != nil {
 			preMint = tokenapi.ScaleTokenAmount(new(big.Int).SetUint64(*input.PreMint), input.Decimals)
@@ -45,6 +44,25 @@ var DeployToken = cldf_ops.NewSequence(
 		// default admin role can update it later with `setCCIPAdmin`.
 		if input.CCIPAdmin == "" && input.ExternalAdmin != "" {
 			input.CCIPAdmin = input.ExternalAdmin
+		}
+
+		// NOTE: the raw input struct is passed to `tokenImpl.Deploy`, so we need to ensure that
+		// the relevant fields are validated ahead of time to prevent any issues downstream.
+		externalAdmin := common.Address{}
+		if input.ExternalAdmin != "" {
+			if !common.IsHexAddress(input.ExternalAdmin) {
+				return sequences.OnChainOutput{}, fmt.Errorf("invalid external admin address: %s", input.ExternalAdmin)
+			} else {
+				externalAdmin = common.HexToAddress(input.ExternalAdmin)
+			}
+		}
+		ccipAdmin := common.Address{}
+		if input.CCIPAdmin != "" {
+			if !common.IsHexAddress(input.CCIPAdmin) {
+				return sequences.OnChainOutput{}, fmt.Errorf("invalid CCIP admin address: %s", input.CCIPAdmin)
+			} else {
+				ccipAdmin = common.HexToAddress(input.CCIPAdmin)
+			}
 		}
 
 		tokenImpl, ok := tokenimpl.Get(input.Type)
@@ -85,13 +103,6 @@ var DeployToken = cldf_ops.NewSequence(
 			writes = append(writes, transferWrites...)
 		}
 		if input.ExternalAdmin != "" && caps.SupportsAdminRole {
-			externalAdmin := common.Address{}
-			if !common.IsHexAddress(input.ExternalAdmin) {
-				return sequences.OnChainOutput{}, fmt.Errorf("invalid external admin address: %s", input.ExternalAdmin)
-			} else {
-				externalAdmin = common.HexToAddress(input.ExternalAdmin)
-			}
-
 			grantWrites, err := tokenImpl.GrantAdminRole(b, chain, tokenAddr, externalAdmin)
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to grant admin role to %s: %w", input.ExternalAdmin, err)
@@ -99,13 +110,6 @@ var DeployToken = cldf_ops.NewSequence(
 			writes = append(writes, grantWrites...)
 		}
 		if input.CCIPAdmin != "" && caps.SupportsCCIPAdmin {
-			ccipAdmin := common.Address{}
-			if !common.IsHexAddress(input.CCIPAdmin) {
-				return sequences.OnChainOutput{}, fmt.Errorf("invalid CCIP admin address: %s", input.CCIPAdmin)
-			} else {
-				ccipAdmin = common.HexToAddress(input.CCIPAdmin)
-			}
-
 			adminWrites, err := tokenImpl.SetCCIPAdmin(b, chain, tokenAddr, ccipAdmin)
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to set CCIP admin: %w", err)

--- a/chains/evm/deployment/v1_0_0/sequences/token.go
+++ b/chains/evm/deployment/v1_0_0/sequences/token.go
@@ -49,20 +49,16 @@ var DeployToken = cldf_ops.NewSequence(
 		// NOTE: the raw input struct is passed to `tokenImpl.Deploy`, so we need to ensure that
 		// the relevant fields are validated ahead of time to prevent any issues downstream.
 		externalAdmin := common.Address{}
-		if input.ExternalAdmin != "" {
-			if !common.IsHexAddress(input.ExternalAdmin) {
-				return sequences.OnChainOutput{}, fmt.Errorf("invalid external admin address: %s", input.ExternalAdmin)
-			} else {
-				externalAdmin = common.HexToAddress(input.ExternalAdmin)
-			}
+		if input.ExternalAdmin != "" && !common.IsHexAddress(input.ExternalAdmin) {
+			return sequences.OnChainOutput{}, fmt.Errorf("invalid external admin address: %s", input.ExternalAdmin)
+		} else {
+			externalAdmin = common.HexToAddress(input.ExternalAdmin)
 		}
 		ccipAdmin := common.Address{}
-		if input.CCIPAdmin != "" {
-			if !common.IsHexAddress(input.CCIPAdmin) {
-				return sequences.OnChainOutput{}, fmt.Errorf("invalid CCIP admin address: %s", input.CCIPAdmin)
-			} else {
-				ccipAdmin = common.HexToAddress(input.CCIPAdmin)
-			}
+		if input.CCIPAdmin != "" && !common.IsHexAddress(input.CCIPAdmin) {
+			return sequences.OnChainOutput{}, fmt.Errorf("invalid CCIP admin address: %s", input.CCIPAdmin)
+		} else {
+			ccipAdmin = common.HexToAddress(input.CCIPAdmin)
 		}
 
 		tokenImpl, ok := tokenimpl.Get(input.Type)

--- a/chains/evm/deployment/v1_0_0/sequences/token.go
+++ b/chains/evm/deployment/v1_0_0/sequences/token.go
@@ -34,18 +34,17 @@ var DeployToken = cldf_ops.NewSequence(
 			preMint = tokenapi.ScaleTokenAmount(new(big.Int).SetUint64(*input.PreMint), input.Decimals)
 		}
 
-		externalAdmin := common.Address{}
-		if input.ExternalAdmin != "" && !common.IsHexAddress(input.ExternalAdmin) {
-			return sequences.OnChainOutput{}, fmt.Errorf("invalid external admin address: %s", input.ExternalAdmin)
-		} else {
-			externalAdmin = common.HexToAddress(input.ExternalAdmin)
-		}
-
-		ccipAdmin := common.Address{}
-		if input.CCIPAdmin != "" && !common.IsHexAddress(input.CCIPAdmin) {
-			return sequences.OnChainOutput{}, fmt.Errorf("invalid CCIP admin address: %s", input.CCIPAdmin)
-		} else {
-			ccipAdmin = common.HexToAddress(input.CCIPAdmin)
+		// NOTE: CCIP admin is only applicable to BnM ERC20 tokens and mostly serves as a public
+		// label. Despite its naming, the CCIP admin does not actually have any admin privileges
+		// on the token contract itself. Instead this field allows the specified account to self
+		// serve token registration with `registerAdminViaGetCCIPAdmin`. The CCIP admin defaults
+		// to the account that deploys the contract (typically the deployer key) so it's usually
+		// safer to set this to the external admin field if it's specified (see the higher-level
+		// TokenExpansion changeset for more info on how this field gets populated). If external
+		// admin is empty, then the CCIP admin remains the contract deployer and anyone with the
+		// default admin role can update it later with `setCCIPAdmin`.
+		if input.CCIPAdmin == "" && input.ExternalAdmin != "" {
+			input.CCIPAdmin = input.ExternalAdmin
 		}
 
 		tokenImpl, ok := tokenimpl.Get(input.Type)
@@ -86,6 +85,13 @@ var DeployToken = cldf_ops.NewSequence(
 			writes = append(writes, transferWrites...)
 		}
 		if input.ExternalAdmin != "" && caps.SupportsAdminRole {
+			externalAdmin := common.Address{}
+			if !common.IsHexAddress(input.ExternalAdmin) {
+				return sequences.OnChainOutput{}, fmt.Errorf("invalid external admin address: %s", input.ExternalAdmin)
+			} else {
+				externalAdmin = common.HexToAddress(input.ExternalAdmin)
+			}
+
 			grantWrites, err := tokenImpl.GrantAdminRole(b, chain, tokenAddr, externalAdmin)
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to grant admin role to %s: %w", input.ExternalAdmin, err)
@@ -93,6 +99,13 @@ var DeployToken = cldf_ops.NewSequence(
 			writes = append(writes, grantWrites...)
 		}
 		if input.CCIPAdmin != "" && caps.SupportsCCIPAdmin {
+			ccipAdmin := common.Address{}
+			if !common.IsHexAddress(input.CCIPAdmin) {
+				return sequences.OnChainOutput{}, fmt.Errorf("invalid CCIP admin address: %s", input.CCIPAdmin)
+			} else {
+				ccipAdmin = common.HexToAddress(input.CCIPAdmin)
+			}
+
 			adminWrites, err := tokenImpl.SetCCIPAdmin(b, chain, tokenAddr, ccipAdmin)
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to set CCIP admin: %w", err)

--- a/chains/evm/deployment/v1_0_0/sequences/token_test.go
+++ b/chains/evm/deployment/v1_0_0/sequences/token_test.go
@@ -80,6 +80,13 @@ func TestEVMTokenDeployments(t *testing.T) {
 			decimals:    18,
 			ccipAdmin:   "0x1111111111111111111111111111111111111111",
 		},
+		{
+			name:        "BurnMintERC20Token_derivesCCIPAdminFromExternal",
+			tokenType:   burn_mint_erc20.ContractType,
+			tokenName:   "Test BurnMint ERC20 Derived CCIP Admin",
+			tokenSymbol: "TBMDERIVE",
+			decimals:    18,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -96,9 +103,11 @@ func TestEVMTokenDeployments(t *testing.T) {
 			chain := e.BlockChains.EVMChains()[chain_selectors.ETHEREUM_MAINNET.Selector]
 			deployerAddr := chain.DeployerKey.From
 
-			// Generate test addresses for CCIP admin and external admins
-			ccipAdminAddr := common.HexToAddress("0x1111111111111111111111111111111111111111")
 			externalAdmin := "0x2222222222222222222222222222222222222222"
+			expectedCCIPAdmin := common.HexToAddress(externalAdmin)
+			if tc.ccipAdmin != "" {
+				expectedCCIPAdmin = common.HexToAddress(tc.ccipAdmin)
+			}
 
 			// Build token input based on test case configuration
 			tokenInput := tokensapi.DeployTokenInput{
@@ -200,8 +209,8 @@ func TestEVMTokenDeployments(t *testing.T) {
 						t.Log("  Verifying CCIP Admin...")
 						onChainCCIPAdmin, err := tokenContract.GetCCIPAdmin(&bind.CallOpts{})
 						require.NoError(t, err, "Failed to get CCIP admin from chain")
-						require.Equal(t, ccipAdminAddr, onChainCCIPAdmin, "CCIP admin mismatch")
-						t.Logf("  On-chain CCIP admin: %s (expected: %s)", onChainCCIPAdmin.Hex(), ccipAdminAddr.Hex())
+						require.Equal(t, expectedCCIPAdmin, onChainCCIPAdmin, "CCIP admin mismatch")
+						t.Logf("  On-chain CCIP admin: %s (expected: %s)", onChainCCIPAdmin.Hex(), expectedCCIPAdmin.Hex())
 
 						// TEST 2: Verify External Admins have the DEFAULT_ADMIN_ROLE
 						t.Log("  Verifying External Admin roles...")

--- a/deployment/docs/changesets.md
+++ b/deployment/docs/changesets.md
@@ -194,7 +194,7 @@ func TokenExpansion() cldf.ChangeSetV2[TokenExpansionInput]
 **Input:** [`TokenExpansionInput`](types.md#tokenexpansioninput)
 
 **Behavior:**
-1. **Deploy tokens** (if `DeployTokenInput` is non-nil): Executes `adapter.DeployToken()`
+1. **Deploy tokens** (if `DeployTokenInput` is non-nil): Executes `adapter.DeployToken()`. When `externalAdmin` or `ccipAdmin` are empty, defaults both from the chain timelock (when available). If only `ccipAdmin` is empty, it is set to `externalAdmin`. The deploy sequence also copies `externalAdmin` to `ccipAdmin` when `ccipAdmin` is unset.
 2. **Deploy token pools** (if `DeployTokenPoolInput` is non-nil): Executes `adapter.DeployTokenPoolForToken()`
 3. **Configure for transfers** (if `TokenTransferConfig` is non-nil): Calls `processTokenConfigForChain()` which executes `adapter.ConfigureTokenForTransfersSequence()`
 4. **Update authorities** (unless `SkipOwnershipTransfer` is true): Executes `adapter.UpdateAuthorities()` to transfer pool ownership to the timelock (Solana: rate limit admin is already set in step 2 via `DeployTokenPoolForToken`; this step only transfers ownership)

--- a/deployment/docs/changesets.md
+++ b/deployment/docs/changesets.md
@@ -194,7 +194,7 @@ func TokenExpansion() cldf.ChangeSetV2[TokenExpansionInput]
 **Input:** [`TokenExpansionInput`](types.md#tokenexpansioninput)
 
 **Behavior:**
-1. **Deploy tokens** (if `DeployTokenInput` is non-nil): Executes `adapter.DeployToken()`. When `externalAdmin` or `ccipAdmin` are empty, defaults both from the chain timelock (when available). If only `ccipAdmin` is empty, it is set to `externalAdmin`. The deploy sequence also copies `externalAdmin` to `ccipAdmin` when `ccipAdmin` is unset.
+1. **Deploy tokens** (if `DeployTokenInput` is non-nil): Executes `adapter.DeployToken()`. In TokenExpansion, empty `externalAdmin` defaults to the chain timelock (when available); empty `ccipAdmin` defaults to `externalAdmin`. The deploy sequence also copies `externalAdmin` to `ccipAdmin` when `ccipAdmin` is unset.
 2. **Deploy token pools** (if `DeployTokenPoolInput` is non-nil): Executes `adapter.DeployTokenPoolForToken()`
 3. **Configure for transfers** (if `TokenTransferConfig` is non-nil): Calls `processTokenConfigForChain()` which executes `adapter.ConfigureTokenForTransfersSequence()`
 4. **Update authorities** (unless `SkipOwnershipTransfer` is true): Executes `adapter.UpdateAuthorities()` to transfer pool ownership to the timelock (Solana: rate limit admin is already set in step 2 via `DeployTokenPoolForToken`; this step only transfers ownership)

--- a/deployment/docs/types.md
+++ b/deployment/docs/types.md
@@ -345,8 +345,8 @@ type DeployTokenInput struct {
     Decimals              uint8               // Token decimals
     Supply                *uint64             // Total supply (decimal scaling happens automatically, nil or 0 means unlimited supply)
     PreMint               *uint64             // Amount to pre-mint (decimal scaling happens automatically, nil or 0 means no pre-mint)
-    ExternalAdmin         string              // External admin address (chain-agnostic string)
-    CCIPAdmin             string              // CCIP admin address (defaults to timelock)
+    ExternalAdmin         string              // Operator admin (hex on EVM). Empty in TokenExpansion defaults to timelock. On EVM BnM, receives DEFAULT_ADMIN_ROLE and is proposed as TokenAdminRegistry administrator.
+    CCIPAdmin             string              // EVM BnM ERC20 only. Optional. Empty defaults to ExternalAdmin (timelock when ExternalAdmin is also empty). Sets getCCIPAdmin() for registerAdminViaGetCCIPAdmin; not mint/burn or registry admin.
     Senders               []string            // Addresses needing special processing (e.g., Solana ATAs)
     Type                  cldf.ContractType   // SPLToken, ERC20, etc.
     TokenPrivKey          string              // Solana: base58 private key for vanity addresses

--- a/deployment/docs/types.md
+++ b/deployment/docs/types.md
@@ -346,7 +346,7 @@ type DeployTokenInput struct {
     Supply                *uint64             // Total supply (decimal scaling happens automatically, nil or 0 means unlimited supply)
     PreMint               *uint64             // Amount to pre-mint (decimal scaling happens automatically, nil or 0 means no pre-mint)
     ExternalAdmin         string              // Operator admin (hex on EVM). Empty in TokenExpansion defaults to timelock. On EVM BnM, receives DEFAULT_ADMIN_ROLE and is proposed as TokenAdminRegistry administrator.
-    CCIPAdmin             string              // EVM BnM ERC20 only. Optional. Empty defaults to ExternalAdmin (timelock when ExternalAdmin is also empty). Sets getCCIPAdmin() for registerAdminViaGetCCIPAdmin; not mint/burn or registry admin.
+    CCIPAdmin             string              // EVM BnM ERC20 only. Optional. Empty in TokenExpansion defaults to ExternalAdmin (timelock when ExternalAdmin is also empty). Sets getCCIPAdmin() for registerAdminViaGetCCIPAdmin; not mint/burn or registry admin.
     Senders               []string            // Addresses needing special processing (e.g., Solana ATAs)
     Type                  cldf.ContractType   // SPLToken, ERC20, etc.
     TokenPrivKey          string              // Solana: base58 private key for vanity addresses

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -49,7 +49,8 @@ type DeployTokenInput struct {
 	// Customer admin who will be granted admin rights on the token
 	// Use string to keep this struct chain-agnostic (EVM uses hex, Solana uses base58, etc.)
 	ExternalAdmin string `yaml:"externalAdmin" json:"externalAdmin"`
-	// CCIPAdmin is applicable to EVM BnM ERC20 tokens only. When empty, defaults to ExternalAdmin (timelock when ExternalAdmin is also empty).
+	// CCIPAdmin is applicable to EVM BnM ERC20 tokens only. When empty, defaults to ExternalAdmin.
+	// In TokenExpansion, empty ExternalAdmin defaults to the chain timelock first (when available).
 	CCIPAdmin string `yaml:"ccipAdmin" json:"ccipAdmin"`
 	// Currency is the TIP20 token currency. This field is only applicable for TIP20 tokens on Tempo. If this field is empty, then a sensible default will be chosen.
 	Currency string `yaml:"currency" json:"currency"`

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -49,7 +49,7 @@ type DeployTokenInput struct {
 	// Customer admin who will be granted admin rights on the token
 	// Use string to keep this struct chain-agnostic (EVM uses hex, Solana uses base58, etc.)
 	ExternalAdmin string `yaml:"externalAdmin" json:"externalAdmin"`
-	// CCIPAdmin is the address to be set as the CCIP admin on the token contract, defaults to the timelock address. Only applicable for EVM BnM ERC20 tokens.
+	// CCIPAdmin is applicable to EVM BnM ERC20 tokens only. When empty, defaults to ExternalAdmin (timelock when ExternalAdmin is also empty).
 	CCIPAdmin string `yaml:"ccipAdmin" json:"ccipAdmin"`
 	// Currency is the TIP20 token currency. This field is only applicable for TIP20 tokens on Tempo. If this field is empty, then a sensible default will be chosen.
 	Currency string `yaml:"currency" json:"currency"`
@@ -228,14 +228,14 @@ func tokenExpansionApply() func(cldf.Environment, TokenExpansionInput) (cldf.Cha
 				deployTokenInput.ExistingDataStore = e.DataStore
 				deployTokenInput.ChainSelector = selector
 
-				// If token is deployed by CLL, set CCIP admin as RBACTimelock by default.
-				// If input has CCIPAdmin and which is external address, set that address as CCIPAdmin
-				// and we may not be able to register the token by CLL in that case.
+				// External admin defaults to timelock admin if not provided. CCIP admin is
+				// only applicable for BnM ERC20 tokens. If unspecified, then it falls back
+				// to the same value as ExternalAdmin, and if ExternalAdmin is unspecified,
+				// then it falls back to timelock.
 				//
-				// External admin defaults to timelock admin if not provided - please take note
-				// that the timelock ref is lazy loaded from the datastore. This is intentional
-				// as some tests may not setup MCMS so querying the timelock ref in those cases
-				// will cause an error.
+				// Please note that the timelock ref is lazy loaded from the datastore. This
+				// is intentional as some tests may not setup MCMS (so querying the timelock
+				// ref too eagerly will cause failures in those tests).
 				if deployTokenInput.CCIPAdmin == "" || deployTokenInput.ExternalAdmin == "" {
 					mcmsReader, ok := mcmsRegistry.GetMCMSReader(family)
 					if !ok {
@@ -246,13 +246,13 @@ func tokenExpansionApply() func(cldf.Environment, TokenExpansionInput) (cldf.Cha
 						return cldf.ChangesetOutput{}, fmt.Errorf("failed to get timelock ref for chain selector %d: %w", selector, err)
 					}
 					if datastore_utils.IsAddressRefEmpty(timelockRef) {
-						e.Logger.Warnf("timelock ref is empty for chain selector %d - adapter must provide a default CCIP admin address", selector)
+						e.Logger.Warnf("timelock ref is empty for chain selector %d - adapter is expected to provide fallbacks for ExternalAdmin and/or CCIPAdmin", selector)
 					} else {
 						if deployTokenInput.ExternalAdmin == "" {
 							deployTokenInput.ExternalAdmin = timelockRef.Address
 						}
 						if deployTokenInput.CCIPAdmin == "" {
-							deployTokenInput.CCIPAdmin = timelockRef.Address
+							deployTokenInput.CCIPAdmin = deployTokenInput.ExternalAdmin
 						}
 					}
 				}

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -237,6 +237,9 @@ func tokenExpansionApply() func(cldf.Environment, TokenExpansionInput) (cldf.Cha
 				// Please note that the timelock ref is lazy loaded from the datastore. This
 				// is intentional as some tests may not setup MCMS (so querying the timelock
 				// ref too eagerly will cause failures in those tests).
+				if deployTokenInput.CCIPAdmin == "" && deployTokenInput.ExternalAdmin != "" {
+					deployTokenInput.CCIPAdmin = deployTokenInput.ExternalAdmin
+				}
 				if deployTokenInput.CCIPAdmin == "" || deployTokenInput.ExternalAdmin == "" {
 					mcmsReader, ok := mcmsRegistry.GetMCMSReader(family)
 					if !ok {

--- a/integration-tests/deployment/tokens_and_token_pools_test.go
+++ b/integration-tests/deployment/tokens_and_token_pools_test.go
@@ -139,7 +139,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 				DisableFreezeAuthority: true,
 				Senders:                []string{solChain.DeployerKey.PublicKey().String()},
 				TokenPrivKey:           "", // if empty, a new key will be generated
-				CCIPAdmin:              "", // default to timelock admin
+				CCIPAdmin:              "", // defaults to ExternalAdmin (timelock when both unset)
 			},
 		},
 		{
@@ -165,7 +165,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 				DisableFreezeAuthority: true,
 				Senders:                []string{solChain.DeployerKey.PublicKey().String()},
 				TokenPrivKey:           "", // if empty, a new key will be generated
-				CCIPAdmin:              "", // default to timelock admin
+				CCIPAdmin:              "", // defaults to ExternalAdmin (timelock when both unset)
 			},
 		},
 	}
@@ -211,7 +211,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 				DisableFreezeAuthority: false,      // not needed for EVM
 				TokenPrivKey:           "",         // not needed for EVM
 				Senders:                []string{}, // not needed for test
-				CCIPAdmin:              "",         // default to timelock admin
+				CCIPAdmin:              "",         // defaults to ExternalAdmin (timelock when both unset)
 			},
 		},
 		{
@@ -238,7 +238,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 				DisableFreezeAuthority: false,      // not needed for EVM
 				TokenPrivKey:           "",         // not needed for EVM
 				Senders:                []string{}, // not needed for test
-				CCIPAdmin:              "",         // default to timelock admin
+				CCIPAdmin:              "",         // defaults to ExternalAdmin (timelock when both unset)
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Derive `ccipAdmin` from `externalAdmin` for EVM BurnMint ERC20 token deploys when `ccipAdmin` is left unset, so operators only need to set one admin field in the common case.

- **`DeployToken` sequence**: if `ccipAdmin` is empty and `externalAdmin` is set, copy `externalAdmin` → `ccipAdmin` before `SetCCIPAdmin`.
- **`TokenExpansion`**: when `ccipAdmin` is empty, default to `externalAdmin` (which still defaults to timelock when both are empty).
- **Docs**: update `DeployTokenInput` field descriptions and TokenExpansion behavior notes to match.
- **Tests**: add unit coverage for derived `ccipAdmin`; refresh integration test comments.

Explicit `ccipAdmin` in config still overrides derivation. CLL-led registration via timelock `proposeAdministrator` is unchanged.

## Motivation

`ccipAdmin` on BnM ERC20 is mainly an on-chain label for `registerAdminViaGetCCIPAdmin` self-registration—not mint/burn or registry control. Requiring operators to set both `externalAdmin` and `ccipAdmin` to the same address was redundant and confusing. Defaulting `ccipAdmin` to `externalAdmin` aligns on-chain `getCCIPAdmin()` with the intended operator while preserving timelock defaults when both fields are blank.