### PR TITLE
Expand overrides for configure lanes and include qualifier in expandLanesToPartialChainConfigs

### DIFF
--- a/chains/evm/deployment/v2_0_0/sequences/lombard/deploy_lombard_chain.go
+++ b/chains/evm/deployment/v2_0_0/sequences/lombard/deploy_lombard_chain.go
@@ -136,6 +136,7 @@ var DeployLombardChain = cldf_ops.NewSequence(
 				Type:           datastore.ContractType(versioned_verifier_resolver.LombardVerifierResolverType),
 				Version:        lombard_verifier.Version,
 				CREATE2Factory: common.HexToAddress(input.DeployerContract),
+				Qualifier:      versioned_verifier_resolver.LombardVerifierResolverType.String(), // The qualifier for LombardVerifierResolver is the same as its type to avoid colliding with CommitteeVerifierResolver deployed with the "default" qualifier
 			})
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to deploy LombardVerifierResolver: %w", err)

--- a/deployment/go.mod
+++ b/deployment/go.mod
@@ -20,6 +20,7 @@ require (
 	golang.org/x/sync v0.20.0
 	google.golang.org/grpc v1.80.0
 	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/utils v0.0.0-20241104163129-6fe5fd82f078
 )
 
 require (
@@ -319,7 +320,6 @@ require (
 	k8s.io/client-go v0.32.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20241212222426-2c72e554b1e7 // indirect
-	k8s.io/utils v0.0.0-20241104163129-6fe5fd82f078 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family.go
@@ -141,21 +141,9 @@ func sortedKeys(m map[uint64]*partialChainConfig) []uint64 {
 func mergeLaneLeg(byChain map[uint64]*partialChainConfig, local, remote uint64, qualifiers []string, o *ChainOverrides) {
 	cfg, ok := byChain[local]
 	if !ok {
-		cvConfigs := make([]committeeVerifierInputConfig, 0, len(qualifiers))
-		for _, q := range qualifiers {
-			cv := committeeVerifierInputConfig{
-				CommitteeQualifier: q,
-				RemoteChains:       make(map[uint64]committeeVerifierRemoteChainInput),
-			}
-			if o != nil {
-				cv.AllowedFinalityConfig = o.CommitteeVerifierFinalityConfig
-			}
-			cvConfigs = append(cvConfigs, cv)
-		}
-
 		cfg = &partialChainConfig{
 			ChainSelector:      local,
-			CommitteeVerifiers: cvConfigs,
+			CommitteeVerifiers: make([]committeeVerifierInputConfig, 0, len(qualifiers)),
 			RemoteChains:       make(map[uint64]PartialRemoteChainConfig),
 		}
 		byChain[local] = cfg
@@ -172,14 +160,10 @@ func mergeLaneLeg(byChain map[uint64]*partialChainConfig, local, remote uint64, 
 	for _, q := range qualifiers {
 		idx, ok := byQualifier[q]
 		if !ok {
-			newCv := committeeVerifierInputConfig{
+			cfg.CommitteeVerifiers = append(cfg.CommitteeVerifiers, committeeVerifierInputConfig{
 				CommitteeQualifier: q,
 				RemoteChains:       make(map[uint64]committeeVerifierRemoteChainInput),
-			}
-			if o != nil {
-				newCv.AllowedFinalityConfig = o.CommitteeVerifierFinalityConfig
-			}
-			cfg.CommitteeVerifiers = append(cfg.CommitteeVerifiers, newCv)
+			})
 			idx = len(cfg.CommitteeVerifiers) - 1
 			byQualifier[q] = idx
 		}

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family.go
@@ -80,7 +80,11 @@ func expandLanesToPartialChainConfigs(lanes []CrossFamilyLanePair, committees ma
 		}
 		sort.Strings(qualifiers)
 		if len(qualifiers) == 0 {
-			qualifiers = []string{defaultQualifier}
+			if len(committees) == 0 {
+				qualifiers = []string{defaultQualifier}
+			} else {
+				return nil, fmt.Errorf("lane %d: no committees have chain_config for remote chain %d", i, lane.ChainB)
+			}
 		}
 		mergeLaneLeg(byChain, lane.ChainA, lane.ChainB, qualifiers, lane.ChainAOverrides)
 		qualifiers = nil
@@ -92,7 +96,11 @@ func expandLanesToPartialChainConfigs(lanes []CrossFamilyLanePair, committees ma
 		}
 		sort.Strings(qualifiers)
 		if len(qualifiers) == 0 {
-			qualifiers = []string{defaultQualifier}
+			if len(committees) == 0 {
+				qualifiers = []string{defaultQualifier}
+			} else {
+				return nil, fmt.Errorf("lane %d: no committees have chain_config for remote chain %d", i, lane.ChainA)
+			}
 		}
 		mergeLaneLeg(byChain, lane.ChainB, lane.ChainA, qualifiers, lane.ChainBOverrides)
 	}
@@ -150,14 +158,32 @@ func mergeLaneLeg(byChain map[uint64]*partialChainConfig, local, remote uint64, 
 	cv := chainOverridesToCommitteeVerifierRemote(o)
 	rc := chainOverridesToPartialRemote(o)
 
-	for i, cfgCv := range cfg.CommitteeVerifiers {
+	// Ensure we have a verifier entry per qualifier, and only attach this remote chain to those qualifiers.
+	byQualifier := make(map[string]int, len(cfg.CommitteeVerifiers))
+	for i := range cfg.CommitteeVerifiers {
+		byQualifier[cfg.CommitteeVerifiers[i].CommitteeQualifier] = i
+	}
+	for _, q := range qualifiers {
+		idx, ok := byQualifier[q]
+		if !ok {
+			cfg.CommitteeVerifiers = append(cfg.CommitteeVerifiers, committeeVerifierInputConfig{
+				CommitteeQualifier: q,
+				RemoteChains:       make(map[uint64]committeeVerifierRemoteChainInput),
+			})
+			idx = len(cfg.CommitteeVerifiers) - 1
+			byQualifier[q] = idx
+		}
+		cfgCv := cfg.CommitteeVerifiers[idx]
 		if existingRemote, ok := cfgCv.RemoteChains[remote]; ok {
 			cfgCv.RemoteChains[remote] = mergeCommitteeVerifierRemoteInput(existingRemote, cv)
 		} else {
 			cfgCv.RemoteChains[remote] = cv
 		}
-		cfg.CommitteeVerifiers[i] = cfgCv
+		cfg.CommitteeVerifiers[idx] = cfgCv
 	}
+	sort.Slice(cfg.CommitteeVerifiers, func(i, j int) bool {
+		return cfg.CommitteeVerifiers[i].CommitteeQualifier < cfg.CommitteeVerifiers[j].CommitteeQualifier
+	})
 
 	if existing, ok := cfg.RemoteChains[remote]; ok {
 		cfg.RemoteChains[remote] = mergePartialRemoteInput(existing, rc)

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family.go
@@ -143,10 +143,14 @@ func mergeLaneLeg(byChain map[uint64]*partialChainConfig, local, remote uint64, 
 	if !ok {
 		cvConfigs := make([]committeeVerifierInputConfig, 0, len(qualifiers))
 		for _, q := range qualifiers {
-			cvConfigs = append(cvConfigs, committeeVerifierInputConfig{
+			cv := committeeVerifierInputConfig{
 				CommitteeQualifier: q,
 				RemoteChains:       make(map[uint64]committeeVerifierRemoteChainInput),
-			})
+			}
+			if o != nil {
+				cv.AllowedFinalityConfig = o.CommitteeVerifierFinalityConfig
+			}
+			cvConfigs = append(cvConfigs, cv)
 		}
 
 		cfg = &partialChainConfig{
@@ -168,15 +172,21 @@ func mergeLaneLeg(byChain map[uint64]*partialChainConfig, local, remote uint64, 
 	for _, q := range qualifiers {
 		idx, ok := byQualifier[q]
 		if !ok {
-			cfg.CommitteeVerifiers = append(cfg.CommitteeVerifiers, committeeVerifierInputConfig{
-				CommitteeQualifier:    q,
-				AllowedFinalityConfig: o.CommitteeVerifierFinalityConfig,
-				RemoteChains:          make(map[uint64]committeeVerifierRemoteChainInput),
-			})
+			newCv := committeeVerifierInputConfig{
+				CommitteeQualifier: q,
+				RemoteChains:       make(map[uint64]committeeVerifierRemoteChainInput),
+			}
+			if o != nil {
+				newCv.AllowedFinalityConfig = o.CommitteeVerifierFinalityConfig
+			}
+			cfg.CommitteeVerifiers = append(cfg.CommitteeVerifiers, newCv)
 			idx = len(cfg.CommitteeVerifiers) - 1
 			byQualifier[q] = idx
 		}
 		cfgCv := cfg.CommitteeVerifiers[idx]
+		if o != nil && o.CommitteeVerifierFinalityConfig != nil {
+			cfgCv.AllowedFinalityConfig = o.CommitteeVerifierFinalityConfig
+		}
 		if existingRemote, ok := cfgCv.RemoteChains[remote]; ok {
 			cfgCv.RemoteChains[remote] = mergeCommitteeVerifierRemoteInput(existingRemote, cv)
 		} else {

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family.go
@@ -8,6 +8,7 @@ import (
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
+	"github.com/smartcontractkit/chainlink-ccip/deployment/finality"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/offchain"
@@ -16,9 +17,10 @@ import (
 // ChainOverrides holds per-chain lane settings that differ from chain-family adapter defaults.
 // Only set fields you need to override; omitted fields use adapter defaults at apply time.
 type ChainOverrides struct {
-	AllowlistEnabled *bool                    `json:"allowlistEnabled,omitempty" yaml:"allowlistEnabled,omitempty"`
-	AllowList        []string                 `json:"allowList,omitempty" yaml:"allowList,omitempty"`
-	RemoteChainCfg   PartialRemoteChainConfig `json:"remoteChainCfg,omitempty" yaml:"remoteChainCfg,omitempty"`
+	AllowlistEnabled                *bool                    `json:"allowlistEnabled,omitempty" yaml:"allowlistEnabled,omitempty"`
+	AllowList                       []string                 `json:"allowList,omitempty" yaml:"allowList,omitempty"`
+	CommitteeVerifierFinalityConfig *finality.Config         `json:"committeeVerifierFinalityConfig,omitempty" yaml:"committeeVerifierFinalityConfig,omitempty"`
+	RemoteChainCfg                  PartialRemoteChainConfig `json:"remoteChainCfg,omitempty" yaml:"remoteChainCfg,omitempty"`
 }
 
 // CrossFamilyLanePair defines a bidirectional lane with optional per-chain overrides.
@@ -167,8 +169,9 @@ func mergeLaneLeg(byChain map[uint64]*partialChainConfig, local, remote uint64, 
 		idx, ok := byQualifier[q]
 		if !ok {
 			cfg.CommitteeVerifiers = append(cfg.CommitteeVerifiers, committeeVerifierInputConfig{
-				CommitteeQualifier: q,
-				RemoteChains:       make(map[uint64]committeeVerifierRemoteChainInput),
+				CommitteeQualifier:    q,
+				AllowedFinalityConfig: o.CommitteeVerifierFinalityConfig,
+				RemoteChains:          make(map[uint64]committeeVerifierRemoteChainInput),
 			})
 			idx = len(cfg.CommitteeVerifiers) - 1
 			byQualifier[q] = idx

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family.go
@@ -72,8 +72,9 @@ func expandLanesToPartialChainConfigs(lanes []CrossFamilyLanePair, committees ma
 			return nil, fmt.Errorf("lane %d: chainA and chainB must differ", i)
 		}
 		var qualifiers []string
+		remoteKey := strconv.FormatUint(lane.ChainB, 10)
 		for _, cvCfg := range committees {
-			if _, exists := cvCfg.ChainConfigs[strconv.FormatUint(lane.ChainA, 10)]; exists {
+			if _, exists := cvCfg.ChainConfigs[remoteKey]; exists {
 				qualifiers = append(qualifiers, cvCfg.Qualifier)
 			}
 		}
@@ -82,9 +83,10 @@ func expandLanesToPartialChainConfigs(lanes []CrossFamilyLanePair, committees ma
 			qualifiers = []string{defaultQualifier}
 		}
 		mergeLaneLeg(byChain, lane.ChainA, lane.ChainB, qualifiers, lane.ChainAOverrides)
-		qualifiers = make([]string, 0, len(committees))
+		qualifiers = nil
+		remoteKey = strconv.FormatUint(lane.ChainA, 10)
 		for _, cvCfg := range committees {
-			if _, exists := cvCfg.ChainConfigs[strconv.FormatUint(lane.ChainB, 10)]; exists {
+			if _, exists := cvCfg.ChainConfigs[remoteKey]; exists {
 				qualifiers = append(qualifiers, cvCfg.Qualifier)
 			}
 		}

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family.go
@@ -58,17 +58,20 @@ type ConfigureChainsForLanesFromTopologyConfig struct {
 
 // expandLanesToPartialChainConfigs converts bidirectional lane pairs into the internal
 // chain-centric representation used by the changeset apply path.
-func expandLanesToPartialChainConfigs(lanes []CrossFamilyLanePair, topology *offchain.NOPTopology) ([]partialChainConfig, error) {
+func expandLanesToPartialChainConfigs(lanes []CrossFamilyLanePair, committees map[string]offchain.CommitteeConfig) ([]partialChainConfig, error) {
 	if len(lanes) == 0 {
 		return nil, fmt.Errorf("at least one lane must be specified")
 	}
 
-	qualifiers := []string{defaultQualifier}
-	if topology != nil && len(topology.Committees) > 0 {
-		qualifiers = make([]string, 0, len(topology.Committees))
-		for qualifier := range topology.Committees {
+	var qualifiers []string
+	if len(committees) > 0 {
+		qualifiers = make([]string, 0, len(committees))
+		for qualifier := range committees {
 			qualifiers = append(qualifiers, qualifier)
 		}
+	}
+	if len(qualifiers) == 0 {
+		qualifiers = []string{defaultQualifier}
 	}
 
 	byChain := make(map[uint64]*partialChainConfig)
@@ -119,17 +122,17 @@ func mergeLaneLeg(byChain map[uint64]*partialChainConfig, local, remote uint64, 
 	cfg, ok := byChain[local]
 	if !ok {
 		cvConfigs := make([]committeeVerifierInputConfig, 0, len(qualifiers))
-		for range qualifiers {
+		for _, q := range qualifiers {
 			cvConfigs = append(cvConfigs, committeeVerifierInputConfig{
-				CommitteeQualifier: defaultQualifier,
+				CommitteeQualifier: q,
 				RemoteChains:       make(map[uint64]committeeVerifierRemoteChainInput),
 			})
 		}
 
 		cfg = &partialChainConfig{
-			ChainSelector: local,
+			ChainSelector:      local,
 			CommitteeVerifiers: cvConfigs,
-			RemoteChains: make(map[uint64]partialRemoteChainConfig),
+			RemoteChains:       make(map[uint64]partialRemoteChainConfig),
 		}
 		byChain[local] = cfg
 	}

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"slices"
 	"sort"
+	"strconv"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 
@@ -62,18 +63,6 @@ func expandLanesToPartialChainConfigs(lanes []CrossFamilyLanePair, committees ma
 		return nil, fmt.Errorf("at least one lane must be specified")
 	}
 
-	var qualifiers []string
-	if len(committees) > 0 {
-		qualifiers = make([]string, 0, len(committees))
-		for qualifier := range committees {
-			qualifiers = append(qualifiers, qualifier)
-		}
-		sort.Strings(qualifiers)
-	}
-	if len(qualifiers) == 0 {
-		qualifiers = []string{defaultQualifier}
-	}
-
 	byChain := make(map[uint64]*partialChainConfig)
 	for i, lane := range lanes {
 		if lane.ChainA == 0 || lane.ChainB == 0 {
@@ -82,8 +71,27 @@ func expandLanesToPartialChainConfigs(lanes []CrossFamilyLanePair, committees ma
 		if lane.ChainA == lane.ChainB {
 			return nil, fmt.Errorf("lane %d: chainA and chainB must differ", i)
 		}
-
+		var qualifiers []string
+		for _, cvCfg := range committees {
+			if _, exists := cvCfg.ChainConfigs[strconv.FormatUint(lane.ChainA, 10)]; exists {
+				qualifiers = append(qualifiers, cvCfg.Qualifier)
+			}
+		}
+		sort.Strings(qualifiers)
+		if len(qualifiers) == 0 {
+			qualifiers = []string{defaultQualifier}
+		}
 		mergeLaneLeg(byChain, lane.ChainA, lane.ChainB, qualifiers, lane.ChainAOverrides)
+		qualifiers = make([]string, 0, len(committees))
+		for _, cvCfg := range committees {
+			if _, exists := cvCfg.ChainConfigs[strconv.FormatUint(lane.ChainB, 10)]; exists {
+				qualifiers = append(qualifiers, cvCfg.Qualifier)
+			}
+		}
+		sort.Strings(qualifiers)
+		if len(qualifiers) == 0 {
+			qualifiers = []string{defaultQualifier}
+		}
 		mergeLaneLeg(byChain, lane.ChainB, lane.ChainA, qualifiers, lane.ChainBOverrides)
 	}
 
@@ -193,7 +201,7 @@ func mergePartialRemoteInput(base, overlay PartialRemoteChainConfig) PartialRemo
 		base.BaseExecutionGasCost = overlay.BaseExecutionGasCost
 	}
 	base.FeeQuoterDestChainConfig = mergeFeeQuoterDestChainConfig(base.FeeQuoterDestChainConfig, overlay.FeeQuoterDestChainConfig)
-	base.ExecutorDestChainConfig = utils.CoalescePtr(base.ExecutorDestChainConfig, overlay.ExecutorDestChainConfig)
+	base.ExecutorDestChainConfig = utils.CoalescePtr(overlay.ExecutorDestChainConfig, base.ExecutorDestChainConfig)
 	if overlay.DefaultInboundCCVs != nil {
 		base.DefaultInboundCCVs = overlay.DefaultInboundCCVs
 	}

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family.go
@@ -58,13 +58,17 @@ type ConfigureChainsForLanesFromTopologyConfig struct {
 
 // expandLanesToPartialChainConfigs converts bidirectional lane pairs into the internal
 // chain-centric representation used by the changeset apply path.
-func expandLanesToPartialChainConfigs(lanes []CrossFamilyLanePair) ([]partialChainConfig, error) {
+func expandLanesToPartialChainConfigs(lanes []CrossFamilyLanePair, topology *offchain.NOPTopology) ([]partialChainConfig, error) {
 	if len(lanes) == 0 {
 		return nil, fmt.Errorf("at least one lane must be specified")
 	}
 
-	byChain := make(map[uint64]*partialChainConfig)
+	qualifiers := make([]string, 0, len(topology.Committees))
+	for qualifier := range topology.Committees {
+		qualifiers = append(qualifiers, qualifier)
+	}
 
+	byChain := make(map[uint64]*partialChainConfig)
 	for i, lane := range lanes {
 		if lane.ChainA == 0 || lane.ChainB == 0 {
 			return nil, fmt.Errorf("lane %d: chainA and chainB are required", i)
@@ -73,8 +77,8 @@ func expandLanesToPartialChainConfigs(lanes []CrossFamilyLanePair) ([]partialCha
 			return nil, fmt.Errorf("lane %d: chainA and chainB must differ", i)
 		}
 
-		mergeLaneLeg(byChain, lane.ChainA, lane.ChainB, lane.ChainAOverrides)
-		mergeLaneLeg(byChain, lane.ChainB, lane.ChainA, lane.ChainBOverrides)
+		mergeLaneLeg(byChain, lane.ChainA, lane.ChainB, qualifiers, lane.ChainAOverrides)
+		mergeLaneLeg(byChain, lane.ChainB, lane.ChainA, qualifiers, lane.ChainBOverrides)
 	}
 
 	out := make([]partialChainConfig, 0, len(byChain))
@@ -108,15 +112,21 @@ func sortedKeys(m map[uint64]*partialChainConfig) []uint64 {
 	return keys
 }
 
-func mergeLaneLeg(byChain map[uint64]*partialChainConfig, local, remote uint64, o *ChainOverrides) {
+func mergeLaneLeg(byChain map[uint64]*partialChainConfig, local, remote uint64, qualifiers[]string, o *ChainOverrides) {
 	cfg, ok := byChain[local]
 	if !ok {
-		cfg = &partialChainConfig{
-			ChainSelector: local,
-			CommitteeVerifiers: []committeeVerifierInputConfig{{
+		cvConfigs := make([]committeeVerifierInputConfig, 0, len(qualifiers))
+		for _, qualifier := range qualifiers {
+			cvConfigs = append(cvConfigs, committeeVerifierInputConfig{
 				CommitteeQualifier: defaultQualifier,
 				RemoteChains:       make(map[uint64]committeeVerifierRemoteChainInput),
-			}},
+				// TODO: AllowedFinalityConfig: local.AllowedFinalityConfig, sourced from where?
+			}),
+		}
+
+		cfg = &partialChainConfig{
+			ChainSelector: local,
+			CommitteeVerifiers: cvConfigs,
 			RemoteChains: make(map[uint64]partialRemoteChainConfig),
 		}
 		byChain[local] = cfg

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family.go
@@ -63,9 +63,12 @@ func expandLanesToPartialChainConfigs(lanes []CrossFamilyLanePair, topology *off
 		return nil, fmt.Errorf("at least one lane must be specified")
 	}
 
-	qualifiers := make([]string, 0, len(topology.Committees))
-	for qualifier := range topology.Committees {
-		qualifiers = append(qualifiers, qualifier)
+	qualifiers := []string{defaultQualifier}
+	if topology != nil && len(topology.Committees) > 0 {
+		qualifiers = make([]string, 0, len(topology.Committees))
+		for qualifier := range topology.Committees {
+			qualifiers = append(qualifiers, qualifier)
+		}
 	}
 
 	byChain := make(map[uint64]*partialChainConfig)
@@ -120,7 +123,6 @@ func mergeLaneLeg(byChain map[uint64]*partialChainConfig, local, remote uint64, 
 			cvConfigs = append(cvConfigs, committeeVerifierInputConfig{
 				CommitteeQualifier: defaultQualifier,
 				RemoteChains:       make(map[uint64]committeeVerifierRemoteChainInput),
-				// TODO: AllowedFinalityConfig: local.AllowedFinalityConfig, sourced from where?
 			})
 		}
 

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family.go
@@ -6,19 +6,29 @@ import (
 	"sort"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/adapters"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/offchain"
 )
 
 // ChainOverrides holds per-chain lane settings that differ from chain-family adapter defaults.
 // Only set fields you need to override; omitted fields use adapter defaults at apply time.
 type ChainOverrides struct {
-	AllowTrafficFrom          *bool    `json:"allowTrafficFrom,omitempty" yaml:"allowTrafficFrom,omitempty"`
-	MessageNetworkFeeUSDCents *uint16  `json:"messageNetworkFeeUSDCents,omitempty" yaml:"messageNetworkFeeUSDCents,omitempty"`
-	TokenNetworkFeeUSDCents   *uint16  `json:"tokenNetworkFeeUSDCents,omitempty" yaml:"tokenNetworkFeeUSDCents,omitempty"`
-	AllowlistEnabled          *bool    `json:"allowlistEnabled,omitempty" yaml:"allowlistEnabled,omitempty"`
-	AllowList                 []string `json:"allowList,omitempty" yaml:"allowList,omitempty"`
+	AllowTrafficFrom          *bool                                      `json:"allowTrafficFrom,omitempty" yaml:"allowTrafficFrom,omitempty"`
+	MessageNetworkFeeUSDCents *uint16                                    `json:"messageNetworkFeeUSDCents,omitempty" yaml:"messageNetworkFeeUSDCents,omitempty"`
+	TokenNetworkFeeUSDCents   *uint16                                    `json:"tokenNetworkFeeUSDCents,omitempty" yaml:"tokenNetworkFeeUSDCents,omitempty"`
+	AllowlistEnabled          *bool                                      `json:"allowlistEnabled,omitempty" yaml:"allowlistEnabled,omitempty"`
+	AllowList                 []string                                   `json:"allowList,omitempty" yaml:"allowList,omitempty"`
+	BaseExecutionGasCost      *uint32                                    `json:"baseExecutionGasCost,omitempty" yaml:"baseExecutionGasCost,omitempty"`
+	TokenReceiverAllowed      *bool                                      `json:"tokenReceiverAllowed,omitempty" yaml:"tokenReceiverAllowed,omitempty"`
+	DefaultExecutorQualifier  *string                                    `json:"defaultExecutorQualifier,omitempty" yaml:"defaultExecutorQualifier,omitempty"`
+	FeeQuoterDestChainConfig  adapters.FeeQuoterDestChainConfigOverrides `json:"feeQuoterDestChainConfig,omitempty" yaml:"feeQuoterDestChainConfig,omitempty"`
+	ExecutorDestChainConfig   *adapters.ExecutorDestChainConfig          `json:"executorDestChainConfig,omitempty" yaml:"executorDestChainConfig,omitempty"`
+	DefaultInBoundCCVs        []datastore.AddressRef                     `json:"defaultInBoundCCVs,omitempty" yaml:"defaultInBoundCCVs,omitempty"`
+	DefaultOutBoundCCVs       []datastore.AddressRef                     `json:"defaultOutBoundCCVs,omitempty" yaml:"defaultOutBoundCCVs,omitempty"`
 }
 
 // CrossFamilyLanePair defines a bidirectional lane with optional per-chain overrides.
@@ -69,6 +79,7 @@ func expandLanesToPartialChainConfigs(lanes []CrossFamilyLanePair, committees ma
 		for qualifier := range committees {
 			qualifiers = append(qualifiers, qualifier)
 		}
+		sort.Strings(qualifiers)
 	}
 	if len(qualifiers) == 0 {
 		qualifiers = []string{defaultQualifier}
@@ -164,6 +175,13 @@ func chainOverridesToPartialRemote(o *ChainOverrides) partialRemoteChainConfig {
 		AllowTrafficFrom:          o.AllowTrafficFrom,
 		MessageNetworkFeeUSDCents: o.MessageNetworkFeeUSDCents,
 		TokenNetworkFeeUSDCents:   o.TokenNetworkFeeUSDCents,
+		DefaultExecutorQualifier:  o.DefaultExecutorQualifier,
+		TokenReceiverAllowed:      o.TokenReceiverAllowed,
+		BaseExecutionGasCost:      o.BaseExecutionGasCost,
+		FeeQuoterDestChainConfig:  o.FeeQuoterDestChainConfig,
+		ExecutorDestChainConfig:   o.ExecutorDestChainConfig,
+		DefaultInboundCCVs:        o.DefaultInBoundCCVs,
+		DefaultOutboundCCVs:       o.DefaultOutBoundCCVs,
 	}
 }
 
@@ -186,6 +204,23 @@ func mergePartialRemoteInput(base, overlay partialRemoteChainConfig) partialRemo
 	}
 	if overlay.TokenNetworkFeeUSDCents != nil {
 		base.TokenNetworkFeeUSDCents = overlay.TokenNetworkFeeUSDCents
+	}
+	if overlay.TokenReceiverAllowed != nil {
+		base.TokenReceiverAllowed = overlay.TokenReceiverAllowed
+	}
+	if overlay.DefaultExecutorQualifier != nil {
+		base.DefaultExecutorQualifier = overlay.DefaultExecutorQualifier
+	}
+	if overlay.BaseExecutionGasCost != nil {
+		base.BaseExecutionGasCost = overlay.BaseExecutionGasCost
+	}
+	base.FeeQuoterDestChainConfig = mergeFeeQuoterDestChainConfig(base.FeeQuoterDestChainConfig, overlay.FeeQuoterDestChainConfig)
+	base.ExecutorDestChainConfig = utils.CoalescePtr(base.ExecutorDestChainConfig, overlay.ExecutorDestChainConfig)
+	if overlay.DefaultInboundCCVs != nil {
+		base.DefaultInboundCCVs = overlay.DefaultInboundCCVs
+	}
+	if overlay.DefaultOutboundCCVs != nil {
+		base.DefaultOutboundCCVs = overlay.DefaultOutboundCCVs
 	}
 	return base
 }

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family.go
@@ -140,10 +140,13 @@ func mergeLaneLeg(byChain map[uint64]*partialChainConfig, local, remote uint64, 
 	cv := chainOverridesToCommitteeVerifierRemote(o)
 	rc := chainOverridesToPartialRemote(o)
 
-	if existing, ok := cfg.CommitteeVerifiers[0].RemoteChains[remote]; ok {
-		cfg.CommitteeVerifiers[0].RemoteChains[remote] = mergeCommitteeVerifierRemoteInput(existing, cv)
-	} else {
-		cfg.CommitteeVerifiers[0].RemoteChains[remote] = cv
+	for i, cfgCv := range cfg.CommitteeVerifiers {
+		if existingRemote, ok := cfgCv.RemoteChains[remote]; ok {
+			cfgCv.RemoteChains[remote] = mergeCommitteeVerifierRemoteInput(existingRemote, cv)
+		} else {
+			cfgCv.RemoteChains[remote] = cv
+		}
+		cfg.CommitteeVerifiers[i] = cfgCv
 	}
 
 	if existing, ok := cfg.RemoteChains[remote]; ok {

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family.go
@@ -6,29 +6,18 @@ import (
 	"sort"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
-	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
-	"github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/adapters"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/offchain"
 )
 
 // ChainOverrides holds per-chain lane settings that differ from chain-family adapter defaults.
 // Only set fields you need to override; omitted fields use adapter defaults at apply time.
 type ChainOverrides struct {
-	AllowTrafficFrom          *bool                                      `json:"allowTrafficFrom,omitempty" yaml:"allowTrafficFrom,omitempty"`
-	MessageNetworkFeeUSDCents *uint16                                    `json:"messageNetworkFeeUSDCents,omitempty" yaml:"messageNetworkFeeUSDCents,omitempty"`
-	TokenNetworkFeeUSDCents   *uint16                                    `json:"tokenNetworkFeeUSDCents,omitempty" yaml:"tokenNetworkFeeUSDCents,omitempty"`
-	AllowlistEnabled          *bool                                      `json:"allowlistEnabled,omitempty" yaml:"allowlistEnabled,omitempty"`
-	AllowList                 []string                                   `json:"allowList,omitempty" yaml:"allowList,omitempty"`
-	BaseExecutionGasCost      *uint32                                    `json:"baseExecutionGasCost,omitempty" yaml:"baseExecutionGasCost,omitempty"`
-	TokenReceiverAllowed      *bool                                      `json:"tokenReceiverAllowed,omitempty" yaml:"tokenReceiverAllowed,omitempty"`
-	DefaultExecutorQualifier  *string                                    `json:"defaultExecutorQualifier,omitempty" yaml:"defaultExecutorQualifier,omitempty"`
-	FeeQuoterDestChainConfig  adapters.FeeQuoterDestChainConfigOverrides `json:"feeQuoterDestChainConfig,omitempty" yaml:"feeQuoterDestChainConfig,omitempty"`
-	ExecutorDestChainConfig   *adapters.ExecutorDestChainConfig          `json:"executorDestChainConfig,omitempty" yaml:"executorDestChainConfig,omitempty"`
-	DefaultInBoundCCVs        []datastore.AddressRef                     `json:"defaultInBoundCCVs,omitempty" yaml:"defaultInBoundCCVs,omitempty"`
-	DefaultOutBoundCCVs       []datastore.AddressRef                     `json:"defaultOutBoundCCVs,omitempty" yaml:"defaultOutBoundCCVs,omitempty"`
+	AllowlistEnabled *bool                    `json:"allowlistEnabled,omitempty" yaml:"allowlistEnabled,omitempty"`
+	AllowList        []string                 `json:"allowList,omitempty" yaml:"allowList,omitempty"`
+	RemoteChainCfg   PartialRemoteChainConfig `json:"remoteChainCfg,omitempty" yaml:"remoteChainCfg,omitempty"`
 }
 
 // CrossFamilyLanePair defines a bidirectional lane with optional per-chain overrides.
@@ -143,7 +132,7 @@ func mergeLaneLeg(byChain map[uint64]*partialChainConfig, local, remote uint64, 
 		cfg = &partialChainConfig{
 			ChainSelector:      local,
 			CommitteeVerifiers: cvConfigs,
-			RemoteChains:       make(map[uint64]partialRemoteChainConfig),
+			RemoteChains:       make(map[uint64]PartialRemoteChainConfig),
 		}
 		byChain[local] = cfg
 	}
@@ -167,22 +156,11 @@ func mergeLaneLeg(byChain map[uint64]*partialChainConfig, local, remote uint64, 
 	}
 }
 
-func chainOverridesToPartialRemote(o *ChainOverrides) partialRemoteChainConfig {
+func chainOverridesToPartialRemote(o *ChainOverrides) PartialRemoteChainConfig {
 	if o == nil {
-		return partialRemoteChainConfig{}
+		return PartialRemoteChainConfig{}
 	}
-	return partialRemoteChainConfig{
-		AllowTrafficFrom:          o.AllowTrafficFrom,
-		MessageNetworkFeeUSDCents: o.MessageNetworkFeeUSDCents,
-		TokenNetworkFeeUSDCents:   o.TokenNetworkFeeUSDCents,
-		DefaultExecutorQualifier:  o.DefaultExecutorQualifier,
-		TokenReceiverAllowed:      o.TokenReceiverAllowed,
-		BaseExecutionGasCost:      o.BaseExecutionGasCost,
-		FeeQuoterDestChainConfig:  o.FeeQuoterDestChainConfig,
-		ExecutorDestChainConfig:   o.ExecutorDestChainConfig,
-		DefaultInboundCCVs:        o.DefaultInBoundCCVs,
-		DefaultOutboundCCVs:       o.DefaultOutBoundCCVs,
-	}
+	return o.RemoteChainCfg
 }
 
 func chainOverridesToCommitteeVerifierRemote(o *ChainOverrides) committeeVerifierRemoteChainInput {
@@ -195,7 +173,7 @@ func chainOverridesToCommitteeVerifierRemote(o *ChainOverrides) committeeVerifie
 	}
 }
 
-func mergePartialRemoteInput(base, overlay partialRemoteChainConfig) partialRemoteChainConfig {
+func mergePartialRemoteInput(base, overlay PartialRemoteChainConfig) PartialRemoteChainConfig {
 	if overlay.AllowTrafficFrom != nil {
 		base.AllowTrafficFrom = overlay.AllowTrafficFrom
 	}
@@ -221,6 +199,12 @@ func mergePartialRemoteInput(base, overlay partialRemoteChainConfig) partialRemo
 	}
 	if overlay.DefaultOutboundCCVs != nil {
 		base.DefaultOutboundCCVs = overlay.DefaultOutboundCCVs
+	}
+	if overlay.LaneMandatedOutboundCCVs != nil {
+		base.LaneMandatedOutboundCCVs = overlay.LaneMandatedOutboundCCVs
+	}
+	if overlay.LaneMandatedInboundCCVs != nil {
+		base.LaneMandatedInboundCCVs = overlay.LaneMandatedInboundCCVs
 	}
 	return base
 }

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family.go
@@ -112,16 +112,16 @@ func sortedKeys(m map[uint64]*partialChainConfig) []uint64 {
 	return keys
 }
 
-func mergeLaneLeg(byChain map[uint64]*partialChainConfig, local, remote uint64, qualifiers[]string, o *ChainOverrides) {
+func mergeLaneLeg(byChain map[uint64]*partialChainConfig, local, remote uint64, qualifiers []string, o *ChainOverrides) {
 	cfg, ok := byChain[local]
 	if !ok {
 		cvConfigs := make([]committeeVerifierInputConfig, 0, len(qualifiers))
-		for _, qualifier := range qualifiers {
+		for range qualifiers {
 			cvConfigs = append(cvConfigs, committeeVerifierInputConfig{
 				CommitteeQualifier: defaultQualifier,
 				RemoteChains:       make(map[uint64]committeeVerifierRemoteChainInput),
 				// TODO: AllowedFinalityConfig: local.AllowedFinalityConfig, sourced from where?
-			}),
+			})
 		}
 
 		cfg = &partialChainConfig{

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family_internal_test.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family_internal_test.go
@@ -1,6 +1,7 @@
 package changesets
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -87,9 +88,13 @@ func TestExpandLanesToPartialChainConfigs_MergesMultipleLanesOnSameChain(t *test
 func TestExpandLanesToPartialChainConfigs_MultipleCommittees(t *testing.T) {
 	chainA := uint64(1)
 	chainB := uint64(2)
+	chainConfigsBoth := map[string]offchain.ChainCommitteeConfig{
+		strconv.FormatUint(chainA, 10): {},
+		strconv.FormatUint(chainB, 10): {},
+	}
 	committees := map[string]offchain.CommitteeConfig{
-		"alpha": {},
-		"beta":  {},
+		"alpha": {Qualifier: "alpha", ChainConfigs: chainConfigsBoth},
+		"beta":  {Qualifier: "beta", ChainConfigs: chainConfigsBoth},
 	}
 
 	chains, err := expandLanesToPartialChainConfigs([]CrossFamilyLanePair{
@@ -120,6 +125,60 @@ func TestExpandLanesToPartialChainConfigs_MultipleCommittees(t *testing.T) {
 	assert.Equal(t, "beta", cfgB.CommitteeVerifiers[1].CommitteeQualifier)
 	assert.Contains(t, cfgB.CommitteeVerifiers[0].RemoteChains, chainA)
 	assert.Contains(t, cfgB.CommitteeVerifiers[1].RemoteChains, chainA)
+}
+
+func TestExpandLanesToPartialChainConfigs_FiltersCommitteeQualifiersPerLocalChain(t *testing.T) {
+	chainA := uint64(100)
+	chainB := uint64(200)
+
+	// alpha is on both chains; beta only on chainA; gamma only on chainB.
+	committees := map[string]offchain.CommitteeConfig{
+		"alpha": {
+			Qualifier: "alpha",
+			ChainConfigs: map[string]offchain.ChainCommitteeConfig{
+				strconv.FormatUint(chainA, 10): {},
+				strconv.FormatUint(chainB, 10): {},
+			},
+		},
+		"beta": {
+			Qualifier: "beta",
+			ChainConfigs: map[string]offchain.ChainCommitteeConfig{
+				strconv.FormatUint(chainA, 10): {},
+			},
+		},
+		"gamma": {
+			Qualifier: "gamma",
+			ChainConfigs: map[string]offchain.ChainCommitteeConfig{
+				strconv.FormatUint(chainB, 10): {},
+			},
+		},
+	}
+
+	chains, err := expandLanesToPartialChainConfigs([]CrossFamilyLanePair{
+		{ChainA: chainA, ChainB: chainB},
+	}, committees)
+	require.NoError(t, err)
+
+	bySel := make(map[uint64]partialChainConfig, len(chains))
+	for _, c := range chains {
+		bySel[c.ChainSelector] = c
+	}
+
+	cfgA := bySel[chainA]
+	require.Len(t, cfgA.CommitteeVerifiers, 2)
+	assert.Equal(t, "alpha", cfgA.CommitteeVerifiers[0].CommitteeQualifier)
+	assert.Equal(t, "beta", cfgA.CommitteeVerifiers[1].CommitteeQualifier)
+	for _, cv := range cfgA.CommitteeVerifiers {
+		assert.Contains(t, cv.RemoteChains, chainB)
+	}
+
+	cfgB := bySel[chainB]
+	require.Len(t, cfgB.CommitteeVerifiers, 2)
+	assert.Equal(t, "alpha", cfgB.CommitteeVerifiers[0].CommitteeQualifier)
+	assert.Equal(t, "gamma", cfgB.CommitteeVerifiers[1].CommitteeQualifier)
+	for _, cv := range cfgB.CommitteeVerifiers {
+		assert.Contains(t, cv.RemoteChains, chainA)
+	}
 }
 
 func TestExpandLanesToPartialChainConfigs_ChainOverridesToCommitteeVerifier(t *testing.T) {

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family_internal_test.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family_internal_test.go
@@ -13,7 +13,7 @@ func TestExpandLanesToPartialChainConfigs_MinimalLane(t *testing.T) {
 
 	chains, err := expandLanesToPartialChainConfigs([]CrossFamilyLanePair{
 		{ChainA: chainA, ChainB: chainB},
-	})
+	}, nil)
 	require.NoError(t, err)
 	require.Len(t, chains, 2)
 
@@ -46,7 +46,7 @@ func TestExpandLanesToPartialChainConfigs_AppliesChainOverrides(t *testing.T) {
 				MessageNetworkFeeUSDCents: &fee,
 			},
 		},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	var cfgA partialChainConfig
@@ -66,7 +66,7 @@ func TestExpandLanesToPartialChainConfigs_MergesMultipleLanesOnSameChain(t *test
 	chains, err := expandLanesToPartialChainConfigs([]CrossFamilyLanePair{
 		{ChainA: chainA, ChainB: chainB},
 		{ChainA: chainA, ChainB: chainC},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	var cfgA partialChainConfig
@@ -93,7 +93,7 @@ func TestExpandLanesToPartialChainConfigs_ChainOverridesToCommitteeVerifier(t *t
 				AllowList:        allow,
 			},
 		},
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	var cfg partialChainConfig

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family_internal_test.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family_internal_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/offchain"
 )
 
 func TestExpandLanesToPartialChainConfigs_MinimalLane(t *testing.T) {
@@ -78,6 +80,44 @@ func TestExpandLanesToPartialChainConfigs_MergesMultipleLanesOnSameChain(t *test
 	assert.Len(t, cfgA.RemoteChains, 2)
 	assert.Contains(t, cfgA.RemoteChains, chainB)
 	assert.Contains(t, cfgA.RemoteChains, chainC)
+}
+
+func TestExpandLanesToPartialChainConfigs_MultipleCommittees(t *testing.T) {
+	chainA := uint64(1)
+	chainB := uint64(2)
+	committees := map[string]offchain.CommitteeConfig{
+		"alpha": {},
+		"beta":  {},
+	}
+
+	chains, err := expandLanesToPartialChainConfigs([]CrossFamilyLanePair{
+		{ChainA: chainA, ChainB: chainB},
+	}, committees)
+	require.NoError(t, err)
+	require.Len(t, chains, 2)
+
+	bySel := make(map[uint64]partialChainConfig, len(chains))
+	for _, c := range chains {
+		bySel[c.ChainSelector] = c
+	}
+
+	cfgA := bySel[chainA]
+	require.Len(t, cfgA.CommitteeVerifiers, 2)
+
+	// Qualifiers must be sorted deterministically.
+	assert.Equal(t, "alpha", cfgA.CommitteeVerifiers[0].CommitteeQualifier)
+	assert.Equal(t, "beta", cfgA.CommitteeVerifiers[1].CommitteeQualifier)
+
+	// Each verifier must have the remote chain entry.
+	assert.Contains(t, cfgA.CommitteeVerifiers[0].RemoteChains, chainB)
+	assert.Contains(t, cfgA.CommitteeVerifiers[1].RemoteChains, chainB)
+
+	cfgB := bySel[chainB]
+	require.Len(t, cfgB.CommitteeVerifiers, 2)
+	assert.Equal(t, "alpha", cfgB.CommitteeVerifiers[0].CommitteeQualifier)
+	assert.Equal(t, "beta", cfgB.CommitteeVerifiers[1].CommitteeQualifier)
+	assert.Contains(t, cfgB.CommitteeVerifiers[0].RemoteChains, chainA)
+	assert.Contains(t, cfgB.CommitteeVerifiers[1].RemoteChains, chainA)
 }
 
 func TestExpandLanesToPartialChainConfigs_ChainOverridesToCommitteeVerifier(t *testing.T) {

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family_internal_test.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family_internal_test.go
@@ -45,7 +45,9 @@ func TestExpandLanesToPartialChainConfigs_AppliesChainOverrides(t *testing.T) {
 			ChainA: chainA,
 			ChainB: chainB,
 			ChainAOverrides: &ChainOverrides{
-				MessageNetworkFeeUSDCents: &fee,
+				RemoteChainCfg: PartialRemoteChainConfig{
+					MessageNetworkFeeUSDCents: &fee,
+				},
 			},
 		},
 	}, nil)

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family_internal_test.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family_internal_test.go
@@ -127,7 +127,7 @@ func TestExpandLanesToPartialChainConfigs_MultipleCommittees(t *testing.T) {
 	assert.Contains(t, cfgB.CommitteeVerifiers[1].RemoteChains, chainA)
 }
 
-func TestExpandLanesToPartialChainConfigs_FiltersCommitteeQualifiersPerLocalChain(t *testing.T) {
+func TestExpandLanesToPartialChainConfigs_FiltersCommitteeQualifiersPerRemoteChain(t *testing.T) {
 	chainA := uint64(100)
 	chainB := uint64(200)
 
@@ -207,4 +207,108 @@ func TestExpandLanesToPartialChainConfigs_ChainOverridesToCommitteeVerifier(t *t
 	require.NotNil(t, rc.AllowlistEnabled)
 	assert.True(t, *rc.AllowlistEnabled)
 	assert.Equal(t, allow, rc.AddedAllowlistedSenders)
+}
+
+func TestMergeLaneLeg(t *testing.T) {
+	local := uint64(10)
+	remoteB := uint64(20)
+	remoteC := uint64(30)
+
+	t.Run("multiple remote same qualifier", func(t *testing.T) {
+		byChain := make(map[uint64]*partialChainConfig)
+		mergeLaneLeg(byChain, local, remoteB, []string{"alpha"}, nil)
+		mergeLaneLeg(byChain, local, remoteC, []string{"alpha"}, nil)
+
+		cfg := byChain[local]
+		require.NotNil(t, cfg)
+		assert.Equal(t, local, cfg.ChainSelector)
+		require.Len(t, cfg.CommitteeVerifiers, 1)
+		assert.Equal(t, "alpha", cfg.CommitteeVerifiers[0].CommitteeQualifier)
+		assert.Contains(t, cfg.CommitteeVerifiers[0].RemoteChains, remoteB)
+		assert.Contains(t, cfg.CommitteeVerifiers[0].RemoteChains, remoteC)
+		assert.Contains(t, cfg.RemoteChains, remoteB)
+		assert.Contains(t, cfg.RemoteChains, remoteC)
+	})
+
+	t.Run("initializes local chain with qualifiers and remote", func(t *testing.T) {
+		byChain := make(map[uint64]*partialChainConfig)
+		mergeLaneLeg(byChain, local, remoteB, []string{"alpha", "beta"}, nil)
+
+		cfg := byChain[local]
+		require.NotNil(t, cfg)
+		assert.Equal(t, local, cfg.ChainSelector)
+		require.Len(t, cfg.CommitteeVerifiers, 2)
+		assert.Equal(t, "alpha", cfg.CommitteeVerifiers[0].CommitteeQualifier)
+		assert.Equal(t, "beta", cfg.CommitteeVerifiers[1].CommitteeQualifier)
+		assert.Contains(t, cfg.CommitteeVerifiers[0].RemoteChains, remoteB)
+		assert.Contains(t, cfg.CommitteeVerifiers[1].RemoteChains, remoteB)
+		assert.Contains(t, cfg.RemoteChains, remoteB)
+	})
+
+	t.Run("adds remote only to qualifiers in second merge", func(t *testing.T) {
+		byChain := make(map[uint64]*partialChainConfig)
+		mergeLaneLeg(byChain, local, remoteB, []string{"alpha", "beta"}, nil)
+		mergeLaneLeg(byChain, local, remoteC, []string{"alpha"}, nil)
+
+		cfg := byChain[local]
+		assert.Contains(t, cfg.CommitteeVerifiers[0].RemoteChains, remoteB)
+		assert.Contains(t, cfg.CommitteeVerifiers[0].RemoteChains, remoteC)
+		assert.Contains(t, cfg.CommitteeVerifiers[1].RemoteChains, remoteB)
+		assert.NotContains(t, cfg.CommitteeVerifiers[1].RemoteChains, remoteC)
+		assert.Contains(t, cfg.RemoteChains, remoteC)
+		assert.Contains(t, cfg.RemoteChains, remoteB)
+	})
+
+	t.Run("adds remote only to new qualifiers in second merge", func(t *testing.T) {
+		byChain := make(map[uint64]*partialChainConfig)
+		mergeLaneLeg(byChain, local, remoteB, []string{"alpha"}, nil)
+		mergeLaneLeg(byChain, local, remoteC, []string{"beta"}, nil)
+
+		cfg := byChain[local]
+		assert.Contains(t, cfg.CommitteeVerifiers[0].RemoteChains, remoteB)
+		assert.NotContains(t, cfg.CommitteeVerifiers[0].RemoteChains, remoteC)
+		assert.NotContains(t, cfg.CommitteeVerifiers[1].RemoteChains, remoteB)
+		assert.Contains(t, cfg.CommitteeVerifiers[1].RemoteChains, remoteC)
+		assert.Contains(t, cfg.RemoteChains, remoteC)
+		assert.Contains(t, cfg.RemoteChains, remoteB)
+	})
+
+	t.Run("appends new qualifier on existing local chain", func(t *testing.T) {
+		byChain := make(map[uint64]*partialChainConfig)
+		mergeLaneLeg(byChain, local, remoteB, []string{"alpha"}, nil)
+		mergeLaneLeg(byChain, local, remoteB, []string{"beta"}, nil)
+
+		cfg := byChain[local]
+		require.Len(t, cfg.CommitteeVerifiers, 2)
+		assert.Equal(t, "alpha", cfg.CommitteeVerifiers[0].CommitteeQualifier)
+		assert.Equal(t, "beta", cfg.CommitteeVerifiers[1].CommitteeQualifier)
+	})
+
+	t.Run("merges chain overrides into committee verifier and remote config", func(t *testing.T) {
+		enabled := true
+		allow := []string{"0xabc"}
+		feeFirst := uint16(10)
+		feeSecond := uint16(20)
+
+		byChain := make(map[uint64]*partialChainConfig)
+		mergeLaneLeg(byChain, local, remoteB, []string{"alpha"}, &ChainOverrides{
+			AllowlistEnabled: &enabled,
+			AllowList:        allow,
+			RemoteChainCfg: PartialRemoteChainConfig{
+				MessageNetworkFeeUSDCents: &feeFirst,
+			},
+		})
+		mergeLaneLeg(byChain, local, remoteB, []string{"alpha"}, &ChainOverrides{
+			RemoteChainCfg: PartialRemoteChainConfig{
+				MessageNetworkFeeUSDCents: &feeSecond,
+			},
+		})
+
+		cfg := byChain[local]
+		cv := cfg.CommitteeVerifiers[0].RemoteChains[remoteB]
+		require.NotNil(t, cv.AllowlistEnabled)
+		assert.True(t, *cv.AllowlistEnabled)
+		assert.Equal(t, allow, cv.AddedAllowlistedSenders)
+		require.Equal(t, feeSecond, *cfg.RemoteChains[remoteB].MessageNetworkFeeUSDCents)
+	})
 }

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family_internal_test.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family_internal_test.go
@@ -184,27 +184,53 @@ func TestExpandLanesToPartialChainConfigs_FiltersCommitteeQualifiersPerRemoteCha
 
 func TestExpandLanesToPartialChainConfigs_ChainOverridesCommitteeVerifierFinalityConfig(t *testing.T) {
 	finalityCfg := &finality.Config{WaitForSafe: true, BlockDepth: 100}
-
+	chainA := uint64(100)
+	chainB := uint64(200)
+	committees := map[string]offchain.CommitteeConfig{
+		"alpha": {
+			Qualifier: "alpha",
+			ChainConfigs: map[string]offchain.ChainCommitteeConfig{
+				strconv.FormatUint(chainA, 10): {},
+				strconv.FormatUint(chainB, 10): {},
+			},
+		},
+		"beta": {
+			Qualifier: "beta",
+			ChainConfigs: map[string]offchain.ChainCommitteeConfig{
+				strconv.FormatUint(chainA, 10): {},
+			},
+		},
+		"gamma": {
+			Qualifier: "gamma",
+			ChainConfigs: map[string]offchain.ChainCommitteeConfig{
+				strconv.FormatUint(chainB, 10): {},
+			},
+		},
+	}
 	chains, err := expandLanesToPartialChainConfigs([]CrossFamilyLanePair{
 		{
-			ChainA: 10,
-			ChainB: 20,
+			ChainA: chainA,
+			ChainB: chainB,
 			ChainAOverrides: &ChainOverrides{
 				CommitteeVerifierFinalityConfig: finalityCfg,
 			},
 		},
-	}, nil)
+	}, committees)
 	require.NoError(t, err)
 
 	var cfg partialChainConfig
 	for _, c := range chains {
-		if c.ChainSelector == 10 {
+		if c.ChainSelector == chainA {
 			cfg = c
 		}
 	}
-	require.Len(t, cfg.CommitteeVerifiers, 1)
-	require.NotNil(t, cfg.CommitteeVerifiers[0].AllowedFinalityConfig)
-	assert.Equal(t, *finalityCfg, *cfg.CommitteeVerifiers[0].AllowedFinalityConfig)
+	require.Len(t, cfg.CommitteeVerifiers, 2)
+	for _, cv := range cfg.CommitteeVerifiers {
+		require.NotNil(t, cv.AllowedFinalityConfig)
+		require.Equal(t, *finalityCfg, *cv.AllowedFinalityConfig)
+		require.Contains(t, cv.RemoteChains, chainB)
+
+	}
 }
 
 func TestExpandLanesToPartialChainConfigs_ChainOverridesToCommitteeVerifier(t *testing.T) {

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family_internal_test.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family_internal_test.go
@@ -167,7 +167,7 @@ func TestExpandLanesToPartialChainConfigs_FiltersCommitteeQualifiersPerLocalChai
 	cfgA := bySel[chainA]
 	require.Len(t, cfgA.CommitteeVerifiers, 2)
 	assert.Equal(t, "alpha", cfgA.CommitteeVerifiers[0].CommitteeQualifier)
-	assert.Equal(t, "beta", cfgA.CommitteeVerifiers[1].CommitteeQualifier)
+	assert.Equal(t, "gamma", cfgA.CommitteeVerifiers[1].CommitteeQualifier)
 	for _, cv := range cfgA.CommitteeVerifiers {
 		assert.Contains(t, cv.RemoteChains, chainB)
 	}
@@ -175,7 +175,7 @@ func TestExpandLanesToPartialChainConfigs_FiltersCommitteeQualifiersPerLocalChai
 	cfgB := bySel[chainB]
 	require.Len(t, cfgB.CommitteeVerifiers, 2)
 	assert.Equal(t, "alpha", cfgB.CommitteeVerifiers[0].CommitteeQualifier)
-	assert.Equal(t, "gamma", cfgB.CommitteeVerifiers[1].CommitteeQualifier)
+	assert.Equal(t, "beta", cfgB.CommitteeVerifiers[1].CommitteeQualifier)
 	for _, cv := range cfgB.CommitteeVerifiers {
 		assert.Contains(t, cv.RemoteChains, chainA)
 	}

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family_internal_test.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-ccip/deployment/finality"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/offchain"
 )
 
@@ -181,6 +182,31 @@ func TestExpandLanesToPartialChainConfigs_FiltersCommitteeQualifiersPerRemoteCha
 	}
 }
 
+func TestExpandLanesToPartialChainConfigs_ChainOverridesCommitteeVerifierFinalityConfig(t *testing.T) {
+	finalityCfg := &finality.Config{WaitForSafe: true, BlockDepth: 100}
+
+	chains, err := expandLanesToPartialChainConfigs([]CrossFamilyLanePair{
+		{
+			ChainA: 10,
+			ChainB: 20,
+			ChainAOverrides: &ChainOverrides{
+				CommitteeVerifierFinalityConfig: finalityCfg,
+			},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	var cfg partialChainConfig
+	for _, c := range chains {
+		if c.ChainSelector == 10 {
+			cfg = c
+		}
+	}
+	require.Len(t, cfg.CommitteeVerifiers, 1)
+	require.NotNil(t, cfg.CommitteeVerifiers[0].AllowedFinalityConfig)
+	assert.Equal(t, *finalityCfg, *cfg.CommitteeVerifiers[0].AllowedFinalityConfig)
+}
+
 func TestExpandLanesToPartialChainConfigs_ChainOverridesToCommitteeVerifier(t *testing.T) {
 	enabled := true
 	allow := []string{"0xabc"}
@@ -282,6 +308,18 @@ func TestMergeLaneLeg(t *testing.T) {
 		require.Len(t, cfg.CommitteeVerifiers, 2)
 		assert.Equal(t, "alpha", cfg.CommitteeVerifiers[0].CommitteeQualifier)
 		assert.Equal(t, "beta", cfg.CommitteeVerifiers[1].CommitteeQualifier)
+	})
+
+	t.Run("applies committee verifier finality config from chain overrides", func(t *testing.T) {
+		byChain := make(map[uint64]*partialChainConfig)
+		finalityCfg := &finality.Config{WaitForSafe: true, BlockDepth: 50}
+		mergeLaneLeg(byChain, local, remoteB, []string{"alpha"}, &ChainOverrides{
+			CommitteeVerifierFinalityConfig: finalityCfg,
+		})
+
+		cfg := byChain[local]
+		require.NotNil(t, cfg.CommitteeVerifiers[0].AllowedFinalityConfig)
+		assert.Equal(t, *finalityCfg, *cfg.CommitteeVerifiers[0].AllowedFinalityConfig)
 	})
 
 	t.Run("merges chain overrides into committee verifier and remote config", func(t *testing.T) {

--- a/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology.go
+++ b/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology.go
@@ -13,6 +13,7 @@ import (
 	mcms_types "github.com/smartcontractkit/mcms/types"
 
 	"github.com/smartcontractkit/chainlink-ccip/deployment/finality"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 	changesetscore "github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
 	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
@@ -435,8 +436,8 @@ func resolveRemoteChainConfig(
 
 	// Apply per-field user overrides on top of adapter defaults via coalesce.
 	// Pointer fields: nil = keep adapter default; non-nil = use caller value.
-	allowTrafficFrom := coalesce(inCfg.AllowTrafficFrom, defaults.AllowTrafficFrom)
-	tokenReceiverAllowed := coalesce(inCfg.TokenReceiverAllowed, defaults.TokenReceiverAllowed)
+	allowTrafficFrom := utils.Coalesce(inCfg.AllowTrafficFrom, defaults.AllowTrafficFrom)
+	tokenReceiverAllowed := utils.Coalesce(inCfg.TokenReceiverAllowed, defaults.TokenReceiverAllowed)
 
 	return adapters.RemoteChainConfig[[]byte, string]{
 		AllowTrafficFrom:          &allowTrafficFrom,
@@ -448,12 +449,12 @@ func resolveRemoteChainConfig(
 		DefaultOutboundCCVs:       defaultOutboundCCVs,
 		LaneMandatedOutboundCCVs:  laneMandatedOutboundCCVs,
 		FeeQuoterDestChainConfig:  fqConfig,
-		ExecutorDestChainConfig:   coalesce(inCfg.ExecutorDestChainConfig, defaults.ExecutorDestChainConfig),
+		ExecutorDestChainConfig:   utils.Coalesce(inCfg.ExecutorDestChainConfig, defaults.ExecutorDestChainConfig),
 		AddressBytesLength:        remoteAdapter.GetAddressBytesLength(),
-		BaseExecutionGasCost:      coalesce(inCfg.BaseExecutionGasCost, defaults.BaseExecutionGasCost),
+		BaseExecutionGasCost:      utils.Coalesce(inCfg.BaseExecutionGasCost, defaults.BaseExecutionGasCost),
 		TokenReceiverAllowed:      &tokenReceiverAllowed,
-		MessageNetworkFeeUSDCents: coalesce(inCfg.MessageNetworkFeeUSDCents, defaults.MessageNetworkFeeUSDCents),
-		TokenNetworkFeeUSDCents:   coalesce(inCfg.TokenNetworkFeeUSDCents, defaults.TokenNetworkFeeUSDCents),
+		MessageNetworkFeeUSDCents: utils.Coalesce(inCfg.MessageNetworkFeeUSDCents, defaults.MessageNetworkFeeUSDCents),
+		TokenNetworkFeeUSDCents:   utils.Coalesce(inCfg.TokenNetworkFeeUSDCents, defaults.TokenNetworkFeeUSDCents),
 	}, nil
 }
 
@@ -538,12 +539,12 @@ func mergeCommitteeVerifierRemoteChainConfig(
 	signatureConfig adapters.CommitteeVerifierSignatureQuorumConfig,
 ) adapters.CommitteeVerifierRemoteChainConfig {
 	return adapters.CommitteeVerifierRemoteChainConfig{
-		AllowlistEnabled:          coalesce(overrides.AllowlistEnabled, defaults.AllowlistEnabled),
+		AllowlistEnabled:          utils.Coalesce(overrides.AllowlistEnabled, defaults.AllowlistEnabled),
 		AddedAllowlistedSenders:   overrides.AddedAllowlistedSenders,
 		RemovedAllowlistedSenders: overrides.RemovedAllowlistedSenders,
-		FeeUSDCents:               coalesce(overrides.FeeUSDCents, defaults.FeeUSDCents),
-		GasForVerification:        coalesce(overrides.GasForVerification, defaults.GasForVerification),
-		PayloadSizeBytes:          coalesce(overrides.PayloadSizeBytes, defaults.PayloadSizeBytes),
+		FeeUSDCents:               utils.Coalesce(overrides.FeeUSDCents, defaults.FeeUSDCents),
+		GasForVerification:        utils.Coalesce(overrides.GasForVerification, defaults.GasForVerification),
+		PayloadSizeBytes:          utils.Coalesce(overrides.PayloadSizeBytes, defaults.PayloadSizeBytes),
 		SignatureConfig:           signatureConfig,
 	}
 }
@@ -623,14 +624,4 @@ func deriveFamiliesFromChains(chains []partialChainConfig) []string {
 		selectors = append(selectors, c.ChainSelector)
 	}
 	return deriveFamiliesFromSelectors(selectors)
-}
-
-// coalesce returns the dereferenced override if non-nil, otherwise returns def.
-// It is the canonical way to apply a user-supplied optional override on top of an
-// adapter-supplied default throughout this changeset.
-func coalesce[T any](override *T, def T) T {
-	if override != nil {
-		return *override
-	}
-	return def
 }

--- a/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology.go
+++ b/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology.go
@@ -11,6 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	mcms_types "github.com/smartcontractkit/mcms/types"
+	"k8s.io/utils/ptr"
 
 	"github.com/smartcontractkit/chainlink-ccip/deployment/finality"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
@@ -45,7 +46,7 @@ type committeeVerifierInputConfig struct {
 // Unset fields use adapter defaults, datastore resolution, or CCV auto-resolution.
 type partialRemoteChainConfig struct {
 	AllowTrafficFrom          *bool
-	DefaultExecutorQualifier  string
+	DefaultExecutorQualifier  *string
 	DefaultInboundCCVs        []datastore.AddressRef
 	LaneMandatedInboundCCVs   []datastore.AddressRef
 	DefaultOutboundCCVs       []datastore.AddressRef
@@ -399,12 +400,12 @@ func resolveRemoteChainConfig(
 	}
 
 	executorQualifier := inCfg.DefaultExecutorQualifier
-	if executorQualifier == "" {
-		executorQualifier = defaultQualifier
+	if executorQualifier == nil {
+		executorQualifier = ptr.To(defaultQualifier)
 	}
-	executorAddr, err := localAdapter.ResolveExecutor(e.DataStore, localChainSelector, executorQualifier)
+	executorAddr, err := localAdapter.ResolveExecutor(e.DataStore, localChainSelector, *executorQualifier)
 	if err != nil {
-		return adapters.RemoteChainConfig[[]byte, string]{}, fmt.Errorf("failed to resolve executor (qualifier %q) on chain %d: %w", executorQualifier, localChainSelector, err)
+		return adapters.RemoteChainConfig[[]byte, string]{}, fmt.Errorf("failed to resolve executor (qualifier %q) on chain %d: %w", *executorQualifier, localChainSelector, err)
 	}
 
 	defaultInboundCCVs, err := resolveDefaultCCVs(e, localChainSelector, inCfg.DefaultInboundCCVs, committeeVerifierContractRegistry)

--- a/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology.go
+++ b/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology.go
@@ -113,7 +113,7 @@ func ConfigureChainsForLanesFromTopology(
 		if cfg.Topology.NOPTopology == nil || len(cfg.Topology.NOPTopology.Committees) == 0 {
 			return fmt.Errorf("no committees defined in topology")
 		}
-		chains, err := expandLanesToPartialChainConfigs(cfg.Lanes, cfg.Topology.NOPTopology)
+		chains, err := expandLanesToPartialChainConfigs(cfg.Lanes, cfg.Topology.NOPTopology.Committees)
 		if err != nil {
 			return err
 		}
@@ -140,7 +140,7 @@ func ConfigureChainsForLanesFromTopology(
 	}
 
 	apply := func(e deployment.Environment, cfg ConfigureChainsForLanesFromTopologyConfig) (deployment.ChangesetOutput, error) {
-		chains, err := expandLanesToPartialChainConfigs(cfg.Lanes, cfg.Topology.NOPTopology)
+		chains, err := expandLanesToPartialChainConfigs(cfg.Lanes, cfg.Topology.NOPTopology.Committees)
 		if err != nil {
 			return deployment.ChangesetOutput{}, err
 		}
@@ -634,4 +634,3 @@ func coalesce[T any](override *T, def T) T {
 	}
 	return def
 }
-

--- a/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology.go
+++ b/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology.go
@@ -42,9 +42,9 @@ type committeeVerifierInputConfig struct {
 	AllowedFinalityConfig *finality.Config
 }
 
-// partialRemoteChainConfig is the internal per-remote chain input after lane expansion.
+// PartialRemoteChainConfig is the internal per-remote chain input after lane expansion.
 // Unset fields use adapter defaults, datastore resolution, or CCV auto-resolution.
-type partialRemoteChainConfig struct {
+type PartialRemoteChainConfig struct {
 	AllowTrafficFrom          *bool
 	DefaultExecutorQualifier  *string
 	DefaultInboundCCVs        []datastore.AddressRef
@@ -62,7 +62,7 @@ type partialRemoteChainConfig struct {
 type partialChainConfig struct {
 	ChainSelector      uint64
 	CommitteeVerifiers []committeeVerifierInputConfig
-	RemoteChains       map[uint64]partialRemoteChainConfig
+	RemoteChains       map[uint64]PartialRemoteChainConfig
 	FamilyExtras       map[string]any
 }
 
@@ -70,7 +70,7 @@ type partialChainConfig struct {
 type enrichedChainConfig struct {
 	ChainSelector      uint64
 	CommitteeVerifiers []adapters.CommitteeVerifierConfig[datastore.AddressRef]
-	RemoteChains       map[uint64]partialRemoteChainConfig
+	RemoteChains       map[uint64]PartialRemoteChainConfig
 	FamilyExtras       map[string]any
 }
 
@@ -387,7 +387,7 @@ func resolveRemoteChainConfig(
 	remoteAdapter adapters.ChainFamily,
 	localChainSelector uint64,
 	remoteChainSelector uint64,
-	inCfg partialRemoteChainConfig,
+	inCfg PartialRemoteChainConfig,
 	committeeVerifierContractRegistry *adapters.CommitteeVerifierContractRegistry,
 ) (adapters.RemoteChainConfig[[]byte, string], error) {
 	remoteOnRampBytes, err := remoteAdapter.GetOnRampAddress(e.DataStore, remoteChainSelector)

--- a/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology.go
+++ b/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology.go
@@ -113,7 +113,7 @@ func ConfigureChainsForLanesFromTopology(
 		if cfg.Topology.NOPTopology == nil || len(cfg.Topology.NOPTopology.Committees) == 0 {
 			return fmt.Errorf("no committees defined in topology")
 		}
-		chains, err := expandLanesToPartialChainConfigs(cfg.Lanes)
+		chains, err := expandLanesToPartialChainConfigs(cfg.Lanes, cfg.Topology.NOPTopology)
 		if err != nil {
 			return err
 		}
@@ -140,7 +140,7 @@ func ConfigureChainsForLanesFromTopology(
 	}
 
 	apply := func(e deployment.Environment, cfg ConfigureChainsForLanesFromTopologyConfig) (deployment.ChangesetOutput, error) {
-		chains, err := expandLanesToPartialChainConfigs(cfg.Lanes)
+		chains, err := expandLanesToPartialChainConfigs(cfg.Lanes, cfg.Topology.NOPTopology)
 		if err != nil {
 			return deployment.ChangesetOutput{}, err
 		}
@@ -634,3 +634,4 @@ func coalesce[T any](override *T, def T) T {
 	}
 	return def
 }
+

--- a/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology_test.go
+++ b/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology_test.go
@@ -558,14 +558,18 @@ func TestConfigureChainsForLanesFromTopology_PerSourceDestinationConfig(t *testi
 				ChainA: chainA,
 				ChainB: sharedDest,
 				ChainAOverrides: &changesets.ChainOverrides{
-					MessageNetworkFeeUSDCents: &feeA,
+					RemoteChainCfg: changesets.PartialRemoteChainConfig{
+						MessageNetworkFeeUSDCents: &feeA,
+					},
 				},
 			},
 			{
 				ChainA: chainB,
 				ChainB: sharedDest,
 				ChainAOverrides: &changesets.ChainOverrides{
-					MessageNetworkFeeUSDCents: &feeB,
+					RemoteChainCfg: changesets.PartialRemoteChainConfig{
+						MessageNetworkFeeUSDCents: &feeB,
+					},
 				},
 			},
 		},
@@ -997,9 +1001,11 @@ func TestConfigureChainsForLanesFromTopology_PointerOverridesReplaceDefaults(t *
 			ChainA: localSelector,
 			ChainB: remoteSelector,
 			ChainAOverrides: &changesets.ChainOverrides{
-				AllowTrafficFrom:          ptrTo(false),
-				MessageNetworkFeeUSDCents: ptrTo[uint16](50),
-				TokenNetworkFeeUSDCents:   ptrTo[uint16](75),
+				RemoteChainCfg: changesets.PartialRemoteChainConfig{
+					AllowTrafficFrom:          ptrTo(false),
+					MessageNetworkFeeUSDCents: ptrTo[uint16](50),
+					TokenNetworkFeeUSDCents:   ptrTo[uint16](75),
+				},
 			},
 		}},
 	))

--- a/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology_test.go
+++ b/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology_test.go
@@ -296,8 +296,9 @@ func TestConfigureChainsForLanesFromTopology_HappyPathAndCrossFamily(t *testing.
 					"default": {
 						Qualifier: "default",
 						ChainConfigs: map[string]offchain.ChainCommitteeConfig{
-							fmt.Sprintf("%d", remoteEVM):    {NOPAliases: []string{"nop-1"}, Threshold: 1},
-							fmt.Sprintf("%d", remoteSolana): {NOPAliases: []string{"nop-1", "nop-2"}, Threshold: 2},
+							fmt.Sprintf("%d", remoteEVM):     {NOPAliases: []string{"nop-1"}, Threshold: 1},
+							fmt.Sprintf("%d", remoteSolana):  {NOPAliases: []string{"nop-1", "nop-2"}, Threshold: 2},
+							fmt.Sprintf("%d", localSelector): {NOPAliases: []string{"nop-1"}, Threshold: 1},
 						},
 					},
 				},
@@ -394,6 +395,7 @@ func TestConfigureChainsForLanesFromTopology_JDFallback(t *testing.T) {
 						Qualifier: "default",
 						ChainConfigs: map[string]offchain.ChainCommitteeConfig{
 							fmt.Sprintf("%d", remoteSelector): {NOPAliases: []string{"nop-1"}, Threshold: 1},
+							fmt.Sprintf("%d", localSelector):  {NOPAliases: []string{"nop-1"}, Threshold: 1},
 						},
 					},
 				},
@@ -436,6 +438,7 @@ func TestConfigureChainsForLanesFromTopology_MissingSignerAfterJDFallback(t *tes
 						Qualifier: "default",
 						ChainConfigs: map[string]offchain.ChainCommitteeConfig{
 							fmt.Sprintf("%d", remoteSelector): {NOPAliases: []string{"nop-1"}, Threshold: 1},
+							fmt.Sprintf("%d", localSelector):  {NOPAliases: []string{"nop-1"}, Threshold: 1},
 						},
 					},
 				},
@@ -486,6 +489,7 @@ func TestConfigureChainsForLanesFromTopology_MissingRemoteAdapter(t *testing.T) 
 						Qualifier: "default",
 						ChainConfigs: map[string]offchain.ChainCommitteeConfig{
 							fmt.Sprintf("%d", remoteSelector): {NOPAliases: []string{"nop-1"}, Threshold: 1},
+							fmt.Sprintf("%d", localSelector):  {NOPAliases: []string{"nop-1"}, Threshold: 1},
 						},
 					},
 				},
@@ -548,6 +552,8 @@ func TestConfigureChainsForLanesFromTopology_PerSourceDestinationConfig(t *testi
 						Qualifier: "default",
 						ChainConfigs: map[string]offchain.ChainCommitteeConfig{
 							fmt.Sprintf("%d", sharedDest): {NOPAliases: []string{"nop-1"}, Threshold: 1},
+							fmt.Sprintf("%d", chainA):     {NOPAliases: []string{"nop-1"}, Threshold: 1},
+							fmt.Sprintf("%d", chainB):     {NOPAliases: []string{"nop-1"}, Threshold: 1},
 						},
 					},
 				},
@@ -629,6 +635,7 @@ func TestConfigureChainsForLanesFromTopology_UsesTestRouterWhenFlagIsSet(t *test
 						Qualifier: "default",
 						ChainConfigs: map[string]offchain.ChainCommitteeConfig{
 							fmt.Sprintf("%d", remoteSelector): {NOPAliases: []string{"nop-1"}, Threshold: 1},
+							fmt.Sprintf("%d", localSelector):  {NOPAliases: []string{"nop-1"}, Threshold: 1},
 						},
 					},
 				},
@@ -686,6 +693,7 @@ func TestConfigureChainsForLanesFromTopology_SelectsStandardRouterWhenBothExist(
 						Qualifier: "default",
 						ChainConfigs: map[string]offchain.ChainCommitteeConfig{
 							fmt.Sprintf("%d", remoteSelector): {NOPAliases: []string{"nop-1"}, Threshold: 1},
+							fmt.Sprintf("%d", localSelector):  {NOPAliases: []string{"nop-1"}, Threshold: 1},
 						},
 					},
 				},
@@ -781,6 +789,10 @@ func TestConfigureChainsForLanesFromTopology_OnlyFetchesSigningKeysForCommitteeN
 								NOPAliases: []string{"committee-nop-1", "committee-nop-2"},
 								Threshold:  2,
 							},
+							fmt.Sprintf("%d", localSelector): {
+								NOPAliases: []string{"committee-nop-1", "committee-nop-2"},
+								Threshold:  2,
+							},
 						},
 					},
 				},
@@ -843,6 +855,7 @@ func TestConfigureChainsForLanesFromTopology_VerifyPreconditions(t *testing.T) {
 							},
 							ChainConfigs: map[string]offchain.ChainCommitteeConfig{
 								fmt.Sprintf("%d", remoteSelector): {NOPAliases: []string{"nop-1"}, Threshold: 1},
+								fmt.Sprintf("%d", localSelector):  {NOPAliases: []string{"nop-1"}, Threshold: 1},
 							},
 						},
 					},
@@ -873,6 +886,7 @@ func TestConfigureChainsForLanesFromTopology_VerifyPreconditions(t *testing.T) {
 							},
 							ChainConfigs: map[string]offchain.ChainCommitteeConfig{
 								fmt.Sprintf("%d", remoteSelector): {NOPAliases: []string{"nop-1"}, Threshold: 1},
+								fmt.Sprintf("%d", localSelector):  {NOPAliases: []string{"nop-1"}, Threshold: 1},
 							},
 						},
 					},
@@ -926,6 +940,7 @@ func TestConfigureChainsForLanesFromTopology_EmptyConfigUsesAdapterDefaults(t *t
 						Qualifier: "default",
 						ChainConfigs: map[string]offchain.ChainCommitteeConfig{
 							fmt.Sprintf("%d", remoteSelector): {NOPAliases: []string{"nop-1"}, Threshold: 1},
+							fmt.Sprintf("%d", localSelector):  {NOPAliases: []string{"nop-1"}, Threshold: 1},
 						},
 					},
 				},
@@ -992,6 +1007,7 @@ func TestConfigureChainsForLanesFromTopology_PointerOverridesReplaceDefaults(t *
 						Qualifier: "default",
 						ChainConfigs: map[string]offchain.ChainCommitteeConfig{
 							fmt.Sprintf("%d", remoteSelector): {NOPAliases: []string{"nop-1"}, Threshold: 1},
+							fmt.Sprintf("%d", localSelector):  {NOPAliases: []string{"nop-1"}, Threshold: 1},
 						},
 					},
 				},
@@ -1064,6 +1080,7 @@ func TestConfigureChainsForLanesFromTopology_EmptyCVConfigUsesAdapterDefaults(t 
 						Qualifier: "default",
 						ChainConfigs: map[string]offchain.ChainCommitteeConfig{
 							fmt.Sprintf("%d", remoteSelector): {NOPAliases: []string{"nop-1"}, Threshold: 1},
+							fmt.Sprintf("%d", localSelector):  {NOPAliases: []string{"nop-1"}, Threshold: 1},
 						},
 					},
 				},
@@ -1131,6 +1148,7 @@ func TestConfigureChainsForLanesFromTopology_CVPointerOverridesReplaceDefaults(t
 						Qualifier: "default",
 						ChainConfigs: map[string]offchain.ChainCommitteeConfig{
 							fmt.Sprintf("%d", remoteSelector): {NOPAliases: []string{"nop-1"}, Threshold: 1},
+							fmt.Sprintf("%d", localSelector):  {NOPAliases: []string{"nop-1"}, Threshold: 1},
 						},
 					},
 				},

--- a/deployment/v2_0_0/changesets/deploy_chain_contracts.go
+++ b/deployment/v2_0_0/changesets/deploy_chain_contracts.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
 	"github.com/smartcontractkit/chainlink-ccip/deployment/deploy"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/adapters"
@@ -130,7 +131,7 @@ func DeployChainContracts(registry *adapters.DeployChainContractsRegistry) deplo
 			)
 			existingAddresses = append(existingAddresses, resolved.NewAddressRefs...)
 
-			deployerContract := coalesce(perChainCfg.DeployerContract, resolved.DeployerContract)
+			deployerContract := utils.Coalesce(perChainCfg.DeployerContract, resolved.DeployerContract)
 
 			input := adapters.DeployChainContractsInput{
 				ChainSelector:     sel,


### PR DESCRIPTION
- Expand lane overrides to more fields
- Expand lane-to-chain config generation to account for multiple committee qualifiers (if diff remote chain uses diff committee qualifier) and add/update tests accordingly.