### PR TITLE
evm: expose protocol-contract & executor deploy params via FamilyExtras

### DIFF
--- a/chains/evm/deployment/v2_0_0/adapters/protocol_contracts_deploy_adapter.go
+++ b/chains/evm/deployment/v2_0_0/adapters/protocol_contracts_deploy_adapter.go
@@ -2,6 +2,8 @@ package adapters
 
 import (
 	"fmt"
+	"math"
+	"math/big"
 
 	"github.com/Masterminds/semver/v3"
 
@@ -42,6 +44,23 @@ const (
 	// (10 and false respectively) when its key is absent.
 	ProtocolContractsExecutorMaxCCVsPerMsgExtra       = "executorMaxCCVsPerMsg"
 	ProtocolContractsExecutorCcvAllowlistEnabledExtra = "executorCcvAllowlistEnabled"
+
+	// The remaining keys override individual contract deploy params. All are
+	// optional; an absent key leaves the corresponding deploy default in place.
+	// The FeeQuoter price fields are big.Int and must be passed as base-10
+	// strings because TOML integers are limited to int64.
+	ProtocolContractsRMNRemoteLegacyRMNExtra = "rmnRemoteLegacyRmn"
+
+	ProtocolContractsOffRampGasForCallExactCheckExtra      = "offRampGasForCallExactCheck"
+	ProtocolContractsOffRampMaxGasBufferToUpdateStateExtra = "offRampMaxGasBufferToUpdateState"
+
+	ProtocolContractsOnRampMaxUSDCentsPerMessageExtra = "onRampMaxUsdCentsPerMessage"
+
+	ProtocolContractsFeeQuoterMaxFeeJuelsPerMsgExtra              = "feeQuoterMaxFeeJuelsPerMsg"
+	ProtocolContractsFeeQuoterLINKPremiumMultiplierWeiPerEthExtra = "feeQuoterLinkPremiumMultiplierWeiPerEth"
+	ProtocolContractsFeeQuoterWETHPremiumMultiplierWeiPerEthExtra = "feeQuoterWethPremiumMultiplierWeiPerEth"
+	ProtocolContractsFeeQuoterUSDPerLINKExtra                     = "feeQuoterUsdPerLink"
+	ProtocolContractsFeeQuoterUSDPerWETHExtra                     = "feeQuoterUsdPerWeth"
 )
 
 // EVMProtocolContractsDeployAdapter implements
@@ -118,6 +137,9 @@ func toEVMProtocolDeployInput(input ccvdeploymentadapters.ProtocolContractsDeplo
 	params.MockReceivers = nil
 	params.OnRamp.FeeAggregator = feeAggregator
 	params.Executors = protocolExecutorParams(input.Executors, feeAggregator, executorOverrides)
+	if err := applyProtocolContractParamOverrides(&params, input.FamilyExtras); err != nil {
+		return sequences.DeployChainContractsInput{}, err
+	}
 
 	return toEVMDeployInput(ccvadapters.DeployChainContractsInput{
 		ChainSelector:     input.ChainSelector,
@@ -197,23 +219,16 @@ func protocolContractsExecutorOverrides(extras map[string]any) (executorDeployOv
 	}
 	overrides.allowedFinality = allowedFinality
 
-	if raw, ok := extras[ProtocolContractsExecutorMaxCCVsPerMsgExtra]; ok {
-		n, ok := asInt64(raw)
-		if !ok {
-			return overrides, fmt.Errorf("FamilyExtras[%q] must be an integer, got %T", ProtocolContractsExecutorMaxCCVsPerMsgExtra, raw)
-		}
-		if n < 0 || n > 255 {
-			return overrides, fmt.Errorf("FamilyExtras[%q] must be in [0, 255], got %d", ProtocolContractsExecutorMaxCCVsPerMsgExtra, n)
-		}
-		maxCCVs := uint8(n)
+	if v, ok, err := extraBoundedInt(extras, ProtocolContractsExecutorMaxCCVsPerMsgExtra, math.MaxUint8); err != nil {
+		return overrides, err
+	} else if ok {
+		maxCCVs := uint8(v)
 		overrides.maxCCVsPerMsg = &maxCCVs
 	}
 
-	if raw, ok := extras[ProtocolContractsExecutorCcvAllowlistEnabledExtra]; ok {
-		enabled, ok := raw.(bool)
-		if !ok {
-			return overrides, fmt.Errorf("FamilyExtras[%q] must be a bool, got %T", ProtocolContractsExecutorCcvAllowlistEnabledExtra, raw)
-		}
+	if enabled, ok, err := extraBool(extras, ProtocolContractsExecutorCcvAllowlistEnabledExtra); err != nil {
+		return overrides, err
+	} else if ok {
 		overrides.ccvAllowlistEnabled = &enabled
 	}
 
@@ -225,30 +240,147 @@ func protocolContractsExecutorOverrides(extras map[string]any) (executorDeployOv
 // default applies). When either key is present it builds the finality.Config
 // from ExecutorBlockDepth (integer, 0-65535) and ExecutorWaitForSafe (bool).
 func protocolContractsExecutorFinality(extras map[string]any) (*finality.Config, error) {
-	rawDepth, hasDepth := extras[ProtocolContractsExecutorBlockDepthExtra]
-	rawSafe, hasSafe := extras[ProtocolContractsExecutorWaitForSafeExtra]
+	depth, hasDepth, err := extraBoundedInt(extras, ProtocolContractsExecutorBlockDepthExtra, math.MaxUint16)
+	if err != nil {
+		return nil, err
+	}
+	safe, hasSafe, err := extraBool(extras, ProtocolContractsExecutorWaitForSafeExtra)
+	if err != nil {
+		return nil, err
+	}
 	if !hasDepth && !hasSafe {
 		return nil, nil
 	}
-	cfg := finality.Config{}
-	if hasDepth {
-		depth, ok := asInt64(rawDepth)
-		if !ok {
-			return nil, fmt.Errorf("FamilyExtras[%q] must be an integer, got %T", ProtocolContractsExecutorBlockDepthExtra, rawDepth)
-		}
-		if depth < 0 || depth > 65535 {
-			return nil, fmt.Errorf("FamilyExtras[%q] must be in [0, 65535], got %d", ProtocolContractsExecutorBlockDepthExtra, depth)
-		}
-		cfg.BlockDepth = uint16(depth)
+	return &finality.Config{
+		BlockDepth:  uint16(depth),
+		WaitForSafe: safe,
+	}, nil
+}
+
+// applyProtocolContractParamOverrides applies the optional contract-parameter
+// FamilyExtras overrides onto the default DeployContractParams. Each override is
+// applied only when its key is present; absent keys leave the deploy default.
+func applyProtocolContractParamOverrides(params *ccvadapters.DeployContractParams, extras map[string]any) error {
+	if v, ok, err := extraString(extras, ProtocolContractsRMNRemoteLegacyRMNExtra); err != nil {
+		return err
+	} else if ok {
+		params.RMNRemote.LegacyRMN = v
 	}
-	if hasSafe {
-		safe, ok := rawSafe.(bool)
-		if !ok {
-			return nil, fmt.Errorf("FamilyExtras[%q] must be a bool, got %T", ProtocolContractsExecutorWaitForSafeExtra, rawSafe)
-		}
-		cfg.WaitForSafe = safe
+
+	if v, ok, err := extraBoundedInt(extras, ProtocolContractsOffRampGasForCallExactCheckExtra, math.MaxUint16); err != nil {
+		return err
+	} else if ok {
+		params.OffRamp.GasForCallExactCheck = uint16(v)
 	}
-	return &cfg, nil
+
+	if v, ok, err := extraBoundedInt(extras, ProtocolContractsOffRampMaxGasBufferToUpdateStateExtra, math.MaxUint32); err != nil {
+		return err
+	} else if ok {
+		params.OffRamp.MaxGasBufferToUpdateState = uint32(v)
+	}
+
+	if v, ok, err := extraBoundedInt(extras, ProtocolContractsOnRampMaxUSDCentsPerMessageExtra, math.MaxUint32); err != nil {
+		return err
+	} else if ok {
+		params.OnRamp.MaxUSDCentsPerMessage = uint32(v)
+	}
+
+	if v, ok, err := extraBoundedInt(extras, ProtocolContractsFeeQuoterLINKPremiumMultiplierWeiPerEthExtra, math.MaxInt64); err != nil {
+		return err
+	} else if ok {
+		params.FeeQuoter.LINKPremiumMultiplierWeiPerEth = uint64(v)
+	}
+
+	if v, ok, err := extraBoundedInt(extras, ProtocolContractsFeeQuoterWETHPremiumMultiplierWeiPerEthExtra, math.MaxInt64); err != nil {
+		return err
+	} else if ok {
+		params.FeeQuoter.WETHPremiumMultiplierWeiPerEth = uint64(v)
+	}
+
+	if v, ok, err := extraBigInt(extras, ProtocolContractsFeeQuoterMaxFeeJuelsPerMsgExtra); err != nil {
+		return err
+	} else if ok {
+		params.FeeQuoter.MaxFeeJuelsPerMsg = v
+	}
+
+	if v, ok, err := extraBigInt(extras, ProtocolContractsFeeQuoterUSDPerLINKExtra); err != nil {
+		return err
+	} else if ok {
+		params.FeeQuoter.USDPerLINK = v
+	}
+
+	if v, ok, err := extraBigInt(extras, ProtocolContractsFeeQuoterUSDPerWETHExtra); err != nil {
+		return err
+	} else if ok {
+		params.FeeQuoter.USDPerWETH = v
+	}
+
+	return nil
+}
+
+// extraBoundedInt reads an optional integer FamilyExtras value, validating it is
+// within [0, max]. The bool return is false when the key is absent.
+func extraBoundedInt(extras map[string]any, key string, max int64) (int64, bool, error) {
+	raw, present := extras[key]
+	if !present {
+		return 0, false, nil
+	}
+	n, ok := asInt64(raw)
+	if !ok {
+		return 0, false, fmt.Errorf("FamilyExtras[%q] must be an integer, got %T", key, raw)
+	}
+	if n < 0 || n > max {
+		return 0, false, fmt.Errorf("FamilyExtras[%q] must be in [0, %d], got %d", key, max, n)
+	}
+	return n, true, nil
+}
+
+// extraBigInt reads an optional base-10 integer string FamilyExtras value into a
+// big.Int. Wei-denominated values that exceed int64 must be passed as strings
+// because TOML integers are limited to int64. The bool return is false when the
+// key is absent.
+func extraBigInt(extras map[string]any, key string) (*big.Int, bool, error) {
+	raw, present := extras[key]
+	if !present {
+		return nil, false, nil
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return nil, false, fmt.Errorf("FamilyExtras[%q] must be a base-10 integer string, got %T", key, raw)
+	}
+	v, ok := new(big.Int).SetString(s, 10)
+	if !ok {
+		return nil, false, fmt.Errorf("FamilyExtras[%q] must be a base-10 integer string, got %q", key, s)
+	}
+	return v, true, nil
+}
+
+// extraString reads an optional string FamilyExtras value. The bool return is
+// false when the key is absent.
+func extraString(extras map[string]any, key string) (string, bool, error) {
+	raw, present := extras[key]
+	if !present {
+		return "", false, nil
+	}
+	s, ok := raw.(string)
+	if !ok {
+		return "", false, fmt.Errorf("FamilyExtras[%q] must be a string, got %T", key, raw)
+	}
+	return s, true, nil
+}
+
+// extraBool reads an optional bool FamilyExtras value. The bool ok return is
+// false when the key is absent.
+func extraBool(extras map[string]any, key string) (value bool, ok bool, err error) {
+	raw, present := extras[key]
+	if !present {
+		return false, false, nil
+	}
+	b, isBool := raw.(bool)
+	if !isBool {
+		return false, false, fmt.Errorf("FamilyExtras[%q] must be a bool, got %T", key, raw)
+	}
+	return b, true, nil
 }
 
 // asInt64 coerces the common numeric types produced by TOML/JSON decoders.

--- a/chains/evm/deployment/v2_0_0/adapters/protocol_contracts_deploy_adapter.go
+++ b/chains/evm/deployment/v2_0_0/adapters/protocol_contracts_deploy_adapter.go
@@ -9,16 +9,40 @@ import (
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/finality"
 	ccvadapters "github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/adapters"
 
 	ccvdeploymentadapters "github.com/smartcontractkit/chainlink-ccv/deployment/adapters"
 )
 
-// ProtocolContractsFeeAggregatorExtra is the FamilyExtras key (string hex
-// address) used to set the fee aggregator on the OnRamp and on deployed
-// executor proxies. It is optional: when absent the fee aggregator defaults to
-// the zero address and is wired up in a later configuration step.
-const ProtocolContractsFeeAggregatorExtra = "feeAggregator"
+const (
+	// ProtocolContractsFeeAggregatorExtra is the FamilyExtras key (string hex
+	// address) used to set the fee aggregator on the OnRamp and on deployed
+	// executor proxies. It is optional: when absent the fee aggregator defaults
+	// to the zero address and is wired up in a later configuration step.
+	ProtocolContractsFeeAggregatorExtra = "feeAggregator"
+
+	// ProtocolContractsExecutorBlockDepthExtra and
+	// ProtocolContractsExecutorWaitForSafeExtra are the optional FamilyExtras
+	// keys used to set the executors' allowed finality config at deploy time.
+	// Executors validate the requested finality in getFee, and (unlike committee
+	// verifiers and token pools) their allowed finality is never reconfigured by
+	// the lane-configuration changesets — it can only be set on the deployed
+	// DynamicConfig. When both keys are absent the deploy default applies; when
+	// either is present the executors are deployed with the resulting
+	// finality.Config. ExecutorBlockDepth is an integer; ExecutorWaitForSafe is
+	// a bool.
+	ProtocolContractsExecutorBlockDepthExtra  = "executorBlockDepth"
+	ProtocolContractsExecutorWaitForSafeExtra = "executorWaitForSafe"
+
+	// ProtocolContractsExecutorMaxCCVsPerMsgExtra (integer, 0-255) and
+	// ProtocolContractsExecutorCcvAllowlistEnabledExtra (bool) are the optional
+	// FamilyExtras keys used to override the executors' MaxCCVsPerMsg and
+	// CcvAllowlistEnabled at deploy time. Each falls back to the deploy default
+	// (10 and false respectively) when its key is absent.
+	ProtocolContractsExecutorMaxCCVsPerMsgExtra       = "executorMaxCCVsPerMsg"
+	ProtocolContractsExecutorCcvAllowlistEnabledExtra = "executorCcvAllowlistEnabled"
+)
 
 // EVMProtocolContractsDeployAdapter implements
 // ccvdeploymentadapters.ProtocolContractsDeployAdapter for EVM chains.
@@ -82,6 +106,10 @@ func toEVMProtocolDeployInput(input ccvdeploymentadapters.ProtocolContractsDeplo
 	if err != nil {
 		return sequences.DeployChainContractsInput{}, err
 	}
+	executorOverrides, err := protocolContractsExecutorOverrides(input.FamilyExtras)
+	if err != nil {
+		return sequences.DeployChainContractsInput{}, err
+	}
 
 	params := defaultDeployContractParams()
 	// Protocol-only deploy: committee verifiers and the mock receivers (which
@@ -89,7 +117,7 @@ func toEVMProtocolDeployInput(input ccvdeploymentadapters.ProtocolContractsDeplo
 	params.CommitteeVerifiers = nil
 	params.MockReceivers = nil
 	params.OnRamp.FeeAggregator = feeAggregator
-	params.Executors = protocolExecutorParams(input.Executors, feeAggregator)
+	params.Executors = protocolExecutorParams(input.Executors, feeAggregator, executorOverrides)
 
 	return toEVMDeployInput(ccvadapters.DeployChainContractsInput{
 		ChainSelector:     input.ChainSelector,
@@ -102,14 +130,25 @@ func toEVMProtocolDeployInput(input ccvdeploymentadapters.ProtocolContractsDeplo
 }
 
 // protocolExecutorParams maps the chain-agnostic executor deploy params onto the
-// EVM executor params, applying EVM defaults (dynamic config, MaxCCVsPerMsg) and
-// the supplied fee aggregator. Version and Qualifier fall back to the defaults
-// when the caller leaves them unset.
-func protocolExecutorParams(executors []ccvdeploymentadapters.ExecutorDeployParams, feeAggregator string) []ccvadapters.ExecutorDeployParams {
+// EVM executor params, applying EVM defaults (dynamic config, MaxCCVsPerMsg), the
+// supplied fee aggregator, and any executor overrides from FamilyExtras. Version
+// and Qualifier fall back to the defaults when the caller leaves them unset; each
+// override field, when set, replaces the corresponding default on every deployed
+// executor.
+func protocolExecutorParams(executors []ccvdeploymentadapters.ExecutorDeployParams, feeAggregator string, overrides executorDeployOverrides) []ccvadapters.ExecutorDeployParams {
 	if len(executors) == 0 {
 		return nil
 	}
 	defaults := defaultExecutorParams(feeAggregator)[0]
+	if overrides.allowedFinality != nil {
+		defaults.DynamicConfig.AllowedFinalityConfig = *overrides.allowedFinality
+	}
+	if overrides.maxCCVsPerMsg != nil {
+		defaults.MaxCCVsPerMsg = *overrides.maxCCVsPerMsg
+	}
+	if overrides.ccvAllowlistEnabled != nil {
+		defaults.DynamicConfig.CcvAllowlistEnabled = *overrides.ccvAllowlistEnabled
+	}
 	result := make([]ccvadapters.ExecutorDeployParams, 0, len(executors))
 	for _, e := range executors {
 		params := defaults
@@ -136,4 +175,92 @@ func protocolContractsFeeAggregator(extras map[string]any) (string, error) {
 		return "", fmt.Errorf("FamilyExtras[%q] must be a string hex address, got %T", ProtocolContractsFeeAggregatorExtra, raw)
 	}
 	return feeAgg, nil
+}
+
+// executorDeployOverrides carries the optional executor deploy-config overrides
+// parsed from FamilyExtras. A nil field means "use the deploy default".
+type executorDeployOverrides struct {
+	allowedFinality     *finality.Config
+	maxCCVsPerMsg       *uint8
+	ccvAllowlistEnabled *bool
+}
+
+// protocolContractsExecutorOverrides reads the optional executor deploy-config
+// overrides from FamilyExtras. Absent keys leave the corresponding field nil so
+// the deploy default applies.
+func protocolContractsExecutorOverrides(extras map[string]any) (executorDeployOverrides, error) {
+	var overrides executorDeployOverrides
+
+	allowedFinality, err := protocolContractsExecutorFinality(extras)
+	if err != nil {
+		return overrides, err
+	}
+	overrides.allowedFinality = allowedFinality
+
+	if raw, ok := extras[ProtocolContractsExecutorMaxCCVsPerMsgExtra]; ok {
+		n, ok := asInt64(raw)
+		if !ok {
+			return overrides, fmt.Errorf("FamilyExtras[%q] must be an integer, got %T", ProtocolContractsExecutorMaxCCVsPerMsgExtra, raw)
+		}
+		if n < 0 || n > 255 {
+			return overrides, fmt.Errorf("FamilyExtras[%q] must be in [0, 255], got %d", ProtocolContractsExecutorMaxCCVsPerMsgExtra, n)
+		}
+		maxCCVs := uint8(n)
+		overrides.maxCCVsPerMsg = &maxCCVs
+	}
+
+	if raw, ok := extras[ProtocolContractsExecutorCcvAllowlistEnabledExtra]; ok {
+		enabled, ok := raw.(bool)
+		if !ok {
+			return overrides, fmt.Errorf("FamilyExtras[%q] must be a bool, got %T", ProtocolContractsExecutorCcvAllowlistEnabledExtra, raw)
+		}
+		overrides.ccvAllowlistEnabled = &enabled
+	}
+
+	return overrides, nil
+}
+
+// protocolContractsExecutorFinality reads the optional executor allowed finality
+// config from FamilyExtras. It returns nil when neither key is set (deploy
+// default applies). When either key is present it builds the finality.Config
+// from ExecutorBlockDepth (integer, 0-65535) and ExecutorWaitForSafe (bool).
+func protocolContractsExecutorFinality(extras map[string]any) (*finality.Config, error) {
+	rawDepth, hasDepth := extras[ProtocolContractsExecutorBlockDepthExtra]
+	rawSafe, hasSafe := extras[ProtocolContractsExecutorWaitForSafeExtra]
+	if !hasDepth && !hasSafe {
+		return nil, nil
+	}
+	cfg := finality.Config{}
+	if hasDepth {
+		depth, ok := asInt64(rawDepth)
+		if !ok {
+			return nil, fmt.Errorf("FamilyExtras[%q] must be an integer, got %T", ProtocolContractsExecutorBlockDepthExtra, rawDepth)
+		}
+		if depth < 0 || depth > 65535 {
+			return nil, fmt.Errorf("FamilyExtras[%q] must be in [0, 65535], got %d", ProtocolContractsExecutorBlockDepthExtra, depth)
+		}
+		cfg.BlockDepth = uint16(depth)
+	}
+	if hasSafe {
+		safe, ok := rawSafe.(bool)
+		if !ok {
+			return nil, fmt.Errorf("FamilyExtras[%q] must be a bool, got %T", ProtocolContractsExecutorWaitForSafeExtra, rawSafe)
+		}
+		cfg.WaitForSafe = safe
+	}
+	return &cfg, nil
+}
+
+// asInt64 coerces the common numeric types produced by TOML/JSON decoders.
+func asInt64(v any) (int64, bool) {
+	switch n := v.(type) {
+	case int64:
+		return n, true
+	case int:
+		return int64(n), true
+	case float64:
+		return int64(n), true
+	default:
+		return 0, false
+	}
 }

--- a/chains/evm/deployment/v2_0_0/adapters/protocol_contracts_deploy_adapter_test.go
+++ b/chains/evm/deployment/v2_0_0/adapters/protocol_contracts_deploy_adapter_test.go
@@ -1,6 +1,8 @@
 package adapters_test
 
 import (
+	"math"
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -102,6 +104,41 @@ func TestEVMProtocolContractsDeployAdapter_Validation(t *testing.T) {
 				in.FamilyExtras = map[string]any{adapters.ProtocolContractsExecutorCcvAllowlistEnabledExtra: "nope"}
 			},
 			wantErrSub: "must be a bool",
+		},
+		{
+			name: "FamilyExtras offRampGasForCallExactCheck wrong type",
+			mutate: func(in *ccvdeploymentadapters.ProtocolContractsDeployInput) {
+				in.FamilyExtras = map[string]any{adapters.ProtocolContractsOffRampGasForCallExactCheckExtra: "nope"}
+			},
+			wantErrSub: "must be an integer",
+		},
+		{
+			name: "FamilyExtras onRampMaxUsdCentsPerMessage out of range",
+			mutate: func(in *ccvdeploymentadapters.ProtocolContractsDeployInput) {
+				in.FamilyExtras = map[string]any{adapters.ProtocolContractsOnRampMaxUSDCentsPerMessageExtra: int64(math.MaxUint32) + 1}
+			},
+			wantErrSub: "must be in [0,",
+		},
+		{
+			name: "FamilyExtras feeQuoterMaxFeeJuelsPerMsg wrong type",
+			mutate: func(in *ccvdeploymentadapters.ProtocolContractsDeployInput) {
+				in.FamilyExtras = map[string]any{adapters.ProtocolContractsFeeQuoterMaxFeeJuelsPerMsgExtra: int64(5)}
+			},
+			wantErrSub: "must be a base-10 integer string",
+		},
+		{
+			name: "FamilyExtras feeQuoterUsdPerLink unparseable string",
+			mutate: func(in *ccvdeploymentadapters.ProtocolContractsDeployInput) {
+				in.FamilyExtras = map[string]any{adapters.ProtocolContractsFeeQuoterUSDPerLINKExtra: "not-a-number"}
+			},
+			wantErrSub: "must be a base-10 integer string",
+		},
+		{
+			name: "FamilyExtras rmnRemoteLegacyRmn wrong type",
+			mutate: func(in *ccvdeploymentadapters.ProtocolContractsDeployInput) {
+				in.FamilyExtras = map[string]any{adapters.ProtocolContractsRMNRemoteLegacyRMNExtra: 42}
+			},
+			wantErrSub: "must be a string",
 		},
 	}
 
@@ -307,4 +344,99 @@ func TestEVMProtocolContractsDeployAdapter_ExecutorOverrides(t *testing.T) {
 			require.Equal(t, tc.wantMaxCCVs, maxCCVs.Output)
 		})
 	}
+}
+
+// TestEVMProtocolContractsDeployAdapter_ContractParamOverrides proves the
+// optional per-contract deploy params (OffRamp gas, OnRamp max message fee,
+// FeeQuoter prices/multipliers, RMNRemote legacy address) are applied from
+// FamilyExtras. It sets every override and reads back the on-chain static
+// configs that expose them — including the big.Int MaxFeeJuelsPerMsg, which must
+// be passed as a base-10 string.
+func TestEVMProtocolContractsDeployAdapter_ContractParamOverrides(t *testing.T) {
+	e, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{testChainSelector}),
+	)
+	require.NoError(t, err)
+	e.DataStore = datastore.NewMemoryDataStore().Seal()
+
+	evmChain := e.BlockChains.EVMChains()[testChainSelector]
+
+	create2FactoryRef, err := contract_utils.MaybeDeployContract(
+		e.OperationsBundle, create2_factory.Deploy, evmChain,
+		contract_utils.DeployInput[create2_factory.ConstructorArgs]{
+			TypeAndVersion: deployment.NewTypeAndVersion(create2_factory.ContractType, *create2_factory.Version),
+			ChainSelector:  testChainSelector,
+			Args: create2_factory.ConstructorArgs{
+				AllowList: []common.Address{evmChain.DeployerKey.From},
+			},
+		}, nil,
+	)
+	require.NoError(t, err)
+
+	adapter := &adapters.EVMProtocolContractsDeployAdapter{}
+
+	wantMaxFeeJuels, ok := new(big.Int).SetString("300000000000000000000", 10)
+	require.True(t, ok)
+
+	in := ccvdeploymentadapters.ProtocolContractsDeployInput{
+		ChainSelector:    testChainSelector,
+		DeployerContract: create2FactoryRef.Address,
+		DeployerKeyOwned: true,
+		Executors: []ccvdeploymentadapters.ExecutorDeployParams{
+			{Version: executor.Version, Qualifier: "default"},
+		},
+		FamilyExtras: map[string]any{
+			adapters.ProtocolContractsFeeAggregatorExtra:                           testFeeAggregator,
+			adapters.ProtocolContractsOffRampGasForCallExactCheckExtra:             int64(7000),
+			adapters.ProtocolContractsOffRampMaxGasBufferToUpdateStateExtra:        int64(15000),
+			adapters.ProtocolContractsOnRampMaxUSDCentsPerMessageExtra:             int64(50000),
+			adapters.ProtocolContractsFeeQuoterMaxFeeJuelsPerMsgExtra:              "300000000000000000000",
+			adapters.ProtocolContractsFeeQuoterLINKPremiumMultiplierWeiPerEthExtra: int64(800000000000000000),
+			adapters.ProtocolContractsFeeQuoterWETHPremiumMultiplierWeiPerEthExtra: int64(1100000000000000000),
+			adapters.ProtocolContractsFeeQuoterUSDPerLINKExtra:                     "16000000000000000000",
+			adapters.ProtocolContractsFeeQuoterUSDPerWETHExtra:                     "2500000000000000000000",
+			adapters.ProtocolContractsRMNRemoteLegacyRMNExtra:                      "0x000000000000000000000000000000000000bEEF",
+		},
+	}
+
+	report, err := cldf_ops.ExecuteSequence(
+		e.OperationsBundle, adapter.DeployProtocolContracts(), e.BlockChains, in,
+	)
+	require.NoError(t, err)
+
+	addrByType := make(map[datastore.ContractType]string)
+	for _, ref := range report.Output.Addresses {
+		addrByType[ref.Type] = ref.Address
+	}
+
+	offRampStatic, err := cldf_ops.ExecuteOperation(
+		e.OperationsBundle, offramp.GetStaticConfig, evmChain,
+		contract_utils.FunctionInput[struct{}]{
+			ChainSelector: evmChain.Selector,
+			Address:       common.HexToAddress(addrByType[datastore.ContractType(offramp.ContractType)]),
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint16(7000), offRampStatic.Output.GasForCallExactCheck)
+	require.Equal(t, uint32(15000), offRampStatic.Output.MaxGasBufferToUpdateState)
+
+	onRampStatic, err := cldf_ops.ExecuteOperation(
+		e.OperationsBundle, onramp.GetStaticConfig, evmChain,
+		contract_utils.FunctionInput[struct{}]{
+			ChainSelector: evmChain.Selector,
+			Address:       common.HexToAddress(addrByType[datastore.ContractType(onramp.ContractType)]),
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, uint32(50000), onRampStatic.Output.MaxUSDCentsPerMessage)
+
+	feeQuoterStatic, err := cldf_ops.ExecuteOperation(
+		e.OperationsBundle, fee_quoter.GetStaticConfig, evmChain,
+		contract_utils.FunctionInput[struct{}]{
+			ChainSelector: evmChain.Selector,
+			Address:       common.HexToAddress(addrByType[datastore.ContractType(fee_quoter.ContractType)]),
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, 0, wantMaxFeeJuels.Cmp(feeQuoterStatic.Output.MaxFeeJuelsPerMsg))
 }

--- a/chains/evm/deployment/v2_0_0/adapters/protocol_contracts_deploy_adapter_test.go
+++ b/chains/evm/deployment/v2_0_0/adapters/protocol_contracts_deploy_adapter_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/fee_quoter"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/offramp"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/onramp"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/finality"
 
 	ccvdeploymentadapters "github.com/smartcontractkit/chainlink-ccv/deployment/adapters"
 )
@@ -66,6 +67,41 @@ func TestEVMProtocolContractsDeployAdapter_Validation(t *testing.T) {
 				in.FamilyExtras = map[string]any{adapters.ProtocolContractsFeeAggregatorExtra: 42}
 			},
 			wantErrSub: "must be a string hex address",
+		},
+		{
+			name: "FamilyExtras executorBlockDepth wrong type",
+			mutate: func(in *ccvdeploymentadapters.ProtocolContractsDeployInput) {
+				in.FamilyExtras = map[string]any{adapters.ProtocolContractsExecutorBlockDepthExtra: "nope"}
+			},
+			wantErrSub: "must be an integer",
+		},
+		{
+			name: "FamilyExtras executorWaitForSafe wrong type",
+			mutate: func(in *ccvdeploymentadapters.ProtocolContractsDeployInput) {
+				in.FamilyExtras = map[string]any{adapters.ProtocolContractsExecutorWaitForSafeExtra: "nope"}
+			},
+			wantErrSub: "must be a bool",
+		},
+		{
+			name: "FamilyExtras executorMaxCCVsPerMsg wrong type",
+			mutate: func(in *ccvdeploymentadapters.ProtocolContractsDeployInput) {
+				in.FamilyExtras = map[string]any{adapters.ProtocolContractsExecutorMaxCCVsPerMsgExtra: "nope"}
+			},
+			wantErrSub: "must be an integer",
+		},
+		{
+			name: "FamilyExtras executorMaxCCVsPerMsg out of range",
+			mutate: func(in *ccvdeploymentadapters.ProtocolContractsDeployInput) {
+				in.FamilyExtras = map[string]any{adapters.ProtocolContractsExecutorMaxCCVsPerMsgExtra: int64(256)}
+			},
+			wantErrSub: "must be in [0, 255]",
+		},
+		{
+			name: "FamilyExtras executorCcvAllowlistEnabled wrong type",
+			mutate: func(in *ccvdeploymentadapters.ProtocolContractsDeployInput) {
+				in.FamilyExtras = map[string]any{adapters.ProtocolContractsExecutorCcvAllowlistEnabledExtra: "nope"}
+			},
+			wantErrSub: "must be a bool",
 		},
 	}
 
@@ -155,4 +191,120 @@ func TestEVMProtocolContractsDeployAdapter_HappyPath(t *testing.T) {
 	// Committee verifiers are deployed separately — none should appear here.
 	require.False(t, deployed[datastore.ContractType(committee_verifier.ContractType)],
 		"committee verifier must not be deployed by the protocol-only adapter")
+}
+
+// TestEVMProtocolContractsDeployAdapter_ExecutorOverrides proves the executor's
+// deploy-time config (allowed finality, max CCVs per message, CCV allowlist) is
+// set from the FamilyExtras overrides. Executors validate the requested finality
+// in getFee and are never reconfigured by the lane-configuration changesets, so
+// deploy time is the only opportunity to set these (e.g. wait-for-safe).
+func TestEVMProtocolContractsDeployAdapter_ExecutorOverrides(t *testing.T) {
+	tests := []struct {
+		name          string
+		extras        map[string]any
+		wantFinality  [4]byte
+		wantMaxCCVs   uint8
+		wantAllowlist bool
+	}{
+		{
+			name:          "defaults when unset",
+			extras:        map[string]any{adapters.ProtocolContractsFeeAggregatorExtra: testFeeAggregator},
+			wantFinality:  finality.Config{BlockDepth: 1}.Raw(),
+			wantMaxCCVs:   10,
+			wantAllowlist: false,
+		},
+		{
+			name: "all overrides applied",
+			extras: map[string]any{
+				adapters.ProtocolContractsFeeAggregatorExtra:               testFeeAggregator,
+				adapters.ProtocolContractsExecutorBlockDepthExtra:          int64(1),
+				adapters.ProtocolContractsExecutorWaitForSafeExtra:         true,
+				adapters.ProtocolContractsExecutorMaxCCVsPerMsgExtra:       int64(5),
+				adapters.ProtocolContractsExecutorCcvAllowlistEnabledExtra: true,
+			},
+			wantFinality:  finality.Config{BlockDepth: 1, WaitForSafe: true}.Raw(),
+			wantMaxCCVs:   5,
+			wantAllowlist: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e, err := environment.New(t.Context(),
+				environment.WithEVMSimulated(t, []uint64{testChainSelector}),
+			)
+			require.NoError(t, err)
+			e.DataStore = datastore.NewMemoryDataStore().Seal()
+
+			evmChain := e.BlockChains.EVMChains()[testChainSelector]
+
+			create2FactoryRef, err := contract_utils.MaybeDeployContract(
+				e.OperationsBundle, create2_factory.Deploy, evmChain,
+				contract_utils.DeployInput[create2_factory.ConstructorArgs]{
+					TypeAndVersion: deployment.NewTypeAndVersion(create2_factory.ContractType, *create2_factory.Version),
+					ChainSelector:  testChainSelector,
+					Args: create2_factory.ConstructorArgs{
+						AllowList: []common.Address{evmChain.DeployerKey.From},
+					},
+				}, nil,
+			)
+			require.NoError(t, err)
+
+			adapter := &adapters.EVMProtocolContractsDeployAdapter{}
+
+			in := ccvdeploymentadapters.ProtocolContractsDeployInput{
+				ChainSelector:    testChainSelector,
+				DeployerContract: create2FactoryRef.Address,
+				DeployerKeyOwned: true,
+				Executors: []ccvdeploymentadapters.ExecutorDeployParams{
+					{Version: executor.Version, Qualifier: "default"},
+				},
+				FamilyExtras: tc.extras,
+			}
+
+			report, err := cldf_ops.ExecuteSequence(
+				e.OperationsBundle, adapter.DeployProtocolContracts(), e.BlockChains, in,
+			)
+			require.NoError(t, err)
+
+			var executorAddr string
+			for _, ref := range report.Output.Addresses {
+				if ref.Type == datastore.ContractType(executor.ContractType) {
+					executorAddr = ref.Address
+					break
+				}
+			}
+			require.NotEmpty(t, executorAddr, "executor must be deployed")
+
+			finalityCfg, err := cldf_ops.ExecuteOperation(
+				e.OperationsBundle, executor.GetAllowedFinalityConfig, evmChain,
+				contract_utils.FunctionInput[struct{}]{
+					ChainSelector: evmChain.Selector,
+					Address:       common.HexToAddress(executorAddr),
+				},
+			)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantFinality, finalityCfg.Output)
+
+			dynamicCfg, err := cldf_ops.ExecuteOperation(
+				e.OperationsBundle, executor.GetDynamicConfig, evmChain,
+				contract_utils.FunctionInput[struct{}]{
+					ChainSelector: evmChain.Selector,
+					Address:       common.HexToAddress(executorAddr),
+				},
+			)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantAllowlist, dynamicCfg.Output.CcvAllowlistEnabled)
+
+			maxCCVs, err := cldf_ops.ExecuteOperation(
+				e.OperationsBundle, executor.GetMaxCCVsPerMessage, evmChain,
+				contract_utils.FunctionInput[struct{}]{
+					ChainSelector: evmChain.Selector,
+					Address:       common.HexToAddress(executorAddr),
+				},
+			)
+			require.NoError(t, err)
+			require.Equal(t, tc.wantMaxCCVs, maxCCVs.Output)
+		})
+	}
 }


### PR DESCRIPTION
## What

Extends the EVM `ProtocolContractsDeployAdapter` to read optional deploy
parameters from `FamilyExtras` (previously only `feeAggregator` was honored):

- **Executor**: `executorBlockDepth`, `executorWaitForSafe` (allowed finality),
  `executorMaxCCVsPerMsg`, `executorCcvAllowlistEnabled`
- **OffRamp**: `offRampGasForCallExactCheck`, `offRampMaxGasBufferToUpdateState`
- **OnRamp**: `onRampMaxUsdCentsPerMessage`
- **FeeQuoter**: `feeQuoterMaxFeeJuelsPerMsg`, `feeQuoterUsdPerLink`,
  `feeQuoterUsdPerWeth`, `feeQuoterLinkPremiumMultiplierWeiPerEth`,
  `feeQuoterWethPremiumMultiplierWeiPerEth`
- **RMNRemote**: `rmnRemoteLegacyRmn`

All keys are optional (flat, camelCase) and fal
when absent. The three `*big.Int` FeeQuoter prices are passed as base-10
strings since TOML integers are limited to int64. `Version` fields stay
hardcoded as they're tied to the contract bindi

## Why

Executors validate `requestedFinality` in `getFee`, and (unlike committee
verifiers and token pools) their allowed finality is never reconfigured by the
lane-configuration changesets — deploy time is h
only `feeAggregator` exposed, executors deployed with the default
`0x00000001` finality and rejected wait-for-safe sends. This restores a
configurable deploy surface and completes it ac
contracts.

## Tests

Shared typed extractors with range validation (no silent integer truncation).
Adds validation cases for every key and a deplo
asserting executor finality/maxCCVs/allowlist and OffRamp/OnRamp/FeeQuoter
static config (including the big.Int `MaxFeeJuelsPerMsg`).