### PR TITLE
 fix(solana): use pool config PDA instead of pool signer in PoolAddress

### DIFF
--- a/chains/solana/deployment/v1_6_0/adapters/cctp_chain.go
+++ b/chains/solana/deployment/v1_6_0/adapters/cctp_chain.go
@@ -242,7 +242,9 @@ func (c *SolanaCCTPChainAdapter) USDCType() adapters.USDCType {
 	return adapters.Canonical
 }
 
-// PoolAddress returns the Solana pool signer bytes. For Solana token pools, the signer PDA identifies the remote pool.
+// PoolAddress returns the Solana pool config PDA bytes. The pool config PDA is the canonical
+// pool identifier encoded in CCIP cross-chain messages and must be registered as the remote
+// pool address on counterpart EVM token pools.
 func (c *SolanaCCTPChainAdapter) PoolAddress(d datastore.DataStore, b chain.BlockChains, chainSelector uint64, registeredPoolRef datastore.AddressRef) ([]byte, error) {
 	tokenPool, err := datastore_utils.FindAndFormatRef(d, registeredPoolRef, chainSelector, sol_utils.ToAddress)
 	if err != nil {
@@ -253,11 +255,11 @@ func (c *SolanaCCTPChainAdapter) PoolAddress(d datastore.DataStore, b chain.Bloc
 	if err != nil {
 		return nil, err
 	}
-	poolSigner, err := sol_token_utils.TokenPoolSignerAddress(tokenMint, tokenPool)
+	poolConfigPDA, err := sol_token_utils.TokenPoolConfigAddress(tokenMint, tokenPool)
 	if err != nil {
-		return nil, fmt.Errorf("failed to derive Solana pool signer: %w", err)
+		return nil, fmt.Errorf("failed to derive Solana pool config PDA: %w", err)
 	}
-	return poolSigner.Bytes(), nil
+	return poolConfigPDA.Bytes(), nil
 }
 
 // TokenAddress returns the Solana USDC mint bytes for the configured CCTP pool.


### PR DESCRIPTION
 ## Summary

  - `SolanaCCTPChainAdapter.PoolAddress()` was returning the pool **signer** PDA
    (`TokenPoolSignerAddress`, seed `"ccip_tokenpool_signer"`) instead of the pool
    **config** PDA (`TokenPoolConfigAddress`, seed `"ccip_tokenpool_config"`).
  - The pool config PDA is the address the Solana CCTPTokenPool encodes as its pool
    identity in CCIP cross-chain messages. EVM counterpart pools (USDCTokenPool v1.6.5,
    USDCTokenPool v1.6.2) must register this address via `addRemotePool` /
    `applyChainUpdates` — not the signer.
  - As a result, every `DeployCCTPChains` run that included Solana as a remote registered
    the wrong address on EVM pools, causing CCIP message validation to fail for
    Solana→EVM lanes.

  ## Root cause

  Two distinct PDAs exist for a Solana token pool:

  | PDA | Seed | Role |
  |-----|------|------|
  | Pool config PDA | `["ccip_tokenpool_config", tokenMint]` | Canonical pool ID in CCIP messages |
  | Pool signer PDA | `["ccip_tokenpool_signer", tokenMint]` | Signs CPI calls (e.g. Circle `receiveMessage`) |
