### PR TITLE
changeset to remove extra fee tokens from feequoter 2.0

### DIFF
--- a/chains/evm/deployment/operations_gen_config.yaml
+++ b/chains/evm/deployment/operations_gen_config.yaml
@@ -36,6 +36,8 @@ contracts:
         access: owner
       - name: applyTokenTransferFeeConfigUpdates
         access: owner
+      - name: applyFeeTokensUpdates
+        access: owner
       - name: getDestChainConfig
         access: public
       - name: getTokenTransferFeeConfig
@@ -185,6 +187,8 @@ contracts:
         access: owner
       - name: applyTokenTransferFeeConfigUpdates
         access: owner
+      - name: applyFeeTokensUpdates
+        access: owner
       - name: getDestChainConfig
         access: public
       - name: getTokenTransferFeeConfig
@@ -254,6 +258,10 @@ contracts:
         access: public
       - name: getAllAuthorizedCallers
         access: public
+      - name: getFeeTokens
+        access: public
+      - name: removeFeeTokens
+        access: owner
 
   - contract_name: CrossChainToken
     version: "2.0.0"

--- a/chains/evm/deployment/v1_2_0/operations/price_registry/price_registry.go
+++ b/chains/evm/deployment/v1_2_0/operations/price_registry/price_registry.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/price_registry"
@@ -15,6 +16,11 @@ var (
 	ContractType = cldf.ContractType("PriceRegistry")
 	Version      = semver.MustParse("1.2.0")
 )
+
+type ApplyFeeTokensInput struct {
+	FeeTokensToAdd    []common.Address
+	FeeTokensToRemove []common.Address
+}
 
 var PriceRegistryGetFeeToken = contract.NewRead(contract.ReadParams[any, []common.Address, *price_registry.PriceRegistry]{
 	Name:         "price_registry:getfeetokens",
@@ -46,5 +52,19 @@ var PriceRegistryGetDestinationChainGasPrice = contract.NewRead(contract.ReadPar
 	NewContract:  price_registry.NewPriceRegistry,
 	CallContract: func(pr *price_registry.PriceRegistry, opts *bind.CallOpts, args uint64) (price_registry.InternalTimestampedPackedUint224, error) {
 		return pr.GetDestinationChainGasPrice(opts, args)
+	},
+})
+
+var PriceRegistryApplyFeeTokenUpdates = contract.NewWrite(contract.WriteParams[ApplyFeeTokensInput, *price_registry.PriceRegistry]{
+	Name:            "price_registry:apply-feetoken-updates",
+	Version:         Version,
+	Description:     "Calls applyFeeTokenUpdates on the contract",
+	ContractType:    ContractType,
+	ContractABI:     price_registry.PriceRegistryABI,
+	NewContract:     price_registry.NewPriceRegistry,
+	IsAllowedCaller: contract.OnlyOwner[*price_registry.PriceRegistry, ApplyFeeTokensInput],
+	Validate:        func(ApplyFeeTokensInput) error { return nil },
+	CallContract: func(pr *price_registry.PriceRegistry, opts *bind.TransactOpts, args ApplyFeeTokensInput) (*types.Transaction, error) {
+		return pr.ApplyFeeTokensUpdates(opts, args.FeeTokensToAdd, args.FeeTokensToRemove)
 	},
 })

--- a/chains/evm/deployment/v1_2_0/sequences/price_registry.go
+++ b/chains/evm/deployment/v1_2_0/sequences/price_registry.go
@@ -16,10 +16,9 @@ import (
 )
 
 type PriceRegistryImportConfigSequenceInput struct {
-	ChainSelector   uint64
-	PriceRegistry   common.Address
-	SupportedTokens []common.Address
-	RemoteChains    []uint64
+	ChainSelector uint64
+	PriceRegistry common.Address
+	RemoteChains  []uint64
 }
 
 type PriceRegistryImportConfigSequenceOutput struct {
@@ -36,14 +35,7 @@ var PriceRegistryImportConfigSequence = operations.NewSequence(
 		if !ok {
 			return sequences.OnChainOutput{}, fmt.Errorf("chain with selector %d not defined", input.ChainSelector)
 		}
-		var allTokens []common.Address
-		// check if any supported token is blank address, if so delete
-		for i, token := range input.SupportedTokens {
-			if token == (common.Address{}) {
-				continue
-			}
-			allTokens = append(allTokens, input.SupportedTokens[i])
-		}
+
 		gasPrices := make(map[uint64]*big.Int)
 		for _, remoteChainSelector := range input.RemoteChains {
 			gasPricesOutput, err := operations.ExecuteOperation(b, priceregistryops.PriceRegistryGetDestinationChainGasPrice, chain, contract.FunctionInput[uint64]{
@@ -67,28 +59,19 @@ var PriceRegistryImportConfigSequence = operations.NewSequence(
 			return sequences.OnChainOutput{}, fmt.Errorf("failed to execute PriceRegistryGetFeeTokenOp "+
 				"on %s for price registry %s: %w", chain.String(), input.PriceRegistry.String(), err)
 		}
-		// check if fee tokens are already present in allTokens
-		allTokenMap := make(map[common.Address]struct{})
-		for _, token := range allTokens {
-			allTokenMap[token] = struct{}{}
-		}
-		for _, token := range feetokensRep.Output {
-			if _, exists := allTokenMap[token]; !exists {
-				allTokenMap[token] = struct{}{}
-				allTokens = append(allTokens, token)
-			}
-		}
+
+		// get token prices for fee tokens
 		tokenPrices := make(map[common.Address]*big.Int)
 		tokenPriceOutput, err := operations.ExecuteOperation(b, priceregistryops.PriceRegistryGetTokenPrices, chain, contract.FunctionInput[[]common.Address]{
 			ChainSelector: chain.Selector,
 			Address:       input.PriceRegistry,
-			Args:          allTokens,
+			Args:          feetokensRep.Output,
 		})
 		if err != nil {
 			return sequences.OnChainOutput{}, fmt.Errorf("failed to execute PriceRegistryGetTokenPricesOp "+
-				"on %s for price registry %s and tokens %v: %w", chain.String(), input.PriceRegistry.String(), allTokens, err)
+				"on %s for price registry %s and fee tokens %v: %w", chain.String(), input.PriceRegistry.String(), feetokensRep.Output, err)
 		}
-		for i, token := range allTokens {
+		for i, token := range feetokensRep.Output {
 			tokenPrices[token] = tokenPriceOutput.Output[i].Value
 		}
 

--- a/chains/evm/deployment/v1_5_0/adapters/configimport.go
+++ b/chains/evm/deployment/v1_5_0/adapters/configimport.go
@@ -15,7 +15,6 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
-	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/evm_2_evm_offramp"
@@ -209,25 +208,13 @@ func (ci *ConfigImportAdapter) SequenceImportConfig() *cldf_ops.Sequence[api.Imp
 			}
 			chainSelector := in.ChainSelector
 			b.Logger.Infof("Importing configuration for chain %d (%s)", chainSelector, evmChain.Name())
-			allTokens := make(map[common.Address]struct{})
-			for _, tokens := range in.TokensPerRemoteChain {
-				for _, token := range tokens {
-					if token == (common.Address{}) {
-						continue
-					}
-					if _, exists := allTokens[token]; !exists {
-						allTokens[token] = struct{}{}
-					}
-				}
-			}
 			var result sequences.OnChainOutput
 			result, err = sequences.RunAndMergeSequence(b, chains,
 				sequences1_2.PriceRegistryImportConfigSequence,
 				sequences1_2.PriceRegistryImportConfigSequenceInput{
-					ChainSelector:   chainSelector,
-					PriceRegistry:   ci.PriceRegistry,
-					SupportedTokens: maps.Keys(allTokens),
-					RemoteChains:    in.RemoteChains,
+					ChainSelector: chainSelector,
+					PriceRegistry: ci.PriceRegistry,
+					RemoteChains:  in.RemoteChains,
 				}, result)
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to import price registry config for chain %d: %w", chainSelector, err)

--- a/chains/evm/deployment/v1_6_0/operations/fee_quoter/fee_quoter.go
+++ b/chains/evm/deployment/v1_6_0/operations/fee_quoter/fee_quoter.go
@@ -77,6 +77,10 @@ func (c *FeeQuoterContract) ApplyTokenTransferFeeConfigUpdates(opts *bind.Transa
 	return c.contract.Transact(opts, "applyTokenTransferFeeConfigUpdates", tokenTransferFeeConfigArgs, tokensToUseDefaultFeeConfigs)
 }
 
+func (c *FeeQuoterContract) ApplyFeeTokensUpdates(opts *bind.TransactOpts, feeTokensToRemove []common.Address, feeTokensToAdd []common.Address) (*types.Transaction, error) {
+	return c.contract.Transact(opts, "applyFeeTokensUpdates", feeTokensToRemove, feeTokensToAdd)
+}
+
 func (c *FeeQuoterContract) GetDestChainConfig(opts *bind.CallOpts, args uint64) (DestChainConfig, error) {
 	var out []any
 	err := c.contract.Call(opts, &out, "getDestChainConfig", args)
@@ -240,6 +244,11 @@ type ApplyTokenTransferFeeConfigUpdatesArgs struct {
 	TokensToUseDefaultFeeConfigs []TokenTransferFeeConfigRemoveArgs
 }
 
+type ApplyFeeTokensUpdatesArgs struct {
+	FeeTokensToRemove []common.Address
+	FeeTokensToAdd    []common.Address
+}
+
 type GetTokenTransferFeeConfigArgs struct {
 	DestChainSelector uint64
 	Token             common.Address
@@ -340,6 +349,24 @@ var ApplyTokenTransferFeeConfigUpdates = contract.NewWrite(contract.WriteParams[
 		args ApplyTokenTransferFeeConfigUpdatesArgs,
 	) (*types.Transaction, error) {
 		return c.ApplyTokenTransferFeeConfigUpdates(opts, args.TokenTransferFeeConfigArgs, args.TokensToUseDefaultFeeConfigs)
+	},
+})
+
+var ApplyFeeTokensUpdates = contract.NewWrite(contract.WriteParams[ApplyFeeTokensUpdatesArgs, *FeeQuoterContract]{
+	Name:            "fee-quoter:apply-fee-tokens-updates",
+	Version:         Version,
+	Description:     "Calls applyFeeTokensUpdates on the contract",
+	ContractType:    ContractType,
+	ContractABI:     FeeQuoterABI,
+	NewContract:     NewFeeQuoterContract,
+	IsAllowedCaller: contract.OnlyOwner[*FeeQuoterContract, ApplyFeeTokensUpdatesArgs],
+	Validate:        func(ApplyFeeTokensUpdatesArgs) error { return nil },
+	CallContract: func(
+		c *FeeQuoterContract,
+		opts *bind.TransactOpts,
+		args ApplyFeeTokensUpdatesArgs,
+	) (*types.Transaction, error) {
+		return c.ApplyFeeTokensUpdates(opts, args.FeeTokensToRemove, args.FeeTokensToAdd)
 	},
 })
 

--- a/chains/evm/deployment/v1_6_0/sequences/fee_quoter.go
+++ b/chains/evm/deployment/v1_6_0/sequences/fee_quoter.go
@@ -8,7 +8,6 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
@@ -213,22 +212,12 @@ var (
 			}
 
 			tokenTransferFeeCfgsPerChain := make(map[uint64]map[common.Address]fqops.TokenTransferFeeConfig)
-			allTokens := make(map[common.Address]struct{})
 			var ttfcMu sync.Mutex
 			tokenGrp, _ := errgroup.WithContext(b.GetContext())
 			tokenGrp.SetLimit(10)
 			for remoteChain, tokens := range in.TokensPerRemoteChain {
 				remoteChain := remoteChain
 				tokens := tokens
-				for _, token := range tokens {
-					if token == (common.Address{}) {
-						continue
-					}
-					if _, exists := allTokens[token]; !exists {
-						allTokens[token] = struct{}{}
-					}
-				}
-
 				tokenGrp.Go(func() error {
 					destChainMu.Lock()
 					_, enabled := destChainConfigs[remoteChain]
@@ -308,26 +297,18 @@ var (
 					fqAddress.Hex(), chainSelector, err)
 			}
 
-			// add fee tokens to all tokens if not present
-			for _, token := range feeTokensRep.Output {
-				if _, exists := allTokens[token]; !exists {
-					allTokens[token] = struct{}{}
-				}
-			}
-
-			tokenSlice := maps.Keys(allTokens)
-			// add fee tokens
+			// get token prices for fee tokens
 			tokenPrices, err := operations.ExecuteOperation(b, fqops.GetTokenPrices, evmChain, contract.FunctionInput[[]common.Address]{
 				Address:       fqAddress,
 				ChainSelector: chainSelector,
-				Args:          tokenSlice,
+				Args:          feeTokensRep.Output,
 			})
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to get token prices from feequoter %s on chain %d: %w",
 					fqAddress.Hex(), chainSelector, err)
 			}
 			tokenPricesPerToken := make(map[common.Address]*big.Int)
-			for i, token := range tokenSlice {
+			for i, token := range feeTokensRep.Output {
 				tokenPricesPerToken[token] = tokenPrices.Output[i].Value
 			}
 			contractMetadata = []datastore.ContractMetadata{

--- a/chains/evm/deployment/v1_6_3/operations/fee_quoter/fee_quoter.go
+++ b/chains/evm/deployment/v1_6_3/operations/fee_quoter/fee_quoter.go
@@ -77,6 +77,10 @@ func (c *FeeQuoterContract) ApplyTokenTransferFeeConfigUpdates(opts *bind.Transa
 	return c.contract.Transact(opts, "applyTokenTransferFeeConfigUpdates", tokenTransferFeeConfigArgs, tokensToUseDefaultFeeConfigs)
 }
 
+func (c *FeeQuoterContract) ApplyFeeTokensUpdates(opts *bind.TransactOpts, feeTokensToRemove []common.Address, feeTokensToAdd []common.Address) (*types.Transaction, error) {
+	return c.contract.Transact(opts, "applyFeeTokensUpdates", feeTokensToRemove, feeTokensToAdd)
+}
+
 func (c *FeeQuoterContract) GetDestChainConfig(opts *bind.CallOpts, args uint64) (DestChainConfig, error) {
 	var out []any
 	err := c.contract.Call(opts, &out, "getDestChainConfig", args)
@@ -250,6 +254,11 @@ type ApplyTokenTransferFeeConfigUpdatesArgs struct {
 	TokensToUseDefaultFeeConfigs []TokenTransferFeeConfigRemoveArgs
 }
 
+type ApplyFeeTokensUpdatesArgs struct {
+	FeeTokensToRemove []common.Address
+	FeeTokensToAdd    []common.Address
+}
+
 type GetTokenTransferFeeConfigArgs struct {
 	DestChainSelector uint64
 	Token             common.Address
@@ -350,6 +359,24 @@ var ApplyTokenTransferFeeConfigUpdates = contract.NewWrite(contract.WriteParams[
 		args ApplyTokenTransferFeeConfigUpdatesArgs,
 	) (*types.Transaction, error) {
 		return c.ApplyTokenTransferFeeConfigUpdates(opts, args.TokenTransferFeeConfigArgs, args.TokensToUseDefaultFeeConfigs)
+	},
+})
+
+var ApplyFeeTokensUpdates = contract.NewWrite(contract.WriteParams[ApplyFeeTokensUpdatesArgs, *FeeQuoterContract]{
+	Name:            "fee-quoter:apply-fee-tokens-updates",
+	Version:         Version,
+	Description:     "Calls applyFeeTokensUpdates on the contract",
+	ContractType:    ContractType,
+	ContractABI:     FeeQuoterABI,
+	NewContract:     NewFeeQuoterContract,
+	IsAllowedCaller: contract.OnlyOwner[*FeeQuoterContract, ApplyFeeTokensUpdatesArgs],
+	Validate:        func(ApplyFeeTokensUpdatesArgs) error { return nil },
+	CallContract: func(
+		c *FeeQuoterContract,
+		opts *bind.TransactOpts,
+		args ApplyFeeTokensUpdatesArgs,
+	) (*types.Transaction, error) {
+		return c.ApplyFeeTokensUpdates(opts, args.FeeTokensToRemove, args.FeeTokensToAdd)
 	},
 })
 

--- a/chains/evm/deployment/v2_0_0/changesets/remove_fee_tokens.go
+++ b/chains/evm/deployment/v2_0_0/changesets/remove_fee_tokens.go
@@ -229,6 +229,10 @@ func extraFeeTokens(fq20Tokens, legacyFeeTokens []common.Address) []common.Addre
 		legacySet[token] = struct{}{}
 	}
 
+	if len(legacySet) == 0 {
+		return nil
+	}
+
 	extra := make([]common.Address, 0)
 	for _, token := range fq20Tokens {
 		if _, exists := legacySet[token]; !exists {

--- a/chains/evm/deployment/v2_0_0/changesets/remove_fee_tokens.go
+++ b/chains/evm/deployment/v2_0_0/changesets/remove_fee_tokens.go
@@ -1,0 +1,235 @@
+package changesets
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/ethereum/go-ethereum/common"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf_deployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
+	adapters1_2 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/adapters"
+	priceregistryops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/operations/price_registry"
+	routerops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/operations/router"
+	seq1_6 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/sequences"
+	fq1_6ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_3/operations/fee_quoter"
+	fqops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/fee_quoter"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
+	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
+)
+
+// RemoveFeeTokensCfg is configuration for the RemoveFeeTokens changeset.
+type RemoveFeeTokensCfg struct {
+	ChainSels []uint64
+}
+
+var RemoveFeeTokens = changesets.NewFromOnChainSequence(changesets.NewFromOnChainSequenceParams[
+	sequences.RemoveFeeTokensInput,
+	cldf_chain.BlockChains,
+	RemoveFeeTokensCfg,
+]{
+	Sequence: sequences.SequenceRemoveFeeTokens,
+	ResolveInput: func(e cldf_deployment.Environment, cfg RemoveFeeTokensCfg) (sequences.RemoveFeeTokensInput, error) {
+		if len(cfg.ChainSels) == 0 {
+			return sequences.RemoveFeeTokensInput{}, fmt.Errorf("at least one chain selector is required")
+		}
+
+		seen := make(map[uint64]struct{}, len(cfg.ChainSels))
+		chainUpdates := make([]sequences.RemoveFeeTokensPerChainInput, 0, len(cfg.ChainSels))
+		for _, chainSel := range cfg.ChainSels {
+			if _, exists := seen[chainSel]; exists {
+				return sequences.RemoveFeeTokensInput{}, fmt.Errorf("duplicate chain selector %d", chainSel)
+			}
+			seen[chainSel] = struct{}{}
+
+			chainUpdate, err := resolveRemoveFeeTokensPerChain(e, chainSel)
+			if err != nil {
+				return sequences.RemoveFeeTokensInput{}, err
+			}
+			chainUpdates = append(chainUpdates, chainUpdate)
+		}
+
+		return sequences.RemoveFeeTokensInput{ChainUpdates: chainUpdates}, nil
+	},
+	ResolveDep: func(e cldf_deployment.Environment, _ RemoveFeeTokensCfg) (cldf_chain.BlockChains, error) {
+		return e.BlockChains, nil
+	},
+})
+
+func resolveRemoveFeeTokensPerChain(e cldf_deployment.Environment, chainSel uint64) (sequences.RemoveFeeTokensPerChainInput, error) {
+	addresses := e.DataStore.Addresses().Filter(datastore.AddressRefByChainSelector(chainSel))
+
+	routerRefs := e.DataStore.Addresses().Filter(
+		datastore.AddressRefByChainSelector(chainSel),
+		datastore.AddressRefByType(datastore.ContractType(routerops.ContractType)),
+		datastore.AddressRefByVersion(routerops.Version),
+	)
+	if len(routerRefs) != 1 {
+		return sequences.RemoveFeeTokensPerChainInput{}, fmt.Errorf(
+			"expected exactly one Router v%s on chain %d, found %d",
+			routerops.Version, chainSel, len(routerRefs),
+		)
+	}
+
+	laneResolver := &adapters1_2.LaneVersionResolver{}
+	_, laneVersions, err := laneResolver.DeriveLaneVersionsForChain(e, chainSel)
+	if err != nil {
+		return sequences.RemoveFeeTokensPerChainInput{}, fmt.Errorf(
+			"failed to derive lane versions for chain %d from router %s: %w",
+			chainSel, routerRefs[0].Address, err,
+		)
+	}
+
+	chain, ok := e.BlockChains.EVMChains()[chainSel]
+	if !ok {
+		return sequences.RemoveFeeTokensPerChainInput{}, fmt.Errorf("chain selector %d not found in environment EVM chains", chainSel)
+	}
+
+	legacyFeeTokens, err := collectLegacyFeeTokens(e, chain, addresses, laneVersions)
+	if err != nil {
+		return sequences.RemoveFeeTokensPerChainInput{}, err
+	}
+
+	fq20Ref := datastore_utils.GetAddressRef(
+		addresses,
+		chainSel,
+		fqops.ContractType,
+		fqops.Version,
+		"",
+	)
+	if datastore_utils.IsAddressRefEmpty(fq20Ref) {
+		return sequences.RemoveFeeTokensPerChainInput{}, fmt.Errorf("no FeeQuoter v%s found on chain selector %d", fqops.Version, chainSel)
+	}
+
+	fq20Tokens, err := queryFeeQuoter20FeeTokens(e, chain, common.HexToAddress(fq20Ref.Address))
+	if err != nil {
+		return sequences.RemoveFeeTokensPerChainInput{}, err
+	}
+
+	return sequences.RemoveFeeTokensPerChainInput{
+		ChainSelector:     chainSel,
+		FeeQuoter20Ref:    fq20Ref,
+		FeeTokensToRemove: extraFeeTokens(fq20Tokens, legacyFeeTokens),
+	}, nil
+}
+
+func collectLegacyFeeTokens(
+	e cldf_deployment.Environment,
+	chain evm.Chain,
+	addresses []datastore.AddressRef,
+	laneVersions []*semver.Version,
+) ([]common.Address, error) {
+	var hasV15, hasV16 bool
+	for _, version := range laneVersions {
+		if version.Major() == 1 && version.Minor() == 5 {
+			hasV15 = true
+		}
+		if version.Major() == 1 && version.Minor() == 6 {
+			hasV16 = true
+		}
+	}
+
+	legacySet := make(map[common.Address]struct{})
+
+	if hasV15 {
+		priceRegistryRef := datastore_utils.GetAddressRef(
+			addresses,
+			chain.Selector,
+			priceregistryops.ContractType,
+			priceregistryops.Version,
+			"",
+		)
+		if datastore_utils.IsAddressRefEmpty(priceRegistryRef) {
+			return nil, fmt.Errorf("no PriceRegistry v%s found on chain selector %d for 1.5 lanes",
+				priceregistryops.Version, chain.Selector)
+		}
+
+		feeTokens, err := queryPriceRegistryFeeTokens(e, chain, common.HexToAddress(priceRegistryRef.Address))
+		if err != nil {
+			return nil, err
+		}
+		for _, token := range feeTokens {
+			legacySet[token] = struct{}{}
+		}
+	}
+
+	if hasV16 {
+		fq16Ref, err := seq1_6.GetFeeQuoterAddress(addresses, chain.Selector, fqops.Version)
+		if err != nil {
+			return nil, fmt.Errorf("no FeeQuoter v1.6.x found on chain selector %d for 1.6 lanes: %w", chain.Selector, err)
+		}
+
+		feeTokens, err := queryFeeQuoter16FeeTokens(e, chain, common.HexToAddress(fq16Ref.Address))
+		if err != nil {
+			return nil, err
+		}
+		for _, token := range feeTokens {
+			legacySet[token] = struct{}{}
+		}
+	}
+
+	legacyFeeTokens := make([]common.Address, 0, len(legacySet))
+	for token := range legacySet {
+		legacyFeeTokens = append(legacyFeeTokens, token)
+	}
+	return legacyFeeTokens, nil
+}
+
+func queryPriceRegistryFeeTokens(e cldf_deployment.Environment, chain evm.Chain, priceRegistry common.Address) ([]common.Address, error) {
+	report, err := cldf_ops.ExecuteOperation(e.OperationsBundle, priceregistryops.PriceRegistryGetFeeToken, chain, contract.FunctionInput[any]{
+		ChainSelector: chain.Selector,
+		Address:       priceRegistry,
+		Args:          nil,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get fee tokens from PriceRegistry %s on chain %d: %w",
+			priceRegistry.Hex(), chain.Selector, err)
+	}
+	return report.Output, nil
+}
+
+func queryFeeQuoter16FeeTokens(e cldf_deployment.Environment, chain evm.Chain, feeQuoter common.Address) ([]common.Address, error) {
+	report, err := cldf_ops.ExecuteOperation(e.OperationsBundle, fq1_6ops.GetFeeTokens, chain, contract.FunctionInput[struct{}]{
+		ChainSelector: chain.Selector,
+		Address:       feeQuoter,
+		Args:          struct{}{},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get fee tokens from FeeQuoter 1.6 %s on chain %d: %w",
+			feeQuoter.Hex(), chain.Selector, err)
+	}
+	return report.Output, nil
+}
+
+func queryFeeQuoter20FeeTokens(e cldf_deployment.Environment, chain evm.Chain, feeQuoter common.Address) ([]common.Address, error) {
+	report, err := cldf_ops.ExecuteOperation(e.OperationsBundle, fqops.GetFeeTokens, chain, contract.FunctionInput[struct{}]{
+		ChainSelector: chain.Selector,
+		Address:       feeQuoter,
+		Args:          struct{}{},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get fee tokens from FeeQuoter 2.0 %s on chain %d: %w",
+			feeQuoter.Hex(), chain.Selector, err)
+	}
+	return report.Output, nil
+}
+
+func extraFeeTokens(fq20Tokens, legacyFeeTokens []common.Address) []common.Address {
+	legacySet := make(map[common.Address]struct{}, len(legacyFeeTokens))
+	for _, token := range legacyFeeTokens {
+		legacySet[token] = struct{}{}
+	}
+
+	extra := make([]common.Address, 0)
+	for _, token := range fq20Tokens {
+		if _, exists := legacySet[token]; !exists {
+			extra = append(extra, token)
+		}
+	}
+	return extra
+}

--- a/chains/evm/deployment/v2_0_0/changesets/remove_fee_tokens.go
+++ b/chains/evm/deployment/v2_0_0/changesets/remove_fee_tokens.go
@@ -76,6 +76,17 @@ func resolveRemoveFeeTokensPerChain(e cldf_deployment.Environment, chainSel uint
 		)
 	}
 
+	fq20Ref := datastore_utils.GetAddressRef(
+		addresses,
+		chainSel,
+		fqops.ContractType,
+		fqops.Version,
+		"",
+	)
+	if datastore_utils.IsAddressRefEmpty(fq20Ref) {
+		return sequences.RemoveFeeTokensPerChainInput{}, fmt.Errorf("no FeeQuoter v%s found on chain selector %d", fqops.Version, chainSel)
+	}
+
 	laneResolver := &adapters1_2.LaneVersionResolver{}
 	_, laneVersions, err := laneResolver.DeriveLaneVersionsForChain(e, chainSel)
 	if err != nil {
@@ -93,17 +104,6 @@ func resolveRemoveFeeTokensPerChain(e cldf_deployment.Environment, chainSel uint
 	legacyFeeTokens, err := collectLegacyFeeTokens(e, chain, addresses, laneVersions)
 	if err != nil {
 		return sequences.RemoveFeeTokensPerChainInput{}, err
-	}
-
-	fq20Ref := datastore_utils.GetAddressRef(
-		addresses,
-		chainSel,
-		fqops.ContractType,
-		fqops.Version,
-		"",
-	)
-	if datastore_utils.IsAddressRefEmpty(fq20Ref) {
-		return sequences.RemoveFeeTokensPerChainInput{}, fmt.Errorf("no FeeQuoter v%s found on chain selector %d", fqops.Version, chainSel)
 	}
 
 	fq20Tokens, err := queryFeeQuoter20FeeTokens(e, chain, common.HexToAddress(fq20Ref.Address))
@@ -132,6 +132,10 @@ func collectLegacyFeeTokens(
 		if version.Major() == 1 && version.Minor() == 6 {
 			hasV16 = true
 		}
+	}
+
+	if !hasV15 && !hasV16 {
+		return []common.Address{}, fmt.Errorf("no legacy fee tokens found")
 	}
 
 	legacySet := make(map[common.Address]struct{})

--- a/chains/evm/deployment/v2_0_0/changesets/remove_fee_tokens.go
+++ b/chains/evm/deployment/v2_0_0/changesets/remove_fee_tokens.go
@@ -3,7 +3,6 @@ package changesets
 import (
 	"fmt"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
@@ -12,9 +11,7 @@ import (
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
-	adapters1_2 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/adapters"
 	priceregistryops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/operations/price_registry"
-	routerops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/operations/router"
 	seq1_6 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/sequences"
 	fq1_6ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_3/operations/fee_quoter"
 	fqops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/fee_quoter"
@@ -64,18 +61,6 @@ var RemoveFeeTokens = changesets.NewFromOnChainSequence(changesets.NewFromOnChai
 func resolveRemoveFeeTokensPerChain(e cldf_deployment.Environment, chainSel uint64) (sequences.RemoveFeeTokensPerChainInput, error) {
 	addresses := e.DataStore.Addresses().Filter(datastore.AddressRefByChainSelector(chainSel))
 
-	routerRefs := e.DataStore.Addresses().Filter(
-		datastore.AddressRefByChainSelector(chainSel),
-		datastore.AddressRefByType(datastore.ContractType(routerops.ContractType)),
-		datastore.AddressRefByVersion(routerops.Version),
-	)
-	if len(routerRefs) != 1 {
-		return sequences.RemoveFeeTokensPerChainInput{}, fmt.Errorf(
-			"expected exactly one Router v%s on chain %d, found %d",
-			routerops.Version, chainSel, len(routerRefs),
-		)
-	}
-
 	fq20Ref := datastore_utils.GetAddressRef(
 		addresses,
 		chainSel,
@@ -87,21 +72,12 @@ func resolveRemoveFeeTokensPerChain(e cldf_deployment.Environment, chainSel uint
 		return sequences.RemoveFeeTokensPerChainInput{}, fmt.Errorf("no FeeQuoter v%s found on chain selector %d", fqops.Version, chainSel)
 	}
 
-	laneResolver := &adapters1_2.LaneVersionResolver{}
-	_, laneVersions, err := laneResolver.DeriveLaneVersionsForChain(e, chainSel)
-	if err != nil {
-		return sequences.RemoveFeeTokensPerChainInput{}, fmt.Errorf(
-			"failed to derive lane versions for chain %d from router %s: %w",
-			chainSel, routerRefs[0].Address, err,
-		)
-	}
-
 	chain, ok := e.BlockChains.EVMChains()[chainSel]
 	if !ok {
 		return sequences.RemoveFeeTokensPerChainInput{}, fmt.Errorf("chain selector %d not found in environment EVM chains", chainSel)
 	}
 
-	legacyFeeTokens, err := collectLegacyFeeTokens(e, chain, addresses, laneVersions)
+	legacyFeeTokens, err := collectLegacyFeeTokens(e, chain, addresses)
 	if err != nil {
 		return sequences.RemoveFeeTokensPerChainInput{}, err
 	}
@@ -122,52 +98,22 @@ func collectLegacyFeeTokens(
 	e cldf_deployment.Environment,
 	chain evm.Chain,
 	addresses []datastore.AddressRef,
-	laneVersions []*semver.Version,
 ) ([]common.Address, error) {
-	var hasV15, hasV16 bool
-	for _, version := range laneVersions {
-		if version.Major() == 1 && version.Minor() == 5 {
-			hasV15 = true
-		}
-		if version.Major() == 1 && version.Minor() == 6 {
-			hasV16 = true
-		}
-	}
-
-	if !hasV15 && !hasV16 {
-		return []common.Address{}, fmt.Errorf("no legacy fee tokens found")
-	}
-
 	legacySet := make(map[common.Address]struct{})
-
-	if hasV15 {
-		priceRegistryRef := datastore_utils.GetAddressRef(
-			addresses,
-			chain.Selector,
-			priceregistryops.ContractType,
-			priceregistryops.Version,
-			"",
-		)
-		if datastore_utils.IsAddressRefEmpty(priceRegistryRef) {
-			return nil, fmt.Errorf("no PriceRegistry v%s found on chain selector %d for 1.5 lanes",
-				priceregistryops.Version, chain.Selector)
-		}
-
-		feeTokens, err := queryPriceRegistryFeeTokens(e, chain, common.HexToAddress(priceRegistryRef.Address))
-		if err != nil {
-			return nil, err
-		}
-		for _, token := range feeTokens {
-			legacySet[token] = struct{}{}
+	var hasFQ16 bool
+	for _, address := range addresses {
+		if address.Type == datastore.ContractType(fq1_6ops.ContractType) {
+			if address.Version.Major() == 1 {
+				hasFQ16 = true
+			}
 		}
 	}
-
-	if hasV16 {
+	// if there is FQ 1.6.x query the feetoken from fq 1.6.x
+	if hasFQ16 {
 		fq16Ref, err := seq1_6.GetFeeQuoterAddress(addresses, chain.Selector, fqops.Version)
 		if err != nil {
 			return nil, fmt.Errorf("no FeeQuoter v1.6.x found on chain selector %d for 1.6 lanes: %w", chain.Selector, err)
 		}
-
 		feeTokens, err := queryFeeQuoter16FeeTokens(e, chain, common.HexToAddress(fq16Ref.Address))
 		if err != nil {
 			return nil, err
@@ -175,13 +121,26 @@ func collectLegacyFeeTokens(
 		for _, token := range feeTokens {
 			legacySet[token] = struct{}{}
 		}
+		return feeTokens, nil
+	}
+	// if no fq is found fallback to price registry
+	priceRegistryRef := datastore_utils.GetAddressRef(
+		addresses,
+		chain.Selector,
+		priceregistryops.ContractType,
+		priceregistryops.Version,
+		"",
+	)
+	if datastore_utils.IsAddressRefEmpty(priceRegistryRef) {
+		return nil, fmt.Errorf("neither PriceRegistry v%s nor FeeQuoter 1.6.x found on chain selector %d",
+			priceregistryops.Version, chain.Selector)
 	}
 
-	legacyFeeTokens := make([]common.Address, 0, len(legacySet))
-	for token := range legacySet {
-		legacyFeeTokens = append(legacyFeeTokens, token)
+	feeTokens, err := queryPriceRegistryFeeTokens(e, chain, common.HexToAddress(priceRegistryRef.Address))
+	if err != nil {
+		return nil, err
 	}
-	return legacyFeeTokens, nil
+	return feeTokens, nil
 }
 
 func queryPriceRegistryFeeTokens(e cldf_deployment.Environment, chain evm.Chain, priceRegistry common.Address) ([]common.Address, error) {

--- a/chains/evm/deployment/v2_0_0/changesets/remove_fee_tokens_test.go
+++ b/chains/evm/deployment/v2_0_0/changesets/remove_fee_tokens_test.go
@@ -1,0 +1,264 @@
+package changesets_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
+	priceregistryops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/operations/price_registry"
+	routerops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/operations/router"
+	onrampv1_5ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/operations/onramp"
+	onrampv1_6ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/operations/onramp"
+	fq16ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/operations/fee_quoter"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/changesets"
+	fq20ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/fee_quoter"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/price_registry"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
+	evm_2_evm_onramp_v1_5_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/evm_2_evm_onramp"
+	fq20binding "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v2_0_0/fee_quoter"
+	cs_core "github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
+	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
+)
+
+const (
+	removeFeeTokensChainSel = uint64(5009297550715157269)
+	remoteChainV15          = uint64(111)
+	remoteChainV16          = uint64(222)
+)
+
+var (
+	legacyLinkToken = common.HexToAddress("0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB")
+	legacyWethToken = common.HexToAddress("0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
+	extraFeeToken1  = common.HexToAddress("0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC")
+	extraFeeToken2  = common.HexToAddress("0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD")
+)
+
+func TestRemoveFeeTokens_RemovesExtraFeeTokensFromFeeQuoter20(t *testing.T) {
+	e, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{removeFeeTokensChainSel}),
+	)
+	require.NoError(t, err)
+
+	chain := e.BlockChains.EVMChains()[removeFeeTokensChainSel]
+	fq20Addr := deployRemoveFeeTokensFixture(t, e)
+
+	fq20, err := fq20binding.NewFeeQuoter(fq20Addr, chain.Client)
+	require.NoError(t, err)
+
+	beforeTokens, err := fq20.GetFeeTokens(nil)
+	require.NoError(t, err)
+	require.True(t, containsAllAddresses(beforeTokens, legacyLinkToken, legacyWethToken, extraFeeToken1, extraFeeToken2))
+
+	mcmsRegistry := cs_core.GetRegistry()
+	_, err = changesets.RemoveFeeTokens(mcmsRegistry).Apply(*e, cs_core.WithMCMS[changesets.RemoveFeeTokensCfg]{
+		MCMS: mcms.Input{},
+		Cfg: changesets.RemoveFeeTokensCfg{
+			ChainSels: []uint64{removeFeeTokensChainSel},
+		},
+	})
+	require.NoError(t, err)
+
+	afterTokens, err := fq20.GetFeeTokens(nil)
+	require.NoError(t, err)
+	require.True(t, containsAllAddresses(afterTokens, legacyLinkToken, legacyWethToken))
+	require.False(t, containsAnyAddress(afterTokens, extraFeeToken1, extraFeeToken2))
+}
+
+func deployRemoveFeeTokensFixture(t *testing.T, e *cldf.Environment) common.Address {
+	t.Helper()
+
+	chain := e.BlockChains.EVMChains()[removeFeeTokensChainSel]
+	ds := datastore.NewMemoryDataStore()
+
+	rmnProxy := common.HexToAddress("0x7777777777777777777777777777777777777777")
+	placeholder := common.HexToAddress("0x8888888888888888888888888888888888888888")
+
+	routerOut, err := cldf_ops.ExecuteOperation(e.OperationsBundle, routerops.Deploy, chain, contract.DeployInput[routerops.ConstructorArgs]{
+		ChainSelector:  removeFeeTokensChainSel,
+		TypeAndVersion: cldf.NewTypeAndVersion(routerops.ContractType, *routerops.Version),
+		Args: routerops.ConstructorArgs{
+			WrappedNative: legacyWethToken,
+			RMNProxy:      rmnProxy,
+		},
+	})
+	require.NoError(t, err)
+	routerAddr := common.HexToAddress(routerOut.Output.Address)
+	require.NoError(t, ds.Addresses().Add(routerOut.Output))
+
+	prAddr, tx, _, err := price_registry.DeployPriceRegistry(
+		chain.DeployerKey, chain.Client,
+		[]common.Address{chain.DeployerKey.From},
+		[]common.Address{legacyLinkToken, legacyWethToken},
+		3600,
+	)
+	require.NoError(t, err)
+	_, err = chain.Confirm(tx)
+	require.NoError(t, err)
+	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
+		ChainSelector: removeFeeTokensChainSel,
+		Type:          datastore.ContractType(priceregistryops.ContractType),
+		Version:       priceregistryops.Version,
+		Address:       prAddr.Hex(),
+	}))
+
+	fq16Out, err := cldf_ops.ExecuteOperation(e.OperationsBundle, fq16ops.Deploy, chain, contract.DeployInput[fq16ops.ConstructorArgs]{
+		ChainSelector:  removeFeeTokensChainSel,
+		TypeAndVersion: cldf.NewTypeAndVersion(fq16ops.ContractType, *fq16ops.Version),
+		Args: fq16ops.ConstructorArgs{
+			StaticConfig: fq16ops.StaticConfig{
+				MaxFeeJuelsPerMsg:            big.NewInt(1e18),
+				LinkToken:                    legacyLinkToken,
+				TokenPriceStalenessThreshold: 3600,
+			},
+			PriceUpdaters: []common.Address{chain.DeployerKey.From},
+			FeeTokens:     []common.Address{legacyLinkToken, legacyWethToken},
+			PremiumMultiplierWeiPerEthArgs: []fq16ops.FeeTokenArgs{
+				{Token: legacyLinkToken, PremiumMultiplierWeiPerEth: 9e17},
+				{Token: legacyWethToken, PremiumMultiplierWeiPerEth: 1e18},
+			},
+		},
+	})
+	require.NoError(t, err)
+	fq16Addr := common.HexToAddress(fq16Out.Output.Address)
+	require.NoError(t, ds.Addresses().Add(fq16Out.Output))
+
+	onRamp15Out, err := cldf_ops.ExecuteOperation(e.OperationsBundle, onrampv1_5ops.DeployOnRamp, chain, contract.DeployInput[onrampv1_5ops.ConstructorArgs]{
+		ChainSelector:  removeFeeTokensChainSel,
+		TypeAndVersion: cldf.NewTypeAndVersion(onrampv1_5ops.ContractType, *onrampv1_5ops.Version),
+		Args: onrampv1_5ops.ConstructorArgs{
+			StaticConfig: evm_2_evm_onramp_v1_5_0.EVM2EVMOnRampStaticConfig{
+				LinkToken:          legacyLinkToken,
+				ChainSelector:      removeFeeTokensChainSel,
+				DestChainSelector:  remoteChainV15,
+				DefaultTxGasLimit:  200_000,
+				MaxNopFeesJuels:    big.NewInt(1e18),
+				RmnProxy:           rmnProxy,
+				TokenAdminRegistry: placeholder,
+			},
+			DynamicConfig: evm_2_evm_onramp_v1_5_0.EVM2EVMOnRampDynamicConfig{
+				Router:            routerAddr,
+				PriceRegistry:     prAddr,
+				MaxDataBytes:      30_000,
+				MaxPerMsgGasLimit: 3_000_000,
+			},
+			RateLimiterConfig: evm_2_evm_onramp_v1_5_0.RateLimiterConfig{
+				IsEnabled: false,
+				Capacity:  big.NewInt(0),
+				Rate:      big.NewInt(0),
+			},
+		},
+	})
+	require.NoError(t, err)
+	onRamp15Addr := common.HexToAddress(onRamp15Out.Output.Address)
+
+	onRamp16Out, err := cldf_ops.ExecuteOperation(e.OperationsBundle, onrampv1_6ops.Deploy, chain, contract.DeployInput[onrampv1_6ops.ConstructorArgs]{
+		ChainSelector:  removeFeeTokensChainSel,
+		TypeAndVersion: cldf.NewTypeAndVersion(onrampv1_6ops.ContractType, *onrampv1_6ops.Version),
+		Args: onrampv1_6ops.ConstructorArgs{
+			StaticConfig: onrampv1_6ops.StaticConfig{
+				ChainSelector:      removeFeeTokensChainSel,
+				RmnRemote:          rmnProxy,
+				NonceManager:       utils.RandomAddress(),
+				TokenAdminRegistry: placeholder,
+			},
+			DynamicConfig: onrampv1_6ops.DynamicConfig{
+				FeeQuoter:     fq16Addr,
+				FeeAggregator: chain.DeployerKey.From,
+				AllowlistAdmin: chain.DeployerKey.From,
+			},
+			DestChainConfigArgs: []onrampv1_6ops.DestChainConfigArgs{
+				{
+					DestChainSelector: remoteChainV16,
+					Router:            routerAddr,
+					AllowlistEnabled:  false,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	onRamp16Addr := common.HexToAddress(onRamp16Out.Output.Address)
+
+	_, err = cldf_ops.ExecuteOperation(e.OperationsBundle, routerops.ApplyRampUpdates, chain, contract.FunctionInput[routerops.ApplyRampsUpdatesArgs]{
+		ChainSelector: removeFeeTokensChainSel,
+		Address:       routerAddr,
+		Args: routerops.ApplyRampsUpdatesArgs{
+			OnRampUpdates: []router.RouterOnRamp{
+				{DestChainSelector: remoteChainV15, OnRamp: onRamp15Addr},
+				{DestChainSelector: remoteChainV16, OnRamp: onRamp16Addr},
+			},
+			OffRampAdds: []router.RouterOffRamp{
+				{SourceChainSelector: remoteChainV15, OffRamp: utils.RandomAddress()},
+				{SourceChainSelector: remoteChainV16, OffRamp: utils.RandomAddress()},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	fq20Out, err := cldf_ops.ExecuteOperation(e.OperationsBundle, fq20ops.Deploy, chain, contract.DeployInput[fq20ops.ConstructorArgs]{
+		ChainSelector:  removeFeeTokensChainSel,
+		TypeAndVersion: cldf.NewTypeAndVersion(fq20ops.ContractType, *fq20ops.Version),
+		Args: fq20ops.ConstructorArgs{
+			StaticConfig: fq20ops.StaticConfig{
+				MaxFeeJuelsPerMsg: big.NewInt(1e18),
+				LinkToken:         legacyLinkToken,
+			},
+			PriceUpdaters: []common.Address{chain.DeployerKey.From},
+		},
+	})
+	require.NoError(t, err)
+	fq20Addr := common.HexToAddress(fq20Out.Output.Address)
+	require.NoError(t, ds.Addresses().Add(fq20Out.Output))
+
+	tokenPrice := big.NewInt(1e18)
+	_, err = cldf_ops.ExecuteOperation(e.OperationsBundle, fq20ops.UpdatePrices, chain, contract.FunctionInput[fq20ops.PriceUpdates]{
+		ChainSelector: removeFeeTokensChainSel,
+		Address:       fq20Addr,
+		Args: fq20ops.PriceUpdates{
+			TokenPriceUpdates: []fq20ops.TokenPriceUpdate{
+				{SourceToken: legacyLinkToken, UsdPerToken: tokenPrice},
+				{SourceToken: legacyWethToken, UsdPerToken: tokenPrice},
+				{SourceToken: extraFeeToken1, UsdPerToken: tokenPrice},
+				{SourceToken: extraFeeToken2, UsdPerToken: tokenPrice},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	e.DataStore = ds.Seal()
+	return fq20Addr
+}
+
+func containsAllAddresses(tokens []common.Address, expected ...common.Address) bool {
+	set := make(map[common.Address]struct{}, len(tokens))
+	for _, token := range tokens {
+		set[token] = struct{}{}
+	}
+	for _, addr := range expected {
+		if _, ok := set[addr]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func containsAnyAddress(tokens []common.Address, candidates ...common.Address) bool {
+	set := make(map[common.Address]struct{}, len(tokens))
+	for _, token := range tokens {
+		set[token] = struct{}{}
+	}
+	for _, addr := range candidates {
+		if _, ok := set[addr]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/chains/evm/deployment/v2_0_0/changesets/remove_fee_tokens_test.go
+++ b/chains/evm/deployment/v2_0_0/changesets/remove_fee_tokens_test.go
@@ -7,32 +7,30 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
+	fq20binding "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v2_0_0/fee_quoter"
+
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/price_registry"
+
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
 	priceregistryops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/operations/price_registry"
-	routerops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/operations/router"
-	onrampv1_5ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/operations/onramp"
-	onrampv1_6ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/operations/onramp"
 	fq16ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/operations/fee_quoter"
+	fq163ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_3/operations/fee_quoter"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/changesets"
 	fq20ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/fee_quoter"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/price_registry"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
-	evm_2_evm_onramp_v1_5_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/evm_2_evm_onramp"
-	fq20binding "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v2_0_0/fee_quoter"
 	cs_core "github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
-	"github.com/smartcontractkit/chainlink-evm/pkg/utils"
 )
 
 const (
-	removeFeeTokensChainSel = uint64(5009297550715157269)
-	remoteChainV15          = uint64(111)
-	remoteChainV16          = uint64(222)
+	removeFeeTokensFQ16ChainSel      = uint64(5009297550715157269)
+	removeFeeTokensPRChainSel        = uint64(4356164186791070119)
+	removeFeeTokensFQ16MultiChainSel = uint64(6433500567565415381)
 )
 
 var (
@@ -44,55 +42,161 @@ var (
 
 func TestRemoveFeeTokens_RemovesExtraFeeTokensFromFeeQuoter20(t *testing.T) {
 	e, err := environment.New(t.Context(),
-		environment.WithEVMSimulated(t, []uint64{removeFeeTokensChainSel}),
+		environment.WithEVMSimulated(t, []uint64{
+			removeFeeTokensFQ16ChainSel,
+			removeFeeTokensPRChainSel,
+			removeFeeTokensFQ16MultiChainSel,
+		}),
 	)
 	require.NoError(t, err)
 
-	chain := e.BlockChains.EVMChains()[removeFeeTokensChainSel]
-	fq20Addr := deployRemoveFeeTokensFixture(t, e)
+	ds := datastore.NewMemoryDataStore()
+	fq16Chain := e.BlockChains.EVMChains()[removeFeeTokensFQ16ChainSel]
+	prChain := e.BlockChains.EVMChains()[removeFeeTokensPRChainSel]
+	fq16MultiChain := e.BlockChains.EVMChains()[removeFeeTokensFQ16MultiChainSel]
 
-	fq20, err := fq20binding.NewFeeQuoter(fq20Addr, chain.Client)
+	fq20FQ16Addr := deployRemoveFeeTokensFixtureWithFeeQuoter16(t, e, ds, removeFeeTokensFQ16ChainSel)
+	fq20PRAddr := deployRemoveFeeTokensFixtureWithPriceRegistry(t, e, ds, removeFeeTokensPRChainSel)
+	fq20FQ16MultiAddr := deployRemoveFeeTokensFixtureWithMultipleFeeQuoter16Versions(t, e, ds, removeFeeTokensFQ16MultiChainSel)
+	e.DataStore = ds.Seal()
+
+	fq20FQ16, err := fq20binding.NewFeeQuoter(fq20FQ16Addr, fq16Chain.Client)
+	require.NoError(t, err)
+	fq20PR, err := fq20binding.NewFeeQuoter(fq20PRAddr, prChain.Client)
+	require.NoError(t, err)
+	fq20FQ16Multi, err := fq20binding.NewFeeQuoter(fq20FQ16MultiAddr, fq16MultiChain.Client)
 	require.NoError(t, err)
 
-	beforeTokens, err := fq20.GetFeeTokens(nil)
-	require.NoError(t, err)
-	require.True(t, containsAllAddresses(beforeTokens, legacyLinkToken, legacyWethToken, extraFeeToken1, extraFeeToken2))
+	fq20ByChain := []*fq20binding.FeeQuoter{fq20FQ16, fq20PR, fq20FQ16Multi}
+
+	for _, fq20 := range fq20ByChain {
+		beforeTokens, err := fq20.GetFeeTokens(nil)
+		require.NoError(t, err)
+		require.True(t, containsAllAddresses(beforeTokens, legacyLinkToken, legacyWethToken, extraFeeToken1, extraFeeToken2))
+	}
 
 	mcmsRegistry := cs_core.GetRegistry()
 	_, err = changesets.RemoveFeeTokens(mcmsRegistry).Apply(*e, cs_core.WithMCMS[changesets.RemoveFeeTokensCfg]{
 		MCMS: mcms.Input{},
 		Cfg: changesets.RemoveFeeTokensCfg{
-			ChainSels: []uint64{removeFeeTokensChainSel},
+			ChainSels: []uint64{
+				removeFeeTokensFQ16ChainSel,
+				removeFeeTokensPRChainSel,
+				removeFeeTokensFQ16MultiChainSel,
+			},
 		},
 	})
 	require.NoError(t, err)
 
-	afterTokens, err := fq20.GetFeeTokens(nil)
-	require.NoError(t, err)
-	require.True(t, containsAllAddresses(afterTokens, legacyLinkToken, legacyWethToken))
-	require.False(t, containsAnyAddress(afterTokens, extraFeeToken1, extraFeeToken2))
+	for _, fq20 := range fq20ByChain {
+		afterTokens, err := fq20.GetFeeTokens(nil)
+		require.NoError(t, err)
+		require.True(t, containsAllAddresses(afterTokens, legacyLinkToken, legacyWethToken))
+		require.False(t, containsAnyAddress(afterTokens, extraFeeToken1, extraFeeToken2))
+	}
 }
 
-func deployRemoveFeeTokensFixture(t *testing.T, e *cldf.Environment) common.Address {
+func deployRemoveFeeTokensFixtureWithFeeQuoter16(
+	t *testing.T,
+	e *cldf.Environment,
+	ds datastore.MutableDataStore,
+	chainSel uint64,
+) common.Address {
 	t.Helper()
 
-	chain := e.BlockChains.EVMChains()[removeFeeTokensChainSel]
-	ds := datastore.NewMemoryDataStore()
+	chain := e.BlockChains.EVMChains()[chainSel]
+	deployFeeQuoter160(t, e, ds, chain, chainSel, []common.Address{legacyLinkToken, legacyWethToken})
 
-	rmnProxy := common.HexToAddress("0x7777777777777777777777777777777777777777")
-	placeholder := common.HexToAddress("0x8888888888888888888888888888888888888888")
+	return deployFeeQuoter20WithExtraTokens(t, e, ds, chain, chainSel)
+}
 
-	routerOut, err := cldf_ops.ExecuteOperation(e.OperationsBundle, routerops.Deploy, chain, contract.DeployInput[routerops.ConstructorArgs]{
-		ChainSelector:  removeFeeTokensChainSel,
-		TypeAndVersion: cldf.NewTypeAndVersion(routerops.ContractType, *routerops.Version),
-		Args: routerops.ConstructorArgs{
-			WrappedNative: legacyWethToken,
-			RMNProxy:      rmnProxy,
+func deployRemoveFeeTokensFixtureWithMultipleFeeQuoter16Versions(
+	t *testing.T,
+	e *cldf.Environment,
+	ds datastore.MutableDataStore,
+	chainSel uint64,
+) common.Address {
+	t.Helper()
+
+	chain := e.BlockChains.EVMChains()[chainSel]
+
+	// FQ 1.6.0 only knows about LINK. If the changeset picked this version, WETH would be
+	// treated as an extra FQ 2.0 token and removed.
+	deployFeeQuoter160(t, e, ds, chain, chainSel, []common.Address{legacyLinkToken})
+
+	// FQ 1.6.3 is the latest 1.6.x deployment and should be selected by GetFeeQuoterAddress.
+	fq163Out, err := cldf_ops.ExecuteOperation(e.OperationsBundle, fq163ops.Deploy, chain, contract.DeployInput[fq163ops.ConstructorArgs]{
+		ChainSelector:  chainSel,
+		TypeAndVersion: cldf.NewTypeAndVersion(fq163ops.ContractType, *fq163ops.Version),
+		Args: fq163ops.ConstructorArgs{
+			StaticConfig: fq163ops.StaticConfig{
+				MaxFeeJuelsPerMsg:            big.NewInt(1e18),
+				LinkToken:                    legacyLinkToken,
+				TokenPriceStalenessThreshold: 3600,
+			},
+			PriceUpdaters: []common.Address{chain.DeployerKey.From},
+			FeeTokens:     []common.Address{legacyLinkToken, legacyWethToken},
+			PremiumMultiplierWeiPerEthArgs: []fq163ops.PremiumMultiplierWeiPerEthArgs{
+				{Token: legacyLinkToken, PremiumMultiplierWeiPerEth: 9e17},
+				{Token: legacyWethToken, PremiumMultiplierWeiPerEth: 1e18},
+			},
 		},
 	})
 	require.NoError(t, err)
-	routerAddr := common.HexToAddress(routerOut.Output.Address)
-	require.NoError(t, ds.Addresses().Add(routerOut.Output))
+	require.NoError(t, ds.Addresses().Add(fq163Out.Output))
+
+	return deployFeeQuoter20WithExtraTokens(t, e, ds, chain, chainSel)
+}
+
+func deployFeeQuoter160(
+	t *testing.T,
+	e *cldf.Environment,
+	ds datastore.MutableDataStore,
+	chain cldf_evm.Chain,
+	chainSel uint64,
+	feeTokens []common.Address,
+) {
+	t.Helper()
+
+	premiumArgs := make([]fq16ops.FeeTokenArgs, 0, len(feeTokens))
+	for _, token := range feeTokens {
+		multiplier := uint64(1e18)
+		if token == legacyLinkToken {
+			multiplier = 9e17
+		}
+		premiumArgs = append(premiumArgs, fq16ops.FeeTokenArgs{
+			Token:                      token,
+			PremiumMultiplierWeiPerEth: multiplier,
+		})
+	}
+
+	fq16Out, err := cldf_ops.ExecuteOperation(e.OperationsBundle, fq16ops.Deploy, chain, contract.DeployInput[fq16ops.ConstructorArgs]{
+		ChainSelector:  chainSel,
+		TypeAndVersion: cldf.NewTypeAndVersion(fq16ops.ContractType, *fq16ops.Version),
+		Args: fq16ops.ConstructorArgs{
+			StaticConfig: fq16ops.StaticConfig{
+				MaxFeeJuelsPerMsg:            big.NewInt(1e18),
+				LinkToken:                    legacyLinkToken,
+				TokenPriceStalenessThreshold: 3600,
+			},
+			PriceUpdaters:                  []common.Address{chain.DeployerKey.From},
+			FeeTokens:                      feeTokens,
+			PremiumMultiplierWeiPerEthArgs: premiumArgs,
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, ds.Addresses().Add(fq16Out.Output))
+}
+
+func deployRemoveFeeTokensFixtureWithPriceRegistry(
+	t *testing.T,
+	e *cldf.Environment,
+	ds datastore.MutableDataStore,
+	chainSel uint64,
+) common.Address {
+	t.Helper()
+
+	chain := e.BlockChains.EVMChains()[chainSel]
 
 	prAddr, tx, _, err := price_registry.DeployPriceRegistry(
 		chain.DeployerKey, chain.Client,
@@ -104,107 +208,26 @@ func deployRemoveFeeTokensFixture(t *testing.T, e *cldf.Environment) common.Addr
 	_, err = chain.Confirm(tx)
 	require.NoError(t, err)
 	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
-		ChainSelector: removeFeeTokensChainSel,
+		ChainSelector: chainSel,
 		Type:          datastore.ContractType(priceregistryops.ContractType),
 		Version:       priceregistryops.Version,
 		Address:       prAddr.Hex(),
 	}))
 
-	fq16Out, err := cldf_ops.ExecuteOperation(e.OperationsBundle, fq16ops.Deploy, chain, contract.DeployInput[fq16ops.ConstructorArgs]{
-		ChainSelector:  removeFeeTokensChainSel,
-		TypeAndVersion: cldf.NewTypeAndVersion(fq16ops.ContractType, *fq16ops.Version),
-		Args: fq16ops.ConstructorArgs{
-			StaticConfig: fq16ops.StaticConfig{
-				MaxFeeJuelsPerMsg:            big.NewInt(1e18),
-				LinkToken:                    legacyLinkToken,
-				TokenPriceStalenessThreshold: 3600,
-			},
-			PriceUpdaters: []common.Address{chain.DeployerKey.From},
-			FeeTokens:     []common.Address{legacyLinkToken, legacyWethToken},
-			PremiumMultiplierWeiPerEthArgs: []fq16ops.FeeTokenArgs{
-				{Token: legacyLinkToken, PremiumMultiplierWeiPerEth: 9e17},
-				{Token: legacyWethToken, PremiumMultiplierWeiPerEth: 1e18},
-			},
-		},
-	})
-	require.NoError(t, err)
-	fq16Addr := common.HexToAddress(fq16Out.Output.Address)
-	require.NoError(t, ds.Addresses().Add(fq16Out.Output))
+	return deployFeeQuoter20WithExtraTokens(t, e, ds, chain, chainSel)
+}
 
-	onRamp15Out, err := cldf_ops.ExecuteOperation(e.OperationsBundle, onrampv1_5ops.DeployOnRamp, chain, contract.DeployInput[onrampv1_5ops.ConstructorArgs]{
-		ChainSelector:  removeFeeTokensChainSel,
-		TypeAndVersion: cldf.NewTypeAndVersion(onrampv1_5ops.ContractType, *onrampv1_5ops.Version),
-		Args: onrampv1_5ops.ConstructorArgs{
-			StaticConfig: evm_2_evm_onramp_v1_5_0.EVM2EVMOnRampStaticConfig{
-				LinkToken:          legacyLinkToken,
-				ChainSelector:      removeFeeTokensChainSel,
-				DestChainSelector:  remoteChainV15,
-				DefaultTxGasLimit:  200_000,
-				MaxNopFeesJuels:    big.NewInt(1e18),
-				RmnProxy:           rmnProxy,
-				TokenAdminRegistry: placeholder,
-			},
-			DynamicConfig: evm_2_evm_onramp_v1_5_0.EVM2EVMOnRampDynamicConfig{
-				Router:            routerAddr,
-				PriceRegistry:     prAddr,
-				MaxDataBytes:      30_000,
-				MaxPerMsgGasLimit: 3_000_000,
-			},
-			RateLimiterConfig: evm_2_evm_onramp_v1_5_0.RateLimiterConfig{
-				IsEnabled: false,
-				Capacity:  big.NewInt(0),
-				Rate:      big.NewInt(0),
-			},
-		},
-	})
-	require.NoError(t, err)
-	onRamp15Addr := common.HexToAddress(onRamp15Out.Output.Address)
-
-	onRamp16Out, err := cldf_ops.ExecuteOperation(e.OperationsBundle, onrampv1_6ops.Deploy, chain, contract.DeployInput[onrampv1_6ops.ConstructorArgs]{
-		ChainSelector:  removeFeeTokensChainSel,
-		TypeAndVersion: cldf.NewTypeAndVersion(onrampv1_6ops.ContractType, *onrampv1_6ops.Version),
-		Args: onrampv1_6ops.ConstructorArgs{
-			StaticConfig: onrampv1_6ops.StaticConfig{
-				ChainSelector:      removeFeeTokensChainSel,
-				RmnRemote:          rmnProxy,
-				NonceManager:       utils.RandomAddress(),
-				TokenAdminRegistry: placeholder,
-			},
-			DynamicConfig: onrampv1_6ops.DynamicConfig{
-				FeeQuoter:     fq16Addr,
-				FeeAggregator: chain.DeployerKey.From,
-				AllowlistAdmin: chain.DeployerKey.From,
-			},
-			DestChainConfigArgs: []onrampv1_6ops.DestChainConfigArgs{
-				{
-					DestChainSelector: remoteChainV16,
-					Router:            routerAddr,
-					AllowlistEnabled:  false,
-				},
-			},
-		},
-	})
-	require.NoError(t, err)
-	onRamp16Addr := common.HexToAddress(onRamp16Out.Output.Address)
-
-	_, err = cldf_ops.ExecuteOperation(e.OperationsBundle, routerops.ApplyRampUpdates, chain, contract.FunctionInput[routerops.ApplyRampsUpdatesArgs]{
-		ChainSelector: removeFeeTokensChainSel,
-		Address:       routerAddr,
-		Args: routerops.ApplyRampsUpdatesArgs{
-			OnRampUpdates: []router.RouterOnRamp{
-				{DestChainSelector: remoteChainV15, OnRamp: onRamp15Addr},
-				{DestChainSelector: remoteChainV16, OnRamp: onRamp16Addr},
-			},
-			OffRampAdds: []router.RouterOffRamp{
-				{SourceChainSelector: remoteChainV15, OffRamp: utils.RandomAddress()},
-				{SourceChainSelector: remoteChainV16, OffRamp: utils.RandomAddress()},
-			},
-		},
-	})
-	require.NoError(t, err)
+func deployFeeQuoter20WithExtraTokens(
+	t *testing.T,
+	e *cldf.Environment,
+	ds datastore.MutableDataStore,
+	chain cldf_evm.Chain,
+	chainSel uint64,
+) common.Address {
+	t.Helper()
 
 	fq20Out, err := cldf_ops.ExecuteOperation(e.OperationsBundle, fq20ops.Deploy, chain, contract.DeployInput[fq20ops.ConstructorArgs]{
-		ChainSelector:  removeFeeTokensChainSel,
+		ChainSelector:  chainSel,
 		TypeAndVersion: cldf.NewTypeAndVersion(fq20ops.ContractType, *fq20ops.Version),
 		Args: fq20ops.ConstructorArgs{
 			StaticConfig: fq20ops.StaticConfig{
@@ -220,7 +243,7 @@ func deployRemoveFeeTokensFixture(t *testing.T, e *cldf.Environment) common.Addr
 
 	tokenPrice := big.NewInt(1e18)
 	_, err = cldf_ops.ExecuteOperation(e.OperationsBundle, fq20ops.UpdatePrices, chain, contract.FunctionInput[fq20ops.PriceUpdates]{
-		ChainSelector: removeFeeTokensChainSel,
+		ChainSelector: chainSel,
 		Address:       fq20Addr,
 		Args: fq20ops.PriceUpdates{
 			TokenPriceUpdates: []fq20ops.TokenPriceUpdate{
@@ -233,7 +256,6 @@ func deployRemoveFeeTokensFixture(t *testing.T, e *cldf.Environment) common.Addr
 	})
 	require.NoError(t, err)
 
-	e.DataStore = ds.Seal()
 	return fq20Addr
 }
 

--- a/chains/evm/deployment/v2_0_0/operations/fee_quoter/fee_quoter.go
+++ b/chains/evm/deployment/v2_0_0/operations/fee_quoter/fee_quoter.go
@@ -127,6 +127,20 @@ func (c *FeeQuoterContract) GetAllAuthorizedCallers(opts *bind.CallOpts) ([]comm
 	return *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address), nil
 }
 
+func (c *FeeQuoterContract) GetFeeTokens(opts *bind.CallOpts) ([]common.Address, error) {
+	var out []any
+	err := c.contract.Call(opts, &out, "getFeeTokens")
+	if err != nil {
+		var zero []common.Address
+		return zero, err
+	}
+	return *abi.ConvertType(out[0], new([]common.Address)).(*[]common.Address), nil
+}
+
+func (c *FeeQuoterContract) RemoveFeeTokens(opts *bind.TransactOpts, args []common.Address) (*types.Transaction, error) {
+	return c.contract.Transact(opts, "removeFeeTokens", args)
+}
+
 type AuthorizedCallerArgs struct {
 	AddedCallers   []common.Address
 	RemovedCallers []common.Address
@@ -355,5 +369,34 @@ var GetAllAuthorizedCallers = contract.NewRead(contract.ReadParams[struct{}, []c
 	NewContract:  NewFeeQuoterContract,
 	CallContract: func(c *FeeQuoterContract, opts *bind.CallOpts, args struct{}) ([]common.Address, error) {
 		return c.GetAllAuthorizedCallers(opts)
+	},
+})
+
+var GetFeeTokens = contract.NewRead(contract.ReadParams[struct{}, []common.Address, *FeeQuoterContract]{
+	Name:         "fee-quoter:get-fee-tokens",
+	Version:      Version,
+	Description:  "Calls getFeeTokens on the contract",
+	ContractType: ContractType,
+	NewContract:  NewFeeQuoterContract,
+	CallContract: func(c *FeeQuoterContract, opts *bind.CallOpts, args struct{}) ([]common.Address, error) {
+		return c.GetFeeTokens(opts)
+	},
+})
+
+var RemoveFeeTokens = contract.NewWrite(contract.WriteParams[[]common.Address, *FeeQuoterContract]{
+	Name:            "fee-quoter:remove-fee-tokens",
+	Version:         Version,
+	Description:     "Calls removeFeeTokens on the contract",
+	ContractType:    ContractType,
+	ContractABI:     FeeQuoterABI,
+	NewContract:     NewFeeQuoterContract,
+	IsAllowedCaller: contract.OnlyOwner[*FeeQuoterContract, []common.Address],
+	Validate:        func([]common.Address) error { return nil },
+	CallContract: func(
+		c *FeeQuoterContract,
+		opts *bind.TransactOpts,
+		args []common.Address,
+	) (*types.Transaction, error) {
+		return c.RemoveFeeTokens(opts, args)
 	},
 })

--- a/chains/evm/deployment/v2_0_0/sequences/fee_quoter.go
+++ b/chains/evm/deployment/v2_0_0/sequences/fee_quoter.go
@@ -754,7 +754,7 @@ var SequenceRemoveFeeTokens = cldf_ops.NewSequence(
 		if err != nil {
 			return sequences.OnChainOutput{}, fmt.Errorf("failed to create batch operation from writes: %w", err)
 		}
-		output.BatchOps = []mcms_types.BatchOperation{batch}
+		output.BatchOps = append(output.BatchOps, batch)
 		return output, nil
 	},
 )

--- a/chains/evm/deployment/v2_0_0/sequences/fee_quoter.go
+++ b/chains/evm/deployment/v2_0_0/sequences/fee_quoter.go
@@ -162,6 +162,7 @@ func (fqu FeeQuoterUpdate) IsEmpty() (bool, error) {
 }
 
 var (
+
 	// SequenceFeeQuoterUpdate is a sequence that deploys or fetches existing FeeQuoter contract
 	// and does the following if the corresponding input is provided -
 	// 1. applies destination chain config updates
@@ -690,6 +691,72 @@ var (
 			}
 			return output, nil
 		})
+)
+
+// RemoveFeeTokensPerChainInput holds per-chain parameters for removing extra fee tokens from FeeQuoter 2.0.
+type RemoveFeeTokensPerChainInput struct {
+	ChainSelector     uint64
+	FeeQuoter20Ref    datastore.AddressRef
+	FeeTokensToRemove []common.Address
+}
+
+// RemoveFeeTokensInput holds the parameters for removing extra fee tokens from FeeQuoter 2.0 on multiple chains.
+type RemoveFeeTokensInput struct {
+	ChainUpdates []RemoveFeeTokensPerChainInput
+}
+
+// SequenceRemoveFeeTokens removes fee tokens from existing FeeQuoter 2.0 contracts on multiple chains.
+var SequenceRemoveFeeTokens = cldf_ops.NewSequence(
+	"fee-quoter-v2.0.0:remove-fee-tokens-sequence",
+	semver.MustParse("2.0.0"),
+	"Removes fee tokens from FeeQuoter 2.0",
+	func(b cldf_ops.Bundle, chains cldf_chain.BlockChains, input RemoveFeeTokensInput) (output sequences.OnChainOutput, err error) {
+		writes := make([]contract.WriteOutput, 0)
+		for _, chainInput := range input.ChainUpdates {
+			if len(chainInput.FeeTokensToRemove) == 0 {
+				continue
+			}
+			if datastore_utils.IsAddressRefEmpty(chainInput.FeeQuoter20Ref) {
+				return sequences.OnChainOutput{}, fmt.Errorf("empty FeeQuoter 2.0 ref for chain selector %d", chainInput.ChainSelector)
+			}
+			if chainInput.FeeQuoter20Ref.ChainSelector != chainInput.ChainSelector {
+				return sequences.OnChainOutput{}, fmt.Errorf(
+					"FeeQuoter 2.0 ref chain selector %d does not match input chain selector %d",
+					chainInput.FeeQuoter20Ref.ChainSelector, chainInput.ChainSelector,
+				)
+			}
+
+			chain, ok := chains.EVMChains()[chainInput.ChainSelector]
+			if !ok {
+				return sequences.OnChainOutput{}, fmt.Errorf("chain with selector %d not found in environment", chainInput.ChainSelector)
+			}
+
+			fqAddr := common.HexToAddress(chainInput.FeeQuoter20Ref.Address)
+			removeReport, err := cldf_ops.ExecuteOperation(
+				b, fqops.RemoveFeeTokens, chain,
+				contract.FunctionInput[[]common.Address]{
+					ChainSelector: chain.Selector,
+					Address:       fqAddr,
+					Args:          chainInput.FeeTokensToRemove,
+				})
+			if err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("failed to remove fee tokens from FeeQuoter(%s) on chain %s: %w",
+					fqAddr.Hex(), chain, err)
+			}
+			writes = append(writes, removeReport.Output)
+		}
+
+		if len(writes) == 0 {
+			return sequences.OnChainOutput{}, nil
+		}
+
+		batch, err := contract.NewBatchOperationFromWrites(writes)
+		if err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to create batch operation from writes: %w", err)
+		}
+		output.BatchOps = []mcms_types.BatchOperation{batch}
+		return output, nil
+	},
 )
 
 // MergeFeeQuoterUpdateOutputs merges FeeQuoterUpdate outputs from the v1.6.x and v1.5.0 import


### PR DESCRIPTION
This changes existing changeset to only import prices for feetokens from previous versions
Adds a changeset to remove extra fee tokens from feequoter 2.0.