### PR TITLE
fix: prevent hung source chain RPC from blocking merkleroot observation

### DIFF
--- a/commit/merkleroot/observation.go
+++ b/commit/merkleroot/observation.go
@@ -649,9 +649,18 @@ func (o observerImpl) ObserveMerkleRoots(
 	for _, chainRange := range ranges {
 		if supportedChains.Contains(chainRange.ChainSel) {
 			wg.Go(func() {
-				msgs, err := o.ccipReader.MsgsBetweenSeqNums(ctx, chainRange.ChainSel, chainRange.SeqNumRange)
+				chainCtx, chainCancel := rpctimeout.Context(ctx)
+				defer chainCancel()
+				msgs, err := o.ccipReader.MsgsBetweenSeqNums(chainCtx, chainRange.ChainSel, chainRange.SeqNumRange)
 				if err != nil {
-					lggr.Warnw("call to MsgsBetweenSeqNums failed", "err", err)
+					if errors.Is(err, context.DeadlineExceeded) {
+						lggr.Warnw("timed out getting messages for source chain",
+							"sourceChain", chainRange.ChainSel,
+							"range", chainRange.SeqNumRange,
+						)
+					} else {
+						lggr.Warnw("call to MsgsBetweenSeqNums failed", "err", err)
+					}
 					return
 				}
 

--- a/commit/merkleroot/observation.go
+++ b/commit/merkleroot/observation.go
@@ -26,6 +26,7 @@ import (
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn"
+	"github.com/smartcontractkit/chainlink-ccip/internal/libs/rpctimeout"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
 	"github.com/smartcontractkit/chainlink-ccip/internal/reader"
@@ -52,30 +53,6 @@ func (p *Processor) ObservationQuorum(
 }
 
 const SendingObservation = "sending merkle root processor observation"
-
-const (
-	defaultChainRPCTimeout           = 10 * time.Second
-	chainRPCTimeoutOCRBudgetFraction = 0.8
-)
-
-// chainRPCTimeoutDuration returns the per-chain RPC timeout as
-// min(80% of remaining OCR budget, defaultChainRPCTimeout).
-func chainRPCTimeoutDuration(ctx context.Context) time.Duration {
-	deadline, ok := ctx.Deadline()
-	if !ok {
-		return defaultChainRPCTimeout
-	}
-	remaining := time.Until(deadline)
-	if remaining <= 0 {
-		return 0
-	}
-	ocrBudget := time.Duration(float64(remaining) * chainRPCTimeoutOCRBudgetFraction)
-	return min(defaultChainRPCTimeout, ocrBudget)
-}
-
-func chainRPCContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(ctx, chainRPCTimeoutDuration(ctx))
-}
 
 // Observation makes external calls to observe information according to the current processor state.
 // According to the state it either observes sequence numbers, root hashes, RMN remote config, etc...
@@ -592,7 +569,7 @@ func (o observerImpl) ObserveLatestOnRampSeqNums(ctx context.Context) []pluginty
 
 	slices.Sort(supportedSourceChains)
 
-	configCtx, configCancel := chainRPCContext(ctx)
+	configCtx, configCancel := rpctimeout.Context(ctx)
 	defer configCancel()
 	sourceChainsCfg, err := o.ccipReader.GetOffRampSourceChainsConfig(configCtx, supportedSourceChains)
 	if err != nil {
@@ -620,7 +597,7 @@ func (o observerImpl) ObserveLatestOnRampSeqNums(ctx context.Context) []pluginty
 				lggr.Warnw("rmn enablement is misconfigured on this lane, skipping observations", "source", sourceChain)
 				return
 			}
-			chainCtx, chainCancel := chainRPCContext(ctx)
+			chainCtx, chainCancel := rpctimeout.Context(ctx)
 			defer chainCancel()
 			latestOnRampSeqNum, err := o.ccipReader.LatestMsgSeqNum(chainCtx, sourceChain)
 			if err != nil {

--- a/commit/merkleroot/observation.go
+++ b/commit/merkleroot/observation.go
@@ -53,6 +53,30 @@ func (p *Processor) ObservationQuorum(
 
 const SendingObservation = "sending merkle root processor observation"
 
+const (
+	defaultChainRPCTimeout           = 10 * time.Second
+	chainRPCTimeoutOCRBudgetFraction = 0.8
+)
+
+// chainRPCTimeoutDuration returns the per-chain RPC timeout as
+// min(80% of remaining OCR budget, defaultChainRPCTimeout).
+func chainRPCTimeoutDuration(ctx context.Context) time.Duration {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return defaultChainRPCTimeout
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return 0
+	}
+	ocrBudget := time.Duration(float64(remaining) * chainRPCTimeoutOCRBudgetFraction)
+	return min(defaultChainRPCTimeout, ocrBudget)
+}
+
+func chainRPCContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, chainRPCTimeoutDuration(ctx))
+}
+
 // Observation makes external calls to observe information according to the current processor state.
 // According to the state it either observes sequence numbers, root hashes, RMN remote config, etc...
 func (p *Processor) Observation(
@@ -568,9 +592,15 @@ func (o observerImpl) ObserveLatestOnRampSeqNums(ctx context.Context) []pluginty
 
 	slices.Sort(supportedSourceChains)
 
-	sourceChainsCfg, err := o.ccipReader.GetOffRampSourceChainsConfig(ctx, supportedSourceChains)
+	configCtx, configCancel := chainRPCContext(ctx)
+	sourceChainsCfg, err := o.ccipReader.GetOffRampSourceChainsConfig(configCtx, supportedSourceChains)
+	configCancel()
 	if err != nil {
-		lggr.Warnw("call to GetOffRampSourceChainsConfig failed", "err", err)
+		if errors.Is(err, context.DeadlineExceeded) {
+			lggr.Warnw("call to GetOffRampSourceChainsConfig timed out", "err", err)
+		} else {
+			lggr.Warnw("call to GetOffRampSourceChainsConfig failed", "err", err)
+		}
 		return nil
 	}
 
@@ -590,12 +620,16 @@ func (o observerImpl) ObserveLatestOnRampSeqNums(ctx context.Context) []pluginty
 				lggr.Warnw("rmn enablement is misconfigured on this lane, skipping observations", "source", sourceChain)
 				return
 			}
-			latestOnRampSeqNum, err := o.ccipReader.LatestMsgSeqNum(ctx, sourceChain)
+			chainCtx, chainCancel := chainRPCContext(ctx)
+			latestOnRampSeqNum, err := o.ccipReader.LatestMsgSeqNum(chainCtx, sourceChain)
+			chainCancel()
 			if err != nil {
 				if isNoBindingsError(err) {
 					// when a source chain is disabled there will not be a binding for the onRamp contract
 					// we don't want to log this as an error.
 					lggr.Debugw("no bindings for source chain, ignore if chain is disabled", "sourceChain", sourceChain)
+				} else if errors.Is(err, context.DeadlineExceeded) {
+					lggr.Warnw("timed out getting latest msg seq num for source chain", "sourceChain", sourceChain)
 				} else {
 					lggr.Errorf("failed to get latest msg seq num for source chain %d: %s", sourceChain, err)
 				}

--- a/commit/merkleroot/observation.go
+++ b/commit/merkleroot/observation.go
@@ -593,8 +593,8 @@ func (o observerImpl) ObserveLatestOnRampSeqNums(ctx context.Context) []pluginty
 	slices.Sort(supportedSourceChains)
 
 	configCtx, configCancel := chainRPCContext(ctx)
+	defer configCancel()
 	sourceChainsCfg, err := o.ccipReader.GetOffRampSourceChainsConfig(configCtx, supportedSourceChains)
-	configCancel()
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
 			lggr.Warnw("call to GetOffRampSourceChainsConfig timed out", "err", err)
@@ -621,8 +621,8 @@ func (o observerImpl) ObserveLatestOnRampSeqNums(ctx context.Context) []pluginty
 				return
 			}
 			chainCtx, chainCancel := chainRPCContext(ctx)
+			defer chainCancel()
 			latestOnRampSeqNum, err := o.ccipReader.LatestMsgSeqNum(chainCtx, sourceChain)
-			chainCancel()
 			if err != nil {
 				if isNoBindingsError(err) {
 					// when a source chain is disabled there will not be a binding for the onRamp contract

--- a/commit/merkleroot/observation_test.go
+++ b/commit/merkleroot/observation_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn"
 	rmntypes "github.com/smartcontractkit/chainlink-ccip/commit/merkleroot/rmn/types"
+	"github.com/smartcontractkit/chainlink-ccip/internal/libs/rpctimeout"
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/testhelpers"
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/testhelpers/rand"
 	"github.com/smartcontractkit/chainlink-ccip/internal/mocks"
@@ -38,7 +39,6 @@ import (
 	common_mock "github.com/smartcontractkit/chainlink-ccip/mocks/internal_/plugincommon"
 	reader_mock "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/reader"
 	readerpkg_mock "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/reader"
-	"github.com/smartcontractkit/chainlink-ccip/internal/libs/rpctimeout"
 	readerpkg "github.com/smartcontractkit/chainlink-ccip/pkg/reader"
 
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
@@ -571,7 +571,6 @@ func Test_ObserveOnRampNextSeqNums(t *testing.T) {
 		hungRPCChains := []cciptypes.ChainSelector{4, 7}
 		hungRPCSupported := mapset.NewSet(hungRPCChains...)
 
-		// Long parent ctx: per-chain RPC must not inherit the full OCR deadline.
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
@@ -844,7 +843,7 @@ func Test_ObserveMerkleRoots(t *testing.T) {
 					err = e
 				}
 				mockCCIPReader.On(
-					"MsgsBetweenSeqNums", ctx, r.ChainSel, r.SeqNumRange,
+					"MsgsBetweenSeqNums", mock.Anything, r.ChainSel, r.SeqNumRange,
 				).Return(tc.msgsBetweenSeqNums[r.ChainSel], err)
 			}
 
@@ -881,6 +880,65 @@ func Test_ObserveMerkleRoots(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("hung RPC on one chain does not block others", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		var nodeID commontypes.OracleID = 1
+		hungChain := cciptypes.ChainSelector(4)
+		okChain := cciptypes.ChainSelector(9)
+		ranges := []plugintypes.ChainRange{
+			{ChainSel: hungChain, SeqNumRange: cciptypes.SeqNumRange{10, 11}},
+			{ChainSel: okChain, SeqNumRange: cciptypes.SeqNumRange{93, 95}},
+		}
+		okMessages := []cciptypes.Message{
+			{Header: cciptypes.RampMessageHeader{MessageID: mustNewMessageID("0xa1"), SequenceNumber: 93}},
+			{Header: cciptypes.RampMessageHeader{MessageID: mustNewMessageID("0xa2"), SequenceNumber: 94}},
+			{Header: cciptypes.RampMessageHeader{MessageID: mustNewMessageID("0xa3"), SequenceNumber: 95}},
+		}
+
+		mockCCIPReader := reader_mock.NewMockCCIPReader(t)
+		mockCCIPReader.EXPECT().MsgsBetweenSeqNums(mock.Anything, mock.Anything, mock.Anything).
+			RunAndReturn(func(
+				callCtx context.Context,
+				chain cciptypes.ChainSelector,
+				_ cciptypes.SeqNumRange,
+			) ([]cciptypes.Message, error) {
+				switch chain {
+				case hungChain:
+					deadline, ok := callCtx.Deadline()
+					require.True(t, ok, "expected per-chain RPC context to have a deadline")
+					assert.LessOrEqual(t, time.Until(deadline), rpctimeout.Default)
+					return nil, context.DeadlineExceeded
+				case okChain:
+					return okMessages, nil
+				default:
+					return nil, fmt.Errorf("unexpected chain %d", chain)
+				}
+			})
+		mockCCIPReader.EXPECT().
+			GetContractAddress(mock.Anything, mock.Anything).
+			Return(cciptypes.Bytes{}, nil).Maybe()
+
+		chainSupport := common_mock.NewMockChainSupport(t)
+		chainSupport.EXPECT().SupportedChains(nodeID).Return(mapset.NewSet(hungChain, okChain), nil)
+
+		o := newObserverImpl(
+			logger.Test(t),
+			nil,
+			nodeID,
+			chainSupport,
+			mockCCIPReader,
+			mocks.NewMessageHasher(),
+		)
+
+		roots := o.ObserveMerkleRoots(ctx, ranges)
+		require.Len(t, roots, 1)
+		assert.Equal(t, okChain, roots[0].ChainSel)
+		assert.Equal(t, "f1b02d28559f60a67b431e2c580ac1d6b3e0fd7319ff055c6c67408aa31788e4",
+			hex.EncodeToString(roots[0].MerkleRoot[:]))
+	})
 }
 
 func Test_computeMerkleRoot(t *testing.T) {

--- a/commit/merkleroot/observation_test.go
+++ b/commit/merkleroot/observation_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"maps"
 	"testing"
+	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/stretchr/testify/assert"
@@ -564,6 +565,88 @@ func Test_ObserveOnRampNextSeqNums(t *testing.T) {
 			assert.Equal(t, tc.expResult, o.ObserveLatestOnRampSeqNums(ctx))
 		})
 	}
+
+	t.Run("hung RPC on one chain does not block others", func(t *testing.T) {
+		hungRPCChains := []cciptypes.ChainSelector{4, 7}
+		hungRPCSupported := mapset.NewSet(hungRPCChains...)
+
+		// Long parent deadline: without per-chain timeout, LatestMsgSeqNum would receive the
+		// full parent context (~30s). Timeout duration behavior is covered by Test_chainRPCTimeoutDuration.
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		chainSupport := common_mock.NewMockChainSupport(t)
+		chainSupport.EXPECT().KnownSourceChainsSlice().Return(hungRPCChains, nil)
+		chainSupport.EXPECT().SupportedChains(nodeID).Return(hungRPCSupported, nil)
+
+		ccipReader := reader_mock.NewMockCCIPReader(t)
+		ccipReader.EXPECT().GetOffRampSourceChainsConfig(mock.Anything, hungRPCChains).
+			Return(map[cciptypes.ChainSelector]readerpkg.StaticSourceChainConfig{
+				cciptypes.ChainSelector(4): {IsRMNVerificationDisabled: true},
+				cciptypes.ChainSelector(7): {IsRMNVerificationDisabled: true},
+			}, nil)
+		ccipReader.EXPECT().LatestMsgSeqNum(mock.Anything, mock.Anything).
+			RunAndReturn(func(callCtx context.Context, chain cciptypes.ChainSelector) (cciptypes.SeqNum, error) {
+				switch chain {
+				case 4:
+					deadline, ok := callCtx.Deadline()
+					require.True(t, ok, "expected per-chain RPC context to have a deadline")
+					assert.LessOrEqual(t, time.Until(deadline), defaultChainRPCTimeout)
+					return 0, context.DeadlineExceeded
+				case 7:
+					return 608, nil
+				default:
+					return 0, fmt.Errorf("unexpected chain %d", chain)
+				}
+			})
+
+		o := newObserverImpl(
+			logger.Test(t),
+			nil,
+			nodeID,
+			chainSupport,
+			ccipReader,
+			mocks.NewMessageHasher(),
+		)
+
+		result := o.ObserveLatestOnRampSeqNums(ctx)
+		assert.Equal(t, []plugintypes.SeqNumChain{plugintypes.NewSeqNumChain(7, 608)}, result)
+	})
+}
+
+func Test_chainRPCTimeoutDuration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses default timeout without parent deadline", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, defaultChainRPCTimeout, chainRPCTimeoutDuration(context.Background()))
+	})
+
+	t.Run("caps at default timeout when OCR budget is larger", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+
+		assert.Equal(t, defaultChainRPCTimeout, chainRPCTimeoutDuration(ctx))
+	})
+
+	t.Run("caps at 80 percent of remaining OCR budget when tighter", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+		defer cancel()
+
+		got := chainRPCTimeoutDuration(ctx)
+		want := time.Duration(float64(8*time.Second) * chainRPCTimeoutOCRBudgetFraction)
+		assert.InDelta(t, float64(want), float64(got), float64(50*time.Millisecond))
+	})
+
+	t.Run("returns zero when parent deadline has expired", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancel()
+
+		assert.Equal(t, time.Duration(0), chainRPCTimeoutDuration(ctx))
+	})
 }
 
 func Test_ObserveMerkleRoots(t *testing.T) {

--- a/commit/merkleroot/observation_test.go
+++ b/commit/merkleroot/observation_test.go
@@ -38,6 +38,7 @@ import (
 	common_mock "github.com/smartcontractkit/chainlink-ccip/mocks/internal_/plugincommon"
 	reader_mock "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/reader"
 	readerpkg_mock "github.com/smartcontractkit/chainlink-ccip/mocks/pkg/reader"
+	"github.com/smartcontractkit/chainlink-ccip/internal/libs/rpctimeout"
 	readerpkg "github.com/smartcontractkit/chainlink-ccip/pkg/reader"
 
 	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
@@ -570,8 +571,7 @@ func Test_ObserveOnRampNextSeqNums(t *testing.T) {
 		hungRPCChains := []cciptypes.ChainSelector{4, 7}
 		hungRPCSupported := mapset.NewSet(hungRPCChains...)
 
-		// Long parent deadline: without per-chain timeout, LatestMsgSeqNum would receive the
-		// full parent context (~30s). Timeout duration behavior is covered by Test_chainRPCTimeoutDuration.
+		// Long parent ctx: per-chain RPC must not inherit the full OCR deadline.
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
@@ -591,7 +591,7 @@ func Test_ObserveOnRampNextSeqNums(t *testing.T) {
 				case 4:
 					deadline, ok := callCtx.Deadline()
 					require.True(t, ok, "expected per-chain RPC context to have a deadline")
-					assert.LessOrEqual(t, time.Until(deadline), defaultChainRPCTimeout)
+					assert.LessOrEqual(t, time.Until(deadline), rpctimeout.Default)
 					return 0, context.DeadlineExceeded
 				case 7:
 					return 608, nil
@@ -611,41 +611,6 @@ func Test_ObserveOnRampNextSeqNums(t *testing.T) {
 
 		result := o.ObserveLatestOnRampSeqNums(ctx)
 		assert.Equal(t, []plugintypes.SeqNumChain{plugintypes.NewSeqNumChain(7, 608)}, result)
-	})
-}
-
-func Test_chainRPCTimeoutDuration(t *testing.T) {
-	t.Parallel()
-
-	t.Run("uses default timeout without parent deadline", func(t *testing.T) {
-		t.Parallel()
-		assert.Equal(t, defaultChainRPCTimeout, chainRPCTimeoutDuration(context.Background()))
-	})
-
-	t.Run("caps at default timeout when OCR budget is larger", func(t *testing.T) {
-		t.Parallel()
-		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-		defer cancel()
-
-		assert.Equal(t, defaultChainRPCTimeout, chainRPCTimeoutDuration(ctx))
-	})
-
-	t.Run("caps at 80 percent of remaining OCR budget when tighter", func(t *testing.T) {
-		t.Parallel()
-		ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
-		defer cancel()
-
-		got := chainRPCTimeoutDuration(ctx)
-		want := time.Duration(float64(8*time.Second) * chainRPCTimeoutOCRBudgetFraction)
-		assert.InDelta(t, float64(want), float64(got), float64(50*time.Millisecond))
-	})
-
-	t.Run("returns zero when parent deadline has expired", func(t *testing.T) {
-		t.Parallel()
-		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
-		defer cancel()
-
-		assert.Equal(t, time.Duration(0), chainRPCTimeoutDuration(ctx))
 	})
 }
 

--- a/internal/libs/rpctimeout/timeout.go
+++ b/internal/libs/rpctimeout/timeout.go
@@ -1,0 +1,32 @@
+package rpctimeout
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	// Default is the ceiling for per-chain RPC calls when no OCR deadline is set.
+	Default = 10 * time.Second
+
+	ocrBudgetFraction = 0.8
+)
+
+// Duration returns the per-chain RPC timeout as min(Default, 80% of remaining OCR budget).
+func Duration(ctx context.Context) time.Duration {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return Default
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return 0
+	}
+	ocrBudget := time.Duration(float64(remaining) * ocrBudgetFraction)
+	return min(Default, ocrBudget)
+}
+
+// Context returns a child context with a per-chain RPC timeout derived from the parent OCR context.
+func Context(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, Duration(ctx))
+}

--- a/internal/libs/rpctimeout/timeout_test.go
+++ b/internal/libs/rpctimeout/timeout_test.go
@@ -1,0 +1,44 @@
+package rpctimeout
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDuration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses default timeout without parent deadline", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, Default, Duration(context.Background()))
+	})
+
+	t.Run("caps at default timeout when OCR budget is larger", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+
+		assert.Equal(t, Default, Duration(ctx))
+	})
+
+	t.Run("caps at 80 percent of remaining OCR budget when tighter", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+		defer cancel()
+
+		got := Duration(ctx)
+		want := time.Duration(float64(8*time.Second) * ocrBudgetFraction)
+		assert.InDelta(t, float64(want), float64(got), float64(50*time.Millisecond))
+	})
+
+	t.Run("returns zero when parent deadline has expired", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancel()
+
+		assert.Equal(t, time.Duration(0), Duration(ctx))
+	})
+}

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -22,6 +22,7 @@ import (
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/query/primitives"
 
+	"github.com/smartcontractkit/chainlink-ccip/internal/libs/rpctimeout"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/addressbook"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/logutil"
@@ -455,6 +456,8 @@ func (r *ccipChainReader) GetWrappedNativeTokenPriceUSD(
 		chain := chainSelector
 
 		wg.Go(func() {
+			chainCtx, chainCancel := rpctimeout.Context(ctx)
+			defer chainCancel()
 
 			chainAccessor, err := getChainAccessor(r.accessors, chain)
 			if err != nil {
@@ -462,9 +465,13 @@ func (r *ccipChainReader) GetWrappedNativeTokenPriceUSD(
 				return
 			}
 
-			config, err := r.configPoller.GetChainConfig(ctx, chain)
+			config, err := r.configPoller.GetChainConfig(chainCtx, chain)
 			if err != nil {
-				lggr.Warnw("failed to get chain config for native token address", "chain", chain, "err", err)
+				if errors.Is(err, context.DeadlineExceeded) {
+					lggr.Warnw("timed out getting chain config for native token address", "chain", chain)
+				} else {
+					lggr.Warnw("failed to get chain config for native token address", "chain", chain, "err", err)
+				}
 				return
 			}
 			nativeTokenAddress := config.Router.WrappedNativeAddress
@@ -475,9 +482,13 @@ func (r *ccipChainReader) GetWrappedNativeTokenPriceUSD(
 				return
 			}
 
-			price, err := chainAccessor.GetTokenPriceUSD(ctx, cciptypes.UnknownAddress(nativeTokenAddress))
+			price, err := chainAccessor.GetTokenPriceUSD(chainCtx, cciptypes.UnknownAddress(nativeTokenAddress))
 			if err != nil {
-				lggr.Errorw("failed to get native token price", "chain", chain, "address", nativeTokenAddress.String(), "err", err)
+				if errors.Is(err, context.DeadlineExceeded) {
+					lggr.Warnw("timed out getting native token price", "chain", chain, "address", nativeTokenAddress.String())
+				} else {
+					lggr.Errorw("failed to get native token price", "chain", chain, "address", nativeTokenAddress.String(), "err", err)
+				}
 				return
 			}
 

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -408,31 +408,39 @@ func (r *ccipChainReader) GetChainsFeeComponents(
 	feeComponents := make(map[cciptypes.ChainSelector]types.ChainFeeComponents, len(r.contractWriters))
 
 	for _, chain := range chains {
-		chainAccessor, err := getChainAccessor(r.accessors, chain)
-		if err != nil {
-			lggr.Errorw("failed to get chain accessor", "chain", chain, "err", err)
-			continue
-		}
+		func(chain cciptypes.ChainSelector) {
+			chainAccessor, err := getChainAccessor(r.accessors, chain)
+			if err != nil {
+				lggr.Errorw("failed to get chain accessor", "chain", chain, "err", err)
+				return
+			}
 
-		feeComponent, err := chainAccessor.GetChainFeeComponents(ctx)
-		if err != nil {
-			lggr.Errorw("failed to get chain fee components", "chain", chain, "err", err)
-			continue
-		}
+			chainCtx, chainCancel := rpctimeout.Context(ctx)
+			defer chainCancel()
+			feeComponent, err := chainAccessor.GetChainFeeComponents(chainCtx)
+			if err != nil {
+				if errors.Is(err, context.DeadlineExceeded) {
+					lggr.Warnw("timed out getting chain fee components", "chain", chain)
+				} else {
+					lggr.Errorw("failed to get chain fee components", "chain", chain, "err", err)
+				}
+				return
+			}
 
-		if feeComponent.ExecutionFee == nil || feeComponent.ExecutionFee.Cmp(big.NewInt(0)) <= 0 {
-			lggr.Errorw("execution fee is nil or non positive", "chain", chain)
-			continue
-		}
-		if feeComponent.DataAvailabilityFee == nil || feeComponent.DataAvailabilityFee.Cmp(big.NewInt(0)) < 0 {
-			lggr.Errorw("data availability fee is nil or negative", "chain", chain)
-			continue
-		}
+			if feeComponent.ExecutionFee == nil || feeComponent.ExecutionFee.Cmp(big.NewInt(0)) <= 0 {
+				lggr.Errorw("execution fee is nil or non positive", "chain", chain)
+				return
+			}
+			if feeComponent.DataAvailabilityFee == nil || feeComponent.DataAvailabilityFee.Cmp(big.NewInt(0)) < 0 {
+				lggr.Errorw("data availability fee is nil or negative", "chain", chain)
+				return
+			}
 
-		feeComponents[chain] = types.ChainFeeComponents{
-			ExecutionFee:        feeComponent.ExecutionFee,
-			DataAvailabilityFee: feeComponent.DataAvailabilityFee,
-		}
+			feeComponents[chain] = types.ChainFeeComponents{
+				ExecutionFee:        feeComponent.ExecutionFee,
+				DataAvailabilityFee: feeComponent.DataAvailabilityFee,
+			}
+		}(chain)
 	}
 	return feeComponents
 }

--- a/pkg/reader/ccip_test.go
+++ b/pkg/reader/ccip_test.go
@@ -22,6 +22,7 @@ import (
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	"github.com/smartcontractkit/chainlink-ccip/internal"
+	"github.com/smartcontractkit/chainlink-ccip/internal/libs/rpctimeout"
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/slicelib"
 	commonccipocr3 "github.com/smartcontractkit/chainlink-ccip/mocks/chainlink_common/ccipocr3"
 	writermocks "github.com/smartcontractkit/chainlink-ccip/mocks/chainlink_common/types"
@@ -1276,6 +1277,72 @@ func TestCCIPChainReader_GetWrappedNativeTokenPriceUSD(t *testing.T) {
 
 		prices := ccipReader.GetWrappedNativeTokenPriceUSD(ctx, []cciptypes.ChainSelector{sourceChain1})
 		require.Empty(t, prices)
+
+		mockCache.AssertExpectations(t)
+	})
+
+	t.Run("hung RPC on one chain does not block others", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		mockCache := new(mockConfigCache)
+		sourceChain1Config := cciptypes.ChainConfigSnapshot{
+			Router: cciptypes.RouterConfig{
+				WrappedNativeAddress: wrappedNative1,
+			},
+		}
+		sourceChain2Config := cciptypes.ChainConfigSnapshot{
+			Router: cciptypes.RouterConfig{
+				WrappedNativeAddress: wrappedNative2,
+			},
+		}
+
+		mockCache.On("GetChainConfig", mock.Anything, sourceChain1).Return(sourceChain1Config, nil)
+		mockCache.On("GetChainConfig", mock.Anything, sourceChain2).Return(sourceChain2Config, nil)
+		mockCache.On("Start", mock.Anything).Return(nil)
+
+		cw := writermocks.NewMockContractWriter(t)
+		contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
+		contractWriters[sourceChain1] = cw
+		contractWriters[sourceChain2] = cw
+
+		offRampAddress := []byte{0x3}
+		chainAccessors := createMockedChainAccessors(t, destChain, sourceChain1, sourceChain2)
+		mockExpectChainAccessorSyncCall(chainAccessors[destChain], consts.ContractNameOffRamp, offRampAddress, nil)
+		chainAccessors[sourceChain1].(*commonccipocr3.MockChainAccessor).EXPECT().
+			GetTokenPriceUSD(mock.Anything, cciptypes.UnknownAddress(wrappedNative1)).
+			RunAndReturn(func(callCtx context.Context, _ cciptypes.UnknownAddress) (cciptypes.TimestampedUnixBig, error) {
+				deadline, ok := callCtx.Deadline()
+				require.True(t, ok, "expected per-chain RPC context to have a deadline")
+				assert.LessOrEqual(t, time.Until(deadline), rpctimeout.Default)
+				return cciptypes.TimestampedUnixBig{}, context.DeadlineExceeded
+			})
+		mockExpectChainAccessorGetTokenPriceUSD(
+			chainAccessors[sourceChain2],
+			cciptypes.UnknownAddress(wrappedNative2),
+			cciptypes.TimestampedUnixBig{Value: big.NewInt(200), Timestamp: uint32(time.Now().Unix())},
+		)
+
+		ccipReader, err := newCCIPChainReaderWithConfigPollerInternal(
+			t.Context(),
+			logger.Test(t),
+			chainAccessors,
+			map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
+				sourceChain1: readermocks.NewMockContractReaderFacade(t),
+				sourceChain2: readermocks.NewMockContractReaderFacade(t),
+			},
+			contractWriters,
+			destChain,
+			offRampAddress,
+			internal.NewMockAddressCodecHex(t),
+			mockCache,
+			false,
+		)
+		require.NoError(t, err)
+
+		prices := ccipReader.GetWrappedNativeTokenPriceUSD(ctx, []cciptypes.ChainSelector{sourceChain1, sourceChain2})
+		require.Len(t, prices, 1)
+		assert.Equal(t, cciptypes.NewBigInt(big.NewInt(200)), prices[sourceChain2])
 
 		mockCache.AssertExpectations(t)
 	})

--- a/pkg/reader/ccip_test.go
+++ b/pkg/reader/ccip_test.go
@@ -658,9 +658,9 @@ func TestCCIPFeeComponents_HappyPath(t *testing.T) {
 	offRampAddress := []byte{0x3}
 	chainAccessors := createMockedChainAccessors(t, chainA, chainB, chainC)
 	mockExpectChainAccessorSyncCall(chainAccessors[chainC], consts.ContractNameOffRamp, offRampAddress, nil)
-	mockExpectChainAccessorGetChainFeeComponentsCall(chainAccessors[chainA], expectedFeeComponents, nil)
-	mockExpectChainAccessorGetChainFeeComponentsCall(chainAccessors[chainB], expectedFeeComponents, nil)
-	mockExpectChainAccessorGetChainFeeComponentsCall(chainAccessors[chainC], expectedFeeComponents, nil)
+	mockExpectChainAccessorGetChainFeeComponentsCall(chainAccessors[chainA], expectedFeeComponents)
+	mockExpectChainAccessorGetChainFeeComponentsCall(chainAccessors[chainB], expectedFeeComponents)
+	mockExpectChainAccessorGetChainFeeComponentsCall(chainAccessors[chainC], expectedFeeComponents)
 	ccipReader, err := newCCIPChainReaderInternal(
 		t.Context(),
 		logger.Test(t),
@@ -695,6 +695,67 @@ func TestCCIPFeeComponents_HappyPath(t *testing.T) {
 	assert.Equal(t, big.NewInt(2), feeComponents[chainA].DataAvailabilityFee)
 	assert.Equal(t, big.NewInt(2), feeComponents[chainB].DataAvailabilityFee)
 	assert.Equal(t, big.NewInt(2), feeComponents[chainC].DataAvailabilityFee)
+}
+
+func TestCCIPFeeComponents_HungRPCOnOneChainDoesNotBlockOthers(t *testing.T) {
+	cw := writermocks.NewMockContractWriter(t)
+	contractWriters := make(map[cciptypes.ChainSelector]types.ContractWriter)
+	contractWriters[chainA] = cw
+	contractWriters[chainB] = cw
+
+	sourceCRs := make(map[cciptypes.ChainSelector]*readermocks.MockContractReaderFacade)
+	for _, chain := range []cciptypes.ChainSelector{chainA, chainB} {
+		sourceCRs[chain] = readermocks.NewMockContractReaderFacade(t)
+	}
+
+	expectedFeeComponents := cciptypes.ChainFeeComponents{
+		ExecutionFee:        big.NewInt(1),
+		DataAvailabilityFee: big.NewInt(2),
+	}
+
+	offRampAddress := []byte{0x3}
+	chainAccessors := createMockedChainAccessors(t, chainA, chainB)
+	mockExpectChainAccessorSyncCall(chainAccessors[chainB], consts.ContractNameOffRamp, offRampAddress, nil)
+	chainAccessors[chainA].(*commonccipocr3.MockChainAccessor).EXPECT().
+		GetChainFeeComponents(mock.Anything).
+		RunAndReturn(func(callCtx context.Context) (cciptypes.ChainFeeComponents, error) {
+			deadline, ok := callCtx.Deadline()
+			require.True(t, ok, "expected per-chain RPC context to have a deadline")
+			assert.LessOrEqual(t, time.Until(deadline), rpctimeout.Default)
+			return cciptypes.ChainFeeComponents{}, context.DeadlineExceeded
+		})
+	mockExpectChainAccessorGetChainFeeComponentsCall(chainAccessors[chainB], expectedFeeComponents)
+
+	ccipReader, err := newCCIPChainReaderInternal(
+		t.Context(),
+		logger.Test(t),
+		chainAccessors,
+		map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
+			chainA: sourceCRs[chainA],
+			chainB: sourceCRs[chainB],
+		},
+		contractWriters,
+		chainB,
+		offRampAddress,
+		internal.NewMockAddressCodecHex(t),
+		false,
+	)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := ccipReader.Close()
+		if err != nil {
+			t.Logf("Error closing ccipReader: %v", err)
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	feeComponents := ccipReader.GetChainsFeeComponents(ctx, []cciptypes.ChainSelector{chainA, chainB})
+	require.Len(t, feeComponents, 1)
+	assert.Equal(t, big.NewInt(1), feeComponents[chainB].ExecutionFee)
+	assert.Equal(t, big.NewInt(2), feeComponents[chainB].DataAvailabilityFee)
 }
 
 func Test_getCurseInfoFromCursedSubjects(t *testing.T) {
@@ -1767,10 +1828,9 @@ func mockExpectChainAccessorGetTokenPriceUSD(
 func mockExpectChainAccessorGetChainFeeComponentsCall(
 	chainAccessor cciptypes.ChainAccessor,
 	feeComponents cciptypes.ChainFeeComponents,
-	err error,
 ) {
 	chainAccessor.(*commonccipocr3.MockChainAccessor).EXPECT().
-		GetChainFeeComponents(mock.Anything).Return(feeComponents, err)
+		GetChainFeeComponents(mock.Anything).Return(feeComponents, nil)
 }
 
 func mockExpectChainAccessorGetChainFeePriceUpdate(


### PR DESCRIPTION
## Description

A hung or slow RPC on one source chain can block commit observations for all chains when work fans out per chain on a shared OCR `ctx`.

This PR adds:
- Bounded per-chain contexts via `internal/libs/rpctimeout`:
   - Timeout: `min(rpctimeout.Default (10s), 80% of remaining OCR deadline)`
   - On timeout or error: log, skip that chain, continue with others
 - Updated `ObserveLatestOnRampSeqNums`, `ObserveMerkleRoots`, `GetChainsFeeComponents`, `GetWrappedNativeTokenPriceUSD` to use the per-chain context instead

## Testing

- Added unit tests for the timeout formula
- Added hung-RPC isolation subtests to ensure per-chain context is applied