### PR TITLE
feat: token expansion auto migrate remote chains

### DIFF
--- a/chains/evm/deployment/v1_0_0/adapters/address_normalizer.go
+++ b/chains/evm/deployment/v1_0_0/adapters/address_normalizer.go
@@ -19,3 +19,21 @@ func (EVMAddressNormalizer) NormalizeAddress(addr string) (string, error) {
 	}
 	return common.HexToAddress(addr).Hex(), nil
 }
+
+// BytesToString converts raw on-chain address bytes to an EIP-55 checksummed hex string. EVM addresses are
+// 20 bytes; values read off a pool (e.g. a remote token/pool) are commonly left-padded to 32 bytes, and
+// common.BytesToAddress takes the right-most 20 bytes, which is correct for that left-padded input.
+func (EVMAddressNormalizer) BytesToString(address []byte) (string, error) {
+	if len(address) == 0 {
+		return "", fmt.Errorf("address bytes cannot be empty")
+	}
+	return common.BytesToAddress(address).Hex(), nil
+}
+
+// StringToBytes converts a hex address string to its 20-byte representation.
+func (EVMAddressNormalizer) StringToBytes(address string) ([]byte, error) {
+	if !common.IsHexAddress(address) {
+		return nil, fmt.Errorf("address %q is not a valid hex address", address)
+	}
+	return common.HexToAddress(address).Bytes(), nil
+}

--- a/chains/evm/deployment/v2_0_0/adapters/tokens.go
+++ b/chains/evm/deployment/v2_0_0/adapters/tokens.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	evm1_0_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/adapters"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/operations/token_admin_registry"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/token_pool"
 	evm_tokens "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences/tokens"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
@@ -21,13 +22,15 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 )
 
 var (
-	_ tokens.TokenFeeAdapter = &TokenAdapter{}
-	_ tokens.TokenAdapter    = &TokenAdapter{}
+	_ tokens.TokenPoolMigrator = &TokenAdapter{}
+	_ tokens.TokenFeeAdapter   = &TokenAdapter{}
+	_ tokens.TokenAdapter      = &TokenAdapter{}
 )
 
 // TokenAdapter handles EVM token pools at version 2.0.0.
@@ -112,11 +115,124 @@ func (t *TokenAdapter) GetOnchainTokenTransferFeeConfig(e deployment.Environment
 	}, nil
 }
 
+// GetActivePool returns the pool currently registered for tokenRef in the TokenAdminRegistry (regRef) as raw
+// address bytes, or empty bytes when none is registered. The registry is taken from regRef when set, otherwise
+// resolved from the datastore (matching ConfigureTokenForTransfers) so callers need not pass a registry ref.
+// The read uses WithForceExecute because it reflects mutable on-chain state that may have been read (and cached)
+// earlier in this bundle.
+func (t *TokenAdapter) GetActivePool(e deployment.Environment, chainSelector uint64, regRef datastore.AddressRef, tokenRef datastore.AddressRef) ([]byte, error) {
+	evmChain, ok := e.BlockChains.EVMChains()[chainSelector]
+	if !ok {
+		return nil, fmt.Errorf("chain with selector %d not found", chainSelector)
+	}
+	registry, err := t.EVMTokenBase.GetTokenAdminRegistryAddress(e.DataStore, chainSelector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve TokenAdminRegistry from datastore on chain %d: %w", chainSelector, err)
+	}
+	token, err := t.EVMTokenBase.ParseNonZeroAddressRef(e.DataStore, tokenRef, chainSelector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse token address from ref %v on chain %d: %w", tokenRef, chainSelector, err)
+	}
+
+	report, err := cldf_ops.ExecuteOperation(
+		e.OperationsBundle,
+		token_admin_registry.GetTokenConfig, evmChain,
+		contract.FunctionInput[common.Address]{ChainSelector: chainSelector, Address: registry, Args: token},
+		cldf_ops.WithForceExecute[contract.FunctionInput[common.Address], evm.Chain](),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get token config from registry %s for token %s on chain %d: %w", registry.Hex(), token.Hex(), chainSelector, err)
+	}
+
+	activePool := report.Output.TokenPool
+	if activePool == (common.Address{}) {
+		return nil, nil // no active pool registered
+	}
+
+	return activePool.Bytes(), nil
+}
+
+// GetSupportedChains returns the remote chain selectors the pool at poolAddr is configured for.
+func (t *TokenAdapter) GetSupportedChains(e deployment.Environment, chainSelector uint64, poolAddr []byte) ([]uint64, error) {
+	evmChain, ok := e.BlockChains.EVMChains()[chainSelector]
+	if !ok {
+		return nil, fmt.Errorf("chain with selector %d not found", chainSelector)
+	}
+
+	report, err := cldf_ops.ExecuteOperation(
+		e.OperationsBundle,
+		token_pool.GetSupportedChains, evmChain,
+		contract.FunctionInput[struct{}]{ChainSelector: chainSelector, Address: common.BytesToAddress(poolAddr)},
+		cldf_ops.WithForceExecute[contract.FunctionInput[struct{}], evm.Chain](),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get supported chains from pool %s on chain %d: %w", common.BytesToAddress(poolAddr).Hex(), chainSelector, err)
+	}
+
+	return report.Output, nil
+}
+
+// GetRemoteToken returns the remote token (raw bytes) the pool at poolAddr uses for remoteSelector.
+func (t *TokenAdapter) GetRemoteToken(e deployment.Environment, chainSelector uint64, poolAddr []byte, remoteSelector uint64) ([]byte, error) {
+	evmChain, ok := e.BlockChains.EVMChains()[chainSelector]
+	if !ok {
+		return nil, fmt.Errorf("chain with selector %d not found", chainSelector)
+	}
+
+	report, err := cldf_ops.ExecuteOperation(
+		e.OperationsBundle,
+		token_pool.GetRemoteToken, evmChain,
+		contract.FunctionInput[uint64]{ChainSelector: chainSelector, Address: common.BytesToAddress(poolAddr), Args: remoteSelector},
+		cldf_ops.WithForceExecute[contract.FunctionInput[uint64], evm.Chain](),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get remote token for chain %d from pool %s: %w", remoteSelector, common.BytesToAddress(poolAddr).Hex(), err)
+	}
+
+	if len(report.Output) == 0 {
+		return nil, fmt.Errorf("pool %s has no remote token registered for chain %d", common.BytesToAddress(poolAddr).Hex(), remoteSelector)
+	}
+
+	return report.Output, nil
+}
+
+// GetRemotePool returns a remote pool (raw bytes) the pool at poolAddr is linked to for remoteSelector. The pool
+// may have more than one during a remote-side upgrade; returning the first valid one is sufficient — the per-chain
+// configure step re-reads and registers the full set, deduping this one.
+func (t *TokenAdapter) GetRemotePool(e deployment.Environment, chainSelector uint64, poolAddr []byte, remoteSelector uint64) ([]byte, error) {
+	evmChain, ok := e.BlockChains.EVMChains()[chainSelector]
+	if !ok {
+		return nil, fmt.Errorf("chain with selector %d not found", chainSelector)
+	}
+
+	report, err := cldf_ops.ExecuteOperation(
+		e.OperationsBundle,
+		token_pool.GetRemotePools, evmChain,
+		contract.FunctionInput[uint64]{ChainSelector: chainSelector, Address: common.BytesToAddress(poolAddr), Args: remoteSelector},
+		cldf_ops.WithForceExecute[contract.FunctionInput[uint64], evm.Chain](),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get remote pools for chain %d from pool %s: %w", remoteSelector, common.BytesToAddress(poolAddr).Hex(), err)
+	}
+
+	remotePools := report.Output
+	if len(remotePools) == 0 {
+		return nil, fmt.Errorf("pool %s has no remote pools registered for chain %d", common.BytesToAddress(poolAddr).Hex(), remoteSelector)
+	}
+	remotePool := remotePools[0]
+	if len(remotePool) == 0 {
+		return nil, fmt.Errorf("pool %s has a remote pool registered for chain %d but it is the zero address", common.BytesToAddress(poolAddr).Hex(), remoteSelector)
+	}
+
+	return remotePool, nil
+}
+
 // poolOpsV200 implements PoolOps using v2.0.0 bindings.
 type poolOpsV200 struct{}
 
 func (p *poolOpsV200) GetToken(b cldf_ops.Bundle, chain evm.Chain, poolAddr common.Address) (common.Address, error) {
-	res, err := cldf_ops.ExecuteOperation(b,
+	res, err := cldf_ops.ExecuteOperation(
+		b,
 		token_pool.GetToken, chain,
 		contract.FunctionInput[struct{}]{
 			ChainSelector: chain.Selector,
@@ -130,7 +246,8 @@ func (p *poolOpsV200) GetToken(b cldf_ops.Bundle, chain evm.Chain, poolAddr comm
 }
 
 func (p *poolOpsV200) GetTokenDecimals(b cldf_ops.Bundle, chain evm.Chain, poolAddr common.Address) (uint8, error) {
-	res, err := cldf_ops.ExecuteOperation(b,
+	res, err := cldf_ops.ExecuteOperation(
+		b,
 		token_pool.GetTokenDecimals, chain,
 		contract.FunctionInput[struct{}]{
 			ChainSelector: chain.Selector,
@@ -234,7 +351,8 @@ func (p *poolOpsV200) SetRateLimitAdmin(b cldf_ops.Bundle, chain evm.Chain, pool
 		return nil, nil
 	}
 
-	report, err := cldf_ops.ExecuteOperation(b,
+	report, err := cldf_ops.ExecuteOperation(
+		b,
 		token_pool.SetDynamicConfig, chain,
 		contract.FunctionInput[token_pool.SetDynamicConfigArgs]{
 			ChainSelector: chain.Selector,

--- a/chains/evm/deployment/v2_0_0/adapters/tokens.go
+++ b/chains/evm/deployment/v2_0_0/adapters/tokens.go
@@ -9,10 +9,12 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 
+	datastore_utils_evm "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/datastore"
 	evm1_0_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/adapters"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/operations/token_admin_registry"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/token_pool"
 	evm_tokens "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences/tokens"
+	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
 
 	tpBindingsV2_0_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v2_0_0/token_pool"
@@ -125,13 +127,25 @@ func (t *TokenAdapter) GetActivePool(e deployment.Environment, chainSelector uin
 	if !ok {
 		return nil, fmt.Errorf("chain with selector %d not found", chainSelector)
 	}
-	registry, err := t.EVMTokenBase.GetTokenAdminRegistryAddress(e.DataStore, chainSelector)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve TokenAdminRegistry from datastore on chain %d: %w", chainSelector, err)
-	}
+
 	token, err := t.EVMTokenBase.ParseNonZeroAddressRef(e.DataStore, tokenRef, chainSelector)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse token address from ref %v on chain %d: %w", tokenRef, chainSelector, err)
+	}
+
+	var registry common.Address
+	if datastore_utils.IsAddressRefEmpty(regRef) {
+		if addr, err := t.EVMTokenBase.GetTokenAdminRegistryAddress(e.DataStore, chainSelector); err != nil {
+			return nil, fmt.Errorf("failed to resolve TokenAdminRegistry from datastore on chain %d: %w", chainSelector, err)
+		} else {
+			registry = addr
+		}
+	} else {
+		if addr, err := datastore_utils.FindAndFormatRef(e.DataStore, regRef, chainSelector, datastore_utils_evm.ToNonZeroEVMAddress); err != nil {
+			return nil, fmt.Errorf("failed to resolve TokenAdminRegistry from ref %v on chain %d: %w", regRef, chainSelector, err)
+		} else {
+			registry = addr
+		}
 	}
 
 	report, err := cldf_ops.ExecuteOperation(

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_for_transfers.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_for_transfers.go
@@ -156,13 +156,13 @@ var ConfigureTokenForTransfers = cldf_ops.NewSequence(
 
 		// Configure token pool for all remote chains (validates active pool supported chains once when upgrading).
 		configureTokenPoolForRemoteChainsReport, err := cldf_ops.ExecuteSequence(b, ConfigureTokenPoolForRemoteChains, chains, ConfigureTokenPoolForRemoteChainsInput{
-			ChainSelector:     input.ChainSelector,
-			TokenPoolAddress:  tokenPoolAddress,
-			AdvancedPoolHooks: advancedPoolHooksAddress.Output,
-			RemoteChains:      input.RemoteChains,
-			RegistryAddress:   registryAddress,
-			TokenAddress:      tokenAddress,
-			AutoMigrateRemoteChains:       input.AutoMigrateRemoteChains,
+			ChainSelector:           input.ChainSelector,
+			TokenPoolAddress:        tokenPoolAddress,
+			AdvancedPoolHooks:       advancedPoolHooksAddress.Output,
+			RemoteChains:            input.RemoteChains,
+			RegistryAddress:         registryAddress,
+			TokenAddress:            tokenAddress,
+			AutoMigrateRemoteChains: input.AutoMigrateRemoteChains,
 		})
 		if err != nil {
 			return sequences.OnChainOutput{}, fmt.Errorf("failed to configure token pool for remote chains: %w", err)

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_for_transfers.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_for_transfers.go
@@ -155,14 +155,13 @@ var ConfigureTokenForTransfers = cldf_ops.NewSequence(
 		}
 
 		// Configure token pool for all remote chains (validates active pool supported chains once when upgrading).
-		configureTokenPoolForRemoteChainsReport, err := cldf_ops.ExecuteSequence(b, ConfigureTokenPoolForRemoteChains, chains, ConfigureTokenPoolForRemoteChainsInput{
-			ChainSelector:           input.ChainSelector,
-			TokenPoolAddress:        tokenPoolAddress,
-			AdvancedPoolHooks:       advancedPoolHooksAddress.Output,
-			RemoteChains:            input.RemoteChains,
-			RegistryAddress:         registryAddress,
-			TokenAddress:            tokenAddress,
-			AutoMigrateRemoteChains: input.AutoMigrateRemoteChains,
+		configureTokenPoolForRemoteChainsReport, err := cldf_ops.ExecuteSequence(b, ConfigureTokenPoolForRemoteChains, evmChain, ConfigureTokenPoolForRemoteChainsInput{
+			ChainSelector:     input.ChainSelector,
+			TokenPoolAddress:  tokenPoolAddress,
+			AdvancedPoolHooks: advancedPoolHooksAddress.Output,
+			RemoteChains:      input.RemoteChains,
+			RegistryAddress:   registryAddress,
+			TokenAddress:      tokenAddress,
 		})
 		if err != nil {
 			return sequences.OnChainOutput{}, fmt.Errorf("failed to configure token pool for remote chains: %w", err)

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_for_transfers.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_for_transfers.go
@@ -162,6 +162,7 @@ var ConfigureTokenForTransfers = cldf_ops.NewSequence(
 			RemoteChains:      input.RemoteChains,
 			RegistryAddress:   registryAddress,
 			TokenAddress:      tokenAddress,
+			AutoMigrate:       input.AutoMigrate,
 		})
 		if err != nil {
 			return sequences.OnChainOutput{}, fmt.Errorf("failed to configure token pool for remote chains: %w", err)

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_for_transfers.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_for_transfers.go
@@ -155,7 +155,7 @@ var ConfigureTokenForTransfers = cldf_ops.NewSequence(
 		}
 
 		// Configure token pool for all remote chains (validates active pool supported chains once when upgrading).
-		configureTokenPoolForRemoteChainsReport, err := cldf_ops.ExecuteSequence(b, ConfigureTokenPoolForRemoteChains, evmChain, ConfigureTokenPoolForRemoteChainsInput{
+		configureTokenPoolForRemoteChainsReport, err := cldf_ops.ExecuteSequence(b, ConfigureTokenPoolForRemoteChains, chains, ConfigureTokenPoolForRemoteChainsInput{
 			ChainSelector:     input.ChainSelector,
 			TokenPoolAddress:  tokenPoolAddress,
 			AdvancedPoolHooks: advancedPoolHooksAddress.Output,

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_for_transfers.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_for_transfers.go
@@ -162,7 +162,7 @@ var ConfigureTokenForTransfers = cldf_ops.NewSequence(
 			RemoteChains:      input.RemoteChains,
 			RegistryAddress:   registryAddress,
 			TokenAddress:      tokenAddress,
-			AutoMigrate:       input.AutoMigrate,
+			AutoMigrateRemoteChains:       input.AutoMigrateRemoteChains,
 		})
 		if err != nil {
 			return sequences.OnChainOutput{}, fmt.Errorf("failed to configure token pool for remote chains: %w", err)

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
@@ -7,14 +7,12 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/erc20"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/operations/token_admin_registry"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/token_pool"
+	evm_contract "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/operations/token_admin_registry"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
-	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
-	evm_contract "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	mcms_types "github.com/smartcontractkit/mcms/types"
 )
@@ -27,9 +25,6 @@ type ConfigureTokenPoolForRemoteChainsInput struct {
 	RemoteChains      map[uint64]tokens.RemoteChainConfig[[]byte, string]
 	RegistryAddress   common.Address
 	TokenAddress      common.Address
-	// AutoMigrateRemoteChains, when true, carries forward remote chains supported by the active pool but not
-	// explicitly listed in RemoteChains. Explicitly listed chains take precedence.
-	AutoMigrateRemoteChains bool
 }
 
 // ConfigureTokenPoolForRemoteChains runs the supported-chains check once (when registry/token set) then calls
@@ -38,82 +33,43 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 	"configure-token-pool-for-remote-chains",
 	semver.MustParse("2.0.0"),
 	"Configures a token pool for all configured remote chains; validates active pool supported chains when upgrading.",
-	func(b cldf_ops.Bundle, chains chain.BlockChains, input ConfigureTokenPoolForRemoteChainsInput) (output sequences.OnChainOutput, err error) {
-		evmChain, ok := chains.EVMChains()[input.ChainSelector]
-		if !ok {
-			return sequences.OnChainOutput{}, fmt.Errorf("chain with selector %d not found", input.ChainSelector)
-		}
+	func(b cldf_ops.Bundle, chain evm.Chain, input ConfigureTokenPoolForRemoteChainsInput) (output sequences.OnChainOutput, err error) {
 		// Active-pool validation: when RegistryAddress and TokenAddress are set, the registry's
 		// "active" pool for that token is queried. For USDC/CCTP the registered pool is the
 		// USDCTokenPoolProxy (so the router uses the proxy). The proxy does not implement
 		// getSupportedChains like a 2.0.0 TokenPool and may revert—so we treat this check as
 		// best-effort and skip validation when the call fails.
 		if input.RegistryAddress != (common.Address{}) && input.TokenAddress != (common.Address{}) {
-			// Force fresh execution: these reads reflect mutable on-chain state (the registry's active
-			// pool and that pool's supported chains). Idempotent caching could return a stale result if
-			// the same op+input ran earlier in this bundle, so we always re-read current state.
-			tokenConfigReport, err := cldf_ops.ExecuteOperation(
-				b,
-				token_admin_registry.GetTokenConfig, evmChain,
-				evm_contract.FunctionInput[common.Address]{
-					ChainSelector: input.ChainSelector,
-					Address:       input.RegistryAddress,
-					Args:          input.TokenAddress,
-				},
-				cldf_ops.WithForceExecute[evm_contract.FunctionInput[common.Address], evm.Chain](),
-			)
+			tokenConfigReport, err := cldf_ops.ExecuteOperation(b, token_admin_registry.GetTokenConfig, chain, evm_contract.FunctionInput[common.Address]{
+				ChainSelector: input.ChainSelector,
+				Address:       input.RegistryAddress,
+				Args:          input.TokenAddress,
+			})
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to get token config from registry for supported-chains check: %w", err)
 			}
 			activePool := tokenConfigReport.Output.TokenPool
 			if activePool != (common.Address{}) {
-				supportedChainsReport, err := cldf_ops.ExecuteOperation(
-					b,
-					token_pool.GetSupportedChains, evmChain,
-					evm_contract.FunctionInput[struct{}]{
-						ChainSelector: input.ChainSelector,
-						Address:       activePool,
-					},
-					cldf_ops.WithForceExecute[evm_contract.FunctionInput[struct{}], evm.Chain](),
-				)
+				supportedChainsReport, err := cldf_ops.ExecuteOperation(b, token_pool.GetSupportedChains, chain, evm_contract.FunctionInput[struct{}]{
+					ChainSelector: input.ChainSelector,
+					Address:       activePool,
+				})
 				if err == nil {
-					// For each chain the active pool supports but the operator did not list:
-					//   - AutoMigrateRemoteChains=false (default): error — the operator must list every active-pool chain (upgrade safety).
-					//   - AutoMigrateRemoteChains=true: discover the chain's remote token, remote pool, and remote decimals from the
-					//     active pool and carry it forward. Rate limits and remote pools are imported per-chain downstream
-					//     by ConfigureTokenPoolForRemoteChain (importConfigFromActivePool), so we only supply the fields
-					//     that import does not provide.
+					// Validate that remoteChains includes all chains the active pool already supports (upgrade safety).
 					supportedChains := supportedChainsReport.Output
 					for _, sel := range supportedChains {
-						if _, ok := input.RemoteChains[sel]; ok {
-							continue
-						}
-						if !input.AutoMigrateRemoteChains {
+						if _, ok := input.RemoteChains[sel]; !ok {
 							slices.Sort(supportedChains)
-							return sequences.OnChainOutput{}, fmt.Errorf(
-								"remoteChains must include all active pool supported chains: pool has %v, remoteChains has %v",
-								supportedChains, slices.Sorted(maps.Keys(input.RemoteChains)),
-							)
+							return sequences.OnChainOutput{}, fmt.Errorf("remoteChains must include all active pool supported chains: pool has %v, remoteChains has %v",
+								supportedChains, slices.Sorted(maps.Keys(input.RemoteChains)))
 						}
-						discovered, err := discoverRemoteChainFromActivePool(b, chains, evmChain, input.ChainSelector, activePool, sel)
-						if err != nil {
-							return sequences.OnChainOutput{}, fmt.Errorf("auto-migrate: failed to discover config for active pool chain %d: %w", sel, err)
-						}
-						if input.RemoteChains == nil {
-							input.RemoteChains = make(map[uint64]tokens.RemoteChainConfig[[]byte, string])
-						}
-						input.RemoteChains[sel] = discovered
 					}
-				} else {
-					// GetSupportedChains failed (e.g. the active pool is a USDCTokenPoolProxy, which reverts).
-					// We skip the supported-chains validation and auto-discovery. For AutoMigrateRemoteChains
-					// this is a silent no-op, so warn that no remote chains are carried forward from the active pool.
-					b.Logger.Warnf("configure-token-pool: could not read supported chains from active pool %s on chain %d (%v); skipping active-pool validation and auto-migrate discovery", activePool.Hex(), input.ChainSelector, err)
 				}
+				// If GetSupportedChains failed (e.g. active pool is USDCTokenPoolProxy and reverts), skip validation.
 			}
 		}
 		ops := make([]mcms_types.BatchOperation, 0)
-		supportedChainsReport, err := cldf_ops.ExecuteOperation(b, token_pool.GetSupportedChains, evmChain, evm_contract.FunctionInput[struct{}]{
+		supportedChainsReport, err := cldf_ops.ExecuteOperation(b, token_pool.GetSupportedChains, chain, evm_contract.FunctionInput[struct{}]{
 			ChainSelector: input.ChainSelector,
 			Address:       input.TokenPoolAddress,
 		})
@@ -126,7 +82,7 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 		}
 		for remoteChainSelector, remoteChainConfig := range input.RemoteChains {
 			_, alreadySupported := supportedSet[remoteChainSelector]
-			report, err := cldf_ops.ExecuteSequence(b, ConfigureTokenPoolForRemoteChain, evmChain, ConfigureTokenPoolForRemoteChainInput{
+			report, err := cldf_ops.ExecuteSequence(b, ConfigureTokenPoolForRemoteChain, chain, ConfigureTokenPoolForRemoteChainInput{
 				ChainSelector:               input.ChainSelector,
 				TokenPoolAddress:            input.TokenPoolAddress,
 				AdvancedPoolHooks:           input.AdvancedPoolHooks,
@@ -144,91 +100,3 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 		return sequences.OnChainOutput{BatchOps: ops}, nil
 	},
 )
-
-// discoverRemoteChainFromActivePool builds a RemoteChainConfig for a chain that the active pool supports but
-// the operator did not explicitly list (AutoMigrateRemoteChains). It reads the remote token and remote pool from the active
-// pool (on the local chain) and the remote token's decimals from the remote chain. Rate limits are intentionally
-// omitted: ConfigureTokenPoolForRemoteChain imports them (and the active pool's remote pools) per-chain via
-// importConfigFromActivePool, which also rebases pre-1.6.1 inbound limits using RemoteDecimals.
-func discoverRemoteChainFromActivePool(
-	b cldf_ops.Bundle,
-	chains chain.BlockChains,
-	localChain evm.Chain,
-	localChainSelector uint64,
-	activePool common.Address,
-	remoteChainSelector uint64,
-) (tokens.RemoteChainConfig[[]byte, string], error) {
-	var zero tokens.RemoteChainConfig[[]byte, string]
-	// Auto-discovery only supports EVM remotes (we read the remote token's ERC20 decimals below). A non-EVM
-	// remote (e.g. Solana) will not be present in EVMChains and errors here; operators must list such remotes
-	// explicitly in RemoteChains, which the caller skips before reaching discovery.
-	remoteChain, ok := chains.EVMChains()[remoteChainSelector]
-	if !ok {
-		return zero, fmt.Errorf("remote chain with selector %d not found among EVM chains; non-EVM remotes must be listed explicitly in remoteChains for auto-migrate", remoteChainSelector)
-	}
-
-	// Force fresh execution: these read the active pool's mutable remote config and must reflect
-	// current on-chain state rather than an idempotent cached result from earlier in the bundle.
-	remoteTokenReport, err := cldf_ops.ExecuteOperation(
-		b,
-		token_pool.GetRemoteToken, localChain,
-		evm_contract.FunctionInput[uint64]{
-			ChainSelector: localChainSelector,
-			Address:       activePool,
-			Args:          remoteChainSelector,
-		},
-		cldf_ops.WithForceExecute[evm_contract.FunctionInput[uint64], evm.Chain](),
-	)
-	if err != nil {
-		return zero, fmt.Errorf("failed to get remote token from active pool: %w", err)
-	}
-
-	remoteToken := remoteTokenReport.Output
-	if len(remoteToken) == 0 {
-		return zero, fmt.Errorf("active pool has no remote token registered for chain %d", remoteChainSelector)
-	}
-
-	remotePoolsReport, err := cldf_ops.ExecuteOperation(
-		b,
-		token_pool.GetRemotePools, localChain,
-		evm_contract.FunctionInput[uint64]{
-			ChainSelector: localChainSelector,
-			Address:       activePool,
-			Args:          remoteChainSelector,
-		},
-		cldf_ops.WithForceExecute[evm_contract.FunctionInput[uint64], evm.Chain](),
-	)
-	if err != nil {
-		return zero, fmt.Errorf("failed to get remote pools from active pool: %w", err)
-	}
-
-	remotePools := remotePoolsReport.Output
-	if len(remotePools) == 0 {
-		return zero, fmt.Errorf("active pool has no remote pool registered for chain %d", remoteChainSelector)
-	}
-
-	remotePool := remotePools[0]
-	if len(remotePool) == 0 {
-		return zero, fmt.Errorf("active pool's remote pool for chain %d is empty", remoteChainSelector)
-	}
-
-	decimalsReport, err := cldf_ops.ExecuteOperation(b, erc20.GetDecimals, remoteChain, evm_contract.FunctionInput[struct{}]{
-		ChainSelector: remoteChainSelector,
-		Address:       common.BytesToAddress(remoteToken),
-	})
-	if err != nil {
-		return zero, fmt.Errorf(
-			"failed to get decimals for remote token %s on chain %d (only ERC20-compatible tokens are supported for auto-migrate): %w",
-			common.BytesToAddress(remoteToken).Hex(), remoteChainSelector, err,
-		)
-	}
-
-	// NOTE: getRemotePools can return >1 address during a remote-side upgrade. `RemotePool` only needs
-	// one valid (already-registered) address — ConfigureTokenPoolForRemoteChain re-reads and registers
-	// the full list (deduping this one), so picking [0] drops nothing.
-	return tokens.RemoteChainConfig[[]byte, string]{
-		RemoteDecimals: decimalsReport.Output,
-		RemoteToken:    remoteToken,
-		RemotePool:     remotePool,
-	}, nil
-}

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
@@ -49,20 +49,33 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 		// getSupportedChains like a 2.0.0 TokenPool and may revert—so we treat this check as
 		// best-effort and skip validation when the call fails.
 		if input.RegistryAddress != (common.Address{}) && input.TokenAddress != (common.Address{}) {
-			tokenConfigReport, err := cldf_ops.ExecuteOperation(b, token_admin_registry.GetTokenConfig, chain, evm_contract.FunctionInput[common.Address]{
-				ChainSelector: input.ChainSelector,
-				Address:       input.RegistryAddress,
-				Args:          input.TokenAddress,
-			})
+			// Force fresh execution: these reads reflect mutable on-chain state (the registry's active
+			// pool and that pool's supported chains). Idempotent caching could return a stale result if
+			// the same op+input ran earlier in this bundle, so we always re-read current state.
+			tokenConfigReport, err := cldf_ops.ExecuteOperation(
+				b,
+				token_admin_registry.GetTokenConfig, chain,
+				evm_contract.FunctionInput[common.Address]{
+					ChainSelector: input.ChainSelector,
+					Address:       input.RegistryAddress,
+					Args:          input.TokenAddress,
+				},
+				cldf_ops.WithForceExecute[evm_contract.FunctionInput[common.Address], evm.Chain](),
+			)
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to get token config from registry for supported-chains check: %w", err)
 			}
 			activePool := tokenConfigReport.Output.TokenPool
 			if activePool != (common.Address{}) {
-				supportedChainsReport, err := cldf_ops.ExecuteOperation(b, token_pool.GetSupportedChains, chain, evm_contract.FunctionInput[struct{}]{
-					ChainSelector: input.ChainSelector,
-					Address:       activePool,
-				})
+				supportedChainsReport, err := cldf_ops.ExecuteOperation(
+					b,
+					token_pool.GetSupportedChains, chain,
+					evm_contract.FunctionInput[struct{}]{
+						ChainSelector: input.ChainSelector,
+						Address:       activePool,
+					},
+					cldf_ops.WithForceExecute[evm_contract.FunctionInput[struct{}], evm.Chain](),
+				)
 				if err == nil {
 					// For each chain the active pool supports but the operator did not list:
 					//   - AutoMigrateRemoteChains=false (default): error — the operator must list every active-pool chain (upgrade safety).
@@ -147,11 +160,18 @@ func discoverRemoteChainFromActivePool(
 		return zero, fmt.Errorf("remote chain with selector %d not found in environment", remoteChainSelector)
 	}
 
-	remoteTokenReport, err := cldf_ops.ExecuteOperation(b, token_pool.GetRemoteToken, localChain, evm_contract.FunctionInput[uint64]{
-		ChainSelector: localChainSelector,
-		Address:       activePool,
-		Args:          remoteChainSelector,
-	})
+	// Force fresh execution: these read the active pool's mutable remote config and must reflect
+	// current on-chain state rather than an idempotent cached result from earlier in the bundle.
+	remoteTokenReport, err := cldf_ops.ExecuteOperation(
+		b,
+		token_pool.GetRemoteToken, localChain,
+		evm_contract.FunctionInput[uint64]{
+			ChainSelector: localChainSelector,
+			Address:       activePool,
+			Args:          remoteChainSelector,
+		},
+		cldf_ops.WithForceExecute[evm_contract.FunctionInput[uint64], evm.Chain](),
+	)
 	if err != nil {
 		return zero, fmt.Errorf("failed to get remote token from active pool: %w", err)
 	}
@@ -161,11 +181,16 @@ func discoverRemoteChainFromActivePool(
 		return zero, fmt.Errorf("active pool has no remote token registered for chain %d", remoteChainSelector)
 	}
 
-	remotePoolsReport, err := cldf_ops.ExecuteOperation(b, token_pool.GetRemotePools, localChain, evm_contract.FunctionInput[uint64]{
-		ChainSelector: localChainSelector,
-		Address:       activePool,
-		Args:          remoteChainSelector,
-	})
+	remotePoolsReport, err := cldf_ops.ExecuteOperation(
+		b,
+		token_pool.GetRemotePools, localChain,
+		evm_contract.FunctionInput[uint64]{
+			ChainSelector: localChainSelector,
+			Address:       activePool,
+			Args:          remoteChainSelector,
+		},
+		cldf_ops.WithForceExecute[evm_contract.FunctionInput[uint64], evm.Chain](),
+	)
 	if err != nil {
 		return zero, fmt.Errorf("failed to get remote pools from active pool: %w", err)
 	}

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
@@ -7,12 +7,14 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
-	evm_contract "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/erc20"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/operations/token_admin_registry"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	evm_contract "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	mcms_types "github.com/smartcontractkit/mcms/types"
 )
@@ -62,14 +64,32 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 					Address:       activePool,
 				})
 				if err == nil {
-					// Validate that remoteChains includes all chains the active pool already supports (upgrade safety).
+					// For each chain the active pool supports but the operator did not list:
+					//   - AutoMigrate=false (default): error — the operator must list every active-pool chain (upgrade safety).
+					//   - AutoMigrate=true: discover the chain's remote token, remote pool, and remote decimals from the
+					//     active pool and carry it forward. Rate limits and remote pools are imported per-chain downstream
+					//     by ConfigureTokenPoolForRemoteChain (importConfigFromActivePool), so we only supply the fields
+					//     that import does not provide.
 					supportedChains := supportedChainsReport.Output
 					for _, sel := range supportedChains {
-						if _, ok := input.RemoteChains[sel]; !ok {
-							slices.Sort(supportedChains)
-							return sequences.OnChainOutput{}, fmt.Errorf("remoteChains must include all active pool supported chains: pool has %v, remoteChains has %v",
-								supportedChains, slices.Sorted(maps.Keys(input.RemoteChains)))
+						if _, ok := input.RemoteChains[sel]; ok {
+							continue
 						}
+						if !input.AutoMigrate {
+							slices.Sort(supportedChains)
+							return sequences.OnChainOutput{}, fmt.Errorf(
+								"remoteChains must include all active pool supported chains: pool has %v, remoteChains has %v",
+								supportedChains, slices.Sorted(maps.Keys(input.RemoteChains)),
+							)
+						}
+						discovered, err := discoverRemoteChainFromActivePool(b, chains, chain, input.ChainSelector, activePool, sel)
+						if err != nil {
+							return sequences.OnChainOutput{}, fmt.Errorf("auto-migrate: failed to discover config for active pool chain %d: %w", sel, err)
+						}
+						if input.RemoteChains == nil {
+							input.RemoteChains = make(map[uint64]tokens.RemoteChainConfig[[]byte, string])
+						}
+						input.RemoteChains[sel] = discovered
 					}
 				}
 				// If GetSupportedChains failed (e.g. active pool is USDCTokenPoolProxy and reverts), skip validation.
@@ -107,3 +127,76 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 		return sequences.OnChainOutput{BatchOps: ops}, nil
 	},
 )
+
+// discoverRemoteChainFromActivePool builds a RemoteChainConfig for a chain that the active pool supports but
+// the operator did not explicitly list (AutoMigrate). It reads the remote token and remote pool from the active
+// pool (on the local chain) and the remote token's decimals from the remote chain. Rate limits are intentionally
+// omitted: ConfigureTokenPoolForRemoteChain imports them (and the active pool's remote pools) per-chain via
+// importConfigFromActivePool, which also rebases pre-1.6.1 inbound limits using RemoteDecimals.
+func discoverRemoteChainFromActivePool(
+	b cldf_ops.Bundle,
+	chains chain.BlockChains,
+	localChain evm.Chain,
+	localChainSelector uint64,
+	activePool common.Address,
+	remoteChainSelector uint64,
+) (tokens.RemoteChainConfig[[]byte, string], error) {
+	var zero tokens.RemoteChainConfig[[]byte, string]
+	remoteChain, ok := chains.EVMChains()[remoteChainSelector]
+	if !ok {
+		return zero, fmt.Errorf("remote chain with selector %d not found in environment", remoteChainSelector)
+	}
+
+	remoteTokenReport, err := cldf_ops.ExecuteOperation(b, token_pool.GetRemoteToken, localChain, evm_contract.FunctionInput[uint64]{
+		ChainSelector: localChainSelector,
+		Address:       activePool,
+		Args:          remoteChainSelector,
+	})
+	if err != nil {
+		return zero, fmt.Errorf("failed to get remote token from active pool: %w", err)
+	}
+
+	remoteToken := remoteTokenReport.Output
+	if len(remoteToken) == 0 {
+		return zero, fmt.Errorf("active pool has no remote token registered for chain %d", remoteChainSelector)
+	}
+
+	remotePoolsReport, err := cldf_ops.ExecuteOperation(b, token_pool.GetRemotePools, localChain, evm_contract.FunctionInput[uint64]{
+		ChainSelector: localChainSelector,
+		Address:       activePool,
+		Args:          remoteChainSelector,
+	})
+	if err != nil {
+		return zero, fmt.Errorf("failed to get remote pools from active pool: %w", err)
+	}
+
+	remotePools := remotePoolsReport.Output
+	if len(remotePools) == 0 {
+		return zero, fmt.Errorf("active pool has no remote pool registered for chain %d", remoteChainSelector)
+	}
+
+	remotePool := remotePools[0]
+	if len(remotePool) == 0 {
+		return zero, fmt.Errorf("active pool's remote pool for chain %d is empty", remoteChainSelector)
+	}
+
+	decimalsReport, err := cldf_ops.ExecuteOperation(b, erc20.GetDecimals, remoteChain, evm_contract.FunctionInput[struct{}]{
+		ChainSelector: remoteChainSelector,
+		Address:       common.BytesToAddress(remoteToken),
+	})
+	if err != nil {
+		return zero, fmt.Errorf(
+			"failed to get decimals for remote token %s on chain %d (only ERC20-compatible tokens are supported for auto-migrate): %w",
+			common.BytesToAddress(remoteToken).Hex(), remoteChainSelector, err,
+		)
+	}
+
+	// NOTE: getRemotePools can return >1 address during a remote-side upgrade. `RemotePool` only needs
+	// one valid (already-registered) address — ConfigureTokenPoolForRemoteChain re-reads and registers
+	// the full list (deduping this one), so picking [0] drops nothing.
+	return tokens.RemoteChainConfig[[]byte, string]{
+		RemoteDecimals: decimalsReport.Output,
+		RemoteToken:    remoteToken,
+		RemotePool:     remotePool,
+	}, nil
+}

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/token_pool"
 	evm_contract "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/operations/token_admin_registry"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
-	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	mcms_types "github.com/smartcontractkit/mcms/types"
 )
@@ -33,7 +33,11 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 	"configure-token-pool-for-remote-chains",
 	semver.MustParse("2.0.0"),
 	"Configures a token pool for all configured remote chains; validates active pool supported chains when upgrading.",
-	func(b cldf_ops.Bundle, chain evm.Chain, input ConfigureTokenPoolForRemoteChainsInput) (output sequences.OnChainOutput, err error) {
+	func(b cldf_ops.Bundle, chains chain.BlockChains, input ConfigureTokenPoolForRemoteChainsInput) (output sequences.OnChainOutput, err error) {
+		chain, ok := chains.EVMChains()[input.ChainSelector]
+		if !ok {
+			return sequences.OnChainOutput{}, fmt.Errorf("chain with selector %d not found", input.ChainSelector)
+		}
 		// Active-pool validation: when RegistryAddress and TokenAddress are set, the registry's
 		// "active" pool for that token is queried. For USDC/CCTP the registered pool is the
 		// USDCTokenPoolProxy (so the router uses the proxy). The proxy does not implement

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
@@ -25,6 +25,9 @@ type ConfigureTokenPoolForRemoteChainsInput struct {
 	RemoteChains      map[uint64]tokens.RemoteChainConfig[[]byte, string]
 	RegistryAddress   common.Address
 	TokenAddress      common.Address
+	// AutoMigrate, when true, carries forward remote chains supported by the active pool but not
+	// explicitly listed in RemoteChains. Explicitly listed chains take precedence.
+	AutoMigrate bool
 }
 
 // ConfigureTokenPoolForRemoteChains runs the supported-chains check once (when registry/token set) then calls

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/token_pool"
-	evm_contract "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/operations/token_admin_registry"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	evm_contract "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	mcms_types "github.com/smartcontractkit/mcms/types"
 )
@@ -44,7 +44,7 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 				ChainSelector: input.ChainSelector,
 				Address:       input.RegistryAddress,
 				Args:          input.TokenAddress,
-			})
+			}, cldf_ops.WithForceExecute[evm_contract.FunctionInput[common.Address], evm.Chain]())
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to get token config from registry for supported-chains check: %w", err)
 			}
@@ -53,7 +53,7 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 				supportedChainsReport, err := cldf_ops.ExecuteOperation(b, token_pool.GetSupportedChains, chain, evm_contract.FunctionInput[struct{}]{
 					ChainSelector: input.ChainSelector,
 					Address:       activePool,
-				})
+				}, cldf_ops.WithForceExecute[evm_contract.FunctionInput[struct{}], evm.Chain]())
 				if err == nil {
 					// Validate that remoteChains includes all chains the active pool already supports (upgrade safety).
 					supportedChains := supportedChainsReport.Output

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
@@ -27,9 +27,9 @@ type ConfigureTokenPoolForRemoteChainsInput struct {
 	RemoteChains      map[uint64]tokens.RemoteChainConfig[[]byte, string]
 	RegistryAddress   common.Address
 	TokenAddress      common.Address
-	// AutoMigrate, when true, carries forward remote chains supported by the active pool but not
+	// AutoMigrateRemoteChains, when true, carries forward remote chains supported by the active pool but not
 	// explicitly listed in RemoteChains. Explicitly listed chains take precedence.
-	AutoMigrate bool
+	AutoMigrateRemoteChains bool
 }
 
 // ConfigureTokenPoolForRemoteChains runs the supported-chains check once (when registry/token set) then calls
@@ -65,8 +65,8 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 				})
 				if err == nil {
 					// For each chain the active pool supports but the operator did not list:
-					//   - AutoMigrate=false (default): error — the operator must list every active-pool chain (upgrade safety).
-					//   - AutoMigrate=true: discover the chain's remote token, remote pool, and remote decimals from the
+					//   - AutoMigrateRemoteChains=false (default): error — the operator must list every active-pool chain (upgrade safety).
+					//   - AutoMigrateRemoteChains=true: discover the chain's remote token, remote pool, and remote decimals from the
 					//     active pool and carry it forward. Rate limits and remote pools are imported per-chain downstream
 					//     by ConfigureTokenPoolForRemoteChain (importConfigFromActivePool), so we only supply the fields
 					//     that import does not provide.
@@ -75,7 +75,7 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 						if _, ok := input.RemoteChains[sel]; ok {
 							continue
 						}
-						if !input.AutoMigrate {
+						if !input.AutoMigrateRemoteChains {
 							slices.Sort(supportedChains)
 							return sequences.OnChainOutput{}, fmt.Errorf(
 								"remoteChains must include all active pool supported chains: pool has %v, remoteChains has %v",
@@ -129,7 +129,7 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 )
 
 // discoverRemoteChainFromActivePool builds a RemoteChainConfig for a chain that the active pool supports but
-// the operator did not explicitly list (AutoMigrate). It reads the remote token and remote pool from the active
+// the operator did not explicitly list (AutoMigrateRemoteChains). It reads the remote token and remote pool from the active
 // pool (on the local chain) and the remote token's decimals from the remote chain. Rate limits are intentionally
 // omitted: ConfigureTokenPoolForRemoteChain imports them (and the active pool's remote pools) per-chain via
 // importConfigFromActivePool, which also rebases pre-1.6.1 inbound limits using RemoteDecimals.

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
@@ -39,7 +39,7 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 	semver.MustParse("2.0.0"),
 	"Configures a token pool for all configured remote chains; validates active pool supported chains when upgrading.",
 	func(b cldf_ops.Bundle, chains chain.BlockChains, input ConfigureTokenPoolForRemoteChainsInput) (output sequences.OnChainOutput, err error) {
-		chain, ok := chains.EVMChains()[input.ChainSelector]
+		evmChain, ok := chains.EVMChains()[input.ChainSelector]
 		if !ok {
 			return sequences.OnChainOutput{}, fmt.Errorf("chain with selector %d not found", input.ChainSelector)
 		}
@@ -54,7 +54,7 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 			// the same op+input ran earlier in this bundle, so we always re-read current state.
 			tokenConfigReport, err := cldf_ops.ExecuteOperation(
 				b,
-				token_admin_registry.GetTokenConfig, chain,
+				token_admin_registry.GetTokenConfig, evmChain,
 				evm_contract.FunctionInput[common.Address]{
 					ChainSelector: input.ChainSelector,
 					Address:       input.RegistryAddress,
@@ -69,7 +69,7 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 			if activePool != (common.Address{}) {
 				supportedChainsReport, err := cldf_ops.ExecuteOperation(
 					b,
-					token_pool.GetSupportedChains, chain,
+					token_pool.GetSupportedChains, evmChain,
 					evm_contract.FunctionInput[struct{}]{
 						ChainSelector: input.ChainSelector,
 						Address:       activePool,
@@ -95,7 +95,7 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 								supportedChains, slices.Sorted(maps.Keys(input.RemoteChains)),
 							)
 						}
-						discovered, err := discoverRemoteChainFromActivePool(b, chains, chain, input.ChainSelector, activePool, sel)
+						discovered, err := discoverRemoteChainFromActivePool(b, chains, evmChain, input.ChainSelector, activePool, sel)
 						if err != nil {
 							return sequences.OnChainOutput{}, fmt.Errorf("auto-migrate: failed to discover config for active pool chain %d: %w", sel, err)
 						}
@@ -104,12 +104,16 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 						}
 						input.RemoteChains[sel] = discovered
 					}
+				} else {
+					// GetSupportedChains failed (e.g. the active pool is a USDCTokenPoolProxy, which reverts).
+					// We skip the supported-chains validation and auto-discovery. For AutoMigrateRemoteChains
+					// this is a silent no-op, so warn that no remote chains are carried forward from the active pool.
+					b.Logger.Warnf("configure-token-pool: could not read supported chains from active pool %s on chain %d (%v); skipping active-pool validation and auto-migrate discovery", activePool.Hex(), input.ChainSelector, err)
 				}
-				// If GetSupportedChains failed (e.g. active pool is USDCTokenPoolProxy and reverts), skip validation.
 			}
 		}
 		ops := make([]mcms_types.BatchOperation, 0)
-		supportedChainsReport, err := cldf_ops.ExecuteOperation(b, token_pool.GetSupportedChains, chain, evm_contract.FunctionInput[struct{}]{
+		supportedChainsReport, err := cldf_ops.ExecuteOperation(b, token_pool.GetSupportedChains, evmChain, evm_contract.FunctionInput[struct{}]{
 			ChainSelector: input.ChainSelector,
 			Address:       input.TokenPoolAddress,
 		})
@@ -122,7 +126,7 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 		}
 		for remoteChainSelector, remoteChainConfig := range input.RemoteChains {
 			_, alreadySupported := supportedSet[remoteChainSelector]
-			report, err := cldf_ops.ExecuteSequence(b, ConfigureTokenPoolForRemoteChain, chain, ConfigureTokenPoolForRemoteChainInput{
+			report, err := cldf_ops.ExecuteSequence(b, ConfigureTokenPoolForRemoteChain, evmChain, ConfigureTokenPoolForRemoteChainInput{
 				ChainSelector:               input.ChainSelector,
 				TokenPoolAddress:            input.TokenPoolAddress,
 				AdvancedPoolHooks:           input.AdvancedPoolHooks,
@@ -155,9 +159,12 @@ func discoverRemoteChainFromActivePool(
 	remoteChainSelector uint64,
 ) (tokens.RemoteChainConfig[[]byte, string], error) {
 	var zero tokens.RemoteChainConfig[[]byte, string]
+	// Auto-discovery only supports EVM remotes (we read the remote token's ERC20 decimals below). A non-EVM
+	// remote (e.g. Solana) will not be present in EVMChains and errors here; operators must list such remotes
+	// explicitly in RemoteChains, which the caller skips before reaching discovery.
 	remoteChain, ok := chains.EVMChains()[remoteChainSelector]
 	if !ok {
-		return zero, fmt.Errorf("remote chain with selector %d not found in environment", remoteChainSelector)
+		return zero, fmt.Errorf("remote chain with selector %d not found among EVM chains; non-EVM remotes must be listed explicitly in remoteChains for auto-migrate", remoteChainSelector)
 	}
 
 	// Force fresh execution: these read the active pool's mutable remote config and must reflect

--- a/chains/solana/deployment/v1_0_0/adapters/address_normalizer.go
+++ b/chains/solana/deployment/v1_0_0/adapters/address_normalizer.go
@@ -20,3 +20,20 @@ func (SolanaAddressNormalizer) NormalizeAddress(addr string) (string, error) {
 	}
 	return pubKey.String(), nil
 }
+
+// BytesToString converts raw on-chain address bytes (a 32-byte public key) to its canonical base58 string.
+func (SolanaAddressNormalizer) BytesToString(address []byte) (string, error) {
+	if len(address) != solana.PublicKeyLength {
+		return "", fmt.Errorf("solana address must be %d bytes, got %d", solana.PublicKeyLength, len(address))
+	}
+	return solana.PublicKeyFromBytes(address).String(), nil
+}
+
+// StringToBytes converts a base58 Solana public key string to its 32-byte representation.
+func (SolanaAddressNormalizer) StringToBytes(address string) ([]byte, error) {
+	pubKey, err := solana.PublicKeyFromBase58(address)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse address '%s' as base58 Solana public key: %w", address, err)
+	}
+	return pubKey.Bytes(), nil
+}

--- a/deployment/deploy/product.go
+++ b/deployment/deploy/product.go
@@ -118,6 +118,8 @@ type LaneVersionResolver interface {
 // of pool contracts is orthogonal).
 type AddressNormalizer interface {
 	NormalizeAddress(address string) (string, error)
+	BytesToString(address []byte) (string, error)
+	StringToBytes(address string) ([]byte, error)
 }
 
 type addressNormalizerID string

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -51,6 +51,13 @@ type TokenTransferConfig struct {
 	// LiquidityMigrationBasisPoints specifies a percentage of the old pool's balance to migrate (1-10000, where 10000 = 100%).
 	// Mutually exclusive with LiquidityMigrationAmount.
 	LiquidityMigrationBasisPoints *uint16 `yaml:"liquidityMigrationBasisPoints,string" json:"liquidityMigrationBasisPoints,string"`
+	// AutoMigrate, when true, instructs the configure step to carry forward all remote chains that the
+	// currently-active pool supports but that are not explicitly listed in RemoteChains. Discovered chains
+	// (and their rate limits, remote pools, and remote tokens) are imported from the active pool; any chain
+	// listed explicitly in RemoteChains takes precedence over its discovered config. When false (the default),
+	// the configure step requires RemoteChains to include every chain the active pool supports and errors
+	// otherwise. Only used by EVM v2.0.0 adapters.
+	AutoMigrate bool `yaml:"autoMigrate" json:"autoMigrate"`
 }
 
 // ConfigureTokensForTransfersConfig is the configuration for the ConfigureTokensForTransfers changeset.
@@ -171,6 +178,7 @@ func processTokenConfigForChain(e cldf.Environment, mcmsRegistry *changesets.MCM
 			LiquidityMigrationAmount:      token.LiquidityMigrationAmount,
 			LiquidityMigrationBasisPoints: token.LiquidityMigrationBasisPoints,
 			TimelockAddress:               timelockAddress,
+			AutoMigrate:                   token.AutoMigrate,
 		})
 		if err != nil {
 			return batchOps, reports, nil, fmt.Errorf("failed to configure token pool on chain with selector %d: %w", selector, err)

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -52,16 +52,22 @@ type TokenTransferConfig struct {
 	// LiquidityMigrationBasisPoints specifies a percentage of the old pool's balance to migrate (1-10000, where 10000 = 100%).
 	// Mutually exclusive with LiquidityMigrationAmount.
 	LiquidityMigrationBasisPoints *uint16 `yaml:"liquidityMigrationBasisPoints,string" json:"liquidityMigrationBasisPoints,string"`
-	// AutoMigrateRemoteChains, when true, instructs the configure step to carry forward all remote chains that the
-	// currently-active pool supports but that are not explicitly listed in RemoteChains. Discovered chains
-	// (and their rate limits, remote pools, and remote tokens) are imported from the active pool; any chain
-	// listed explicitly in RemoteChains takes precedence over its discovered config. When false (the default),
-	// the configure step requires RemoteChains to include every chain the active pool supports and errors
-	// otherwise. Only used by adapters that implement TokenPoolMigrator (currently EVM v2.0.0).
+	// AutoMigrateRemoteChains, when true, runs discovery in this changeset (before the adapter sequence):
+	// it reads the pool currently registered in the TAR, enumerates its supported remote chains, and fills
+	// in any missing RemoteChains entries (token, pool, decimals). Rate limits are imported later by
+	// ConfigureTokenPoolForRemoteChain from the active pool. Explicit RemoteChains entries take precedence.
+	// Requires an adapter implementing TokenPoolMigrator (EVM v2.0.0 today).
 	//
-	// Discovery resolves each remote chain's token decimals through that chain family's adapter, so it works for
-	// EVM and non-EVM remotes (e.g. Solana) alike. Remote addresses read from the active pool are converted to
-	// each family's canonical form via the AddressNormalizer registry before being resolved.
+	// When false (default), this changeset does not discover remotes. Upgrade safety is enforced downstream
+	// by ConfigureTokenPoolForRemoteChains (EVM v2.0.0), which errors if RemoteChains omits a chain the
+	// active pool already supports.
+	//
+	// Discovery resolves remote token decimals via each remote chain family's adapter; remote pool addresses
+	// are normalized via the AddressNormalizer registry before ResolveTokenPoolRef.
+	//
+	// Limitation: discovery calls getSupportedChains on the TAR-registered active pool. Pools that do not
+	// implement that interface (e.g. USDCTokenPoolProxy) cause auto-migrate to fail; list remote chains
+	// explicitly in that case.
 	AutoMigrateRemoteChains bool `yaml:"autoMigrateRemoteChains" json:"autoMigrateRemoteChains"`
 }
 
@@ -247,7 +253,6 @@ func processTokenConfigForChain(e cldf.Environment, mcmsRegistry *changesets.MCM
 			LiquidityMigrationAmount:      token.LiquidityMigrationAmount,
 			LiquidityMigrationBasisPoints: token.LiquidityMigrationBasisPoints,
 			TimelockAddress:               timelockAddress,
-			AutoMigrateRemoteChains:       token.AutoMigrateRemoteChains,
 		})
 		if err != nil {
 			return batchOps, reports, nil, fmt.Errorf("failed to configure token pool on chain with selector %d: %w", selector, err)

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -51,13 +51,13 @@ type TokenTransferConfig struct {
 	// LiquidityMigrationBasisPoints specifies a percentage of the old pool's balance to migrate (1-10000, where 10000 = 100%).
 	// Mutually exclusive with LiquidityMigrationAmount.
 	LiquidityMigrationBasisPoints *uint16 `yaml:"liquidityMigrationBasisPoints,string" json:"liquidityMigrationBasisPoints,string"`
-	// AutoMigrate, when true, instructs the configure step to carry forward all remote chains that the
+	// AutoMigrateRemoteChains, when true, instructs the configure step to carry forward all remote chains that the
 	// currently-active pool supports but that are not explicitly listed in RemoteChains. Discovered chains
 	// (and their rate limits, remote pools, and remote tokens) are imported from the active pool; any chain
 	// listed explicitly in RemoteChains takes precedence over its discovered config. When false (the default),
 	// the configure step requires RemoteChains to include every chain the active pool supports and errors
 	// otherwise. Only used by EVM v2.0.0 adapters.
-	AutoMigrate bool `yaml:"autoMigrate" json:"autoMigrate"`
+	AutoMigrateRemoteChains bool `yaml:"autoMigrateRemoteChains" json:"autoMigrateRemoteChains"`
 }
 
 // ConfigureTokensForTransfersConfig is the configuration for the ConfigureTokensForTransfers changeset.
@@ -178,7 +178,7 @@ func processTokenConfigForChain(e cldf.Environment, mcmsRegistry *changesets.MCM
 			LiquidityMigrationAmount:      token.LiquidityMigrationAmount,
 			LiquidityMigrationBasisPoints: token.LiquidityMigrationBasisPoints,
 			TimelockAddress:               timelockAddress,
-			AutoMigrate:                   token.AutoMigrate,
+			AutoMigrateRemoteChains:                   token.AutoMigrateRemoteChains,
 		})
 		if err != nil {
 			return batchOps, reports, nil, fmt.Errorf("failed to configure token pool on chain with selector %d: %w", selector, err)

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -13,6 +13,7 @@ import (
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	mcms_types "github.com/smartcontractkit/mcms/types"
 
+	"github.com/smartcontractkit/chainlink-ccip/deployment/deploy"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/fees"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/finality"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
@@ -56,12 +57,11 @@ type TokenTransferConfig struct {
 	// (and their rate limits, remote pools, and remote tokens) are imported from the active pool; any chain
 	// listed explicitly in RemoteChains takes precedence over its discovered config. When false (the default),
 	// the configure step requires RemoteChains to include every chain the active pool supports and errors
-	// otherwise. Only used by EVM v2.0.0 adapters.
+	// otherwise. Only used by adapters that implement TokenPoolMigrator (currently EVM v2.0.0).
 	//
-	// Auto-discovery only supports EVM remote chains, because it reads the remote token's ERC20 decimals from
-	// the remote chain. Non-EVM remotes (e.g. Solana) must be listed explicitly in RemoteChains — explicitly
-	// listed chains are skipped by discovery and used as provided, so a mixed-family token can list its non-EVM
-	// remotes and let AutoMigrateRemoteChains carry forward the EVM ones.
+	// Discovery resolves each remote chain's token decimals through that chain family's adapter, so it works for
+	// EVM and non-EVM remotes (e.g. Solana) alike. Remote addresses read from the active pool are converted to
+	// each family's canonical form via the AddressNormalizer registry before being resolved.
 	AutoMigrateRemoteChains bool `yaml:"autoMigrateRemoteChains" json:"autoMigrateRemoteChains"`
 }
 
@@ -104,6 +104,7 @@ func makeApply(_ *TokenAdapterRegistry, mcmsRegistry *changesets.MCMSReaderRegis
 }
 
 func processTokenConfigForChain(e cldf.Environment, mcmsRegistry *changesets.MCMSReaderRegistry, mcmsInput mcms.Input, cfg map[uint64]TokenTransferConfig) ([]mcms_types.BatchOperation, []cldf_ops.Report[any, any], *datastore.MemoryDataStore, error) {
+	normalizerRegistry := deploy.GetAddressNormalizerRegistry()
 	tokenRegistry := GetTokenAdapterRegistry()
 	batchOps := make([]mcms_types.BatchOperation, 0)
 	reports := make([]cldf_ops.Report[any, any], 0)
@@ -156,6 +157,69 @@ func processTokenConfigForChain(e cldf.Environment, mcmsRegistry *changesets.MCM
 			}
 		}
 
+		if token.AutoMigrateRemoteChains {
+			localMigrator, ok := adapter.(TokenPoolMigrator)
+			if !ok {
+				return nil, nil, nil, fmt.Errorf("adapter for chain selector %d does not support token pool migration, which is required for auto-migrating remote chains", selector)
+			}
+			activePool, err := localMigrator.GetActivePool(e, selector, token.RegistryRef, fullTokenRef)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("failed to get active pool for token pool on chain selector %d: %w", selector, err)
+			}
+			allRemotes := []uint64{}
+			if len(activePool) > 0 {
+				// An empty active pool means the token has no currently-registered pool (e.g. a brand-new token)
+				// so there are no remotes to carry forward and allRemotes stays nil (the loop below is a no-op).
+				if supported, err := localMigrator.GetSupportedChains(e, selector, activePool); err != nil {
+					return nil, nil, nil, fmt.Errorf("failed to get supported remote chains for token pool on chain selector %d: %w", selector, err)
+				} else {
+					allRemotes = supported
+				}
+			}
+			for _, remoteSelector := range allRemotes {
+				if _, ok := remoteChains[remoteSelector]; !ok {
+					remoteFamily, err := chain_selectors.GetSelectorFamily(remoteSelector)
+					if err != nil {
+						return nil, nil, nil, fmt.Errorf("failed to get chain family for remote chain selector %d: %w", remoteSelector, err)
+					}
+					remoteNormalizer, ok := normalizerRegistry.GetAddressNormalizer(remoteFamily)
+					if !ok {
+						return nil, nil, nil, fmt.Errorf("no address normalizer found for chain family %s of remote chain selector %d", remoteFamily, remoteSelector)
+					}
+					remoteTokenBytes, err := localMigrator.GetRemoteToken(e, selector, activePool, remoteSelector)
+					if err != nil {
+						return nil, nil, nil, fmt.Errorf("failed to get remote token for remote chain selector %d: %w", remoteSelector, err)
+					}
+					remotePoolBytes, err := localMigrator.GetRemotePool(e, selector, activePool, remoteSelector)
+					if err != nil {
+						return nil, nil, nil, fmt.Errorf("failed to get remote pools for remote chain selector %d: %w", remoteSelector, err)
+					}
+					remotePoolAddr, err := remoteNormalizer.BytesToString(remotePoolBytes)
+					if err != nil {
+						return nil, nil, nil, fmt.Errorf("failed to normalize remote pool address for remote chain selector %d: %w", remoteSelector, err)
+					}
+					remotePoolRef, err := ResolveTokenPoolRef(e, tokenRegistry, remoteSelector, datastore.AddressRef{Address: remotePoolAddr})
+					if err != nil {
+						return nil, nil, nil, fmt.Errorf("failed to resolve token pool ref for remote chain selector %d: %w", remoteSelector, err)
+					}
+					remoteAdapter, _, err := ResolveAdapter(tokenRegistry, remoteSelector, remotePoolRef.Version)
+					if err != nil {
+						return nil, nil, nil, fmt.Errorf("failed to resolve adapter for remote chain selector %d: %w", remoteSelector, err)
+					}
+					remoteTokenDecimals, err := remoteAdapter.DeriveTokenDecimals(e, remoteSelector, remotePoolRef, remoteTokenBytes)
+					if err != nil {
+						return nil, nil, nil, fmt.Errorf("failed to derive remote token decimals for remote chain selector %d: %w", remoteSelector, err)
+					}
+					remoteChains[remoteSelector] = RemoteChainConfig[[]byte, string]{
+						// We only need to set a few fields here - the other ones will be imported later downstream
+						RemoteDecimals: remoteTokenDecimals,
+						RemoteToken:    remoteTokenBytes,
+						RemotePool:     remotePoolBytes,
+					}
+				}
+			}
+		}
+
 		// Resolve the timelock address if a liquidity migration is requested.
 		var timelockAddress string
 		if token.LiquidityMigrationAmount != nil || token.LiquidityMigrationBasisPoints != nil {
@@ -201,7 +265,8 @@ func processTokenConfigForChain(e cldf.Environment, mcmsRegistry *changesets.MCM
 			srcPoolVers := tokenPool.Version
 			srcTokenRef := fullTokenRef
 			srcSelector := selector
-			output, err := maybeApplyTokenTransferFeeConfig(e,
+			output, err := maybeApplyTokenTransferFeeConfig(
+				e,
 				srcPoolVers,
 				srcSelector,
 				dstSelector,
@@ -316,7 +381,8 @@ func maybeApplyTokenTransferFeeConfig(
 	}
 
 	// Apply the token transfer fee config
-	result, err := cldf_ops.ExecuteSequence(e.OperationsBundle,
+	result, err := cldf_ops.ExecuteSequence(
+		e.OperationsBundle,
 		adapter.SetTokenTransferFee(e, feeRef),
 		e.BlockChains,
 		fees.SetTokenTransferFeeSequenceInput{

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -57,6 +57,11 @@ type TokenTransferConfig struct {
 	// listed explicitly in RemoteChains takes precedence over its discovered config. When false (the default),
 	// the configure step requires RemoteChains to include every chain the active pool supports and errors
 	// otherwise. Only used by EVM v2.0.0 adapters.
+	//
+	// Auto-discovery only supports EVM remote chains, because it reads the remote token's ERC20 decimals from
+	// the remote chain. Non-EVM remotes (e.g. Solana) must be listed explicitly in RemoteChains — explicitly
+	// listed chains are skipped by discovery and used as provided, so a mixed-family token can list its non-EVM
+	// remotes and let AutoMigrateRemoteChains carry forward the EVM ones.
 	AutoMigrateRemoteChains bool `yaml:"autoMigrateRemoteChains" json:"autoMigrateRemoteChains"`
 }
 
@@ -178,7 +183,7 @@ func processTokenConfigForChain(e cldf.Environment, mcmsRegistry *changesets.MCM
 			LiquidityMigrationAmount:      token.LiquidityMigrationAmount,
 			LiquidityMigrationBasisPoints: token.LiquidityMigrationBasisPoints,
 			TimelockAddress:               timelockAddress,
-			AutoMigrateRemoteChains:                   token.AutoMigrateRemoteChains,
+			AutoMigrateRemoteChains:       token.AutoMigrateRemoteChains,
 		})
 		if err != nil {
 			return batchOps, reports, nil, fmt.Errorf("failed to configure token pool on chain with selector %d: %w", selector, err)

--- a/deployment/tokens/product.go
+++ b/deployment/tokens/product.go
@@ -74,6 +74,24 @@ type RateLimitReaderAdapter interface {
 	) (RateLimiterConfig, error)
 }
 
+// TokenPoolMigrator is an optional interface implemented by adapters that can read an existing pool's
+// cross-chain configuration on-chain. It powers AutoMigrateRemoteChains: during an upgrade, the remote
+// chains/tokens/pools the active pool is configured for are read back (as raw bytes) and carried forward
+// onto the new pool. All addresses are raw on-chain bytes so the interface stays chain-family-agnostic;
+// callers convert them per family via the AddressNormalizer registry when a string form is needed.
+type TokenPoolMigrator interface {
+	// GetActivePool returns the pool currently registered for the token (tokenRef) in the TokenAdminRegistry
+	// (regRef), as raw address bytes. Returns empty bytes (no error) when no pool is registered.
+	GetActivePool(e deployment.Environment, chainSelector uint64, regRef datastore.AddressRef, tokenRef datastore.AddressRef) ([]byte, error)
+	// GetSupportedChains returns the remote chain selectors the pool at poolAddr is configured for.
+	GetSupportedChains(e deployment.Environment, chainSelector uint64, poolAddr []byte) ([]uint64, error)
+	// GetRemoteToken returns the remote token (raw bytes) the pool at poolAddr uses for remoteSelector.
+	GetRemoteToken(e deployment.Environment, chainSelector uint64, poolAddr []byte, remoteSelector uint64) ([]byte, error)
+	// GetRemotePool returns a remote pool (raw bytes) the pool at poolAddr is linked to for remoteSelector.
+	// A pool may have more than one during a remote-side upgrade; one valid entry is sufficient for the caller.
+	GetRemotePool(e deployment.Environment, chainSelector uint64, poolAddr []byte, remoteSelector uint64) ([]byte, error)
+}
+
 // TokenAdapter defines the interface that each chain family + token pool version combo must implement to support cross-chain token configuration.
 type TokenAdapter interface {
 	// ConfigureTokenForTransfersSequence returns a sequence that configures a token pool for cross-chain transfers.

--- a/deployment/tokens/product.go
+++ b/deployment/tokens/product.go
@@ -315,9 +315,9 @@ type ConfigureTokenForTransfersInput struct {
 	// TimelockAddress is the MCMS timelock address, resolved by the changeset from MCMS config.
 	// Required when a liquidity migration is triggered.
 	TimelockAddress string
-	// AutoMigrate, when true, carries forward remote chains supported by the active pool but not
+	// AutoMigrateRemoteChains, when true, carries forward remote chains supported by the active pool but not
 	// explicitly listed in RemoteChains. Explicitly listed chains take precedence. Only used by EVM adapters.
-	AutoMigrate bool
+	AutoMigrateRemoteChains bool
 	// Below are not provided by the user and populated programmatically.
 	// ExistingDataStore is the datastore containing existing deployment data.
 	ExistingDataStore datastore.DataStore

--- a/deployment/tokens/product.go
+++ b/deployment/tokens/product.go
@@ -315,6 +315,9 @@ type ConfigureTokenForTransfersInput struct {
 	// TimelockAddress is the MCMS timelock address, resolved by the changeset from MCMS config.
 	// Required when a liquidity migration is triggered.
 	TimelockAddress string
+	// AutoMigrate, when true, carries forward remote chains supported by the active pool but not
+	// explicitly listed in RemoteChains. Explicitly listed chains take precedence. Only used by EVM adapters.
+	AutoMigrate bool
 	// Below are not provided by the user and populated programmatically.
 	// ExistingDataStore is the datastore containing existing deployment data.
 	ExistingDataStore datastore.DataStore

--- a/deployment/tokens/product.go
+++ b/deployment/tokens/product.go
@@ -333,9 +333,6 @@ type ConfigureTokenForTransfersInput struct {
 	// TimelockAddress is the MCMS timelock address, resolved by the changeset from MCMS config.
 	// Required when a liquidity migration is triggered.
 	TimelockAddress string
-	// AutoMigrateRemoteChains, when true, carries forward remote chains supported by the active pool but not
-	// explicitly listed in RemoteChains. Explicitly listed chains take precedence. Only used by EVM adapters.
-	AutoMigrateRemoteChains bool
 	// Below are not provided by the user and populated programmatically.
 	// ExistingDataStore is the datastore containing existing deployment data.
 	ExistingDataStore datastore.DataStore

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -393,7 +393,10 @@ func tokenExpansionApply() func(cldf.Environment, TokenExpansionInput) (cldf.Cha
 						allRemotes[remoteSelector] = remoteConfig
 					}
 				}
-				if len(input.TokenTransferConfig.RemoteChains) != 0 {
+				// Reach the configure step when remote chains are explicitly listed OR when AutoMigrateRemoteChains
+				// is set (the latter discovers the active pool's remote chains downstream, so an empty RemoteChains
+				// is valid and must not be skipped here).
+				if len(input.TokenTransferConfig.RemoteChains) != 0 || input.TokenTransferConfig.AutoMigrateRemoteChains {
 					allTokenConfigs[selector] = *input.TokenTransferConfig
 				}
 			}

--- a/integration-tests/deployment/helpers.go
+++ b/integration-tests/deployment/helpers.go
@@ -90,7 +90,8 @@ func SolanaTransferOwnership(t *testing.T, e *cldf_deployment.Environment, selec
 	timelockSigner := utils.GetTimelockSignerPDA(
 		e.DataStore.Addresses().Filter(),
 		chain.Selector,
-		common_utils.CLLQualifier)
+		common_utils.CLLQualifier,
+	)
 	mcmSigner := utils.GetMCMSignerPDA(
 		e.DataStore.Addresses().Filter(),
 		chain.Selector,
@@ -217,7 +218,8 @@ func SolanaTransferMCMSContracts(t *testing.T, e *cldf_deployment.Environment, s
 	timelockSigner := utils.GetTimelockSignerPDA(
 		e.DataStore.Addresses().Filter(),
 		chain.Selector,
-		qualifier)
+		qualifier,
+	)
 	mcmSigner := utils.GetMCMSignerPDA(
 		e.DataStore.Addresses().Filter(),
 		chain.Selector,
@@ -478,15 +480,17 @@ func DeployChainContractsV2_0_0(t *testing.T, e *cldf_deployment.Environment, cu
 
 func RequireBigIntsEqual(t *testing.T, want, got *big.Int, msg string) {
 	t.Helper()
-	w := want
-	if w == nil {
-		w = big.NewInt(0)
-	}
-	g := got
-	if g == nil {
-		g = big.NewInt(0)
-	}
-	require.Zero(t, w.Cmp(g), "%s: want %s got %s", msg, w.String(), g.String())
+	require.NotNil(t, got, msg)
+	require.Zero(t, want.Cmp(got), "%s: want %s got %s", msg, want.String(), got.String())
+}
+
+// RequireBigIntApprox asserts |want-got| <= tolerance. Used for rate-limit values where GenerateTPRLConfigs'
+// float64 x1.1 premium introduces sub-token rounding noise that differs across pool-version code paths.
+func RequireBigIntsApprox(t *testing.T, want, got *big.Int, tolerance int64, msg string) {
+	t.Helper()
+	require.NotNil(t, got, msg)
+	diff := new(big.Int).Abs(new(big.Int).Sub(want, got))
+	require.LessOrEqualf(t, diff.Cmp(big.NewInt(tolerance)), 0, "%s: want ~%s got %s (diff %s > tolerance %d)", msg, want, got, diff, tolerance)
 }
 
 func NewRandHex(t *testing.T, nBytes int) string {

--- a/integration-tests/deployment/helpers.go
+++ b/integration-tests/deployment/helpers.go
@@ -484,7 +484,7 @@ func RequireBigIntsEqual(t *testing.T, want, got *big.Int, msg string) {
 	require.Zero(t, want.Cmp(got), "%s: want %s got %s", msg, want.String(), got.String())
 }
 
-// RequireBigIntApprox asserts |want-got| <= tolerance. Used for rate-limit values where GenerateTPRLConfigs'
+// RequireBigIntsApprox asserts |want-got| <= tolerance. Used for rate-limit values where GenerateTPRLConfigs'
 // float64 x1.1 premium introduces sub-token rounding noise that differs across pool-version code paths.
 func RequireBigIntsApprox(t *testing.T, want, got *big.Int, tolerance int64, msg string) {
 	t.Helper()

--- a/integration-tests/deployment/token_expansion_migration_test.go
+++ b/integration-tests/deployment/token_expansion_migration_test.go
@@ -1,0 +1,293 @@
+package deployment
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/stretchr/testify/require"
+
+	evm_datastore_utils "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/datastore"
+	bnmERC20ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/burn_mint_erc20"
+	bnmOpsV2_0_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/burn_mint_token_pool"
+	evmtokensseq "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences/tokens"
+	tarbindings "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/token_admin_registry"
+	tokenpoolV2_0_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v2_0_0/token_pool"
+	tokensapi "github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
+	cciputils "github.com/smartcontractkit/chainlink-ccip/deployment/utils"
+	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	evmseqV1_6_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/sequences"
+
+	_ "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_1/adapters"
+	_ "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_1/adapters"
+	_ "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/adapters"
+)
+
+// Chain A is 18 decimals, chain B is 6 decimals. The decimal mismatch exercises the pre-1.6.1 inbound
+// rate-limit decimal rebasing in the auto-migrate import path.
+const (
+	migDecimalsA = 18
+	migDecimalsB = 6
+)
+
+// legacyBnMPair is the result of deploying and connecting a legacy BurnMint pool pair across two chains,
+// used as the starting point for v2.0 upgrade tests.
+type legacyBnMPair struct {
+	env          *deployment.Environment
+	selA, selB   uint64
+	tokAddrA     common.Address
+	tokAddrB     common.Address
+	oldPoolAddrA common.Address
+	oldPoolAddrB common.Address
+	tarAddrA     common.Address
+}
+
+// setupLegacyConnectedBnMPair deploys v2.0 core contracts on two chains, then deploys a legacy
+// (oldPoolVersion) BurnMint token+pool pair, connects them bidirectionally, and registers each in its
+// TokenAdminRegistry. It returns the resolved addresses for use in upgrade tests.
+func setupLegacyConnectedBnMPair(t *testing.T, oldPoolVersion *semver.Version) legacyBnMPair {
+	t.Helper()
+
+	const tokenSymbolA = "MIG_TOK_A"
+	const tokenSymbolB = "MIG_TOK_B"
+
+	selA := chainsel.TEST_90000001.Selector
+	selB := chainsel.TEST_90000002.Selector
+
+	e, err := environment.New(t.Context(), environment.WithEVMSimulated(t, []uint64{selA, selB}))
+	require.NoError(t, err)
+
+	// Deploy v2.0 core contracts (deployer-owned, so changesets run with the deployer key and no MCMS).
+	cumulative := datastore.NewMemoryDataStore()
+	DeployChainContractsV2_0_0(t, e, cumulative, selA)
+	DeployChainContractsV2_0_0(t, e, cumulative, selB)
+	e.DataStore = cumulative.Seal()
+
+	defaultRL := tokensapi.RateLimiterConfigFloatInput{IsEnabled: true, Capacity: 100, Rate: 10}
+	maxSupply := uint64(1e6)
+	oldPoolQualA := "MIG_OLD_POOL_A"
+	oldPoolQualB := "MIG_OLD_POOL_B"
+	bmPoolType := cciputils.BurnMintTokenPool
+
+	// Deploy a legacy BurnMint pool pair (token + pool on each chain), connect them, and register in TAR.
+	oldOut, err := tokensapi.TokenExpansion().Apply(*e, tokensapi.TokenExpansionInput{
+		ChainAdapterVersion: cciputils.Version_1_6_0,
+		MCMS:                mcms.Input{},
+		TokenExpansionInputPerChain: map[uint64]tokensapi.TokenExpansionInputPerChain{
+			selA: {
+				SkipOwnershipTransfer: true,
+				TokenPoolVersion:      oldPoolVersion,
+				DeployTokenInput: &tokensapi.DeployTokenInput{
+					Name: "Migration Token A", Symbol: tokenSymbolA, Decimals: migDecimalsA,
+					Type: bnmERC20ops.ContractType, Supply: &maxSupply,
+				},
+				DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
+					TokenPoolQualifier: oldPoolQualA,
+					PoolType:           bmPoolType.String(),
+				},
+				TokenTransferConfig: &tokensapi.TokenTransferConfig{
+					RemoteChains: map[uint64]tokensapi.RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
+						selB: {OutboundRateLimiterConfig: &defaultRL},
+					},
+				},
+			},
+			selB: {
+				SkipOwnershipTransfer: true,
+				TokenPoolVersion:      oldPoolVersion,
+				DeployTokenInput: &tokensapi.DeployTokenInput{
+					Name: "Migration Token B", Symbol: tokenSymbolB, Decimals: migDecimalsB,
+					Type: bnmERC20ops.ContractType, Supply: &maxSupply,
+				},
+				DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
+					TokenPoolQualifier: oldPoolQualB,
+					PoolType:           bmPoolType.String(),
+				},
+				TokenTransferConfig: &tokensapi.TokenTransferConfig{
+					RemoteChains: map[uint64]tokensapi.RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
+						selA: {OutboundRateLimiterConfig: &defaultRL},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	MergeAddresses(t, e, oldOut.DataStore)
+
+	evmAdapter := evmseqV1_6_0.EVMAdapter{}
+	chainA := e.BlockChains.EVMChains()[selA]
+
+	oldPoolAddrA, err := evmAdapter.FindLatestAddressRef(e.DataStore, datastore.AddressRef{ChainSelector: selA, Qualifier: oldPoolQualA, Type: datastore.ContractType(bmPoolType)})
+	require.NoError(t, err)
+	oldPoolAddrB, err := evmAdapter.FindLatestAddressRef(e.DataStore, datastore.AddressRef{ChainSelector: selB, Qualifier: oldPoolQualB, Type: datastore.ContractType(bmPoolType)})
+	require.NoError(t, err)
+	tokAddrA, err := evmAdapter.FindOneTokenAddress(e.DataStore, selA, &datastore.AddressRef{Qualifier: tokenSymbolA})
+	require.NoError(t, err)
+	tokAddrB, err := evmAdapter.FindOneTokenAddress(e.DataStore, selB, &datastore.AddressRef{Qualifier: tokenSymbolB})
+	require.NoError(t, err)
+
+	// Sanity-check: old pool A is connected to B and is the active pool in the TAR.
+	// getSupportedChains is ABI-identical across pool versions, so the v2.0 binding reads any version.
+	oldPoolA, err := tokenpoolV2_0_0.NewTokenPool(oldPoolAddrA, chainA.Client)
+	require.NoError(t, err)
+	oldSupported, err := oldPoolA.GetSupportedChains(&bind.CallOpts{Context: t.Context()})
+	require.NoError(t, err)
+	require.Contains(t, oldSupported, selB, "old pool A should support chain B before upgrade")
+
+	tarAddrA, err := evmAdapter.GetTokenAdminRegistryAddress(e.DataStore, selA)
+	require.NoError(t, err)
+	tarA, err := tarbindings.NewTokenAdminRegistry(tarAddrA, chainA.Client)
+	require.NoError(t, err)
+	cfgBefore, err := tarA.GetTokenConfig(&bind.CallOpts{Context: t.Context()}, tokAddrA)
+	require.NoError(t, err)
+	require.Equal(t, oldPoolAddrA, cfgBefore.TokenPool, "active pool before upgrade should be the legacy pool")
+
+	return legacyBnMPair{
+		env:          e,
+		selA:         selA,
+		selB:         selB,
+		tokAddrA:     tokAddrA,
+		tokAddrB:     tokAddrB,
+		oldPoolAddrA: oldPoolAddrA,
+		oldPoolAddrB: oldPoolAddrB,
+		tarAddrA:     tarAddrA,
+	}
+}
+
+// TestTokenExpansionMigration_AutoMigrateRemoteChains exercises the AutoMigrateRemoteChains upgrade path:
+// it deploys a legacy BurnMint pool pair, connects them, then upgrades chain A's pool to v2.0 using
+// AutoMigrateRemoteChains with an EMPTY RemoteChains map. The new pool must inherit chain B as a supported
+// remote (token + remote pool + rate limits carried forward from the active pool), and the TokenAdminRegistry
+// must be switched to point at the new pool — all without the operator listing any remote chains.
+//
+// Both legacy versions are covered: v1.5.1 (< 1.6.1) stores inbound rate limits in remote/source decimals and
+// is rebased on import; v1.6.1 (>= 1.6.1) stores them in local decimals and is imported as-is. With chain A at
+// 18 decimals and chain B at 6 decimals, both paths must converge (within float ULP) on the same on-chain
+// values for the new pool, which validates the inbound decimal rebasing end-to-end.
+func TestTokenExpansionMigration_AutoMigrateRemoteChains(t *testing.T) {
+	cases := []struct {
+		name           string
+		oldPoolVersion *semver.Version
+	}{
+		{"v1_5_1_to_v2_0_0", cciputils.Version_1_5_1},
+		{"v1_6_1_to_v2_0_0", cciputils.Version_1_6_1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runAutoMigrateRemoteChainsUpgrade(t, tc.oldPoolVersion)
+		})
+	}
+}
+
+func runAutoMigrateRemoteChainsUpgrade(t *testing.T, oldPoolVersion *semver.Version) {
+	s := setupLegacyConnectedBnMPair(t, oldPoolVersion)
+	e, selA, selB := s.env, s.selA, s.selB
+	chainA := e.BlockChains.EVMChains()[selA]
+
+	// Upgrade chain A's pool to v2.0 using AutoMigrateRemoteChains with an EMPTY RemoteChains map.
+	// Chain B must be discovered from the active pool.
+	newPoolQualA := "MIG_NEW_POOL_A"
+	upgradeOut, err := tokensapi.TokenExpansion().Apply(*e, tokensapi.TokenExpansionInput{
+		ChainAdapterVersion: cciputils.Version_2_0_0,
+		MCMS:                mcms.Input{},
+		TokenExpansionInputPerChain: map[uint64]tokensapi.TokenExpansionInputPerChain{
+			selA: {
+				SkipOwnershipTransfer: true,
+				TokenPoolVersion:      bnmOpsV2_0_0.Version,
+				DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
+					TokenPoolQualifier: newPoolQualA,
+					PoolType:           bnmOpsV2_0_0.ContractType.String(),
+					TokenRef:           &datastore.AddressRef{Address: s.tokAddrA.Hex()},
+				},
+				TokenTransferConfig: &tokensapi.TokenTransferConfig{
+					// No remote chains listed — they must be discovered from the active pool.
+					AutoMigrateRemoteChains: true,
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	MergeAddresses(t, e, upgradeOut.DataStore)
+
+	// Assert the new v2.0 pool inherited chain B and the TAR switched.
+	newPoolRef := datastore.AddressRef{ChainSelector: selA, Type: datastore.ContractType(bnmOpsV2_0_0.ContractType), Version: bnmOpsV2_0_0.Version, Qualifier: newPoolQualA}
+	newPoolAddrA, err := datastore_utils.FindAndFormatRef(e.DataStore, newPoolRef, selA, evm_datastore_utils.ToEVMAddress)
+	require.NoError(t, err)
+	require.NotEqual(t, s.oldPoolAddrA, newPoolAddrA, "new pool must be a distinct contract from the old pool")
+	newPoolA, err := tokenpoolV2_0_0.NewTokenPool(newPoolAddrA, chainA.Client)
+	require.NoError(t, err)
+
+	// The new pool supports chain B even though the operator never listed it.
+	newSupported, err := newPoolA.GetSupportedChains(&bind.CallOpts{Context: t.Context()})
+	require.NoError(t, err)
+	require.Contains(t, newSupported, selB, "auto-migrated new pool A should support chain B")
+
+	// Remote token carried forward from the active pool.
+	gotRemoteToken, err := newPoolA.GetRemoteToken(&bind.CallOpts{Context: t.Context()}, selB)
+	require.NoError(t, err)
+	require.Equal(t, common.LeftPadBytes(s.tokAddrB.Bytes(), 32), gotRemoteToken, "remote token for chain B should be carried forward")
+
+	// Remote pool carried forward — the old remote pool (pool B) must be among the registered remotes.
+	gotRemotePools, err := newPoolA.GetRemotePools(&bind.CallOpts{Context: t.Context()}, selB)
+	require.NoError(t, err)
+	require.Contains(t, gotRemotePools, common.LeftPadBytes(s.oldPoolAddrB.Bytes(), 32), "remote pool B should be carried forward")
+
+	// Rate limits carried forward and decimal-correct (all expressed in chain A's 18 decimals).
+	// Outbound is scaled by local decimals with no premium, so it is exact for both versions. Inbound is
+	// the counterpart's outbound + 10%; the x1.1 introduces a float64 rounding artifact in GenerateTPRLConfigs
+	// whose magnitude differs between the rebased (v1.5.1) and native (v1.6.1) paths, so we assert inbound
+	// within a tolerance far below 1 token yet far above any decimal-magnitude error (which would be off by
+	// factors of 10^6 or more).
+	e18 := new(big.Int).Exp(big.NewInt(10), big.NewInt(migDecimalsA), nil)
+	const rlTolerance = int64(1e9) // ~1e-9 tokens at 18 decimals; absorbs float ULP, catches decimal bugs
+	rl, err := newPoolA.GetCurrentRateLimiterState(&bind.CallOpts{Context: t.Context()}, selB, false)
+	require.NoError(t, err)
+	require.True(t, rl.OutboundRateLimiterState.IsEnabled, "outbound rate limit should be enabled")
+	RequireBigIntsEqual(t, new(big.Int).Mul(big.NewInt(100), e18), rl.OutboundRateLimiterState.Capacity, "outbound capacity")
+	RequireBigIntsEqual(t, new(big.Int).Mul(big.NewInt(10), e18), rl.OutboundRateLimiterState.Rate, "outbound rate")
+	require.True(t, rl.InboundRateLimiterState.IsEnabled, "inbound rate limit should be enabled")
+	RequireBigIntsApprox(t, new(big.Int).Mul(big.NewInt(110), e18), rl.InboundRateLimiterState.Capacity, rlTolerance, "inbound capacity")
+	RequireBigIntsApprox(t, new(big.Int).Mul(big.NewInt(11), e18), rl.InboundRateLimiterState.Rate, rlTolerance, "inbound rate")
+
+	// The TokenAdminRegistry now points at the new pool.
+	tarA, err := tarbindings.NewTokenAdminRegistry(s.tarAddrA, chainA.Client)
+	require.NoError(t, err)
+	cfgAfter, err := tarA.GetTokenConfig(&bind.CallOpts{Context: t.Context()}, s.tokAddrA)
+	require.NoError(t, err)
+	require.Equal(t, newPoolAddrA, cfgAfter.TokenPool, "TAR should be switched to the new v2.0 pool")
+}
+
+// TestTokenExpansionMigration_RequiresAllChainsWithoutAutoMigrate is the negative case: when
+// AutoMigrateRemoteChains is false (the default), configuring a v2.0 pool over an existing active pool must
+// still error if RemoteChains does not include every chain the active pool supports. This preserves the
+// pre-existing upgrade-safety check. We invoke the ConfigureTokenPoolForRemoteChains sequence directly with
+// an empty RemoteChains so the active pool's supported chain (B) is missing.
+func TestTokenExpansionMigration_RequiresAllChainsWithoutAutoMigrate(t *testing.T) {
+	s := setupLegacyConnectedBnMPair(t, cciputils.Version_1_5_1)
+
+	// RegistryAddress + TokenAddress are set, so the active-pool supported-chains check runs. The active
+	// pool (old pool A) supports chain B, which is absent from RemoteChains and the flag is off → error.
+	_, err := cldf_ops.ExecuteSequence(
+		s.env.OperationsBundle,
+		evmtokensseq.ConfigureTokenPoolForRemoteChains,
+		s.env.BlockChains,
+		evmtokensseq.ConfigureTokenPoolForRemoteChainsInput{
+			ChainSelector:           s.selA,
+			TokenPoolAddress:        s.oldPoolAddrA, // unused before the error returns
+			RegistryAddress:         s.tarAddrA,
+			TokenAddress:            s.tokAddrA,
+			RemoteChains:            nil,
+			AutoMigrateRemoteChains: false,
+		},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "remoteChains must include all active pool supported chains")
+}

--- a/integration-tests/deployment/token_expansion_migration_test.go
+++ b/integration-tests/deployment/token_expansion_migration_test.go
@@ -51,6 +51,58 @@ type legacyBnMPair struct {
 	tarAddrA     common.Address
 }
 
+// TestTokenExpansionMigration_AutoMigrateRemoteChains exercises the AutoMigrateRemoteChains upgrade path:
+// it deploys a legacy BurnMint pool pair, connects them, then upgrades chain A's pool to v2.0 using
+// AutoMigrateRemoteChains with an EMPTY RemoteChains map. The new pool must inherit chain B as a supported
+// remote (token + remote pool + rate limits carried forward from the active pool), and the TokenAdminRegistry
+// must be switched to point at the new pool — all without the operator listing any remote chains.
+//
+// Both legacy versions are covered: v1.5.1 (< 1.6.1) stores inbound rate limits in remote/source decimals and
+// is rebased on import; v1.6.1 (>= 1.6.1) stores them in local decimals and is imported as-is. With chain A at
+// 18 decimals and chain B at 6 decimals, both paths must converge (within float ULP) on the same on-chain
+// values for the new pool, which validates the inbound decimal rebasing end-to-end.
+func TestTokenExpansionMigration_AutoMigrateRemoteChains(t *testing.T) {
+	cases := []struct {
+		name           string
+		oldPoolVersion *semver.Version
+	}{
+		{"v1_5_1_to_v2_0_0", cciputils.Version_1_5_1},
+		{"v1_6_1_to_v2_0_0", cciputils.Version_1_6_1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runAutoMigrateRemoteChainsUpgrade(t, tc.oldPoolVersion)
+		})
+	}
+}
+
+// TestTokenExpansionMigration_RequiresAllChainsWithoutAutoMigrate is the negative case: when
+// AutoMigrateRemoteChains is false (the default), configuring a v2.0 pool over an existing active pool must
+// still error if RemoteChains does not include every chain the active pool supports. This preserves the
+// pre-existing upgrade-safety check. We invoke the ConfigureTokenPoolForRemoteChains sequence directly with
+// an empty RemoteChains so the active pool's supported chain (B) is missing.
+func TestTokenExpansionMigration_RequiresAllChainsWithoutAutoMigrate(t *testing.T) {
+	s := setupLegacyConnectedBnMPair(t, cciputils.Version_1_5_1)
+
+	// RegistryAddress + TokenAddress are set, so the active-pool supported-chains check runs. The active
+	// pool (old pool A) supports chain B, which is absent from RemoteChains and the flag is off → error.
+	chainA := s.env.BlockChains.EVMChains()[s.selA]
+	_, err := cldf_ops.ExecuteSequence(
+		s.env.OperationsBundle,
+		evmtokensseq.ConfigureTokenPoolForRemoteChains,
+		chainA,
+		evmtokensseq.ConfigureTokenPoolForRemoteChainsInput{
+			ChainSelector:    s.selA,
+			TokenPoolAddress: s.oldPoolAddrA, // unused before the error returns
+			RegistryAddress:  s.tarAddrA,
+			TokenAddress:     s.tokAddrA,
+			RemoteChains:     nil,
+		},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "remoteChains must include all active pool supported chains")
+}
+
 // setupLegacyConnectedBnMPair deploys v2.0 core contracts on two chains, then deploys a legacy
 // (oldPoolVersion) BurnMint token+pool pair, connects them bidirectionally, and registers each in its
 // TokenAdminRegistry. It returns the resolved addresses for use in upgrade tests.
@@ -162,32 +214,9 @@ func setupLegacyConnectedBnMPair(t *testing.T, oldPoolVersion *semver.Version) l
 	}
 }
 
-// TestTokenExpansionMigration_AutoMigrateRemoteChains exercises the AutoMigrateRemoteChains upgrade path:
-// it deploys a legacy BurnMint pool pair, connects them, then upgrades chain A's pool to v2.0 using
-// AutoMigrateRemoteChains with an EMPTY RemoteChains map. The new pool must inherit chain B as a supported
-// remote (token + remote pool + rate limits carried forward from the active pool), and the TokenAdminRegistry
-// must be switched to point at the new pool — all without the operator listing any remote chains.
-//
-// Both legacy versions are covered: v1.5.1 (< 1.6.1) stores inbound rate limits in remote/source decimals and
-// is rebased on import; v1.6.1 (>= 1.6.1) stores them in local decimals and is imported as-is. With chain A at
-// 18 decimals and chain B at 6 decimals, both paths must converge (within float ULP) on the same on-chain
-// values for the new pool, which validates the inbound decimal rebasing end-to-end.
-func TestTokenExpansionMigration_AutoMigrateRemoteChains(t *testing.T) {
-	cases := []struct {
-		name           string
-		oldPoolVersion *semver.Version
-	}{
-		{"v1_5_1_to_v2_0_0", cciputils.Version_1_5_1},
-		{"v1_6_1_to_v2_0_0", cciputils.Version_1_6_1},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			runAutoMigrateRemoteChainsUpgrade(t, tc.oldPoolVersion)
-		})
-	}
-}
-
 func runAutoMigrateRemoteChainsUpgrade(t *testing.T, oldPoolVersion *semver.Version) {
+	t.Helper()
+
 	s := setupLegacyConnectedBnMPair(t, oldPoolVersion)
 	e, selA, selB := s.env, s.selA, s.selB
 	chainA := e.BlockChains.EVMChains()[selA]
@@ -263,31 +292,4 @@ func runAutoMigrateRemoteChainsUpgrade(t *testing.T, oldPoolVersion *semver.Vers
 	cfgAfter, err := tarA.GetTokenConfig(&bind.CallOpts{Context: t.Context()}, s.tokAddrA)
 	require.NoError(t, err)
 	require.Equal(t, newPoolAddrA, cfgAfter.TokenPool, "TAR should be switched to the new v2.0 pool")
-}
-
-// TestTokenExpansionMigration_RequiresAllChainsWithoutAutoMigrate is the negative case: when
-// AutoMigrateRemoteChains is false (the default), configuring a v2.0 pool over an existing active pool must
-// still error if RemoteChains does not include every chain the active pool supports. This preserves the
-// pre-existing upgrade-safety check. We invoke the ConfigureTokenPoolForRemoteChains sequence directly with
-// an empty RemoteChains so the active pool's supported chain (B) is missing.
-func TestTokenExpansionMigration_RequiresAllChainsWithoutAutoMigrate(t *testing.T) {
-	s := setupLegacyConnectedBnMPair(t, cciputils.Version_1_5_1)
-
-	// RegistryAddress + TokenAddress are set, so the active-pool supported-chains check runs. The active
-	// pool (old pool A) supports chain B, which is absent from RemoteChains and the flag is off → error.
-	chainA := s.env.BlockChains.EVMChains()[s.selA]
-	_, err := cldf_ops.ExecuteSequence(
-		s.env.OperationsBundle,
-		evmtokensseq.ConfigureTokenPoolForRemoteChains,
-		chainA,
-		evmtokensseq.ConfigureTokenPoolForRemoteChainsInput{
-			ChainSelector:    s.selA,
-			TokenPoolAddress:   s.oldPoolAddrA, // unused before the error returns
-			RegistryAddress:    s.tarAddrA,
-			TokenAddress:       s.tokAddrA,
-			RemoteChains:       nil,
-		},
-	)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "remoteChains must include all active pool supported chains")
 }

--- a/integration-tests/deployment/token_expansion_migration_test.go
+++ b/integration-tests/deployment/token_expansion_migration_test.go
@@ -275,17 +275,17 @@ func TestTokenExpansionMigration_RequiresAllChainsWithoutAutoMigrate(t *testing.
 
 	// RegistryAddress + TokenAddress are set, so the active-pool supported-chains check runs. The active
 	// pool (old pool A) supports chain B, which is absent from RemoteChains and the flag is off → error.
+	chainA := s.env.BlockChains.EVMChains()[s.selA]
 	_, err := cldf_ops.ExecuteSequence(
 		s.env.OperationsBundle,
 		evmtokensseq.ConfigureTokenPoolForRemoteChains,
-		s.env.BlockChains,
+		chainA,
 		evmtokensseq.ConfigureTokenPoolForRemoteChainsInput{
-			ChainSelector:           s.selA,
-			TokenPoolAddress:        s.oldPoolAddrA, // unused before the error returns
-			RegistryAddress:         s.tarAddrA,
-			TokenAddress:            s.tokAddrA,
-			RemoteChains:            nil,
-			AutoMigrateRemoteChains: false,
+			ChainSelector:    s.selA,
+			TokenPoolAddress:   s.oldPoolAddrA, // unused before the error returns
+			RegistryAddress:    s.tarAddrA,
+			TokenAddress:       s.tokAddrA,
+			RemoteChains:       nil,
 		},
 	)
 	require.Error(t, err)

--- a/integration-tests/deployment/token_expansion_scenarios_test.go
+++ b/integration-tests/deployment/token_expansion_scenarios_test.go
@@ -15,12 +15,16 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/stretchr/testify/require"
 
+	evm_datastore_utils "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/datastore"
 	evmadapters "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/adapters"
 	bnmERC20ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/burn_mint_erc20"
 	erc20ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/erc20"
 	evmseqV1_6_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/sequences"
+	bnmOpsV2_0_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/burn_mint_token_pool"
+	tarbindings "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/token_admin_registry"
 	bnmpool "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/burn_mint_token_pool"
 	lrpool "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/lock_release_token_pool"
+	tokenpoolV2_0_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v2_0_0/token_pool"
 	solanautils "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/utils"
 	routerops "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_6_0/operations/router"
 	solseqV1_6_0 "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_6_0/sequences"
@@ -45,6 +49,7 @@ import (
 
 	_ "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_1/adapters"
 	_ "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_1/adapters"
+	_ "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/adapters"
 
 	// Registers SolanaAddressNormalizer (v1_6_0 sequences do not import v1_0_0 adapters).
 	_ "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_0_0/adapters"
@@ -1473,10 +1478,171 @@ func TestTokenExpansionScenariosSolana(t *testing.T) {
 			})
 		})
 	})
+
+	// Scenario6 exercises AutoMigrateRemoteChains end-to-end across chain families: a legacy EVM pool connected
+	// to a Solana remote is upgraded to v2.0 with an empty RemoteChains map; the changeset must discover the
+	// Solana lane (token, pool, decimals) and carry it forward onto the new pool.
+	t.Run("Scenario6_AutoMigrateDiscoversSolanaRemote", func(t *testing.T) {
+		const evmTokenSymbol = "S6_EVM_TOK"
+		const solTokenSymbol = "S6_SOL_TOK"
+		const evmPoolQual = "S6_EVM_POOL"
+		const newEvmPoolQual = "S6_NEW_EVM_POOL"
+		evmDecimals := uint8(18)
+		svmDecimals := uint8(9)
+		maxSupply := uint64(1e6)
+		preMint := uint64(1e5)
+		defaultRL := tokensapi.RateLimiterConfigFloatInput{Capacity: 100, Rate: 10, IsEnabled: true}
+
+		// v2.0 pool deployment requires v2.0 core on the EVM chain (migration-test order).
+		v2CoreDS := datastore.NewMemoryDataStore()
+		DeployChainContractsV2_0_0(t, env, v2CoreDS, evmChainSel)
+		MergeAddresses(t, env, v2CoreDS)
+
+		// Deploy a legacy EVM v1.5.1 BurnMint pool connected to a Solana v1.6.0 LockRelease pool, registered in
+		// each chain's TokenAdminRegistry.
+		connectOut, err := tokensapi.TokenExpansion().Apply(*env, tokensapi.TokenExpansionInput{
+			ChainAdapterVersion: v1_6_0_scenarios,
+			MCMS:                NewDefaultInputForMCMS("Scenario 6 connect"),
+			TokenExpansionInputPerChain: map[uint64]tokensapi.TokenExpansionInputPerChain{
+				evmChainSel: {
+					TokenPoolVersion: v1_5_1_scenarios,
+					DeployTokenInput: &tokensapi.DeployTokenInput{
+						Name: "Scenario6 EVM Token", Symbol: evmTokenSymbol, Decimals: evmDecimals,
+						Type: bnmERC20ops.ContractType, Supply: &maxSupply, PreMint: &preMint,
+					},
+					DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
+						TokenPoolQualifier: evmPoolQual,
+						PoolType:           cciputils.BurnMintTokenPool.String(),
+					},
+					TokenTransferConfig: &tokensapi.TokenTransferConfig{
+						RemoteChains: map[uint64]tokensapi.RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
+							solChainSel: {OutboundRateLimiterConfig: &defaultRL},
+						},
+					},
+				},
+				solChainSel: {
+					TokenPoolVersion: v1_6_0_scenarios,
+					DeployTokenInput: &tokensapi.DeployTokenInput{
+						Name: "Scenario6 SOL Token", Symbol: solTokenSymbol, Decimals: svmDecimals,
+						Type:                   solanautils.SPLTokens,
+						ExternalAdmin:          solana.NewWallet().PublicKey().String(),
+						DisableFreezeAuthority: true,
+						Senders:                []string{solChain.DeployerKey.PublicKey().String()},
+						PreMint:                &preMint,
+					},
+					DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
+						TokenPoolQualifier: "",
+						PoolType:           cciputils.LockReleaseTokenPool.String(),
+					},
+					TokenTransferConfig: &tokensapi.TokenTransferConfig{
+						RemoteChains: map[uint64]tokensapi.RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
+							evmChainSel: {OutboundRateLimiterConfig: &defaultRL},
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		MergeAddresses(t, env, connectOut.DataStore)
+		testhelpers.ProcessTimelockProposals(t, *env, connectOut.MCMSTimelockProposals, false)
+
+		// Validate that the token and pool addresses were saved to the datastore.
+		evmTokAddr := assertTokenExists(t, env, evmChainSel, evmTokenSymbol, "Scenario6 EVM Token", evmDecimals)
+		oldPoolAddr, err := evmAdapter.FindLatestAddressRef(env.DataStore, datastore.AddressRef{
+			ChainSelector: evmChainSel,
+			Qualifier:     evmPoolQual,
+			Type:          datastore.ContractType(cciputils.BurnMintTokenPool),
+		})
+		require.NoError(t, err)
+
+		// Validate that the old pool has the expected Solana remote token and pool before the upgrade.
+		oldPool, err := bnmpool.NewBurnMintTokenPool(oldPoolAddr, evmChain.Client)
+		require.NoError(t, err)
+		oldRemoteToken, err := oldPool.GetRemoteToken(&bind.CallOpts{Context: t.Context()}, solChainSel)
+		require.NoError(t, err)
+		require.NotEmpty(t, oldRemoteToken)
+		oldRemotePools, err := oldPool.GetRemotePools(&bind.CallOpts{Context: t.Context()}, solChainSel)
+		require.NoError(t, err)
+		require.NotEmpty(t, oldRemotePools)
+
+		// Upgrade to v2.0 with AutoMigrateRemoteChains and no RemoteChains — Solana must be discovered.
+		upgradeOut, err := tokensapi.TokenExpansion().Apply(*env, tokensapi.TokenExpansionInput{
+			ChainAdapterVersion: cciputils.Version_2_0_0,
+			MCMS:                NewDefaultInputForMCMS("Scenario 6 upgrade"),
+			TokenExpansionInputPerChain: map[uint64]tokensapi.TokenExpansionInputPerChain{
+				evmChainSel: {
+					TokenPoolVersion: bnmOpsV2_0_0.Version,
+					DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
+						TokenPoolQualifier: newEvmPoolQual,
+						PoolType:           bnmOpsV2_0_0.ContractType.String(),
+						TokenRef:           &datastore.AddressRef{Address: evmTokAddr.Hex()},
+					},
+					TokenTransferConfig: &tokensapi.TokenTransferConfig{
+						AutoMigrateRemoteChains: true,
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		MergeAddresses(t, env, upgradeOut.DataStore)
+		testhelpers.ProcessTimelockProposals(t, *env, upgradeOut.MCMSTimelockProposals, false)
+
+		// Validate that the new pool was saved to the datastore
+		newPoolRef := datastore.AddressRef{
+			ChainSelector: evmChainSel,
+			Type:          datastore.ContractType(bnmOpsV2_0_0.ContractType),
+			Version:       bnmOpsV2_0_0.Version,
+			Qualifier:     newEvmPoolQual,
+		}
+		newPoolAddr, err := datastore_utils.FindAndFormatRef(env.DataStore, newPoolRef, evmChainSel, evm_datastore_utils.ToEVMAddress)
+		require.NoError(t, err)
+		require.NotEqual(t, oldPoolAddr, newPoolAddr, "new pool must be a distinct contract from the old pool")
+
+		// Validate that the new v2.0 pool has the same Solana remote token and pool carried forward, and that
+		// Solana is in the supported chains list even though we did not explicitly configure it on the v2.0
+		// side (AutoMigrateRemoteChains should have discovered and carried it forward).
+		newPool, err := tokenpoolV2_0_0.NewTokenPool(newPoolAddr, evmChain.Client)
+		require.NoError(t, err)
+		newSupported, err := newPool.GetSupportedChains(&bind.CallOpts{Context: t.Context()})
+		require.NoError(t, err)
+		require.Contains(t, newSupported, solChainSel, "auto-migrated pool should support Solana without it being listed")
+		gotRemoteToken, err := newPool.GetRemoteToken(&bind.CallOpts{Context: t.Context()}, solChainSel)
+		require.NoError(t, err)
+		require.True(t, bytes.Equal(oldRemoteToken, gotRemoteToken), "remote Solana token should be carried forward")
+		gotRemotePools, err := newPool.GetRemotePools(&bind.CallOpts{Context: t.Context()}, solChainSel)
+		require.NoError(t, err)
+		require.Contains(t, gotRemotePools, oldRemotePools[0], "remote Solana pool should be carried forward")
+
+		// Outbound is exact in local (18) decimals. Inbound is imported from the v1.5.1 active pool (stored in
+		// remote 9-decimal units) and rebased to local decimals; allow float ULP like the EVM-only migration test.
+		const rlTolerance = int64(1e9)
+		rl, err := newPool.GetCurrentRateLimiterState(&bind.CallOpts{Context: t.Context()}, solChainSel, false)
+		require.NoError(t, err)
+		require.True(t, rl.OutboundRateLimiterState.IsEnabled, "outbound rate limit should be enabled")
+		RequireBigIntsEqual(t, tokensapi.ScaleFloatToBigInt(defaultRL.Capacity, int(evmDecimals), 0), rl.OutboundRateLimiterState.Capacity, "outbound capacity")
+		RequireBigIntsEqual(t, tokensapi.ScaleFloatToBigInt(defaultRL.Rate, int(evmDecimals), 0), rl.OutboundRateLimiterState.Rate, "outbound rate")
+		require.True(t, rl.InboundRateLimiterState.IsEnabled, "inbound rate limit should be enabled")
+		expInboundCap := tokensapi.ScaleFloatToBigInt(defaultRL.Capacity, int(svmDecimals), 0.10)
+		expInboundRate := tokensapi.ScaleFloatToBigInt(defaultRL.Rate, int(svmDecimals), 0.10)
+		svmToEvm := new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(evmDecimals-svmDecimals)), nil)
+		expInboundCap.Mul(expInboundCap, svmToEvm)
+		expInboundRate.Mul(expInboundRate, svmToEvm)
+		RequireBigIntsApprox(t, expInboundCap, rl.InboundRateLimiterState.Capacity, rlTolerance, "inbound capacity")
+		RequireBigIntsApprox(t, expInboundRate, rl.InboundRateLimiterState.Rate, rlTolerance, "inbound rate")
+
+		// Ensure that the active pool in the TAR is switched to the new v2.0 pool
+		tarAddr, err := evmAdapter.GetTokenAdminRegistryAddress(env.DataStore, evmChainSel)
+		require.NoError(t, err)
+		tar, err := tarbindings.NewTokenAdminRegistry(tarAddr, evmChain.Client)
+		require.NoError(t, err)
+		cfgAfter, err := tar.GetTokenConfig(&bind.CallOpts{Context: t.Context()}, evmTokAddr)
+		require.NoError(t, err)
+		require.Equal(t, newPoolAddr, cfgAfter.TokenPool, "TAR should be switched to the new v2.0 pool")
+	})
 }
 
 // ---------------------------------------------------------------------------
-// Scenario 6: MCMS batches do NOT execute immediately, so the changeset should
+// Scenario 7: MCMS batches do NOT execute immediately, so the changeset should
 // not perform validation assuming on-chain state changes have already occurred
 // within the same batch until the batch is executed. This is relevant to token
 // expansion flows where multiple changesets in the same batch update the Token


### PR DESCRIPTION
# Auto-migrate remote chains on token pool upgrades

## Summary

Adds an opt-in `autoMigrateRemoteChains` option to token transfer configuration. When enabled, upgrading a
token to a new pool automatically carries forward the remote chains the currently-active pool is already
connected to, instead of requiring the operator to re-enumerate every remote chain by hand.

## Motivation

Upgrading a token pool (for example to v2.0.0) requires the new pool to be configured for the same set of
remote chains the previous pool served. Until now that list had to be supplied manually and completely: with
`autoMigrateRemoteChains` off (the default), `ConfigureTokenPoolForRemoteChains` rejects an upgrade whose
`remoteChains` does not cover every chain the active pool already supports. For a token connected to many
chains this is verbose and easy to get wrong, and it forces operators to maintain an off-chain list that
mirrors on-chain state. This change lets the active pool's on-chain state be the source of truth for that
list when the flag is on.

## What it does

- Introduces `autoMigrateRemoteChains` on `TokenTransferConfig`, defaulting to off. With it off, behavior is
  unchanged.
- With it on, the `ConfigureTokensForTransfers` changeset (before the adapter sequence) reads the pool
  currently registered in the TAR, enumerates its supported remote chains, and fills in any missing
  `remoteChains` entries — remote token, remote pool, and decimals. Rate limits are imported later by
  `ConfigureTokenPoolForRemoteChain` from the active pool.
- Remote chains the operator lists explicitly always take precedence over discovered ones, so the option can be
  combined with per-lane overrides.

Example (upgrade EVM pool to v2.0 without re-listing remotes):

```yaml
tokenTransferConfig:
  autoMigrateRemoteChains: true
  # remoteChains may be empty or partial; omitted chains are discovered from the active pool
```

## Design choices

- **Opt-in and backwards compatible.** Default-off preserves the existing strict behavior: the EVM v2.0
  `ConfigureTokenPoolForRemoteChains` sequence still errors when `remoteChains` omits a chain the active pool
  supports. Existing configurations are unaffected.

- **On-chain state is the source of truth for discovered chains.** A discovered chain's configuration is read
  from the active pool rather than from operator input. A direct consequence is that discovered chains do not
  require a symmetric counterpart configuration in the same changeset — unlike explicitly-listed chains, whose
  inbound limits are derived from the counterpart's outbound entry.

- **Rate limits remain semantically equivalent across pool versions.** Carried-forward limits reflect what the
  active pool currently enforces, accounting for the decimal-scaling differences between legacy and current
  pool versions so the new pool ends up enforcing the same real-world limits.

- **Chain-family agnostic.** Discovery works in terms of raw on-chain address bytes and resolves each remote's
  token decimals through that remote chain's own adapter, converting addresses to each family's canonical form
  through a shared per-family normalization layer. This keeps discovery independent of any single family's
  address encoding and lets it carry forward both EVM and non-EVM (e.g. Solana) remotes.

- **Capability-gated.** The behavior is available only for adapters implementing `TokenPoolMigrator`; today
  that is EVM v2.0.0.

- **Fresh on-chain reads.** Discovery reflects current, mutable on-chain state and bypasses idempotent
  operation caching, so it is never served a stale result produced earlier in the same run.

- **Discovery is changeset-only.** Remote-chain enumeration and cross-family decimal resolution run in
  `ConfigureTokensForTransfers` before the EVM adapter sequence. The sequence layer does not discover remotes;
  when auto-migrate is off it only validates that `remoteChains` covers the active pool's supported chains.

- **Active pool must expose supported chains.** Auto-migrate calls `getSupportedChains` on the pool registered
  in the TAR. Pools that do not implement it (e.g. USDCTokenPoolProxy) cause discovery to fail; operators must
  list remote chains explicitly for those tokens.

## Scope and non-goals

- This option governs only the carry-forward of remote-chain *configuration*. It never moves funds.
- Liquidity migration for lock/release pools is intentionally decoupled and remains its own explicit opt-in.
  The naming is deliberately broad to describe configuration carry-forward without implying liquidity movement.

## Test plan

- [x] `TestTokenExpansionMigration_AutoMigrateRemoteChains` — EVM→EVM upgrade with empty `remoteChains` (v1.5.1 and v1.6.1 legacy pools)
- [x] `TestTokenExpansionMigration_RequiresAllChainsWithoutAutoMigrate` — upgrade-safety preserved when flag is off
- [x] `Scenario6_AutoMigrateDiscoversSolanaRemote` — EVM→Solana cross-family auto-migrate E2E
