### PR TITLE
Enable Proper Package Names

### DIFF
--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -47,73 +47,56 @@ jobs:
       matrix:
         type:
           - name: "Fees Test"
-            file: ccip_fees_test.go
-            run: ""
+            run: "Test_CCIPFees"
             timeout: 12m
           - name: "Token Transfer Test"
-            file: ccip_token_transfer_test.go
             run: "TestTokenTransfer_EVM2EVM"
             timeout: 12m
           - name: "USDC Test"
-            file: ccip_usdc_test.go
-            run: ""
+            run: "TestUSDCTokenTransfer"
             timeout: 12m
           - name: "OOO Execution Test"
-            file: ccip_ooo_execution_test.go
-            run: ""
+            run: "Test_OutOfOrderExecution"
             timeout: 12m
           - name: "Messaging Test Test_CCIPMessaging_EVM2EVM"
-            file: ccip_messaging_test.go
             run: "^Test_CCIPMessaging_EVM2EVM$"
             timeout: 20m
           # Tests broken as of 2026-02-20
           # - name: "Messaging Test Test_CCIPMessaging_EVM2Solana"
-          #   file: ccip_messaging_test.go
           #   run: "^Test_CCIPMessaging_EVM2Solana$"
           #   timeout: 30m
           # - name: "Messaging Test Test_CCIPMessaging_Solana2EVM"
-          #   file: ccip_messaging_test.go
           #   run: "^Test_CCIPMessaging_Solana2EVM$"
           #   timeout: 30m
           - name: "Messaging Test Test_CCIPMessaging_EVM2SolanaMultiExecReports"
-            file: ccip_messaging_test.go
             run: "^Test_CCIPMessaging_EVM2SolanaMultiExecReports$"
             timeout: 35m
           - name: "Batching Test Test_CCIPBatching_MaxBatchSizeEVM"
-            file: ccip_batching_test.go
             run: "Test_CCIPBatching_MaxBatchSizeEVM"
             timeout: 12m
           - name: "Batching Test Test_CCIPBatching_MultiSource"
-            file: ccip_batching_test.go
             run: "^Test_CCIPBatching_MultiSource$"
             timeout: 12m
           - name: "Batching Test Test_CCIPBatching_MultiSource_MultiRoot"
-            file: ccip_batching_test.go
             run: "Test_CCIPBatching_MultiSource_MultiRoot"
             timeout: 12m
           - name: "Batching Test Test_CCIPBatching_SingleSource"
-            file: ccip_batching_test.go
             run: "^Test_CCIPBatching_SingleSource$"
             timeout: 12m
           - name: "Batching Test Test_CCIPBatching_SingleSource_MultiRoot"
-            file: ccip_batching_test.go
             run: "Test_CCIPBatching_SingleSource_MultiRoot"
             timeout: 12m
           - name: "Gas Price Updates Test"
-            file: ccip_gas_price_updates_test.go
-            run: ""
+            run: "Test_CCIPGasPriceUpdates"
             timeout: 12m
           # TODO: this can only run in docker for now, switch to in-memory and uncomment
           # - name: "Token Price Updates Test"
-          #   file: ccip_token_price_updates_test.go
-          #   run: ""
+          #   run: "Test_CCIPTokenPriceUpdates"
           #   timeout: 12m
           - name: "CCIPReader Test"
-            file: ccip_reader_test.go
-            run: ""
+            run: "TestCCIPReader|Test_GetChainFeePriceUpdates|Test_GetWrappedNativeTokenPriceUSD"
             timeout: 5m
           - name: "Test_CCIPTopologies_EVM2EVM_RoleDON_AllSupportSource_SomeSupportDest"
-            file: ccip_topologies_test.go
             run: "^Test_CCIPTopologies_EVM2EVM_RoleDON_AllSupportSource_SomeSupportDest$"
             timeout: 20m
 
@@ -264,11 +247,7 @@ jobs:
         id: run-tests
         continue-on-error: true
         run: |
-          run="${{ matrix.type.run }}"
-          run_cmd="gotestsum --junitfile=test-results.xml --format=github-actions -- ${{ matrix.type.file }} -timeout ${{ matrix.type.timeout }}"
-          if [ -n "$run" ]; then
-            run_cmd="$run_cmd -run $run"
-          fi
+          run_cmd="gotestsum --junitfile=test-results.xml --format=github-actions -- . -run '${{ matrix.type.run }}' -timeout ${{ matrix.type.timeout }}"
           echo "$run_cmd"
           cd $GITHUB_WORKSPACE/chainlink/integration-tests/smoke/ccip && $run_cmd
         env:


### PR DESCRIPTION
When you run go tests with specific filenames, go doesn't have package info. Instead, it reports the test packages as `command-line-arguments`, which confuses our flaky test-tracking system.

This fixes the issue so that package names are properly reported.