### PR TITLE
Change Minimum NOPs in Topology to be Validated for Each Chain Family

### DIFF
--- a/chains/evm/deployment/v2_0_0/adapters/chain_family.go
+++ b/chains/evm/deployment/v2_0_0/adapters/chain_family.go
@@ -261,7 +261,7 @@ func (a *ChainFamilyAdapter) GetDefaultGasPrice() *big.Int {
 	return big.NewInt(2e12)
 }
 
-func (a *ChainFamilyAdapter) ValidateMinimumNOPsTopology(chainSelector string, nopCount int) error {
+func (a *ChainFamilyAdapter) ValidateNOPsTopology(chainSelector string, nopCount int) error {
 	if nopCount < minProductionChainNOPs {
 		return fmt.Errorf(
 			"chain %q requires at least %d unique NOPs for production environments, got %d",

--- a/chains/evm/deployment/v2_0_0/adapters/chain_family.go
+++ b/chains/evm/deployment/v2_0_0/adapters/chain_family.go
@@ -29,6 +29,9 @@ import (
 	ccvadapters "github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/adapters"
 )
 
+// minProductionChainNOPs is the minimum number of NOPs we must have for a production chain.
+const minProductionChainNOPs = 15
+
 // ChainFamilyAdapter is the adapter for chains of the EVM family.
 type ChainFamilyAdapter struct{}
 
@@ -256,4 +259,16 @@ func (a *ChainFamilyAdapter) GetDefaultFinalityConfig() finality.Config {
 
 func (a *ChainFamilyAdapter) GetDefaultGasPrice() *big.Int {
 	return big.NewInt(2e12)
+}
+
+func (a *ChainFamilyAdapter) ValidateMinimumNOPsTopology(chainSelector string, nopCount int) error {
+	if nopCount < minProductionChainNOPs {
+		return fmt.Errorf(
+			"chain %q requires at least %d unique NOPs for production environments, got %d",
+			chainSelector,
+			minProductionChainNOPs,
+			nopCount,
+		)
+	}
+	return nil
 }

--- a/chains/evm/deployment/v2_0_0/adapters/chain_family_test.go
+++ b/chains/evm/deployment/v2_0_0/adapters/chain_family_test.go
@@ -443,3 +443,40 @@ func TestChainFamilyAdapter_DefaultsAppliedOnChainViaConfigureChainsForLanesFrom
 		remoteSelector,
 	)
 }
+
+func TestChainFamilyAdapter_ValidateMinimumNOPsTopology(t *testing.T) {
+	adapter := &evmadapters.ChainFamilyAdapter{}
+	const chainSelector = "5009297550715157269"
+
+	tests := []struct {
+		name     string
+		nopCount int
+		wantErr  string
+	}{
+		{
+			name:     "fewer than the minimum is rejected",
+			nopCount: 14,
+			wantErr:  `chain "5009297550715157269" requires at least 15 unique NOPs for production environments, got 14`,
+		},
+		{
+			name:     "exactly the minimum is allowed",
+			nopCount: 15,
+		},
+		{
+			name:     "more than the minimum is allowed",
+			nopCount: 20,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := adapter.ValidateMinimumNOPsTopology(chainSelector, tt.nopCount)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Equal(t, tt.wantErr, err.Error())
+		})
+	}
+}

--- a/chains/evm/deployment/v2_0_0/adapters/chain_family_test.go
+++ b/chains/evm/deployment/v2_0_0/adapters/chain_family_test.go
@@ -17,17 +17,17 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
 	contract_utils "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/operations/router"
 	_ "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/adapters"
 	evmadapters "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/adapters"
 	evmchangesets "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/changesets"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/operations/router"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/create2_factory"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/committee_verifier"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/executor"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/fee_quoter"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/offramp"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/onramp"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/proxy"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/create2_factory"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/testsetup"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/lanes"
@@ -260,7 +260,7 @@ func assertAdapterDefaultsOnChain(
 
 	verifierFee, err := operations.ExecuteOperation(b, committee_verifier.GetFee, evmChain, contract_utils.FunctionInput[committee_verifier.GetFeeArgs]{
 		ChainSelector: evmChain.Selector, Address: common.HexToAddress(local.committeeVerifier),
-		Args:          committee_verifier.GetFeeArgs{DestChainSelector: remoteSelector},
+		Args: committee_verifier.GetFeeArgs{DestChainSelector: remoteSelector},
 	})
 	require.NoError(t, err)
 	assert.Equal(t, cvDefaults.FeeUSDCents, verifierFee.Output.FeeUSDCents)
@@ -444,7 +444,7 @@ func TestChainFamilyAdapter_DefaultsAppliedOnChainViaConfigureChainsForLanesFrom
 	)
 }
 
-func TestChainFamilyAdapter_ValidateMinimumNOPsTopology(t *testing.T) {
+func TestChainFamilyAdapter_ValidateNOPsTopology(t *testing.T) {
 	adapter := &evmadapters.ChainFamilyAdapter{}
 	const chainSelector = "5009297550715157269"
 
@@ -470,7 +470,7 @@ func TestChainFamilyAdapter_ValidateMinimumNOPsTopology(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := adapter.ValidateMinimumNOPsTopology(chainSelector, tt.nopCount)
+			err := adapter.ValidateNOPsTopology(chainSelector, tt.nopCount)
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 				return

--- a/deployment/v2_0_0/adapters/chain_family.go
+++ b/deployment/v2_0_0/adapters/chain_family.go
@@ -118,6 +118,7 @@ type ChainFamily interface {
 	GetDefaultRemoteChainConfig(sourceChainSelector, remoteChainSelector uint64) RemoteChainDefaults
 	GetDefaultCommitteeVerifierRemoteChainConfig() CommitteeVerifierRemoteChainDefaults
 	GetDefaultFinalityConfig() finality.Config
+	ValidateMinimumNOPsTopology(chainSelector string, nopCount int) error
 }
 
 // ChainFamilyRegistry maintains a registry of chain families.

--- a/deployment/v2_0_0/adapters/chain_family.go
+++ b/deployment/v2_0_0/adapters/chain_family.go
@@ -118,7 +118,7 @@ type ChainFamily interface {
 	GetDefaultRemoteChainConfig(sourceChainSelector, remoteChainSelector uint64) RemoteChainDefaults
 	GetDefaultCommitteeVerifierRemoteChainConfig() CommitteeVerifierRemoteChainDefaults
 	GetDefaultFinalityConfig() finality.Config
-	ValidateMinimumNOPsTopology(chainSelector string, nopCount int) error
+	ValidateNOPsTopology(chainSelector string, nopCount int) error
 }
 
 // ChainFamilyRegistry maintains a registry of chain families.

--- a/deployment/v2_0_0/adapters/chain_family_test.go
+++ b/deployment/v2_0_0/adapters/chain_family_test.go
@@ -82,7 +82,7 @@ func (m *mockChainFamily) GetDefaultFinalityConfig() finality.Config {
 	return finality.Config{}
 }
 
-func (m *mockChainFamily) ValidateMinimumNOPsTopology(chainSelector string, nopCount int) error {
+func (m *mockChainFamily) ValidateNOPsTopology(chainSelector string, nopCount int) error {
 	return nil
 }
 

--- a/deployment/v2_0_0/adapters/chain_family_test.go
+++ b/deployment/v2_0_0/adapters/chain_family_test.go
@@ -82,6 +82,10 @@ func (m *mockChainFamily) GetDefaultFinalityConfig() finality.Config {
 	return finality.Config{}
 }
 
+func (m *mockChainFamily) ValidateMinimumNOPsTopology(chainSelector string, nopCount int) error {
+	return nil
+}
+
 func TestChainFamilyRegistry_RegisterAndGet(t *testing.T) {
 	registry := adapters.NewChainFamilyRegistry()
 	adapter := &mockChainFamily{}

--- a/deployment/v2_0_0/changesets/apply_config_cl_mode_test.go
+++ b/deployment/v2_0_0/changesets/apply_config_cl_mode_test.go
@@ -115,7 +115,7 @@ func TestApplyVerifierConfig_FailsWhenNOPMissingChainSupport(t *testing.T) {
 	env.Offchain = mockJD
 	env.NodeIDs = []string{"node-1", "node-2"}
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -179,7 +179,7 @@ func TestApplyVerifierConfig_PassesWhenNOPSupportsExtraChains(t *testing.T) {
 	env.Offchain = mockJD
 	env.NodeIDs = []string{"node-1", "node-2"}
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -209,7 +209,7 @@ func TestApplyVerifierConfig_SkipsChainSupportValidationForStandaloneNOPs(t *tes
 	topo := newVerifierTopology([]string{"nop1", "nop2"}, "c1", []uint64{sel1}, shared.NOPModeStandalone)
 	env := newVerifierTestEnv(t, []uint64{sel1})
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -269,7 +269,7 @@ func TestApplyVerifierConfig_PassesWhenNonTargetNOPMissingChainSupport(t *testin
 	env.Offchain = mockJD
 	env.NodeIDs = []string{"node-1", "node-2"}
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -339,7 +339,7 @@ func TestApplyExecutorConfig_FailsWhenNOPMissingChainSupport(t *testing.T) {
 	env.Offchain = mockJD
 	env.NodeIDs = []string{"node-1", "node-2"}
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",
@@ -403,7 +403,7 @@ func TestApplyExecutorConfig_PassesWhenNOPSupportsExtraChains(t *testing.T) {
 	env.Offchain = mockJD
 	env.NodeIDs = []string{"node-1", "node-2"}
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",
@@ -434,7 +434,7 @@ func TestApplyExecutorConfig_SkipsChainSupportValidationForStandaloneNOPs(t *tes
 	topo := newMinimalTopology([]string{"nop1", "nop2"}, "pool1", shared.NOPModeStandalone)
 	env := newTestExecutorEnv(t, []uint64{sel1})
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",
@@ -494,7 +494,7 @@ func TestApplyExecutorConfig_PassesWhenNonTargetNOPMissingChainSupport(t *testin
 	env.Offchain = mockJD
 	env.NodeIDs = []string{"node-1", "node-2"}
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",
@@ -552,7 +552,7 @@ func TestApplyVerifierConfig_ProposesCorrectSpecToCorrectNode(t *testing.T) {
 	env.Offchain = mockJD
 	env.NodeIDs = []string{"node-1", "node-2"}
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -630,7 +630,7 @@ func TestApplyExecutorConfig_ProposesCorrectSpecToCorrectNode(t *testing.T) {
 	env.Offchain = mockJD
 	env.NodeIDs = []string{"node-1", "node-2"}
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",
@@ -709,7 +709,7 @@ func TestApplyVerifierConfig_ExtraNodeIDsDoNotReceiveProposals(t *testing.T) {
 	env.Offchain = mockJD
 	env.NodeIDs = []string{"node-1", "node-2", "node-extra"}
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -753,7 +753,7 @@ func TestApplyVerifierConfig_FailsWhenTopologyNOPNotInNodeIDs(t *testing.T) {
 	env.Offchain = mockJD
 	env.NodeIDs = []string{"node-1"}
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -809,7 +809,7 @@ func TestApplyVerifierConfig_ListNodesFilteredByNodeIDs(t *testing.T) {
 	env.Offchain = mockJD
 	env.NodeIDs = []string{"node-1", "node-2"}
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -871,7 +871,7 @@ func TestApplyVerifierConfig_TargetNOPsScopesProposals(t *testing.T) {
 	env.Offchain = mockJD
 	env.NodeIDs = []string{"node-1", "node-2", "node-3"}
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -938,7 +938,7 @@ func TestApplyVerifierConfig_RevokeOrphanedJobsDoesNotAffectOtherCommittees(t *t
 		&jobpb.ProposeJobResponse{Proposal: &jobpb.Proposal{Id: "prop-1"}}, nil,
 	)
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -1000,7 +1000,7 @@ func TestApplyExecutorConfig_RevokeOrphanedJobsDoesNotAffectVerifierJobs(t *test
 		&jobpb.ProposeJobResponse{Proposal: &jobpb.Proposal{Id: "prop-1"}}, nil,
 	)
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:           topo,
 		ExecutorQualifier:  "pool1",
@@ -1080,7 +1080,7 @@ func TestApplyVerifierConfig_TargetNOPsSucceedsWhenNonTargetedNOPMissingFromJD(t
 	env.Offchain = mockJD
 	env.NodeIDs = []string{"node-1"}
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -1152,7 +1152,7 @@ func TestApplyVerifierConfig_UntargetedNOPMissingSignerDoesNotBlockTargetedNOPs(
 	env.Offchain = mockJD
 	env.NodeIDs = []string{"node-1"}
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -1200,7 +1200,7 @@ func TestApplyVerifierConfig_WrapperPassesTargetNOPsAndRevokeOrphanedJobsToSeque
 	env.Offchain = mockJD
 	env.NodeIDs = []string{"node-1", "node-2"}
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",

--- a/deployment/v2_0_0/changesets/apply_executor_config.go
+++ b/deployment/v2_0_0/changesets/apply_executor_config.go
@@ -26,12 +26,12 @@ type ApplyExecutorConfigInput struct {
 	RevokeOrphanedJobs bool
 }
 
-func ApplyExecutorConfig(registry *adapters.ExecutorConfigRegistry) deployment.ChangeSetV2[ApplyExecutorConfigInput] {
+func ApplyExecutorConfig(registry *adapters.ExecutorConfigRegistry, chainFamilyRegistry *adapters.ChainFamilyRegistry) deployment.ChangeSetV2[ApplyExecutorConfigInput] {
 	validate := func(e deployment.Environment, cfg ApplyExecutorConfigInput) error {
 		if cfg.Topology == nil {
 			return fmt.Errorf("topology is required")
 		}
-		if err := cfg.Topology.ValidateForEnvironment(e.Name); err != nil {
+		if err := cfg.Topology.ValidateForEnvironment(e.Name, chainFamilyRegistry); err != nil {
 			return fmt.Errorf("topology validation failed: %w", err)
 		}
 

--- a/deployment/v2_0_0/changesets/apply_executor_config_lifecycle_test.go
+++ b/deployment/v2_0_0/changesets/apply_executor_config_lifecycle_test.go
@@ -69,7 +69,7 @@ func TestApplyExecutorConfig_GeneratesValidJobSpec(t *testing.T) {
 	topo.IndexerAddress = []string{"http://indexer:8100", "http://indexer:8101"}
 	env := newTestExecutorEnv(t, []uint64{sel1, sel2})
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",
@@ -116,7 +116,7 @@ func TestApplyExecutorConfig_PreservesExistingJobSpecs(t *testing.T) {
 	topo := newMinimalTopology([]string{"nop1"}, "pool1", shared.NOPModeStandalone)
 	env := newExecutorTestEnvWithDS(t, []uint64{sel1}, ds.Seal())
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",
@@ -165,7 +165,7 @@ func TestApplyExecutorConfig_RemovesOrphanedJobSpecs(t *testing.T) {
 	topo := newMinimalTopology([]string{"nop1"}, "pool1", shared.NOPModeStandalone)
 	env := newExecutorTestEnvWithDS(t, []uint64{sel1}, ds.Seal())
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:           topo,
 		ExecutorQualifier:  "pool1",
@@ -209,7 +209,7 @@ func TestApplyExecutorConfig_PreservesOrphanedJobSpecsWhenRevokeOrphanedJobsFals
 	topo := newMinimalTopology([]string{"nop1"}, "pool1", shared.NOPModeStandalone)
 	env := newExecutorTestEnvWithDS(t, []uint64{sel1}, ds.Seal())
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",
@@ -253,7 +253,7 @@ func TestApplyExecutorConfig_TargetNOPsScopingPreservesUntargetedJobs(t *testing
 	topo := newMinimalTopology([]string{"nop1", "nop2"}, "pool1", shared.NOPModeStandalone)
 	env := newExecutorTestEnvWithDS(t, []uint64{sel1}, ds.Seal())
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",
@@ -306,7 +306,7 @@ func TestApplyExecutorConfig_OnlyIncludesDeployedChains(t *testing.T) {
 	)
 	env := newTestExecutorEnv(t, []uint64{sel1, sel2, sel3})
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",
@@ -359,7 +359,7 @@ func TestApplyExecutorConfig_PoolMembershipIncludedInJobSpec(t *testing.T) {
 
 	env := newTestExecutorEnv(t, []uint64{sel1})
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",
@@ -422,7 +422,7 @@ func TestApplyExecutorConfig_PerChainPoolMembershipAndIntervalInJobSpec(t *testi
 
 	env := newTestExecutorEnv(t, []uint64{sel1, sel2})
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",
@@ -493,7 +493,7 @@ func TestApplyExecutorConfig_FailsWhenPoolChainHasNoDeployedContracts(t *testing
 
 	env := newTestExecutorEnv(t, []uint64{sel1})
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",
@@ -532,7 +532,7 @@ func TestApplyExecutorConfig_UpdatesJobsWhenChainRemovedFromTopology(t *testing.
 	)
 	env := newTestExecutorEnv(t, []uint64{sel1, sel2})
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	firstOutput, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",
@@ -600,7 +600,7 @@ func TestApplyExecutorConfig_AllNOPsUpdatedWhenMemberAddedToPool(t *testing.T) {
 
 	env := newTestExecutorEnv(t, []uint64{sel1})
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	firstOutput, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          initialTopo,
 		ExecutorQualifier: "pool1",
@@ -693,7 +693,7 @@ func TestApplyExecutorConfig_AllNOPsUpdatedWhenMemberRemovedFromPool(t *testing.
 
 	env := newTestExecutorEnv(t, []uint64{sel1})
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	firstOutput, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          initialTopo,
 		ExecutorQualifier: "pool1",

--- a/deployment/v2_0_0/changesets/apply_executor_config_test.go
+++ b/deployment/v2_0_0/changesets/apply_executor_config_test.go
@@ -144,7 +144,7 @@ func TestApplyExecutorConfig_Validation(t *testing.T) {
 				ExecutorQualifier: "pool1",
 			},
 			chainFamily: newRejectingChainFamilyRegistry(),
-			wantErr:     `executor pool "pool1" validation failed: stub chain family rejected topology`,
+			wantErr:     fmt.Sprintf(`executor pool "pool1" validation failed on chain "%d": stub chain family rejected topology`, sel1),
 		},
 		{
 			name: "missing executor qualifier returns error",

--- a/deployment/v2_0_0/changesets/apply_executor_config_test.go
+++ b/deployment/v2_0_0/changesets/apply_executor_config_test.go
@@ -108,10 +108,11 @@ func TestApplyExecutorConfig_Validation(t *testing.T) {
 	registry.Register(chainsel.FamilyEVM, &mockExecutorConfigAdapter{})
 
 	tests := []struct {
-		name    string
-		env     deployment.Environment
-		input   changesets.ApplyExecutorConfigInput
-		wantErr string
+		name        string
+		env         deployment.Environment
+		input       changesets.ApplyExecutorConfigInput
+		chainFamily *adapters.ChainFamilyRegistry
+		wantErr     string
 	}{
 		{
 			name:    "missing topology returns error",
@@ -136,13 +137,14 @@ func TestApplyExecutorConfig_Validation(t *testing.T) {
 			wantErr: "nop_topology is required",
 		},
 		{
-			name: "production topology with fewer than fifteen NOPs returns error",
+			name: "production topology rejected by chain family adapter returns error",
 			env:  deployment.Environment{Name: "prod_mainnet", BlockChains: newExecutorTestBlockChains([]uint64{sel1})},
 			input: changesets.ApplyExecutorConfigInput{
 				Topology:          newMinimalTopology([]string{"nop1"}, "pool1", ""),
 				ExecutorQualifier: "pool1",
 			},
-			wantErr: "requires at least 15 unique NOPs",
+			chainFamily: newRejectingChainFamilyRegistry(),
+			wantErr:     `executor pool "pool1" validation failed: stub chain family rejected topology`,
 		},
 		{
 			name: "missing executor qualifier returns error",
@@ -188,7 +190,11 @@ func TestApplyExecutorConfig_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cs := changesets.ApplyExecutorConfig(registry)
+			chainFamilyRegistry := tt.chainFamily
+			if chainFamilyRegistry == nil {
+				chainFamilyRegistry = newTestChainFamilyRegistry()
+			}
+			cs := changesets.ApplyExecutorConfig(registry, chainFamilyRegistry)
 			err := cs.VerifyPreconditions(tt.env, tt.input)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
@@ -218,7 +224,7 @@ func TestApplyExecutorConfig_HappyPathBuildsJobSpecs(t *testing.T) {
 	topo := newMinimalTopology([]string{"nop1", "nop2"}, "pool1", shared.NOPModeStandalone)
 	env := newTestExecutorEnv(t, []uint64{sel1})
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",
@@ -251,7 +257,7 @@ func TestApplyExecutorConfig_NoDeployedChainsReturnsEmpty(t *testing.T) {
 	topo := newMinimalTopology([]string{"nop1"}, "pool1", shared.NOPModeStandalone)
 	env := newTestExecutorEnv(t, []uint64{sel1})
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",
@@ -276,7 +282,7 @@ func TestApplyExecutorConfig_BuildChainConfigErrorPropagates(t *testing.T) {
 	topo := newMinimalTopology([]string{"nop1"}, "pool1", shared.NOPModeStandalone)
 	env := newTestExecutorEnv(t, []uint64{sel1})
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",
@@ -308,7 +314,7 @@ func TestApplyExecutorConfig_UsesAllDeployedChains(t *testing.T) {
 	topo := newMinimalTopology([]string{"nop1"}, "pool1", shared.NOPModeStandalone)
 	env := newTestExecutorEnv(t, []uint64{sel1, sel2})
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",
@@ -339,7 +345,7 @@ func TestApplyExecutorConfig_TargetNOPsFiltersJobSpecs(t *testing.T) {
 	topo := newMinimalTopology([]string{"nop1", "nop2", "nop3"}, "pool1", shared.NOPModeStandalone)
 	env := newTestExecutorEnv(t, []uint64{sel1})
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",
@@ -459,7 +465,7 @@ func TestApplyExecutorConfig_PerChainNOPsIncludesAllChains(t *testing.T) {
 	)
 
 	env := newTestExecutorEnv(t, []uint64{sel1, sel2, sel3})
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",
@@ -505,7 +511,7 @@ func TestApplyExecutorConfig_AllChainsNOPsGetAllChains(t *testing.T) {
 	)
 	env := newTestExecutorEnv(t, []uint64{sel1, sel2})
 
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",
@@ -551,7 +557,7 @@ func TestApplyExecutorConfig_ExecutorPoolFieldMatchesChainPool(t *testing.T) {
 	)
 
 	env := newTestExecutorEnv(t, []uint64{sel1, sel2})
-	cs := changesets.ApplyExecutorConfig(registry)
+	cs := changesets.ApplyExecutorConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyExecutorConfigInput{
 		Topology:          topo,
 		ExecutorQualifier: "pool1",

--- a/deployment/v2_0_0/changesets/apply_verifier_config.go
+++ b/deployment/v2_0_0/changesets/apply_verifier_config.go
@@ -29,12 +29,12 @@ type ApplyVerifierConfigInput struct {
 	RevokeOrphanedJobs bool
 }
 
-func ApplyVerifierConfig(registry *adapters.VerifierConfigRegistry) deployment.ChangeSetV2[ApplyVerifierConfigInput] {
+func ApplyVerifierConfig(registry *adapters.VerifierConfigRegistry, chainFamilyRegistry *adapters.ChainFamilyRegistry) deployment.ChangeSetV2[ApplyVerifierConfigInput] {
 	validate := func(e deployment.Environment, cfg ApplyVerifierConfigInput) error {
 		if cfg.Topology == nil {
 			return fmt.Errorf("topology is required")
 		}
-		if err := cfg.Topology.ValidateForEnvironment(e.Name); err != nil {
+		if err := cfg.Topology.ValidateForEnvironment(e.Name, chainFamilyRegistry); err != nil {
 			return fmt.Errorf("topology validation failed: %w", err)
 		}
 

--- a/deployment/v2_0_0/changesets/apply_verifier_config_lifecycle_test.go
+++ b/deployment/v2_0_0/changesets/apply_verifier_config_lifecycle_test.go
@@ -109,7 +109,7 @@ func TestApplyVerifierConfig_GeneratesValidJobSpec(t *testing.T) {
 	topo := newVerifierTopology([]string{"nop1"}, "c1", []uint64{sel1}, shared.NOPModeStandalone)
 	env := newVerifierTestEnv(t, []uint64{sel1})
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -159,7 +159,7 @@ func TestApplyVerifierConfig_PreservesExistingJobSpecs(t *testing.T) {
 	env := newVerifierTestEnvWithDS(t, []uint64{sel1}, ds.Seal())
 
 	topo := newVerifierTopology([]string{"nop1"}, "c1", []uint64{sel1}, shared.NOPModeStandalone)
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -201,7 +201,7 @@ func TestApplyVerifierConfig_MultipleAggregators(t *testing.T) {
 	topo := newVerifierTopologyWithAggregators([]string{"nop1"}, "c1", []uint64{sel1}, shared.NOPModeStandalone, aggregators, nil)
 	env := newVerifierTestEnv(t, []uint64{sel1})
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -256,7 +256,7 @@ func TestApplyVerifierConfig_RemovesOrphanedJobSpecs(t *testing.T) {
 	env := newVerifierTestEnvWithDS(t, []uint64{sel1}, ds.Seal())
 
 	topo := newVerifierTopology([]string{"nop1"}, "c1", []uint64{sel1}, shared.NOPModeStandalone)
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -301,7 +301,7 @@ func TestApplyVerifierConfig_PreservesOrphanedJobSpecsWhenRevokeOrphanedJobsFals
 	env := newVerifierTestEnvWithDS(t, []uint64{sel1}, ds.Seal())
 
 	topo := newVerifierTopology([]string{"nop1"}, "c1", []uint64{sel1}, shared.NOPModeStandalone)
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -346,7 +346,7 @@ func TestApplyVerifierConfig_TargetNOPsScopingPreservesUntargetedJobs(t *testing
 	env := newVerifierTestEnvWithDS(t, []uint64{sel1}, ds.Seal())
 
 	topo := newVerifierTopology([]string{"nop1", "nop2"}, "c1", []uint64{sel1}, shared.NOPModeStandalone)
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -397,7 +397,7 @@ func TestApplyVerifierConfig_OnlyIncludesCommitteeChains(t *testing.T) {
 	topo := newVerifierTopologyWithAggregators([]string{"nop1"}, "c1", nil, shared.NOPModeStandalone, nil, chainConfigs)
 	env := newVerifierTestEnv(t, []uint64{sel1, sel2, sel3})
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -446,7 +446,7 @@ func TestApplyVerifierConfig_FiltersChainsPerNOPMembership(t *testing.T) {
 	topo := newVerifierTopologyWithAggregators([]string{"nop1", "nop2"}, "c1", nil, shared.NOPModeStandalone, nil, chainConfigs)
 	env := newVerifierTestEnv(t, []uint64{sel1, sel2})
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -508,7 +508,7 @@ func TestApplyVerifierConfig_SkipsNOPsNotInAnyChainConfig(t *testing.T) {
 	}
 	env := newVerifierTestEnv(t, []uint64{sel1})
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -544,7 +544,7 @@ func TestApplyVerifierConfig_SkipsUnchangedJobSpecs(t *testing.T) {
 	topo := newVerifierTopology([]string{"nop1"}, "c1", []uint64{sel1}, shared.NOPModeStandalone)
 	env := newVerifierTestEnv(t, []uint64{sel1})
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	firstOutput, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -595,7 +595,7 @@ func TestApplyVerifierConfig_UpdatesJobsWhenChainRemoved(t *testing.T) {
 	topo := newVerifierTopology([]string{"nop1"}, "c1", []uint64{sel1, sel2}, shared.NOPModeStandalone)
 	env := newVerifierTestEnv(t, []uint64{sel1, sel2})
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	firstOutput, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -654,7 +654,7 @@ func TestApplyVerifierConfig_RemovesJobWhenNOPRemovedFromCommittee(t *testing.T)
 	topoBoth := newVerifierTopology([]string{"nop1", "nop2"}, "c1", []uint64{sel1, sel2}, shared.NOPModeStandalone)
 	env := newVerifierTestEnv(t, []uint64{sel1, sel2})
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	firstOutput, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topoBoth,
 		CommitteeQualifier:       "c1",
@@ -719,7 +719,7 @@ func TestApplyVerifierConfig_CreatesJobWhenNOPAddedToCommittee(t *testing.T) {
 	topoNOP1Only := newVerifierTopologyWithAggregators([]string{"nop1", "nop2"}, "c1", nil, shared.NOPModeStandalone, nil, chainConfigsNOP1Only)
 	env := newVerifierTestEnv(t, []uint64{sel1, sel2})
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	firstOutput, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topoNOP1Only,
 		CommitteeQualifier:       "c1",

--- a/deployment/v2_0_0/changesets/apply_verifier_config_test.go
+++ b/deployment/v2_0_0/changesets/apply_verifier_config_test.go
@@ -221,7 +221,7 @@ func TestApplyVerifierConfig_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cs := changesets.ApplyVerifierConfig(registry)
+			cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 			err := cs.VerifyPreconditions(tt.env, tt.input)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)
@@ -249,7 +249,7 @@ func TestApplyVerifierConfig_HappyPathBuildsJobSpecs(t *testing.T) {
 	topo := newVerifierTopology([]string{"nop1", "nop2"}, "c1", []uint64{sel1}, shared.NOPModeStandalone)
 	env := newVerifierTestEnv(t, []uint64{sel1})
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -280,7 +280,7 @@ func TestApplyVerifierConfig_AdapterErrorPropagates(t *testing.T) {
 	topo := newVerifierTopology([]string{"nop1"}, "c1", []uint64{sel1}, shared.NOPModeStandalone)
 	env := newVerifierTestEnv(t, []uint64{sel1})
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -310,7 +310,7 @@ func TestApplyVerifierConfig_TargetNOPsFiltersJobSpecs(t *testing.T) {
 	topo := newVerifierTopology([]string{"nop1", "nop2", "nop3"}, "c1", []uint64{sel1}, shared.NOPModeStandalone)
 	env := newVerifierTestEnv(t, []uint64{sel1})
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -353,7 +353,7 @@ func TestApplyVerifierConfig_MissingSignerAddressReturnsError(t *testing.T) {
 
 	env := newVerifierTestEnv(t, []uint64{sel1})
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -379,7 +379,7 @@ func TestApplyVerifierConfig_NoChainConfigsPreservesExistingJobs(t *testing.T) {
 	env := newVerifierTestEnvWithDS(t, []uint64{sel1}, ds.Seal())
 
 	topo := newVerifierTopology([]string{"nop1"}, "c1", []uint64{}, shared.NOPModeStandalone)
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -417,7 +417,7 @@ func TestApplyVerifierConfig_NoChainConfigsWithRevokeRemovesOrphanedJobs(t *test
 	env := newVerifierTestEnvWithDS(t, []uint64{sel1}, ds.Seal())
 
 	topo := newVerifierTopology([]string{"nop1"}, "c1", []uint64{}, shared.NOPModeStandalone)
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",
@@ -458,7 +458,7 @@ func TestApplyVerifierConfig_UsesAllCommitteeChains(t *testing.T) {
 	topo := newVerifierTopology([]string{"nop1"}, "c1", []uint64{sel1}, shared.NOPModeStandalone)
 	env := newVerifierTestEnv(t, []uint64{sel1, sel2})
 
-	cs := changesets.ApplyVerifierConfig(registry)
+	cs := changesets.ApplyVerifierConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.ApplyVerifierConfigInput{
 		Topology:                 topo,
 		CommitteeQualifier:       "c1",

--- a/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology.go
+++ b/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology.go
@@ -109,7 +109,7 @@ func ConfigureChainsForLanesFromTopology(
 		if cfg.Topology == nil {
 			return fmt.Errorf("topology is required")
 		}
-		if err := cfg.Topology.ValidateForEnvironment(e.Name); err != nil {
+		if err := cfg.Topology.ValidateForEnvironment(e.Name, chainFamilyRegistry); err != nil {
 			return fmt.Errorf("topology validation failed: %w", err)
 		}
 		if cfg.Topology.NOPTopology == nil || len(cfg.Topology.NOPTopology.Committees) == 0 {

--- a/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology_test.go
+++ b/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology_test.go
@@ -2,6 +2,7 @@ package changesets_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -137,6 +138,46 @@ func (m *mockChainFamilyAdapter) GetDefaultFinalityConfig() finality.Config {
 		WaitForSafe:     true,
 		BlockDepth:      1,
 	}
+}
+
+// ValidateMinimumNOPsTopology accepts every topology. The production NOP
+// minimum is a chain-family concern owned and tested against each real adapter
+// (see the EVM adapter's chain_family_test.go); changeset tests only need a
+// benign default here. Use newRejectingChainFamilyRegistry to exercise the
+// failure path.
+func (m *mockChainFamilyAdapter) ValidateMinimumNOPsTopology(_ string, _ int) error {
+	return nil
+}
+
+// newTestChainFamilyRegistry returns a chain family registry with the mock
+// adapter registered for the EVM family, suitable for changeset tests that need
+// to satisfy the ValidateForEnvironment signature.
+func newTestChainFamilyRegistry() *adapters.ChainFamilyRegistry {
+	registry := adapters.NewChainFamilyRegistry()
+	registry.RegisterChainFamily(chainsel.FamilyEVM, &mockChainFamilyAdapter{})
+	return registry
+}
+
+// errStubNOPValidation is returned by rejectingChainFamilyAdapter so tests can
+// assert that changesets surface chain-family NOP validation failures.
+var errStubNOPValidation = errors.New("stub chain family rejected topology")
+
+// rejectingChainFamilyAdapter is a ChainFamily test double whose only behaviour
+// is to reject production NOP validation. The embedded nil interface satisfies
+// the rest of the contract; those methods are never called during
+// VerifyPreconditions.
+type rejectingChainFamilyAdapter struct {
+	adapters.ChainFamily
+}
+
+func (rejectingChainFamilyAdapter) ValidateMinimumNOPsTopology(_ string, _ int) error {
+	return errStubNOPValidation
+}
+
+func newRejectingChainFamilyRegistry() *adapters.ChainFamilyRegistry {
+	registry := adapters.NewChainFamilyRegistry()
+	registry.RegisterChainFamily(chainsel.FamilyEVM, rejectingChainFamilyAdapter{})
+	return registry
 }
 
 func (m *mockChainFamilyAdapter) getAddress(chainSelector uint64, contractType string) ([]byte, error) {

--- a/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology_test.go
+++ b/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology_test.go
@@ -140,12 +140,12 @@ func (m *mockChainFamilyAdapter) GetDefaultFinalityConfig() finality.Config {
 	}
 }
 
-// ValidateMinimumNOPsTopology accepts every topology. The production NOP
+// ValidateNOPsTopology accepts every topology. The production NOP
 // minimum is a chain-family concern owned and tested against each real adapter
 // (see the EVM adapter's chain_family_test.go); changeset tests only need a
 // benign default here. Use newRejectingChainFamilyRegistry to exercise the
 // failure path.
-func (m *mockChainFamilyAdapter) ValidateMinimumNOPsTopology(_ string, _ int) error {
+func (m *mockChainFamilyAdapter) ValidateNOPsTopology(_ string, _ int) error {
 	return nil
 }
 
@@ -170,7 +170,7 @@ type rejectingChainFamilyAdapter struct {
 	adapters.ChainFamily
 }
 
-func (rejectingChainFamilyAdapter) ValidateMinimumNOPsTopology(_ string, _ int) error {
+func (rejectingChainFamilyAdapter) ValidateNOPsTopology(_ string, _ int) error {
 	return errStubNOPValidation
 }
 

--- a/deployment/v2_0_0/changesets/deploy_chain_contracts.go
+++ b/deployment/v2_0_0/changesets/deploy_chain_contracts.go
@@ -48,13 +48,13 @@ func (c DeployChainContractsCfg) resolvePerChainCfg(sel uint64) DeployChainContr
 	return c.ChainOverrides[sel]
 }
 
-func DeployChainContracts(registry *adapters.DeployChainContractsRegistry) deployment.ChangeSetV2[changesets.WithMCMS[DeployChainContractsCfg]] {
+func DeployChainContracts(registry *adapters.DeployChainContractsRegistry, chainFamilyRegistry *adapters.ChainFamilyRegistry) deployment.ChangeSetV2[changesets.WithMCMS[DeployChainContractsCfg]] {
 	mcmsReaderRegistry := changesets.GetRegistry()
 	validate := func(e deployment.Environment, cfg changesets.WithMCMS[DeployChainContractsCfg]) error {
 		if cfg.Cfg.Topology == nil {
 			return fmt.Errorf("topology is required")
 		}
-		if err := cfg.Cfg.Topology.ValidateForEnvironment(e.Name); err != nil {
+		if err := cfg.Cfg.Topology.ValidateForEnvironment(e.Name, chainFamilyRegistry); err != nil {
 			return fmt.Errorf("topology validation failed: %w", err)
 		}
 

--- a/deployment/v2_0_0/changesets/deploy_chain_contracts_test.go
+++ b/deployment/v2_0_0/changesets/deploy_chain_contracts_test.go
@@ -208,7 +208,7 @@ func TestDeployChainContracts_Validate(t *testing.T) {
 
 	env := newDeployTestEnv(t, []uint64{sel1})
 	registry := adapters.NewDeployChainContractsRegistry()
-	cs := changesets.DeployChainContracts(registry)
+	cs := changesets.DeployChainContracts(registry, newTestChainFamilyRegistry())
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -241,7 +241,7 @@ func TestDeployChainContracts_Apply_MinimalConfigWithoutOverrides(t *testing.T) 
 	registry := adapters.NewDeployChainContractsRegistry()
 	registry.Register(chainsel.FamilyEVM, mock)
 
-	cs := changesets.DeployChainContracts(registry)
+	cs := changesets.DeployChainContracts(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, cs_core.WithMCMS[changesets.DeployChainContractsCfg]{
 		MCMS: mcms.Input{},
 		Cfg:  newDeployChainContractsCfg(sel1),
@@ -271,7 +271,7 @@ func TestDeployChainContracts_Apply_SingleChainSuccess(t *testing.T) {
 	registry := adapters.NewDeployChainContractsRegistry()
 	registry.Register(chainsel.FamilyEVM, mock)
 
-	cs := changesets.DeployChainContracts(registry)
+	cs := changesets.DeployChainContracts(registry, newTestChainFamilyRegistry())
 	out, err := cs.Apply(env, cs_core.WithMCMS[changesets.DeployChainContractsCfg]{
 		MCMS: mcms.Input{},
 		Cfg:  newDeployChainContractsCfg(sel1),
@@ -309,7 +309,7 @@ func TestDeployChainContracts_Apply_MultiChainSuccess(t *testing.T) {
 	registry := adapters.NewDeployChainContractsRegistry()
 	registry.Register(chainsel.FamilyEVM, mock)
 
-	cs := changesets.DeployChainContracts(registry)
+	cs := changesets.DeployChainContracts(registry, newTestChainFamilyRegistry())
 	out, err := cs.Apply(env, cs_core.WithMCMS[changesets.DeployChainContractsCfg]{
 		MCMS: mcms.Input{},
 		Cfg:  newDeployChainContractsCfg(sel1, sel2),
@@ -334,7 +334,7 @@ func TestDeployChainContracts_Apply_PerChainContractParamsOverrideIsUsed(t *test
 	registry := adapters.NewDeployChainContractsRegistry()
 	registry.Register(chainsel.FamilyEVM, captureAdapter)
 
-	cs := changesets.DeployChainContracts(registry)
+	cs := changesets.DeployChainContracts(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, cs_core.WithMCMS[changesets.DeployChainContractsCfg]{
 		MCMS: mcms.Input{},
 		Cfg: changesets.DeployChainContractsCfg{
@@ -378,7 +378,7 @@ func TestDeployChainContracts_Apply_PerChainDeployFlagsAreUsed(t *testing.T) {
 	registry := adapters.NewDeployChainContractsRegistry()
 	registry.Register(chainsel.FamilyEVM, captureAdapter)
 
-	cs := changesets.DeployChainContracts(registry)
+	cs := changesets.DeployChainContracts(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, cs_core.WithMCMS[changesets.DeployChainContractsCfg]{
 		MCMS: mcms.Input{},
 		Cfg: changesets.DeployChainContractsCfg{
@@ -453,7 +453,7 @@ func TestDeployChainContracts_Apply_AdapterErrorPropagated(t *testing.T) {
 	registry := adapters.NewDeployChainContractsRegistry()
 	registry.Register(chainsel.FamilyEVM, mock)
 
-	cs := changesets.DeployChainContracts(registry)
+	cs := changesets.DeployChainContracts(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, cs_core.WithMCMS[changesets.DeployChainContractsCfg]{
 		MCMS: mcms.Input{},
 		Cfg:  newDeployChainContractsCfg(sel1),
@@ -471,7 +471,7 @@ func TestDeployChainContracts_Apply_ReturnsError_WhenNoCommitteesHaveChainConfig
 	registry := adapters.NewDeployChainContractsRegistry()
 	registry.Register(chainsel.FamilyEVM, mock)
 
-	cs := changesets.DeployChainContracts(registry)
+	cs := changesets.DeployChainContracts(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, cs_core.WithMCMS[changesets.DeployChainContractsCfg]{
 		MCMS: mcms.Input{},
 		Cfg: changesets.DeployChainContractsCfg{
@@ -488,7 +488,7 @@ func TestDeployChainContracts_Apply_NoAdapterRegistered(t *testing.T) {
 	env := newDeployTestEnv(t, []uint64{sel1})
 
 	registry := adapters.NewDeployChainContractsRegistry()
-	cs := changesets.DeployChainContracts(registry)
+	cs := changesets.DeployChainContracts(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, cs_core.WithMCMS[changesets.DeployChainContractsCfg]{
 		MCMS: mcms.Input{},
 		Cfg:  newDeployChainContractsCfg(sel1),

--- a/deployment/v2_0_0/changesets/generate_aggregator_config.go
+++ b/deployment/v2_0_0/changesets/generate_aggregator_config.go
@@ -19,7 +19,7 @@ type GenerateAggregatorConfigInput struct {
 	Topology           *offchain.EnvironmentTopology
 }
 
-func GenerateAggregatorConfig(registry *adapters.AggregatorConfigRegistry) deployment.ChangeSetV2[GenerateAggregatorConfigInput] {
+func GenerateAggregatorConfig(registry *adapters.AggregatorConfigRegistry, chainFamilyRegistry *adapters.ChainFamilyRegistry) deployment.ChangeSetV2[GenerateAggregatorConfigInput] {
 	validate := func(e deployment.Environment, cfg GenerateAggregatorConfigInput) error {
 		if cfg.ServiceIdentifier == "" {
 			return fmt.Errorf("service identifier is required")
@@ -27,12 +27,12 @@ func GenerateAggregatorConfig(registry *adapters.AggregatorConfigRegistry) deplo
 		if cfg.CommitteeQualifier == "" {
 			return fmt.Errorf("committee qualifier is required")
 		}
-		_, err := resolveAggregatorChainSelectors(e, cfg)
+		_, err := resolveAggregatorChainSelectors(e, cfg, chainFamilyRegistry)
 		return err
 	}
 
 	apply := func(e deployment.Environment, cfg GenerateAggregatorConfigInput) (deployment.ChangesetOutput, error) {
-		chainSelectors, err := resolveAggregatorChainSelectors(e, cfg)
+		chainSelectors, err := resolveAggregatorChainSelectors(e, cfg, chainFamilyRegistry)
 		if err != nil {
 			return deployment.ChangesetOutput{}, err
 		}
@@ -61,11 +61,11 @@ func GenerateAggregatorConfig(registry *adapters.AggregatorConfigRegistry) deplo
 	return deployment.CreateChangeSet(apply, validate)
 }
 
-func resolveAggregatorChainSelectors(e deployment.Environment, cfg GenerateAggregatorConfigInput) ([]uint64, error) {
+func resolveAggregatorChainSelectors(e deployment.Environment, cfg GenerateAggregatorConfigInput, chainFamilyRegistry *adapters.ChainFamilyRegistry) ([]uint64, error) {
 	if cfg.Topology == nil {
 		return nil, fmt.Errorf("topology is required")
 	}
-	if err := cfg.Topology.ValidateForEnvironment(e.Name); err != nil {
+	if err := cfg.Topology.ValidateForEnvironment(e.Name, chainFamilyRegistry); err != nil {
 		return nil, fmt.Errorf("topology validation failed: %w", err)
 	}
 	if cfg.Topology.NOPTopology == nil {

--- a/deployment/v2_0_0/changesets/generate_aggregator_config_test.go
+++ b/deployment/v2_0_0/changesets/generate_aggregator_config_test.go
@@ -90,7 +90,7 @@ func TestGenerateAggregatorConfig_Validation(t *testing.T) {
 	sel2 := chainsel.TEST_90000002.Selector
 
 	registry := newAggregatorConfigRegistry()
-	cs := changesets.GenerateAggregatorConfig(registry)
+	cs := changesets.GenerateAggregatorConfig(registry, newTestChainFamilyRegistry())
 
 	tests := []struct {
 		name        string
@@ -219,7 +219,7 @@ func TestGenerateAggregatorConfig_BuildsCorrectConfig(t *testing.T) {
 		BlockChains: newTestBlockChains([]uint64{sel1, sel2, sel3}),
 	}
 
-	cs := changesets.GenerateAggregatorConfig(registry)
+	cs := changesets.GenerateAggregatorConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.GenerateAggregatorConfigInput{
 		ServiceIdentifier:  "test-aggregator",
 		CommitteeQualifier: qualifier,
@@ -265,7 +265,7 @@ func TestGenerateAggregatorConfig_ScanError(t *testing.T) {
 		BlockChains: newTestBlockChains([]uint64{sel1}),
 	}
 
-	cs := changesets.GenerateAggregatorConfig(registry)
+	cs := changesets.GenerateAggregatorConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.GenerateAggregatorConfigInput{
 		ServiceIdentifier:  "test-aggregator",
 		CommitteeQualifier: "default",
@@ -302,7 +302,7 @@ func TestGenerateAggregatorConfig_ResolveAddressError(t *testing.T) {
 		BlockChains: newTestBlockChains([]uint64{sel1}),
 	}
 
-	cs := changesets.GenerateAggregatorConfig(registry)
+	cs := changesets.GenerateAggregatorConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.GenerateAggregatorConfigInput{
 		ServiceIdentifier:  "test-aggregator",
 		CommitteeQualifier: qualifier,
@@ -326,7 +326,7 @@ func TestGenerateAggregatorConfig_CommitteeNotFound(t *testing.T) {
 		BlockChains: newTestBlockChains([]uint64{sel1}),
 	}
 
-	cs := changesets.GenerateAggregatorConfig(registry)
+	cs := changesets.GenerateAggregatorConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.GenerateAggregatorConfigInput{
 		ServiceIdentifier:  "test-aggregator",
 		CommitteeQualifier: "default",
@@ -391,7 +391,7 @@ func TestGenerateAggregatorConfig_DuplicateSourceChainAcrossDestinationsSucceeds
 		BlockChains: newTestBlockChains([]uint64{destChainA, destChainB, sourceChain}),
 	}
 
-	cs := changesets.GenerateAggregatorConfig(registry)
+	cs := changesets.GenerateAggregatorConfig(registry, newTestChainFamilyRegistry())
 	output, err := cs.Apply(env, changesets.GenerateAggregatorConfigInput{
 		ServiceIdentifier:  "test-aggregator",
 		CommitteeQualifier: qualifier,
@@ -444,7 +444,7 @@ func TestGenerateAggregatorConfig_DuplicateQualifierOnSameChainFails(t *testing.
 		BlockChains: newTestBlockChains([]uint64{sel1}),
 	}
 
-	cs := changesets.GenerateAggregatorConfig(registry)
+	cs := changesets.GenerateAggregatorConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.GenerateAggregatorConfigInput{
 		ServiceIdentifier:  "test-aggregator",
 		CommitteeQualifier: qualifier,
@@ -503,7 +503,7 @@ func TestGenerateAggregatorConfig_DuplicateSourceChain_DifferentSigners_ReturnsE
 		BlockChains: newTestBlockChains([]uint64{destChainA, destChainB, sourceChain}),
 	}
 
-	cs := changesets.GenerateAggregatorConfig(registry)
+	cs := changesets.GenerateAggregatorConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.GenerateAggregatorConfigInput{
 		ServiceIdentifier:  "test-aggregator",
 		CommitteeQualifier: qualifier,
@@ -561,7 +561,7 @@ func TestGenerateAggregatorConfig_DuplicateSourceChain_DifferentThreshold_Return
 		BlockChains: newTestBlockChains([]uint64{destChainA, destChainB, sourceChain}),
 	}
 
-	cs := changesets.GenerateAggregatorConfig(registry)
+	cs := changesets.GenerateAggregatorConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.GenerateAggregatorConfigInput{
 		ServiceIdentifier:  "test-aggregator",
 		CommitteeQualifier: qualifier,
@@ -580,7 +580,7 @@ func TestGenerateAggregatorConfig_MissingAdapterForFamily(t *testing.T) {
 		BlockChains: newTestBlockChains([]uint64{sel1}),
 	}
 
-	cs := changesets.GenerateAggregatorConfig(registry)
+	cs := changesets.GenerateAggregatorConfig(registry, newTestChainFamilyRegistry())
 	_, err := cs.Apply(env, changesets.GenerateAggregatorConfigInput{
 		ServiceIdentifier:  "test-aggregator",
 		CommitteeQualifier: "default",

--- a/deployment/v2_0_0/offchain/topology.go
+++ b/deployment/v2_0_0/offchain/topology.go
@@ -201,6 +201,10 @@ func (c *EnvironmentTopology) ValidateForEnvironment(envName string, chainFamily
 		return nil
 	}
 
+	if chainFamilyRegistry == nil {
+		return fmt.Errorf("chain family registry is required to validate production environment %q", envName)
+	}
+
 	if err := c.NOPTopology.validateMinimumNOPsPerChain(chainFamilyRegistry); err != nil {
 		return err
 	}
@@ -290,9 +294,9 @@ func (t *NOPTopology) validateMinimumNOPsPerChain(chainFamilyRegistry *adapters.
 				return fmt.Errorf("no adapter registered for chain family %q", selectorFamily)
 			}
 
-			err = familyAdapter.ValidateMinimumNOPsTopology(chainSelectorString, nopCount)
+			err = familyAdapter.ValidateNOPsTopology(chainSelectorString, nopCount)
 			if err != nil {
-				return fmt.Errorf("committee %q validation failed: %w", qualifier, err)
+				return fmt.Errorf("committee %q validation failed on chain %q: %w", qualifier, chainSelectorString, err)
 			}
 		}
 	}
@@ -380,9 +384,9 @@ func (p *ExecutorPoolConfig) validateMinimumNOPsPerChain(poolName string, chainF
 			return fmt.Errorf("no adapter registered for chain family %q", selectorFamily)
 		}
 
-		err = familyAdapter.ValidateMinimumNOPsTopology(chainSelectorString, nopCount)
+		err = familyAdapter.ValidateNOPsTopology(chainSelectorString, nopCount)
 		if err != nil {
-			return fmt.Errorf("executor pool %q validation failed: %w", poolName, err)
+			return fmt.Errorf("executor pool %q validation failed on chain %q: %w", poolName, chainSelectorString, err)
 		}
 	}
 	return nil

--- a/deployment/v2_0_0/offchain/topology.go
+++ b/deployment/v2_0_0/offchain/topology.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/Masterminds/semver/v3"
+	chainsel "github.com/smartcontractkit/chain-selectors"
 
+	"github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/adapters"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/offchain/shared"
 )
 
@@ -190,7 +192,7 @@ func WriteEnvironmentTopology(path string, cfg EnvironmentTopology) error {
 	return nil
 }
 
-func (c *EnvironmentTopology) ValidateForEnvironment(envName string) error {
+func (c *EnvironmentTopology) ValidateForEnvironment(envName string, chainFamilyRegistry *adapters.ChainFamilyRegistry) error {
 	if err := c.Validate(); err != nil {
 		return err
 	}
@@ -199,11 +201,11 @@ func (c *EnvironmentTopology) ValidateForEnvironment(envName string) error {
 		return nil
 	}
 
-	if err := c.NOPTopology.validateMinimumNOPsPerChain(); err != nil {
+	if err := c.NOPTopology.validateMinimumNOPsPerChain(chainFamilyRegistry); err != nil {
 		return err
 	}
 	for poolName, pool := range c.ExecutorPools {
-		if err := pool.validateMinimumNOPsPerChain(poolName); err != nil {
+		if err := pool.validateMinimumNOPsPerChain(poolName, chainFamilyRegistry); err != nil {
 			return err
 		}
 	}
@@ -271,22 +273,38 @@ func (t *NOPTopology) Validate() error {
 	return nil
 }
 
-func (t *NOPTopology) validateMinimumNOPsPerChain() error {
+func (t *NOPTopology) validateMinimumNOPsPerChain(chainFamilyRegistry *adapters.ChainFamilyRegistry) error {
 	for qualifier, committee := range t.Committees {
-		for chainSelector, chainCfg := range committee.ChainConfigs {
+		for chainSelectorString, chainCfg := range committee.ChainConfigs {
 			nopCount := uniqueNOPCount(chainCfg.NOPAliases)
-			if nopCount < minProductionChainNOPs {
-				return fmt.Errorf(
-					"committee %q chain %q requires at least %d unique NOPs for production environments, got %d",
-					qualifier,
-					chainSelector,
-					minProductionChainNOPs,
-					nopCount,
-				)
+			chainSelector, err := strconv.ParseUint(chainSelectorString, 10, 64)
+			if err != nil {
+				return fmt.Errorf("committee chain_configs key %q is not a valid chain selector: %w", chainSelectorString, err)
+			}
+			selectorFamily, err := chainsel.GetSelectorFamily(chainSelector)
+			if err != nil {
+				return fmt.Errorf("failed to get chain family for chain selector %d: %w", chainSelector, err)
+			}
+			familyAdapter, ok := chainFamilyRegistry.GetChainFamily(selectorFamily)
+			if !ok {
+				return fmt.Errorf("no adapter registered for chain family %q", selectorFamily)
+			}
+
+			err = familyAdapter.ValidateMinimumNOPsTopology(chainSelectorString, nopCount)
+			if err != nil {
+				return fmt.Errorf("committee %q validation failed: %w", qualifier, err)
 			}
 		}
 	}
 	return nil
+}
+
+func uniqueNOPCount(aliases []string) int {
+	seen := make(map[string]struct{}, len(aliases))
+	for _, alias := range aliases {
+		seen[alias] = struct{}{}
+	}
+	return len(seen)
 }
 
 func (c *CommitteeConfig) Validate(topology *NOPTopology) error {
@@ -346,28 +364,28 @@ func (p *ExecutorPoolConfig) Validate(poolName string, topology *NOPTopology) er
 	return nil
 }
 
-func (p *ExecutorPoolConfig) validateMinimumNOPsPerChain(poolName string) error {
-	for chainSelector, chainCfg := range p.ChainConfigs {
+func (p *ExecutorPoolConfig) validateMinimumNOPsPerChain(poolName string, chainFamilyRegistry *adapters.ChainFamilyRegistry) error {
+	for chainSelectorString, chainCfg := range p.ChainConfigs {
 		nopCount := uniqueNOPCount(chainCfg.NOPAliases)
-		if nopCount < minProductionChainNOPs {
-			return fmt.Errorf(
-				"executor pool %q chain %q requires at least %d unique NOPs for production environments, got %d",
-				poolName,
-				chainSelector,
-				minProductionChainNOPs,
-				nopCount,
-			)
+		chainSelector, err := strconv.ParseUint(chainSelectorString, 10, 64)
+		if err != nil {
+			return fmt.Errorf("executor pool config key %q is not a valid chain selector: %w", chainSelectorString, err)
+		}
+		selectorFamily, err := chainsel.GetSelectorFamily(chainSelector)
+		if err != nil {
+			return fmt.Errorf("failed to get chain family for chain selector %d: %w", chainSelector, err)
+		}
+		familyAdapter, ok := chainFamilyRegistry.GetChainFamily(selectorFamily)
+		if !ok {
+			return fmt.Errorf("no adapter registered for chain family %q", selectorFamily)
+		}
+
+		err = familyAdapter.ValidateMinimumNOPsTopology(chainSelectorString, nopCount)
+		if err != nil {
+			return fmt.Errorf("executor pool %q validation failed: %w", poolName, err)
 		}
 	}
 	return nil
-}
-
-func uniqueNOPCount(aliases []string) int {
-	seen := make(map[string]struct{}, len(aliases))
-	for _, alias := range aliases {
-		seen[alias] = struct{}{}
-	}
-	return len(seen)
 }
 
 func (c *EnvironmentTopology) GetNOPsForPool(poolName string) ([]string, error) {

--- a/deployment/v2_0_0/offchain/topology_test.go
+++ b/deployment/v2_0_0/offchain/topology_test.go
@@ -2,15 +2,40 @@ package offchain
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
+	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/adapters"
 )
 
+// stubChainFamily is a minimal ChainFamily test double used to verify how
+// ValidateForEnvironment orchestrates the per-chain NOP check (production-only,
+// per committee/pool, with error wrapping). It enforces an arbitrary test
+// threshold rather than the real production minimum, which is owned and tested
+// separately for each chain family. The embedded nil interface
+// satisfies the rest of the ChainFamily contract; those methods are never
+// called by ValidateForEnvironment.
+type stubChainFamily struct {
+	adapters.ChainFamily
+	minNOPs int
+}
+
+func (s stubChainFamily) ValidateMinimumNOPsTopology(chainSelector string, nopCount int) error {
+	if nopCount < s.minNOPs {
+		return fmt.Errorf("chain %q rejected: %d NOPs below test minimum %d", chainSelector, nopCount, s.minNOPs)
+	}
+	return nil
+}
+
 func TestEnvironmentTopologyValidateForEnvironment_ProductionMinimumNOPs(t *testing.T) {
-	fifteenAliases := testNOPAliases(15)
-	fourteenAliases := testNOPAliases(14)
+	const testMinNOPs = 3
+	chainSelector := strconv.FormatUint(chainsel.TEST_90000001.Selector, 10)
+	enough := testNOPAliases(testMinNOPs)
+	tooFew := testNOPAliases(testMinNOPs - 1)
 
 	tests := []struct {
 		name             string
@@ -20,33 +45,27 @@ func TestEnvironmentTopologyValidateForEnvironment_ProductionMinimumNOPs(t *test
 		wantErr          string
 	}{
 		{
-			name:             "prod committee chain with fifteen unique NOPs fails",
+			name:             "production committee below minimum is rejected and wrapped",
 			envName:          "prod_mainnet",
-			committeeAliases: fourteenAliases,
-			poolAliases:      fifteenAliases,
-			wantErr:          `committee "default" chain "1" requires at least 15 unique NOPs`,
+			committeeAliases: tooFew,
+			poolAliases:      enough,
+			wantErr:          fmt.Sprintf(`committee "default" validation failed: chain %q rejected`, chainSelector),
 		},
 		{
-			name:             "prod committee chain with fifteen unique NOPs passes",
+			name:             "production executor pool below minimum is rejected and wrapped",
+			envName:          "prod_testnet",
+			committeeAliases: enough,
+			poolAliases:      tooFew,
+			wantErr:          fmt.Sprintf(`executor pool "default" validation failed: chain %q rejected`, chainSelector),
+		},
+		{
+			name:             "production topology meeting the minimum passes",
 			envName:          "prod_mainnet",
-			committeeAliases: fifteenAliases,
-			poolAliases:      fifteenAliases,
+			committeeAliases: enough,
+			poolAliases:      enough,
 		},
 		{
-			name:             "prod executor pool chain with fifteen unique NOPs fails",
-			envName:          "prod_testnet",
-			committeeAliases: fifteenAliases,
-			poolAliases:      fourteenAliases,
-			wantErr:          `executor pool "default" chain "1" requires at least 15 unique NOPs`,
-		},
-		{
-			name:             "prod executor pool chain with fifteen unique NOPs passes",
-			envName:          "prod_testnet",
-			committeeAliases: fifteenAliases,
-			poolAliases:      fifteenAliases,
-		},
-		{
-			name:             "non prod chain with fewer than fifteen NOPs passes",
+			name:             "non production environment skips the chain family check",
 			envName:          "test",
 			committeeAliases: []string{"nop-1"},
 			poolAliases:      []string{"nop-1"},
@@ -54,17 +73,19 @@ func TestEnvironmentTopologyValidateForEnvironment_ProductionMinimumNOPs(t *test
 		{
 			name:             "duplicate committee aliases do not count toward minimum",
 			envName:          "prod_mainnet",
-			committeeAliases: append(testNOPAliases(14), "nop-1"),
-			poolAliases:      fifteenAliases,
-			wantErr:          `committee "default" chain "1" requires at least 15 unique NOPs`,
+			committeeAliases: append(testNOPAliases(testMinNOPs-1), "nop-1"),
+			poolAliases:      enough,
+			wantErr:          fmt.Sprintf(`committee "default" validation failed: chain %q rejected`, chainSelector),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			topology := testEnvironmentTopology(tt.committeeAliases, tt.poolAliases)
+			topology := testEnvironmentTopology(chainSelector, tt.committeeAliases, tt.poolAliases)
+			registry := adapters.NewChainFamilyRegistry()
+			registry.RegisterChainFamily(chainsel.FamilyEVM, stubChainFamily{minNOPs: testMinNOPs})
 
-			err := topology.ValidateForEnvironment(tt.envName)
+			err := topology.ValidateForEnvironment(tt.envName, registry)
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 				return
@@ -84,7 +105,7 @@ func TestEnvironmentTopologyValidate_NilNOPTopology(t *testing.T) {
 	assert.Contains(t, err.Error(), "nop_topology is required")
 }
 
-func testEnvironmentTopology(committeeAliases []string, poolAliases []string) *EnvironmentTopology {
+func testEnvironmentTopology(chainSelector string, committeeAliases []string, poolAliases []string) *EnvironmentTopology {
 	nops := make([]NOPConfig, 0, len(committeeAliases)+len(poolAliases))
 	seen := make(map[string]struct{}, len(committeeAliases)+len(poolAliases))
 	for _, alias := range append(append([]string{}, committeeAliases...), poolAliases...) {
@@ -109,7 +130,7 @@ func testEnvironmentTopology(committeeAliases []string, poolAliases []string) *E
 						{Name: "agg-1", Address: "http://aggregator:8080"},
 					},
 					ChainConfigs: map[string]ChainCommitteeConfig{
-						"1": {NOPAliases: committeeAliases, Threshold: 1},
+						chainSelector: {NOPAliases: committeeAliases, Threshold: 1},
 					},
 				},
 			},
@@ -117,7 +138,7 @@ func testEnvironmentTopology(committeeAliases []string, poolAliases []string) *E
 		ExecutorPools: map[string]ExecutorPoolConfig{
 			"default": {
 				ChainConfigs: map[string]ChainExecutorPoolConfig{
-					"1": {NOPAliases: poolAliases},
+					chainSelector: {NOPAliases: poolAliases},
 				},
 			},
 		},

--- a/deployment/v2_0_0/offchain/topology_test.go
+++ b/deployment/v2_0_0/offchain/topology_test.go
@@ -24,7 +24,7 @@ type stubChainFamily struct {
 	minNOPs int
 }
 
-func (s stubChainFamily) ValidateMinimumNOPsTopology(chainSelector string, nopCount int) error {
+func (s stubChainFamily) ValidateNOPsTopology(chainSelector string, nopCount int) error {
 	if nopCount < s.minNOPs {
 		return fmt.Errorf("chain %q rejected: %d NOPs below test minimum %d", chainSelector, nopCount, s.minNOPs)
 	}
@@ -49,14 +49,14 @@ func TestEnvironmentTopologyValidateForEnvironment_ProductionMinimumNOPs(t *test
 			envName:          "prod_mainnet",
 			committeeAliases: tooFew,
 			poolAliases:      enough,
-			wantErr:          fmt.Sprintf(`committee "default" validation failed: chain %q rejected`, chainSelector),
+			wantErr:          fmt.Sprintf(`committee "default" validation failed on chain %q`, chainSelector),
 		},
 		{
 			name:             "production executor pool below minimum is rejected and wrapped",
 			envName:          "prod_testnet",
 			committeeAliases: enough,
 			poolAliases:      tooFew,
-			wantErr:          fmt.Sprintf(`executor pool "default" validation failed: chain %q rejected`, chainSelector),
+			wantErr:          fmt.Sprintf(`executor pool "default" validation failed on chain %q`, chainSelector),
 		},
 		{
 			name:             "production topology meeting the minimum passes",
@@ -75,7 +75,7 @@ func TestEnvironmentTopologyValidateForEnvironment_ProductionMinimumNOPs(t *test
 			envName:          "prod_mainnet",
 			committeeAliases: append(testNOPAliases(testMinNOPs-1), "nop-1"),
 			poolAliases:      enough,
-			wantErr:          fmt.Sprintf(`committee "default" validation failed: chain %q rejected`, chainSelector),
+			wantErr:          fmt.Sprintf(`committee "default" validation failed on chain %q`, chainSelector),
 		},
 	}
 


### PR DESCRIPTION
### What
- Changes minimum number of NOPs to be verified per-chain-family 
- Changes tests to match this new pattern

### Why
- Some chain families such as EVM will need a minimum of 15 NOPs while others such as Canton will only need 4