### PR TITLE
refactor: remove env from fee adapter and fee resolver

### DIFF
--- a/chains/evm/deployment/v1_0_0/adapters/fees.go
+++ b/chains/evm/deployment/v1_0_0/adapters/fees.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
 	evm_datastore_utils "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/datastore"
@@ -19,8 +19,8 @@ var _ fees.FeeResolver = (*EVMFeeResolver)(nil)
 
 type EVMFeeResolver struct{}
 
-func (a *EVMFeeResolver) GetOnRampRef(e cldf.Environment, src uint64, dst uint64) (datastore.AddressRef, error) {
-	srcChain, ok := e.BlockChains.EVMChains()[src]
+func (a *EVMFeeResolver) GetOnRampRef(b cldf_ops.Bundle, chains cldf_chain.BlockChains, ds datastore.DataStore, src uint64, dst uint64) (datastore.AddressRef, error) {
+	srcChain, ok := chains.EVMChains()[src]
 	if !ok {
 		return datastore.AddressRef{}, fmt.Errorf("chain with selector %d not defined", src)
 	}
@@ -29,7 +29,7 @@ func (a *EVMFeeResolver) GetOnRampRef(e cldf.Environment, src uint64, dst uint64
 	// address. Therefore, it is not necessary for the user to know the OnRamp version when setting token transfer
 	// fee configs between some source and destination chains - we can infer this purely from on-chain state.
 	routerAddr, err := datastore_utils.FindAndFormatRef(
-		e.DataStore,
+		ds,
 		datastore.AddressRef{
 			Type:          datastore.ContractType(routerops.ContractType),
 			Version:       routerops.Version,
@@ -44,9 +44,9 @@ func (a *EVMFeeResolver) GetOnRampRef(e cldf.Environment, src uint64, dst uint64
 
 	// NOTE: the returned OnRamp address could be either v1.5.0 or v1.6.0 - we make no assumptions about the
 	// version being returned and do not import any version-specific code here to avoid any potential issues
-	e.Logger.Infof("Found Router address %s for chain %s:", routerAddr.Hex(), srcChain.String())
+	b.Logger.Infof("Found Router address %s for chain %s:", routerAddr.Hex(), srcChain.String())
 	getOnRampReport, err := cldf_ops.ExecuteOperation(
-		e.OperationsBundle,
+		b,
 		routerops.GetOnRamp,
 		srcChain,
 		contract.FunctionInput[uint64]{
@@ -67,9 +67,9 @@ func (a *EVMFeeResolver) GetOnRampRef(e cldf.Environment, src uint64, dst uint64
 	// NOTE: the OnRamp ContractType varies between v1.5 and v1.6. For v1.5 it's `EVM2EVMOnRamp` and
 	// for v1.6 it's `OnRamp`, so we should avoid filtering on the ContractType otherwise the search
 	// may be too restrictive and this call will incorrectly fail
-	e.Logger.Infof("Found OnRamp address %s for src %d and dst %d", onRampAddr.Hex(), src, dst)
+	b.Logger.Infof("Found OnRamp address %s for src %d and dst %d", onRampAddr.Hex(), src, dst)
 	onRampRef, err := datastore_utils.FindAndFormatRef(
-		e.DataStore,
+		ds,
 		datastore.AddressRef{ChainSelector: src, Address: onRampAddr.Hex()},
 		src,
 		datastore_utils.FullRef,
@@ -78,7 +78,7 @@ func (a *EVMFeeResolver) GetOnRampRef(e cldf.Environment, src uint64, dst uint64
 		return datastore.AddressRef{}, fmt.Errorf("failed to find OnRamp address ref for address %s on chain selector %d: %w", getOnRampReport.Output.Hex(), src, err)
 	}
 
-	e.Logger.Infof(
+	b.Logger.Infof(
 		"OnRamp ref for src %d and dst %d: %s",
 		src, dst, datastore_utils.SprintRef(onRampRef),
 	)

--- a/chains/evm/deployment/v1_5_0/adapters/fees.go
+++ b/chains/evm/deployment/v1_5_0/adapters/fees.go
@@ -16,7 +16,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 )
 
@@ -43,7 +42,7 @@ func (a *FeesAdapter) validateFeeRef(feeRef datastore.AddressRef) error {
 	return nil
 }
 
-func (a *FeesAdapter) GetFeeContractRef(e cldf.Environment, onRampRef datastore.AddressRef, src uint64, dst uint64) (datastore.AddressRef, error) {
+func (a *FeesAdapter) GetFeeContractRef(_ operations.Bundle, _ cldf_chain.BlockChains, _ datastore.DataStore, onRampRef datastore.AddressRef, src uint64, dst uint64) (datastore.AddressRef, error) {
 	if err := a.validateFeeRef(onRampRef); err != nil {
 		return datastore.AddressRef{}, fmt.Errorf("invalid OnRamp address ref for src %d and dst %d: %w", src, dst, err)
 	}
@@ -55,13 +54,13 @@ func (a *FeesAdapter) GetDefaultTokenTransferFeeConfig(src uint64, dst uint64) f
 	return fees.GetDefaultChainAgnosticTokenTransferFeeConfig(src, dst)
 }
 
-func (a *FeesAdapter) GetOnchainTokenTransferFeeConfig(e cldf.Environment, feeRef datastore.AddressRef, src uint64, dst uint64, token string) (fees.TokenTransferFeeArgs, error) {
+func (a *FeesAdapter) GetOnchainTokenTransferFeeConfig(b operations.Bundle, chains cldf_chain.BlockChains, feeRef datastore.AddressRef, src uint64, dst uint64, token string) (fees.TokenTransferFeeArgs, error) {
 	err := a.validateFeeRef(feeRef)
 	if err != nil {
 		return fees.TokenTransferFeeArgs{}, fmt.Errorf("invalid OnRamp address ref for src %d and dst %d: %w", src, dst, err)
 	}
 
-	chain, ok := e.BlockChains.EVMChains()[src]
+	chain, ok := chains.EVMChains()[src]
 	if !ok {
 		return fees.TokenTransferFeeArgs{}, fmt.Errorf("chain with selector %d not defined", src)
 	}
@@ -79,12 +78,12 @@ func (a *FeesAdapter) GetOnchainTokenTransferFeeConfig(e cldf.Environment, feeRe
 
 	// This gets the token transfer fee config for the given token from the EVM2EVMOnRamp contract
 	// https://sepolia.etherscan.io/address/0xf9765c80F6448e6d4d02BeF4a6b4152131A2F513#code#F1#L719
-	cfg, err := onRamp.GetTokenTransferFeeConfig(&bind.CallOpts{Context: e.GetContext()}, common.HexToAddress(token))
+	cfg, err := onRamp.GetTokenTransferFeeConfig(&bind.CallOpts{Context: b.GetContext()}, common.HexToAddress(token))
 	if err != nil {
 		return fees.TokenTransferFeeArgs{}, fmt.Errorf("failed to get token transfer fee config from OnRamp at %s for src %d, dst %d, token %s: %w", onRampAddr.Hex(), src, dst, token, err)
 	}
 
-	e.Logger.Infof("Fetched on-chain token transfer fee config for src %d, dst %d, token %s: %+v", src, dst, token, cfg)
+	b.Logger.Infof("Fetched on-chain token transfer fee config for src %d, dst %d, token %s: %+v", src, dst, token, cfg)
 	return fees.TokenTransferFeeArgs{
 		DestBytesOverhead: cfg.DestBytesOverhead,
 		DestGasOverhead:   cfg.DestGasOverhead,
@@ -95,7 +94,7 @@ func (a *FeesAdapter) GetOnchainTokenTransferFeeConfig(e cldf.Environment, feeRe
 	}, nil
 }
 
-func (a *FeesAdapter) SetTokenTransferFee(e cldf.Environment, feeRef datastore.AddressRef) *operations.Sequence[fees.SetTokenTransferFeeSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains] {
+func (a *FeesAdapter) SetTokenTransferFee(_ datastore.DataStore, feeRef datastore.AddressRef) *operations.Sequence[fees.SetTokenTransferFeeSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains] {
 	return operations.NewSequence(
 		"SetTokenTransferFee",
 		utils.Version_1_5_0,
@@ -175,12 +174,12 @@ func (a *FeesAdapter) GetDefaultDestChainConfig(src, dst uint64) lanes.FeeQuoter
 }
 
 // GetOnchainDestChainConfig is not supported for v1.5 (no FeeQuoter contract).
-func (a *FeesAdapter) GetOnchainDestChainConfig(_ cldf.Environment, _ datastore.AddressRef, _, _ uint64) (lanes.FeeQuoterDestChainConfig, error) {
+func (a *FeesAdapter) GetOnchainDestChainConfig(_ operations.Bundle, _ cldf_chain.BlockChains, _ datastore.AddressRef, _, _ uint64) (lanes.FeeQuoterDestChainConfig, error) {
 	return lanes.FeeQuoterDestChainConfig{}, fmt.Errorf("FeeQuoter dest chain config reads are not supported for v1.5 (no FeeQuoter contract)")
 }
 
 // ApplyDestChainConfigUpdates is not supported for v1.5 (no FeeQuoter contract).
-func (a *FeesAdapter) ApplyDestChainConfigUpdates(e cldf.Environment, feeRef datastore.AddressRef) *operations.Sequence[fees.ApplyDestChainConfigSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains] {
+func (a *FeesAdapter) ApplyDestChainConfigUpdates(_ datastore.DataStore, _ datastore.AddressRef) *operations.Sequence[fees.ApplyDestChainConfigSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains] {
 	return operations.NewSequence(
 		"ApplyDestChainConfigUpdatesV1_5",
 		utils.Version_1_5_0,

--- a/chains/evm/deployment/v1_6_0/adapters/fees.go
+++ b/chains/evm/deployment/v1_6_0/adapters/fees.go
@@ -19,7 +19,6 @@ import (
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 )
 
@@ -48,7 +47,7 @@ func (a *FeesAdapter) validateFeeRef(feeRef datastore.AddressRef) error {
 	return nil
 }
 
-func (a *FeesAdapter) GetFeeContractRef(e cldf.Environment, onRampRef datastore.AddressRef, src uint64, dst uint64) (datastore.AddressRef, error) {
+func (a *FeesAdapter) GetFeeContractRef(b operations.Bundle, chains cldf_chain.BlockChains, ds datastore.DataStore, onRampRef datastore.AddressRef, src uint64, dst uint64) (datastore.AddressRef, error) {
 	if onRampRef.Type.String() != onramp.ContractType.String() {
 		return datastore.AddressRef{}, fmt.Errorf("unexpected contract type for OnRamp address ref for src %d and dst %d: got %s, want %s", src, dst, onRampRef.Type.String(), onramp.ContractType)
 	}
@@ -61,13 +60,13 @@ func (a *FeesAdapter) GetFeeContractRef(e cldf.Environment, onRampRef datastore.
 		return datastore.AddressRef{}, fmt.Errorf("failed to convert OnRamp address ref to EVM address for src %d and dst %d: %w", src, dst, err)
 	}
 
-	chain, ok := e.BlockChains.EVMChains()[src]
+	chain, ok := chains.EVMChains()[src]
 	if !ok {
 		return datastore.AddressRef{}, fmt.Errorf("chain with selector %d not defined", src)
 	}
 
 	report, err := operations.ExecuteOperation(
-		e.OperationsBundle,
+		b,
 		onramp.GetDynamicConfig,
 		chain,
 		contract.FunctionInput[struct{}]{
@@ -82,7 +81,7 @@ func (a *FeesAdapter) GetFeeContractRef(e cldf.Environment, onRampRef datastore.
 
 	// NOTE: version is omitted intentionally here - we could have a v1.6 OnRamp connected to a v2.0 FQ for example
 	fqRef, err := datastore_utils.FindAndFormatRef(
-		e.DataStore,
+		ds,
 		datastore.AddressRef{
 			ChainSelector: src,
 			Address:       report.Output.FeeQuoter.Hex(),
@@ -102,13 +101,13 @@ func (a *FeesAdapter) GetDefaultTokenTransferFeeConfig(src uint64, dst uint64) f
 	return fees.GetDefaultChainAgnosticTokenTransferFeeConfig(src, dst)
 }
 
-func (a *FeesAdapter) GetOnchainTokenTransferFeeConfig(e cldf.Environment, feeRef datastore.AddressRef, src uint64, dst uint64, token string) (fees.TokenTransferFeeArgs, error) {
+func (a *FeesAdapter) GetOnchainTokenTransferFeeConfig(b operations.Bundle, chains cldf_chain.BlockChains, feeRef datastore.AddressRef, src uint64, dst uint64, token string) (fees.TokenTransferFeeArgs, error) {
 	err := a.validateFeeRef(feeRef)
 	if err != nil {
 		return fees.TokenTransferFeeArgs{}, fmt.Errorf("invalid FeeQuoter address ref for src %d and dst %d: %w", src, dst, err)
 	}
 
-	chain, ok := e.BlockChains.EVMChains()[src]
+	chain, ok := chains.EVMChains()[src]
 	if !ok {
 		return fees.TokenTransferFeeArgs{}, fmt.Errorf("chain with selector %d not defined", src)
 	}
@@ -126,12 +125,12 @@ func (a *FeesAdapter) GetOnchainTokenTransferFeeConfig(e cldf.Environment, feeRe
 
 	// This gets the token transfer fee config for the given token from the FeeQuoter contract
 	// https://etherscan.io/address/0x40858070814a57FdF33a613ae84fE0a8b4a874f7#code#F1#L819
-	cfg, err := fq.GetTokenTransferFeeConfig(&bind.CallOpts{Context: e.GetContext()}, dst, common.HexToAddress(token))
+	cfg, err := fq.GetTokenTransferFeeConfig(&bind.CallOpts{Context: b.GetContext()}, dst, common.HexToAddress(token))
 	if err != nil {
 		return fees.TokenTransferFeeArgs{}, fmt.Errorf("failed to get token transfer fee config from FeeQuoter at %s for src %d, dst %d, token %s: %w", fqAddr.Hex(), src, dst, token, err)
 	}
 
-	e.Logger.Infof("Fetched on-chain token transfer fee config for src %d, dst %d, token %s: %+v", src, dst, token, cfg)
+	b.Logger.Infof("Fetched on-chain token transfer fee config for src %d, dst %d, token %s: %+v", src, dst, token, cfg)
 	return fees.TokenTransferFeeArgs{
 		DestBytesOverhead: cfg.DestBytesOverhead,
 		DestGasOverhead:   cfg.DestGasOverhead,
@@ -142,7 +141,7 @@ func (a *FeesAdapter) GetOnchainTokenTransferFeeConfig(e cldf.Environment, feeRe
 	}, nil
 }
 
-func (a *FeesAdapter) SetTokenTransferFee(e cldf.Environment, feeRef datastore.AddressRef) *operations.Sequence[fees.SetTokenTransferFeeSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains] {
+func (a *FeesAdapter) SetTokenTransferFee(_ datastore.DataStore, feeRef datastore.AddressRef) *operations.Sequence[fees.SetTokenTransferFeeSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains] {
 	return operations.NewSequence(
 		"SetTokenTransferFee",
 		utils.Version_1_6_0,
@@ -232,13 +231,13 @@ func (a *FeesAdapter) GetDefaultDestChainConfig(src, dst uint64) lanes.FeeQuoter
 	return a.evm.GetFeeQuoterDestChainConfig()
 }
 
-func (a *FeesAdapter) GetOnchainDestChainConfig(e cldf.Environment, feeRef datastore.AddressRef, src uint64, dst uint64) (lanes.FeeQuoterDestChainConfig, error) {
+func (a *FeesAdapter) GetOnchainDestChainConfig(b operations.Bundle, chains cldf_chain.BlockChains, feeRef datastore.AddressRef, src uint64, dst uint64) (lanes.FeeQuoterDestChainConfig, error) {
 	err := a.validateFeeRef(feeRef)
 	if err != nil {
 		return lanes.FeeQuoterDestChainConfig{}, fmt.Errorf("invalid FeeQuoter address ref for src %d and dst %d: %w", src, dst, err)
 	}
 
-	chain, ok := e.BlockChains.EVMChains()[src]
+	chain, ok := chains.EVMChains()[src]
 	if !ok {
 		return lanes.FeeQuoterDestChainConfig{}, fmt.Errorf("chain with selector %d not defined", src)
 	}
@@ -251,7 +250,7 @@ func (a *FeesAdapter) GetOnchainDestChainConfig(e cldf.Environment, feeRef datas
 		return lanes.FeeQuoterDestChainConfig{}, fmt.Errorf("failed to instantiate FeeQuoter contract at address %s on chain selector %d: %w", fqAddr.Hex(), src, err)
 	}
 
-	onchain, err := fq.GetDestChainConfig(&bind.CallOpts{Context: e.GetContext()}, dst)
+	onchain, err := fq.GetDestChainConfig(&bind.CallOpts{Context: b.GetContext()}, dst)
 	if err != nil {
 		return lanes.FeeQuoterDestChainConfig{}, fmt.Errorf("failed to get dest chain config from FeeQuoter at %s for src %d, dst %d: %w", fqAddr.Hex(), src, dst, err)
 	}
@@ -279,7 +278,7 @@ func (a *FeesAdapter) GetOnchainDestChainConfig(e cldf.Environment, feeRef datas
 	}), nil
 }
 
-func (a *FeesAdapter) ApplyDestChainConfigUpdates(e cldf.Environment, feeRef datastore.AddressRef) *operations.Sequence[fees.ApplyDestChainConfigSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains] {
+func (a *FeesAdapter) ApplyDestChainConfigUpdates(_ datastore.DataStore, feeRef datastore.AddressRef) *operations.Sequence[fees.ApplyDestChainConfigSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains] {
 	return operations.NewSequence(
 		"ApplyDestChainConfigUpdates",
 		utils.Version_1_6_0,

--- a/chains/evm/deployment/v2_0_0/adapters/fees.go
+++ b/chains/evm/deployment/v2_0_0/adapters/fees.go
@@ -19,7 +19,6 @@ import (
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 )
 
@@ -48,7 +47,7 @@ func (a *FeesAdapter) validateFeeRef(feeRef datastore.AddressRef) error {
 	return nil
 }
 
-func (a *FeesAdapter) GetFeeContractRef(e cldf.Environment, onRampRef datastore.AddressRef, src uint64, dst uint64) (datastore.AddressRef, error) {
+func (a *FeesAdapter) GetFeeContractRef(b operations.Bundle, chains cldf_chain.BlockChains, ds datastore.DataStore, onRampRef datastore.AddressRef, src uint64, dst uint64) (datastore.AddressRef, error) {
 	if onRampRef.Type.String() != onramp.ContractType.String() {
 		return datastore.AddressRef{}, fmt.Errorf("unexpected contract type for OnRamp address ref for src %d and dst %d: got %s, want %s", src, dst, onRampRef.Type.String(), onramp.ContractType)
 	}
@@ -61,13 +60,13 @@ func (a *FeesAdapter) GetFeeContractRef(e cldf.Environment, onRampRef datastore.
 		return datastore.AddressRef{}, fmt.Errorf("failed to convert OnRamp address ref to EVM address for src %d and dst %d: %w", src, dst, err)
 	}
 
-	chain, ok := e.BlockChains.EVMChains()[src]
+	chain, ok := chains.EVMChains()[src]
 	if !ok {
 		return datastore.AddressRef{}, fmt.Errorf("chain with selector %d not defined", src)
 	}
 
 	report, err := operations.ExecuteOperation(
-		e.OperationsBundle,
+		b,
 		onramp.GetDynamicConfig,
 		chain,
 		contract.FunctionInput[struct{}]{
@@ -82,7 +81,7 @@ func (a *FeesAdapter) GetFeeContractRef(e cldf.Environment, onRampRef datastore.
 
 	// NOTE: version is omitted intentionally here - we could have a v2.0 OnRamp connected to a v1.6 FQ for example
 	fqRef, err := datastore_utils.FindAndFormatRef(
-		e.DataStore,
+		ds,
 		datastore.AddressRef{
 			ChainSelector: src,
 			Address:       report.Output.FeeQuoter.Hex(),
@@ -102,13 +101,13 @@ func (a *FeesAdapter) GetDefaultTokenTransferFeeConfig(src uint64, dst uint64) f
 	return fees.GetDefaultChainAgnosticTokenTransferFeeConfig(src, dst)
 }
 
-func (a *FeesAdapter) GetOnchainTokenTransferFeeConfig(e cldf.Environment, feeRef datastore.AddressRef, src uint64, dst uint64, address string) (fees.TokenTransferFeeArgs, error) {
+func (a *FeesAdapter) GetOnchainTokenTransferFeeConfig(b operations.Bundle, chains cldf_chain.BlockChains, feeRef datastore.AddressRef, src uint64, dst uint64, address string) (fees.TokenTransferFeeArgs, error) {
 	err := a.validateFeeRef(feeRef)
 	if err != nil {
 		return fees.TokenTransferFeeArgs{}, fmt.Errorf("invalid FeeQuoter address ref for src %d and dst %d: %w", src, dst, err)
 	}
 
-	chain, ok := e.BlockChains.EVMChains()[src]
+	chain, ok := chains.EVMChains()[src]
 	if !ok {
 		return fees.TokenTransferFeeArgs{}, fmt.Errorf("chain with selector %d not defined", src)
 	}
@@ -126,14 +125,14 @@ func (a *FeesAdapter) GetOnchainTokenTransferFeeConfig(e cldf.Environment, feeRe
 
 	// This gets the token transfer fee config for the given token from the FeeQuoter contract
 	// https://testnet-explorer.plume.org/address/0x66bc24445e94FF302710E66Ce127E3174F723BD4?tab=contract
-	cfg, err := fq.GetTokenTransferFeeConfig(&bind.CallOpts{Context: e.GetContext()}, dst, common.HexToAddress(address))
+	cfg, err := fq.GetTokenTransferFeeConfig(&bind.CallOpts{Context: b.GetContext()}, dst, common.HexToAddress(address))
 	if err != nil {
 		return fees.TokenTransferFeeArgs{}, fmt.Errorf("failed to get token transfer fee config from FeeQuoter at %s for src %d, dst %d, token %s: %w", fqAddr.Hex(), src, dst, address, err)
 	}
 
 	// Max fee is not defined in 2.0.0 version of FeeQuoter contract, so we set it to 0
 	// In 2.0.0 version of FeeQuoter contract, there is only a single fee parameter (FeeUSDCents): https://github.com/smartcontractkit/chainlink-ccip/blob/73fcb2020b9335c965a7d2bb5d932c0fa05c7948/chains/evm/contracts/FeeQuoter.sol#L97
-	e.Logger.Infof("Fetched on-chain token transfer fee config for src %d, dst %d, token %s: %+v", src, dst, address, cfg)
+	b.Logger.Infof("Fetched on-chain token transfer fee config for src %d, dst %d, token %s: %+v", src, dst, address, cfg)
 	return fees.TokenTransferFeeArgs{
 		DestBytesOverhead: cfg.DestBytesOverhead,
 		DestGasOverhead:   cfg.DestGasOverhead,
@@ -143,7 +142,7 @@ func (a *FeesAdapter) GetOnchainTokenTransferFeeConfig(e cldf.Environment, feeRe
 	}, nil
 }
 
-func (a *FeesAdapter) SetTokenTransferFee(e cldf.Environment, feeRef datastore.AddressRef) *operations.Sequence[fees.SetTokenTransferFeeSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains] {
+func (a *FeesAdapter) SetTokenTransferFee(_ datastore.DataStore, feeRef datastore.AddressRef) *operations.Sequence[fees.SetTokenTransferFeeSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains] {
 	return operations.NewSequence(
 		"SetTokenTransferFee",
 		utils.Version_2_0_0,
@@ -226,13 +225,13 @@ func (a *FeesAdapter) GetDefaultDestChainConfig(src, dst uint64) lanes.FeeQuoter
 	return a.evm.GetFeeQuoterDestChainConfig()
 }
 
-func (a *FeesAdapter) GetOnchainDestChainConfig(e cldf.Environment, feeRef datastore.AddressRef, src uint64, dst uint64) (lanes.FeeQuoterDestChainConfig, error) {
+func (a *FeesAdapter) GetOnchainDestChainConfig(b operations.Bundle, chains cldf_chain.BlockChains, feeRef datastore.AddressRef, src uint64, dst uint64) (lanes.FeeQuoterDestChainConfig, error) {
 	err := a.validateFeeRef(feeRef)
 	if err != nil {
 		return lanes.FeeQuoterDestChainConfig{}, fmt.Errorf("invalid FeeQuoter address ref for src %d and dst %d: %w", src, dst, err)
 	}
 
-	chain, ok := e.BlockChains.EVMChains()[src]
+	chain, ok := chains.EVMChains()[src]
 	if !ok {
 		return lanes.FeeQuoterDestChainConfig{}, fmt.Errorf("chain with selector %d not defined", src)
 	}
@@ -245,7 +244,7 @@ func (a *FeesAdapter) GetOnchainDestChainConfig(e cldf.Environment, feeRef datas
 		return lanes.FeeQuoterDestChainConfig{}, fmt.Errorf("failed to instantiate FeeQuoter contract at address %s on chain selector %d: %w", fqAddr.Hex(), src, err)
 	}
 
-	onchain, err := fq.GetDestChainConfig(&bind.CallOpts{Context: e.GetContext()}, dst)
+	onchain, err := fq.GetDestChainConfig(&bind.CallOpts{Context: b.GetContext()}, dst)
 	if err != nil {
 		return lanes.FeeQuoterDestChainConfig{}, fmt.Errorf("failed to get dest chain config from FeeQuoter 2.0 at %s for src %d, dst %d: %w", fqAddr.Hex(), src, dst, err)
 	}
@@ -253,7 +252,7 @@ func (a *FeesAdapter) GetOnchainDestChainConfig(e cldf.Environment, feeRef datas
 	return evmseqV1_6_0.ReverseTranslateFQV2(onchain), nil
 }
 
-func (a *FeesAdapter) ApplyDestChainConfigUpdates(e cldf.Environment, feeRef datastore.AddressRef) *operations.Sequence[fees.ApplyDestChainConfigSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains] {
+func (a *FeesAdapter) ApplyDestChainConfigUpdates(_ datastore.DataStore, feeRef datastore.AddressRef) *operations.Sequence[fees.ApplyDestChainConfigSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains] {
 	return operations.NewSequence(
 		"ApplyDestChainConfigUpdatesV2",
 		utils.Version_2_0_0,

--- a/chains/solana/deployment/v1_0_0/adapters/fees.go
+++ b/chains/solana/deployment/v1_0_0/adapters/fees.go
@@ -6,22 +6,23 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_6_0/operations/router"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/fees"
 	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 )
 
 var _ fees.FeeResolver = (*SolanaFeeResolver)(nil)
 
 type SolanaFeeResolver struct{}
 
-func (a *SolanaFeeResolver) GetOnRampRef(e cldf.Environment, src uint64, dst uint64) (datastore.AddressRef, error) {
-	if _, ok := e.BlockChains.SolanaChains()[src]; !ok {
+func (a *SolanaFeeResolver) GetOnRampRef(_ cldf_ops.Bundle, chains cldf_chain.BlockChains, ds datastore.DataStore, src uint64, dst uint64) (datastore.AddressRef, error) {
+	if _, ok := chains.SolanaChains()[src]; !ok {
 		return datastore.AddressRef{}, fmt.Errorf("solana chain not found for selector %d", src)
 	}
 
 	// NOTE: for Solana, the Router and OnRamp are the same program.
 	routerRef, err := datastore_utils.FindAndFormatRef(
-		e.DataStore,
+		ds,
 		datastore.AddressRef{
 			Type:          datastore.ContractType(router.ContractType),
 			Version:       router.Version,

--- a/chains/solana/deployment/v1_6_0/adapters/fees.go
+++ b/chains/solana/deployment/v1_6_0/adapters/fees.go
@@ -21,7 +21,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 )
 
@@ -50,7 +49,7 @@ func (a *FeesAdapter) validateFeeRef(feeRef datastore.AddressRef) error {
 	return nil
 }
 
-func (a *FeesAdapter) GetFeeContractRef(e cldf.Environment, onRampRef datastore.AddressRef, src uint64, dst uint64) (datastore.AddressRef, error) {
+func (a *FeesAdapter) GetFeeContractRef(b operations.Bundle, chains cldf_chain.BlockChains, ds datastore.DataStore, onRampRef datastore.AddressRef, src uint64, dst uint64) (datastore.AddressRef, error) {
 	if onRampRef.Type.String() != routerops.ContractType.String() {
 		return datastore.AddressRef{}, fmt.Errorf("unexpected contract type for Router address ref for src %d and dst %d: got %s, want %s", src, dst, onRampRef.Type.String(), routerops.ContractType)
 	}
@@ -65,7 +64,7 @@ func (a *FeesAdapter) GetFeeContractRef(e cldf.Environment, onRampRef datastore.
 		ccip_router.SetProgramID(routerPubkey)
 	}
 
-	chain, ok := e.BlockChains.SolanaChains()[src]
+	chain, ok := chains.SolanaChains()[src]
 	if !ok {
 		return datastore.AddressRef{}, fmt.Errorf("solana chain not found for selector %d", src)
 	}
@@ -76,12 +75,12 @@ func (a *FeesAdapter) GetFeeContractRef(e cldf.Environment, onRampRef datastore.
 	}
 
 	var routerConfig ccip_router.Config
-	if err := chain.GetAccountDataBorshInto(e.GetContext(), routerConfigPDA, &routerConfig); err != nil {
+	if err := chain.GetAccountDataBorshInto(b.GetContext(), routerConfigPDA, &routerConfig); err != nil {
 		return datastore.AddressRef{}, fmt.Errorf("failed to read Router config for router %s on chain selector %d: %w", routerPubkey, src, err)
 	}
 
 	fqRef, err := datastore_utils.FindAndFormatRef(
-		e.DataStore,
+		ds,
 		datastore.AddressRef{
 			Type:          datastore.ContractType(fqops.ContractType),
 			Address:       routerConfig.FeeQuoter.String(),
@@ -101,13 +100,13 @@ func (a *FeesAdapter) GetDefaultTokenTransferFeeConfig(src uint64, dst uint64) f
 	return fees.GetDefaultChainAgnosticTokenTransferFeeConfig(src, dst)
 }
 
-func (a *FeesAdapter) GetOnchainTokenTransferFeeConfig(e cldf.Environment, feeRef datastore.AddressRef, src uint64, dst uint64, address string) (fees.TokenTransferFeeArgs, error) {
+func (a *FeesAdapter) GetOnchainTokenTransferFeeConfig(b operations.Bundle, chains cldf_chain.BlockChains, feeRef datastore.AddressRef, src uint64, dst uint64, address string) (fees.TokenTransferFeeArgs, error) {
 	err := a.validateFeeRef(feeRef)
 	if err != nil {
 		return fees.TokenTransferFeeArgs{}, fmt.Errorf("invalid FeeQuoter address ref for src %d and dst %d: %w", src, dst, err)
 	}
 
-	chain, ok := e.BlockChains.SolanaChains()[src]
+	chain, ok := chains.SolanaChains()[src]
 	if !ok {
 		return fees.TokenTransferFeeArgs{}, fmt.Errorf("solana chain not found for selector %d", src)
 	}
@@ -127,12 +126,12 @@ func (a *FeesAdapter) GetOnchainTokenTransferFeeConfig(e cldf.Environment, feeRe
 
 	// NOTE: ErrNotFound is expected if no config has been set on-chain yet - we return a zeroed config in that case
 	var cfg fee_quoter.PerChainPerTokenConfig
-	err = chain.GetAccountDataBorshInto(e.GetContext(), remoteBillingPDA, &cfg)
+	err = chain.GetAccountDataBorshInto(b.GetContext(), remoteBillingPDA, &cfg)
 	if err != nil && !errors.Is(err, rpc.ErrNotFound) {
 		return fees.TokenTransferFeeArgs{}, fmt.Errorf("failed to deserialize PerChainPerTokenConfig (src = %d, dst = %d, token = %s, pda = %s): %w", src, dst, token, remoteBillingPDA, err)
 	}
 
-	e.Logger.Infof("Fetched on-chain token transfer fee config for src %d, dst %d, token %s: %+v", src, dst, token, cfg)
+	b.Logger.Infof("Fetched on-chain token transfer fee config for src %d, dst %d, token %s: %+v", src, dst, token, cfg)
 	return fees.TokenTransferFeeArgs{
 		DestBytesOverhead: cfg.TokenTransferConfig.DestBytesOverhead,
 		DestGasOverhead:   cfg.TokenTransferConfig.DestGasOverhead,
@@ -143,7 +142,7 @@ func (a *FeesAdapter) GetOnchainTokenTransferFeeConfig(e cldf.Environment, feeRe
 	}, nil
 }
 
-func (a *FeesAdapter) SetTokenTransferFee(e cldf.Environment, feeRef datastore.AddressRef) *operations.Sequence[fees.SetTokenTransferFeeSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains] {
+func (a *FeesAdapter) SetTokenTransferFee(_ datastore.DataStore, feeRef datastore.AddressRef) *operations.Sequence[fees.SetTokenTransferFeeSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains] {
 	return operations.NewSequence(
 		"SetTokenTransferFee",
 		utils.Version_1_6_0,
@@ -222,13 +221,13 @@ func (a *FeesAdapter) GetDefaultDestChainConfig(src, dst uint64) lanes.FeeQuoter
 	return a.sol.GetFeeQuoterDestChainConfig()
 }
 
-func (a *FeesAdapter) GetOnchainDestChainConfig(e cldf.Environment, feeRef datastore.AddressRef, src uint64, dst uint64) (lanes.FeeQuoterDestChainConfig, error) {
+func (a *FeesAdapter) GetOnchainDestChainConfig(b operations.Bundle, chains cldf_chain.BlockChains, feeRef datastore.AddressRef, src uint64, dst uint64) (lanes.FeeQuoterDestChainConfig, error) {
 	err := a.validateFeeRef(feeRef)
 	if err != nil {
 		return lanes.FeeQuoterDestChainConfig{}, fmt.Errorf("invalid FeeQuoter address ref for src %d and dst %d: %w", src, dst, err)
 	}
 
-	chain, ok := e.BlockChains.SolanaChains()[src]
+	chain, ok := chains.SolanaChains()[src]
 	if !ok {
 		return lanes.FeeQuoterDestChainConfig{}, fmt.Errorf("solana chain not found for selector %d", src)
 	}
@@ -243,7 +242,7 @@ func (a *FeesAdapter) GetOnchainDestChainConfig(e cldf.Environment, feeRef datas
 	}
 
 	var destChainAccount fee_quoter.DestChain
-	err = chain.GetAccountDataBorshInto(e.GetContext(), destChainPDA, &destChainAccount)
+	err = chain.GetAccountDataBorshInto(b.GetContext(), destChainPDA, &destChainAccount)
 	if err != nil {
 		if errors.Is(err, rpc.ErrNotFound) {
 			return lanes.FeeQuoterDestChainConfig{}, nil
@@ -254,7 +253,7 @@ func (a *FeesAdapter) GetOnchainDestChainConfig(e cldf.Environment, feeRef datas
 	return solseq.ReverseTranslateFQ(destChainAccount.Config), nil
 }
 
-func (a *FeesAdapter) ApplyDestChainConfigUpdates(e cldf.Environment, feeRef datastore.AddressRef) *operations.Sequence[fees.ApplyDestChainConfigSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains] {
+func (a *FeesAdapter) ApplyDestChainConfigUpdates(ds datastore.DataStore, feeRef datastore.AddressRef) *operations.Sequence[fees.ApplyDestChainConfigSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains] {
 	return operations.NewSequence(
 		"ApplyDestChainConfigUpdatesSolana",
 		utils.Version_1_6_0,
@@ -277,7 +276,7 @@ func (a *FeesAdapter) ApplyDestChainConfigUpdates(e cldf.Environment, feeRef dat
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to parse FeeQuoter address %q for chain selector %d: %w", feeRef.Address, src, err)
 			}
 
-			offRampAddr, err := a.sol.GetOffRampAddress(e.DataStore, src)
+			offRampAddr, err := a.sol.GetOffRampAddress(ds, src)
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to get OffRamp address for chain %d: %w", src, err)
 			}

--- a/deployment/docs/interfaces.md
+++ b/deployment/docs/interfaces.md
@@ -186,23 +186,62 @@ tokens.GetTokenAdapterRegistry().RegisterTokenAdapter(chain_selectors.FamilyEVM,
 
 ### FeeAdapter
 
-Handles token transfer fee configuration and retrieval.
+Handles token transfer fee configuration and retrieval, plus FeeQuoter destination chain config reads/writes.
 
-**Source:** [fees/product.go](../fees/product.go)
+**Source:** [fees/product.go](../fees/product.go), [fees/defaults.go](../fees/defaults.go)
 **Registry:** `FeeAdapterRegistry` via `fees.GetRegistry()`
-**Key:** `chainFamily-version`
+**Key:** `chainFamily-version` (adapters); `chainFamily` (resolvers)
+
+Adapters take explicit dependencies instead of `Environment`: `Bundle` (logger + context), `BlockChains`, and `DataStore`. Changesets decompose `Environment` at the call site; private helpers may still accept `Environment` and decompose internally.
+
+#### FeeResolver
+
+Infers the on-ramp for a lane from on-chain state (via the router). Registered per chain family in `chains/<family>/deployment/v1_0_0/adapters/fees.go`.
+
+```go
+type FeeResolver interface {
+    GetOnRampRef(b Bundle, chains BlockChains, ds DataStore, src uint64, dst uint64) (datastore.AddressRef, error)
+}
+```
+
+**Registration:**
+```go
+fees.GetRegistry().RegisterFeeResolver(chain_selectors.FamilyEVM, &EVMFeeResolver{})
+```
+
+#### FeeAdapter
 
 ```go
 type FeeAdapter interface {
+    // GetFeeContractRef resolves the fee contract (OnRamp for v1.5, FeeQuoter for v1.6+/v2) from an on-ramp ref.
+    GetFeeContractRef(b Bundle, chains BlockChains, ds DataStore, onRamp datastore.AddressRef, src uint64, dst uint64) (datastore.AddressRef, error)
+
     // SetTokenTransferFee returns a sequence that sets per-token transfer fees for each destination chain.
-    SetTokenTransferFee(e Environment) *Sequence[SetTokenTransferFeeSequenceInput, OnChainOutput, BlockChains]
+    SetTokenTransferFee(ds DataStore, fq datastore.AddressRef) *Sequence[SetTokenTransferFeeSequenceInput, OnChainOutput, BlockChains]
 
     // GetOnchainTokenTransferFeeConfig reads the current on-chain fee configuration for a token on a lane.
-    GetOnchainTokenTransferFeeConfig(e Environment, src uint64, dst uint64, token string) (TokenTransferFeeArgs, error)
+    GetOnchainTokenTransferFeeConfig(b Bundle, chains BlockChains, fq datastore.AddressRef, src uint64, dst uint64, token string) (TokenTransferFeeArgs, error)
 
     // GetDefaultTokenTransferFeeConfig returns default fee configuration for a token on a lane.
     GetDefaultTokenTransferFeeConfig(src uint64, dst uint64) TokenTransferFeeArgs
+
+    // ApplyDestChainConfigUpdates returns a sequence that updates FeeQuoter destination chain configs.
+    ApplyDestChainConfigUpdates(ds DataStore, fq datastore.AddressRef) *Sequence[ApplyDestChainConfigSequenceInput, OnChainOutput, BlockChains]
+
+    // GetOnchainDestChainConfig reads the current FeeQuoter destination chain config for a lane.
+    GetOnchainDestChainConfig(b Bundle, chains BlockChains, fq datastore.AddressRef, src uint64, dst uint64) (FeeQuoterDestChainConfig, error)
+
+    // GetDefaultDestChainConfig returns default destination chain config for a lane.
+    GetDefaultDestChainConfig(src, dst uint64) FeeQuoterDestChainConfig
 }
+```
+
+#### ResolveFeeAdapter
+
+Shared helper in [fees/defaults.go](../fees/defaults.go) that performs the full lane lookup: router → on-ramp → fee contract → adapter (using the **fee contract version**, not the on-ramp version).
+
+```go
+func ResolveFeeAdapter(b Bundle, chains BlockChains, ds DataStore, src, dst uint64) (FeeAdapter, datastore.AddressRef, error)
 ```
 
 **Registration:**

--- a/deployment/fees/defaults.go
+++ b/deployment/fees/defaults.go
@@ -1,9 +1,13 @@
 package fees
 
 import (
+	"fmt"
 	"math"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
+	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 )
 
 func GetDefaultChainAgnosticTokenTransferFeeConfig(src uint64, dst uint64, overrides ...func(*TokenTransferFeeArgs)) TokenTransferFeeArgs {
@@ -31,4 +35,44 @@ func GetDefaultChainAgnosticTokenTransferFeeConfig(src uint64, dst uint64, overr
 	}
 
 	return cfg
+}
+
+func ResolveFeeAdapter(b cldf_ops.Bundle, chains cldf_chain.BlockChains, ds datastore.DataStore, src, dst uint64) (FeeAdapter, datastore.AddressRef, error) {
+	// NOTE: the OnRamp version and FeeQuoter versions are not guaranteed to be the same.
+	// We need to do a multi-step lookup in order to get the fee quoter that's currently
+	// configured on-chain.
+	registry := GetRegistry()
+
+	fam, err := chainsel.GetSelectorFamily(src)
+	if err != nil {
+		return nil, datastore.AddressRef{}, fmt.Errorf("failed to get chain selector family for selector %d: %w", src, err)
+	}
+
+	// Fee Quoter resolution part 1: get the current on ramp from the router
+	resolver, ok := registry.GetFeeResolver(fam)
+	if !ok {
+		return nil, datastore.AddressRef{}, fmt.Errorf("no fee resolver found for chain selector %d", src)
+	}
+	onRampRef, err := resolver.GetOnRampRef(b, chains, ds, src, dst)
+	if err != nil {
+		return nil, datastore.AddressRef{}, fmt.Errorf("failed to resolve on-ramp ref for chain selector %d and remote chain selector %d: %w", src, dst, err)
+	}
+
+	// Fee Quoter resolution part 2: get the current fee quoter from the on ramp
+	onRampAdp, ok := registry.GetFeeAdapter(fam, onRampRef.Version)
+	if !ok {
+		return nil, datastore.AddressRef{}, fmt.Errorf("no fee adapter found for chain selector %d, version %s", src, onRampRef.Version)
+	}
+	feeRef, err := onRampAdp.GetFeeContractRef(b, chains, ds, onRampRef, src, dst)
+	if err != nil {
+		return nil, datastore.AddressRef{}, fmt.Errorf("failed to get fee contract ref for chain selector %d and remote chain selector %d: %w", src, dst, err)
+	}
+
+	// Fee Quoter resolution part 3: lookup the adapter using the fee quoter version
+	feeQuoterAdp, ok := registry.GetFeeAdapter(fam, feeRef.Version)
+	if !ok {
+		return nil, datastore.AddressRef{}, fmt.Errorf("no fee adapter found for chain selector %d and fee quoter version %s", src, feeRef.Version)
+	}
+
+	return feeQuoterAdp, feeRef, nil
 }

--- a/deployment/fees/product.go
+++ b/deployment/fees/product.go
@@ -9,7 +9,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
-	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 )
 
@@ -26,19 +25,19 @@ type feeAdapterID string
 
 // FeeResolver defines the interface for fee resolvers that can infer the appropriate fee adapter version based on the chain family.
 type FeeResolver interface {
-	GetOnRampRef(e cldf.Environment, src uint64, dst uint64) (datastore.AddressRef, error)
+	GetOnRampRef(b cldf_ops.Bundle, chains cldf_chain.BlockChains, ds datastore.DataStore, src uint64, dst uint64) (datastore.AddressRef, error)
 }
 
 // FeeAdapter defines the interface for fee adapters.
 type FeeAdapter interface {
-	GetFeeContractRef(e cldf.Environment, onRamp datastore.AddressRef, src uint64, dst uint64) (datastore.AddressRef, error)
+	GetFeeContractRef(b cldf_ops.Bundle, chains cldf_chain.BlockChains, ds datastore.DataStore, onRamp datastore.AddressRef, src uint64, dst uint64) (datastore.AddressRef, error)
 
-	SetTokenTransferFee(e cldf.Environment, fq datastore.AddressRef) *cldf_ops.Sequence[SetTokenTransferFeeSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains]
-	GetOnchainTokenTransferFeeConfig(e cldf.Environment, fq datastore.AddressRef, src uint64, dst uint64, token string) (TokenTransferFeeArgs, error)
+	SetTokenTransferFee(ds datastore.DataStore, fq datastore.AddressRef) *cldf_ops.Sequence[SetTokenTransferFeeSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains]
+	GetOnchainTokenTransferFeeConfig(b cldf_ops.Bundle, chains cldf_chain.BlockChains, fq datastore.AddressRef, src uint64, dst uint64, token string) (TokenTransferFeeArgs, error)
 	GetDefaultTokenTransferFeeConfig(src uint64, dst uint64) TokenTransferFeeArgs
 
-	ApplyDestChainConfigUpdates(e cldf.Environment, fq datastore.AddressRef) *cldf_ops.Sequence[ApplyDestChainConfigSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains]
-	GetOnchainDestChainConfig(e cldf.Environment, fq datastore.AddressRef, src uint64, dst uint64) (lanes.FeeQuoterDestChainConfig, error)
+	ApplyDestChainConfigUpdates(ds datastore.DataStore, fq datastore.AddressRef) *cldf_ops.Sequence[ApplyDestChainConfigSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains]
+	GetOnchainDestChainConfig(b cldf_ops.Bundle, chains cldf_chain.BlockChains, fq datastore.AddressRef, src uint64, dst uint64) (lanes.FeeQuoterDestChainConfig, error)
 	GetDefaultDestChainConfig(src, dst uint64) lanes.FeeQuoterDestChainConfig
 }
 

--- a/deployment/fees/set_token_transfer_fee.go
+++ b/deployment/fees/set_token_transfer_fee.go
@@ -113,7 +113,7 @@ func makeApply(feeRegistry *FeeAdapterRegistry, mcmsRegistry *changesets.MCMSRea
 			feeGroups := map[datastore.AddressRefKey]FeeGroup{}
 			for _, dst := range src.Settings {
 				// Version inference part 1: we use the router contract to infer the currently configured on ramp
-				onRampRef, err := srcResolver.GetOnRampRef(e, src.Selector, dst.Selector)
+				onRampRef, err := srcResolver.GetOnRampRef(e.OperationsBundle, e.BlockChains, e.DataStore, src.Selector, dst.Selector)
 				if err != nil {
 					return cldf.ChangesetOutput{}, fmt.Errorf("failed to get OnRamp address ref from Router for src %d and dst %d: %w", src.Selector, dst.Selector, err)
 				}
@@ -123,7 +123,7 @@ func makeApply(feeRegistry *FeeAdapterRegistry, mcmsRegistry *changesets.MCMSRea
 				}
 
 				// Version inference part 2: we use the on ramp to get the currently configure fee contract (e.g. EVM2EVMOnRamp for v1.5.x and FeeQuoter for v1.6.x and v2.0.x)
-				feeQuoterRef, err := onRampAdp.GetFeeContractRef(e, onRampRef, src.Selector, dst.Selector)
+				feeQuoterRef, err := onRampAdp.GetFeeContractRef(e.OperationsBundle, e.BlockChains, e.DataStore, onRampRef, src.Selector, dst.Selector)
 				if err != nil {
 					return cldf.ChangesetOutput{}, fmt.Errorf("failed to get fee contract ref for src %d and dst %d: %w", src.Selector, dst.Selector, err)
 				}
@@ -167,7 +167,7 @@ func makeApply(feeRegistry *FeeAdapterRegistry, mcmsRegistry *changesets.MCMSRea
 				}
 				report, err := cldf_ops.ExecuteSequence(
 					e.OperationsBundle,
-					group.adapter.SetTokenTransferFee(e, group.fqRefDS),
+					group.adapter.SetTokenTransferFee(e.DataStore, group.fqRefDS),
 					e.BlockChains,
 					SetTokenTransferFeeSequenceInput{
 						Selector: src.Selector,
@@ -191,7 +191,7 @@ func makeApply(feeRegistry *FeeAdapterRegistry, mcmsRegistry *changesets.MCMSRea
 
 func inferTokenTransferFeeArgs(adapter FeeAdapter, e cldf.Environment, fq datastore.AddressRef, src uint64, dst uint64, cfg TokenTransferFee) (*TokenTransferFeeArgs, bool, error) {
 	e.Logger.Infof("Inferring token transfer fee config for src %d, dst %d, and token %s", src, dst, cfg.Address)
-	onchainCfg, err := adapter.GetOnchainTokenTransferFeeConfig(e, fq, src, dst, cfg.Address)
+	onchainCfg, err := adapter.GetOnchainTokenTransferFeeConfig(e.OperationsBundle, e.BlockChains, fq, src, dst, cfg.Address)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to get on-chain token transfer fee config for src %d, dst %d, and token %s: %w", src, dst, cfg.Address, err)
 	}

--- a/deployment/fees/update_fq_dests.go
+++ b/deployment/fees/update_fq_dests.go
@@ -75,7 +75,7 @@ func makeFQDestsApply(feeRegistry *FeeAdapterRegistry, mcmsRegistry *changesets.
 			feeGroups := map[datastore.AddressRefKey]DestsGroup{}
 			for _, dst := range src.Settings {
 				// Version inference part 1: we use the router contract to infer the currently configured on ramp
-				onRampRef, err := srcResolver.GetOnRampRef(e, src.Selector, dst.Selector)
+				onRampRef, err := srcResolver.GetOnRampRef(e.OperationsBundle, e.BlockChains, e.DataStore, src.Selector, dst.Selector)
 				if err != nil {
 					return cldf.ChangesetOutput{}, fmt.Errorf("failed to get OnRamp address ref from Router for src %d and dst %d: %w", src.Selector, dst.Selector, err)
 				}
@@ -85,7 +85,7 @@ func makeFQDestsApply(feeRegistry *FeeAdapterRegistry, mcmsRegistry *changesets.
 				}
 
 				// Version inference part 2: we use the on ramp to get the currently configure fee contract (e.g. EVM2EVMOnRamp for v1.5.x and FeeQuoter for v1.6.x and v2.0.x)
-				feeQuoterRef, err := onRampAdp.GetFeeContractRef(e, onRampRef, src.Selector, dst.Selector)
+				feeQuoterRef, err := onRampAdp.GetFeeContractRef(e.OperationsBundle, e.BlockChains, e.DataStore, onRampRef, src.Selector, dst.Selector)
 				if err != nil {
 					return cldf.ChangesetOutput{}, fmt.Errorf("failed to get fee contract ref for src %d and dst %d: %w", src.Selector, dst.Selector, err)
 				}
@@ -119,7 +119,7 @@ func makeFQDestsApply(feeRegistry *FeeAdapterRegistry, mcmsRegistry *changesets.
 				}
 				report, err := cldf_ops.ExecuteSequence(
 					e.OperationsBundle,
-					group.adapter.ApplyDestChainConfigUpdates(e, group.fqRefDS),
+					group.adapter.ApplyDestChainConfigUpdates(e.DataStore, group.fqRefDS),
 					e.BlockChains,
 					ApplyDestChainConfigSequenceInput{
 						Selector: src.Selector,
@@ -143,7 +143,7 @@ func makeFQDestsApply(feeRegistry *FeeAdapterRegistry, mcmsRegistry *changesets.
 
 // resolveDestChainConfig reads on-chain state (or defaults) and applies the user's override.
 func resolveDestChainConfig(adapter FeeAdapter, e cldf.Environment, fq datastore.AddressRef, src, dst uint64, override *lanes.FeeQuoterDestChainConfigOverride) (lanes.FeeQuoterDestChainConfig, error) {
-	onchain, err := adapter.GetOnchainDestChainConfig(e, fq, src, dst)
+	onchain, err := adapter.GetOnchainDestChainConfig(e.OperationsBundle, e.BlockChains, fq, src, dst)
 	if err != nil {
 		return lanes.FeeQuoterDestChainConfig{}, fmt.Errorf("failed to read on-chain dest chain config for src %d, dst %d: %w", src, dst, err)
 	}

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -297,7 +297,6 @@ func maybeApplyTokenTransferFeeConfig(
 ) (cldf_ops.SequenceReport[fees.SetTokenTransferFeeSequenceInput, sequences.OnChainOutput], error) {
 	// Helper vars
 	emptyReport := cldf_ops.SequenceReport[fees.SetTokenTransferFeeSequenceInput, sequences.OnChainOutput]{}
-	feeRegistry := fees.GetRegistry()
 
 	// NOTE: for pre-v2 pools, token transfer fees can only be set on the fee quoter. For
 	// v2 pools, token transfer fees can be set on both the fee quoter or the token pool.
@@ -316,34 +315,14 @@ func maybeApplyTokenTransferFeeConfig(
 	if err != nil {
 		return emptyReport, fmt.Errorf("failed to get chain selector family for selector %d: %w", src, err)
 	}
-
-	// Fee Quoter resolution part 1: get the current on ramp from the router
-	resolver, ok := feeRegistry.GetFeeResolver(fam)
-	if !ok {
+	if _, ok := fees.GetRegistry().GetFeeResolver(fam); !ok {
 		e.Logger.Warnf("No fee resolver found for chain selector %d, skipping token transfer fee config for remote chain selector %d", src, dst)
 		return emptyReport, nil
 	}
-	onRampRef, err := resolver.GetOnRampRef(e, src, dst)
-	if err != nil {
-		return emptyReport, fmt.Errorf("failed to resolve fee ref for chain selector %d and remote chain selector %d: %w", src, dst, err)
-	}
 
-	// Fee Quoter resolution part 2: get the current fee quoter from the on ramp
-	onRampAdp, ok := feeRegistry.GetFeeAdapter(fam, onRampRef.Version)
-	if !ok {
-		e.Logger.Warnf("No fee adapter found for chain selector %d, version %s, skipping token transfer fee config for remote chain selector %d", src, onRampRef.Version, dst)
-		return emptyReport, nil
-	}
-	feeRef, err := onRampAdp.GetFeeContractRef(e, onRampRef, src, dst)
+	feeQuoterAdp, feeRef, err := fees.ResolveFeeAdapter(e.OperationsBundle, e.BlockChains, e.DataStore, src, dst)
 	if err != nil {
-		return emptyReport, fmt.Errorf("failed to get fee contract ref for chain selector %d and remote chain selector %d: %w", src, dst, err)
-	}
-
-	// Fee Quoter resolution part 3: use the fee quoter version for read/write operations.
-	// A v1.6 OnRamp may point at a v2.0 FeeQuoter, so the on ramp adapter alone is not sufficient.
-	feeQuoterAdp, ok := feeRegistry.GetFeeAdapter(fam, feeRef.Version)
-	if !ok {
-		return emptyReport, fmt.Errorf("no fee adapter found for chain selector %d and fee quoter version %s", src, feeRef.Version)
+		return emptyReport, fmt.Errorf("failed to resolve fee adapter for chain selector %d and remote chain selector %d: %w", src, dst, err)
 	}
 
 	// NOTE: the TokenTransferFeeConfig for token pools is V2-focused and
@@ -353,7 +332,7 @@ func maybeApplyTokenTransferFeeConfig(
 	// at the moment, but realistically speaking this should not an issue
 	// since we've never had the need to modify it after we initially set
 	// it to MaxUint32.
-	onChainConfig, err := feeQuoterAdp.GetOnchainTokenTransferFeeConfig(e, feeRef, src, dst, srcTokRef.Address)
+	onChainConfig, err := feeQuoterAdp.GetOnchainTokenTransferFeeConfig(e.OperationsBundle, e.BlockChains, feeRef, src, dst, srcTokRef.Address)
 	if err != nil {
 		return emptyReport, fmt.Errorf("failed to get current on-chain token transfer fee config for chain selector %d and remote chain selector %d: %w", src, dst, err)
 	}
@@ -395,7 +374,7 @@ func maybeApplyTokenTransferFeeConfig(
 	// Apply the token transfer fee config
 	result, err := cldf_ops.ExecuteSequence(
 		e.OperationsBundle,
-		feeQuoterAdp.SetTokenTransferFee(e, feeRef),
+		feeQuoterAdp.SetTokenTransferFee(e.DataStore, feeRef),
 		e.BlockChains,
 		fees.SetTokenTransferFeeSequenceInput{
 			Selector: src,

--- a/integration-tests/deployment/set_token_transfer_fee_test.go
+++ b/integration-tests/deployment/set_token_transfer_fee_test.go
@@ -109,14 +109,14 @@ func TestSetTokenTransferFeeV1_6_0(t *testing.T) {
 	srcOnRampRef := datastore.AddressRef{ChainSelector: src, Type: datastore.ContractType(router.ContractType), Version: utils.Version_1_6_0}
 	srcOnRampRef, err = datastore_utils.FindAndFormatRef(env.DataStore, srcOnRampRef, src, datastore_utils.FullRef)
 	require.NoError(t, err)
-	srcFQ, err := solFeesAdapter.GetFeeContractRef(*env, srcOnRampRef, src, dst)
+	srcFQ, err := solFeesAdapter.GetFeeContractRef(env.OperationsBundle, env.BlockChains, env.DataStore, srcOnRampRef, src, dst)
 	require.NoError(t, err)
 
 	// Get the FQ on the destination
 	dstOnRampRef := datastore.AddressRef{ChainSelector: dst, Type: datastore.ContractType(onrampV1_6.ContractType), Version: utils.Version_1_6_0}
 	dstOnRampRef, err = datastore_utils.FindAndFormatRef(env.DataStore, dstOnRampRef, dst, datastore_utils.FullRef)
 	require.NoError(t, err)
-	dstFQ, err := evmFeesAdapter.GetFeeContractRef(*env, dstOnRampRef, dst, src)
+	dstFQ, err := evmFeesAdapter.GetFeeContractRef(env.OperationsBundle, env.BlockChains, env.DataStore, dstOnRampRef, dst, src)
 	require.NoError(t, err)
 
 	// Set the token transfer fee config for LINK
@@ -165,7 +165,7 @@ func TestSetTokenTransferFeeV1_6_0(t *testing.T) {
 	require.NoError(t, err)
 
 	// Confirm that the config was correctly set on the source
-	srcCfg, err := solFeesAdapter.GetOnchainTokenTransferFeeConfig(*env, srcFQ, src, dst, srcTokenAddress)
+	srcCfg, err := solFeesAdapter.GetOnchainTokenTransferFeeConfig(env.OperationsBundle, env.BlockChains, srcFQ, src, dst, srcTokenAddress)
 	require.NoError(t, err)
 	srcSensibleDefaults := solFeesAdapter.GetDefaultTokenTransferFeeConfig(src, dst)
 	require.Equal(t, srcCfg.DestBytesOverhead, srcSensibleDefaults.DestBytesOverhead)
@@ -176,7 +176,7 @@ func TestSetTokenTransferFeeV1_6_0(t *testing.T) {
 	require.True(t, srcCfg.IsEnabled)
 
 	// Confirm that the config was correctly set on the destination
-	dstCfg, err := evmFeesAdapter.GetOnchainTokenTransferFeeConfig(*env, dstFQ, dst, src, dstTokenAddress)
+	dstCfg, err := evmFeesAdapter.GetOnchainTokenTransferFeeConfig(env.OperationsBundle, env.BlockChains, dstFQ, dst, src, dstTokenAddress)
 	require.NoError(t, err)
 	dstSensibleDefaults := evmFeesAdapter.GetDefaultTokenTransferFeeConfig(dst, src)
 	require.Equal(t, dstCfg.DestBytesOverhead, dstSensibleDefaults.DestBytesOverhead)
@@ -228,12 +228,12 @@ func TestSetTokenTransferFeeV1_6_0(t *testing.T) {
 	require.NoError(t, err)
 
 	// Confirm that the config was disabled on the source
-	srcCfg, err = solFeesAdapter.GetOnchainTokenTransferFeeConfig(*env, srcFQ, src, dst, srcTokenAddress)
+	srcCfg, err = solFeesAdapter.GetOnchainTokenTransferFeeConfig(env.OperationsBundle, env.BlockChains, srcFQ, src, dst, srcTokenAddress)
 	require.NoError(t, err)
 	require.False(t, srcCfg.IsEnabled)
 
 	// Confirm that the config was disabled on the destination
-	dstCfg, err = evmFeesAdapter.GetOnchainTokenTransferFeeConfig(*env, dstFQ, dst, src, dstTokenAddress)
+	dstCfg, err = evmFeesAdapter.GetOnchainTokenTransferFeeConfig(env.OperationsBundle, env.BlockChains, dstFQ, dst, src, dstTokenAddress)
 	require.NoError(t, err)
 	require.False(t, dstCfg.IsEnabled)
 }
@@ -327,7 +327,7 @@ func TestSetTokenTransferFeeV2_0_0(t *testing.T) {
 	srcOnRampRef := datastore.AddressRef{ChainSelector: src, Type: datastore.ContractType(onrampV1_6.ContractType), Version: utils.Version_1_6_0}
 	srcOnRampRef, err = datastore_utils.FindAndFormatRef(e.DataStore, srcOnRampRef, src, datastore_utils.FullRef)
 	require.NoError(t, err)
-	srcFQ, err := evmFeesAdapterV1_6_0.GetFeeContractRef(*e, srcOnRampRef, src, dst)
+	srcFQ, err := evmFeesAdapterV1_6_0.GetFeeContractRef(e.OperationsBundle, e.BlockChains, e.DataStore, srcOnRampRef, src, dst)
 	require.NoError(t, err)
 	require.True(t, srcFQ.Version.Equal(utils.Version_2_0_0), "Expected v1.6 OnRamp to be connected to v2.0 FeeQuoter after upgrade, but got version %s", srcFQ.Version.String())
 
@@ -335,7 +335,7 @@ func TestSetTokenTransferFeeV2_0_0(t *testing.T) {
 	dstOnRampRef := datastore.AddressRef{ChainSelector: dst, Type: datastore.ContractType(onrampV1_6.ContractType), Version: utils.Version_1_6_0}
 	dstOnRampRef, err = datastore_utils.FindAndFormatRef(e.DataStore, dstOnRampRef, dst, datastore_utils.FullRef)
 	require.NoError(t, err)
-	dstFQ, err := evmFeesAdapterV1_6_0.GetFeeContractRef(*e, dstOnRampRef, dst, src)
+	dstFQ, err := evmFeesAdapterV1_6_0.GetFeeContractRef(e.OperationsBundle, e.BlockChains, e.DataStore, dstOnRampRef, dst, src)
 	require.NoError(t, err)
 	require.True(t, dstFQ.Version.Equal(utils.Version_2_0_0), "Expected v1.6 OnRamp to be connected to v2.0 FeeQuoter after upgrade, but got version %s", dstFQ.Version.String())
 
@@ -386,7 +386,7 @@ func TestSetTokenTransferFeeV2_0_0(t *testing.T) {
 	testhelpers.ProcessTimelockProposals(t, *e, out.MCMSTimelockProposals, false)
 
 	// Confirm that the config was correctly set on the source
-	srcCfg, err := evmFeesAdapterV2_0_0.GetOnchainTokenTransferFeeConfig(*e, srcFQ, src, dst, srcTokenAddress)
+	srcCfg, err := evmFeesAdapterV2_0_0.GetOnchainTokenTransferFeeConfig(e.OperationsBundle, e.BlockChains, srcFQ, src, dst, srcTokenAddress)
 	require.NoError(t, err)
 	srcSensibleDefaults := evmFeesAdapterV2_0_0.GetDefaultTokenTransferFeeConfig(src, dst)
 	require.Equal(t, srcCfg.DestBytesOverhead, srcSensibleDefaults.DestBytesOverhead)
@@ -395,7 +395,7 @@ func TestSetTokenTransferFeeV2_0_0(t *testing.T) {
 	require.True(t, srcCfg.IsEnabled)
 
 	// Confirm that the config was correctly set on the destination
-	dstCfg, err := evmFeesAdapterV2_0_0.GetOnchainTokenTransferFeeConfig(*e, dstFQ, dst, src, dstTokenAddress)
+	dstCfg, err := evmFeesAdapterV2_0_0.GetOnchainTokenTransferFeeConfig(e.OperationsBundle, e.BlockChains, dstFQ, dst, src, dstTokenAddress)
 	require.NoError(t, err)
 	dstSensibleDefaults := evmFeesAdapterV2_0_0.GetDefaultTokenTransferFeeConfig(dst, src)
 	require.Equal(t, dstCfg.DestBytesOverhead, dstSensibleDefaults.DestBytesOverhead)
@@ -489,12 +489,12 @@ func TestSetTokenTransferFeeV2_0_0(t *testing.T) {
 	testhelpers.ProcessTimelockProposals(t, *e, out.MCMSTimelockProposals, false)
 
 	// Confirm that the config was disabled on the source
-	srcCfg, err = evmFeesAdapterV2_0_0.GetOnchainTokenTransferFeeConfig(*e, srcFQ, src, dst, srcTokenAddress)
+	srcCfg, err = evmFeesAdapterV2_0_0.GetOnchainTokenTransferFeeConfig(e.OperationsBundle, e.BlockChains, srcFQ, src, dst, srcTokenAddress)
 	require.NoError(t, err)
 	require.False(t, srcCfg.IsEnabled)
 
 	// Confirm that the config was disabled on the destination
-	dstCfg, err = evmFeesAdapterV2_0_0.GetOnchainTokenTransferFeeConfig(*e, dstFQ, dst, src, dstTokenAddress)
+	dstCfg, err = evmFeesAdapterV2_0_0.GetOnchainTokenTransferFeeConfig(e.OperationsBundle, e.BlockChains, dstFQ, dst, src, dstTokenAddress)
 	require.NoError(t, err)
 	require.False(t, dstCfg.IsEnabled)
 }

--- a/integration-tests/deployment/tokens_and_token_pools_test.go
+++ b/integration-tests/deployment/tokens_and_token_pools_test.go
@@ -92,7 +92,6 @@ func TestTokensAndTokenPools(t *testing.T) {
 	deployRegistry := deployapi.GetRegistry()
 	lanesRegistry := lanes.GetLaneAdapterRegistry()
 	mcmsRegistry := changesets.GetRegistry()
-	feesRegistry := fees.GetRegistry()
 
 	// Registration happens automatically, so the `Register...`
 	// calls below aren't needed, but are left here for clarity
@@ -608,28 +607,15 @@ func TestTokensAndTokenPools(t *testing.T) {
 			require.NoError(t, err)
 			testhelpers.ProcessTimelockProposals(t, *env, out.MCMSTimelockProposals, false)
 
-			// Get fee resolver
-			feeResolver, ok := feesRegistry.GetFeeResolver(chainsel.FamilyEVM)
-			require.True(t, ok, "EVM fee resolver should be registered")
-
-			// Get the fee quoter contract on EVM chain A
-			onRampA, err := feeResolver.GetOnRampRef(*env, evmA.Chain.Selector, evmB.Chain.Selector)
-			require.NoError(t, err)
-			feeAdapterA, ok := feesRegistry.GetFeeAdapter(chainsel.FamilyEVM, onRampA.Version)
-			require.True(t, ok, fmt.Sprintf("fee adapter for version %q should be registered", onRampA.Version))
-			fqA, err := feeAdapterA.GetFeeContractRef(*env, onRampA, evmA.Chain.Selector, evmB.Chain.Selector)
+			// Resolve fee adapters by on-chain fee contract version (not on-ramp version)
+			feeAdapterA, fqA, err := fees.ResolveFeeAdapter(env.OperationsBundle, env.BlockChains, env.DataStore, evmA.Chain.Selector, evmB.Chain.Selector)
 			require.NoError(t, err)
 
-			// Get the fee quoter contract on EVM chain B
-			onRampB, err := feeResolver.GetOnRampRef(*env, evmB.Chain.Selector, evmA.Chain.Selector)
-			require.NoError(t, err)
-			feeAdapterB, ok := feesRegistry.GetFeeAdapter(chainsel.FamilyEVM, onRampB.Version)
-			require.True(t, ok, fmt.Sprintf("fee adapter for version %q should be registered", onRampB.Version))
-			fqB, err := feeAdapterB.GetFeeContractRef(*env, onRampB, evmB.Chain.Selector, evmA.Chain.Selector)
+			feeAdapterB, fqB, err := fees.ResolveFeeAdapter(env.OperationsBundle, env.BlockChains, env.DataStore, evmB.Chain.Selector, evmA.Chain.Selector)
 			require.NoError(t, err)
 
 			// Make sure EVM chain A was set
-			feeA, err := feeAdapterA.GetOnchainTokenTransferFeeConfig(*env, fqA, evmA.Chain.Selector, evmB.Chain.Selector, tokA.Hex())
+			feeA, err := feeAdapterA.GetOnchainTokenTransferFeeConfig(env.OperationsBundle, env.BlockChains, fqA, evmA.Chain.Selector, evmB.Chain.Selector, tokA.Hex())
 			require.NoError(t, err)
 			expectedFeeA := fees.GetDefaultChainAgnosticTokenTransferFeeConfig(evmA.Chain.Selector, evmB.Chain.Selector)
 			expectedFeeA.DeciBps = evmInitDeciBpsA.Value
@@ -641,7 +627,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 			require.Equal(t, expectedFeeA.DeciBps, feeA.DeciBps)
 
 			// Make sure EVM chain B fee config was set
-			feeB, err := feeAdapterB.GetOnchainTokenTransferFeeConfig(*env, fqB, evmB.Chain.Selector, evmA.Chain.Selector, tokB.Hex())
+			feeB, err := feeAdapterB.GetOnchainTokenTransferFeeConfig(env.OperationsBundle, env.BlockChains, fqB, evmB.Chain.Selector, evmA.Chain.Selector, tokB.Hex())
 			require.NoError(t, err)
 			expectedFeeB := fees.GetDefaultChainAgnosticTokenTransferFeeConfig(evmB.Chain.Selector, evmA.Chain.Selector)
 			expectedFeeB.DeciBps = evmInitDeciBpsB.Value
@@ -763,7 +749,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 				require.True(t, bytes.Equal(remoteTokenAB, common.LeftPadBytes(tokB.Bytes(), 32)))
 
 				// Verify that the fee config on chain A for transfers to chain B matches what we set in the input, merged with any defaults from the adapter
-				feeA, err = feeAdapterA.GetOnchainTokenTransferFeeConfig(*env, fqA, evmA.Chain.Selector, evmB.Chain.Selector, tokA.Hex())
+				feeA, err = feeAdapterA.GetOnchainTokenTransferFeeConfig(env.OperationsBundle, env.BlockChains, fqA, evmA.Chain.Selector, evmB.Chain.Selector, tokA.Hex())
 				require.NoError(t, err)
 				feeDefaultsA := tokensapi.GetDefaultChainAgnosticTokenTransferFeeConfig(evmA.Chain.Selector, evmB.Chain.Selector)
 				evmA.FeeConfig.DefaultFinalityTransferFeeBps = evmInitDeciBpsA // seed value should still be present
@@ -776,7 +762,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 				require.Equal(t, uint32(math.MaxUint32), feeA.MaxFeeUSDCents)
 
 				// Verify that the fee config on chain B for transfers to chain A matches what we set in the input, merged with any defaults from the adapter
-				feeB, err = feeAdapterB.GetOnchainTokenTransferFeeConfig(*env, fqB, evmB.Chain.Selector, evmA.Chain.Selector, tokB.Hex())
+				feeB, err = feeAdapterB.GetOnchainTokenTransferFeeConfig(env.OperationsBundle, env.BlockChains, fqB, evmB.Chain.Selector, evmA.Chain.Selector, tokB.Hex())
 				require.NoError(t, err)
 				feeDefaultsB := tokensapi.GetDefaultChainAgnosticTokenTransferFeeConfig(evmB.Chain.Selector, evmA.Chain.Selector)
 				evmB.FeeConfig.DefaultFinalityTransferFeeBps = evmInitDeciBpsB // seed value should still be present
@@ -821,10 +807,10 @@ func TestTokensAndTokenPools(t *testing.T) {
 				testhelpers.ProcessTimelockProposals(t, *env, out.MCMSTimelockProposals, false)
 
 				// Verify configs were reset
-				feeA, err = feeAdapterA.GetOnchainTokenTransferFeeConfig(*env, fqA, evmA.Chain.Selector, evmB.Chain.Selector, tokA.Hex())
+				feeA, err = feeAdapterA.GetOnchainTokenTransferFeeConfig(env.OperationsBundle, env.BlockChains, fqA, evmA.Chain.Selector, evmB.Chain.Selector, tokA.Hex())
 				require.NoError(t, err)
 				require.False(t, feeA.IsEnabled, "fee should be disabled after reset")
-				feeB, err = feeAdapterB.GetOnchainTokenTransferFeeConfig(*env, fqB, evmB.Chain.Selector, evmA.Chain.Selector, tokB.Hex())
+				feeB, err = feeAdapterB.GetOnchainTokenTransferFeeConfig(env.OperationsBundle, env.BlockChains, fqB, evmB.Chain.Selector, evmA.Chain.Selector, tokB.Hex())
 				require.NoError(t, err)
 				require.False(t, feeB.IsEnabled, "fee should be disabled after reset")
 			}
@@ -1312,24 +1298,13 @@ func TestTokensAndTokenPools(t *testing.T) {
 					results := env.DataStore.Addresses().Filter(filters...)
 					require.Len(t, results, 1, fmt.Sprintf("token address for symbol %q on chain selector %d should be found in datastore", src.tok.Symbol, src.sel))
 					token := results[0].Address
-					fam, err := chainsel.GetSelectorFamily(src.sel)
-					require.NoError(t, err)
 
-					// Get the on ramp contract on the source chain
-					feeResolver, ok := feesRegistry.GetFeeResolver(fam)
-					require.True(t, ok, "EVM fee resolver should be registered")
-					onRampSrc, err := feeResolver.GetOnRampRef(*env, src.sel, dst.sel)
-					require.NoError(t, err)
-
-					// Get the fee contract on the source chain
-					feeAdapter, ok := feesRegistry.GetFeeAdapter(fam, onRampSrc.Version)
-					require.True(t, ok, fmt.Sprintf("fee adapter for version %q should be registered", onRampSrc.Version))
-					fqSrc, err := feeAdapter.GetFeeContractRef(*env, onRampSrc, src.sel, dst.sel)
+					feeAdapter, fqSrc, err := fees.ResolveFeeAdapter(env.OperationsBundle, env.BlockChains, env.DataStore, src.sel, dst.sel)
 					require.NoError(t, err)
 
 					// Verify token transfer fee config is correct
 					expectedFee := src.fee.MergeWith(tokensapi.GetDefaultChainAgnosticTokenTransferFeeConfig(src.sel, dst.sel))
-					actualFee, err := feeAdapter.GetOnchainTokenTransferFeeConfig(*env, fqSrc, src.sel, dst.sel, token)
+					actualFee, err := feeAdapter.GetOnchainTokenTransferFeeConfig(env.OperationsBundle, env.BlockChains, fqSrc, src.sel, dst.sel, token)
 					require.NoError(t, err)
 					require.Equal(t, expectedFee.DefaultFinalityTransferFeeBps, actualFee.DeciBps)
 					require.Equal(t, expectedFee.DefaultFinalityFeeUSDCents, actualFee.MinFeeUSDCents)

--- a/integration-tests/deployment/update_fq_dests_test.go
+++ b/integration-tests/deployment/update_fq_dests_test.go
@@ -73,10 +73,10 @@ func testUpdateFQDestsEVMOnly(t *testing.T) {
 	srcOnRampRef := datastore.AddressRef{ChainSelector: src, Type: datastore.ContractType(onramp.ContractType), Version: utils.Version_1_6_0}
 	srcOnRampRef, err = datastore_utils.FindAndFormatRef(e.DataStore, srcOnRampRef, src, datastore_utils.FullRef)
 	require.NoError(t, err)
-	srcFQ, err := evmFeesAdapter.GetFeeContractRef(*e, srcOnRampRef, src, dst)
+	srcFQ, err := evmFeesAdapter.GetFeeContractRef(e.OperationsBundle, e.BlockChains, e.DataStore, srcOnRampRef, src, dst)
 	require.NoError(t, err)
 
-	initialCfg, err := evmFeesAdapter.GetOnchainDestChainConfig(*e, srcFQ, src, dst)
+	initialCfg, err := evmFeesAdapter.GetOnchainDestChainConfig(e.OperationsBundle, e.BlockChains, srcFQ, src, dst)
 	require.NoError(t, err)
 	require.True(t, initialCfg.IsEnabled)
 
@@ -108,7 +108,7 @@ func testUpdateFQDestsEVMOnly(t *testing.T) {
 		})
 	require.NoError(t, err)
 
-	updatedCfg, err := evmFeesAdapter.GetOnchainDestChainConfig(*e, srcFQ, src, dst)
+	updatedCfg, err := evmFeesAdapter.GetOnchainDestChainConfig(e.OperationsBundle, e.BlockChains, srcFQ, src, dst)
 	require.NoError(t, err)
 	require.True(t, updatedCfg.IsEnabled)
 	require.Equal(t, newMaxDataBytes, updatedCfg.MaxDataBytes, "MaxDataBytes should be updated")
@@ -171,10 +171,10 @@ func testUpdateFQDestsCrossChain(t *testing.T) {
 		evmOnRampRef := datastore.AddressRef{ChainSelector: evmSel, Type: datastore.ContractType(onramp.ContractType), Version: utils.Version_1_6_0}
 		evmOnRampRef, err = datastore_utils.FindAndFormatRef(e.DataStore, evmOnRampRef, evmSel, datastore_utils.FullRef)
 		require.NoError(t, err)
-		evmFQ, err := evmFeesAdapter.GetFeeContractRef(*e, evmOnRampRef, evmSel, solSel)
+		evmFQ, err := evmFeesAdapter.GetFeeContractRef(e.OperationsBundle, e.BlockChains, e.DataStore, evmOnRampRef, evmSel, solSel)
 		require.NoError(t, err)
 
-		initialCfg, err := evmFeesAdapter.GetOnchainDestChainConfig(*e, evmFQ, evmSel, solSel)
+		initialCfg, err := evmFeesAdapter.GetOnchainDestChainConfig(e.OperationsBundle, e.BlockChains, evmFQ, evmSel, solSel)
 		require.NoError(t, err)
 		require.True(t, initialCfg.IsEnabled)
 
@@ -205,7 +205,7 @@ func testUpdateFQDestsCrossChain(t *testing.T) {
 			})
 		require.NoError(t, err)
 
-		updatedCfg, err := evmFeesAdapter.GetOnchainDestChainConfig(*e, evmFQ, evmSel, solSel)
+		updatedCfg, err := evmFeesAdapter.GetOnchainDestChainConfig(e.OperationsBundle, e.BlockChains, evmFQ, evmSel, solSel)
 		require.NoError(t, err)
 		require.True(t, updatedCfg.IsEnabled)
 		require.Equal(t, newMaxDataBytes, updatedCfg.MaxDataBytes, "MaxDataBytes should be updated")
@@ -217,10 +217,10 @@ func testUpdateFQDestsCrossChain(t *testing.T) {
 		solOnRampRef := datastore.AddressRef{ChainSelector: solSel, Type: datastore.ContractType(router.ContractType), Version: utils.Version_1_6_0}
 		solOnRampRef, err = datastore_utils.FindAndFormatRef(e.DataStore, solOnRampRef, solSel, datastore_utils.FullRef)
 		require.NoError(t, err)
-		solFQ, err := solFeesAdapter.GetFeeContractRef(*e, solOnRampRef, solSel, evmSel)
+		solFQ, err := solFeesAdapter.GetFeeContractRef(e.OperationsBundle, e.BlockChains, e.DataStore, solOnRampRef, solSel, evmSel)
 		require.NoError(t, err)
 
-		initialCfg, err := solFeesAdapter.GetOnchainDestChainConfig(*e, solFQ, solSel, evmSel)
+		initialCfg, err := solFeesAdapter.GetOnchainDestChainConfig(e.OperationsBundle, e.BlockChains, solFQ, solSel, evmSel)
 		require.NoError(t, err)
 		require.True(t, initialCfg.IsEnabled)
 
@@ -251,7 +251,7 @@ func testUpdateFQDestsCrossChain(t *testing.T) {
 			})
 		require.NoError(t, err)
 
-		updatedCfg, err := solFeesAdapter.GetOnchainDestChainConfig(*e, solFQ, solSel, evmSel)
+		updatedCfg, err := solFeesAdapter.GetOnchainDestChainConfig(e.OperationsBundle, e.BlockChains, solFQ, solSel, evmSel)
 		require.NoError(t, err)
 		require.True(t, updatedCfg.IsEnabled)
 		require.Equal(t, newMaxDataBytes, updatedCfg.MaxDataBytes, "MaxDataBytes should be updated")


### PR DESCRIPTION
# Remove Environment from FeeAdapter and FeeResolver

## Summary

Refactors the fee adapter layer so `FeeAdapter` and `FeeResolver` no longer depend on
`deployment.Environment`. Implementations and call sites now pass explicit inputs: an operations
`Bundle` (logger + context), `BlockChains`, and `DataStore`. A shared `ResolveFeeAdapter` helper
encapsulates the full on-chain lane lookup used when fee configuration must target whatever fee
contract is actually wired today.

## Motivation

`Environment` is a changeset-level aggregate. Fee resolution and on-chain reads only need a subset of
what it carries. Tying the adapter interfaces to `Environment` forces every caller—including code
that already has `Bundle`, chains, and datastore separately—to construct or thread a full env, and
it blocks reuse from sequence helpers or token configuration paths that sit one layer below
changesets.

This refactor decouples the fee product interfaces from that deployment shell so adapter logic can
be invoked with the minimal dependencies it actually uses.

## What it adds

- **`FeeResolver.GetOnRampRef(b, chains, ds, src, dst)`** — family-level resolver (EVM reads router →
  on-ramp from chain; Solana returns router ref directly).
- **`FeeAdapter` methods split by dependency** — on-chain reads take `(b, chains, …)`; sequence
  factories take `(ds, feeRef)` and close over the fee ref in the sequence body as before.
- **`fees.ResolveFeeAdapter(b, chains, ds, src, dst)`** — router → on-ramp → fee contract → adapter
  lookup, selecting the adapter by **fee contract version** (not on-ramp version). This matters when
  a v1.6 on-ramp points at a v2.0 fee quoter.
- **Updated changeset and token configure call sites** — apply loops decompose `Environment` at the
  adapter boundary (`e.OperationsBundle`, `e.BlockChains`, `e.DataStore`).
- **Documentation** — `deployment/docs/interfaces.md` reflects the new surface, including
  `FeeResolver` and `ResolveFeeAdapter`.

## Design choices

- **Explicit dependencies over Environment in the public adapter API.** Adapters declare exactly what
  they need. Callers that still operate inside a changeset keep `Environment` locally and decompose
  when crossing into the fee layer.

- **Private helpers may keep Environment.** Functions like `inferTokenTransferFeeArgs` and
  `resolveDestChainConfig` remain `(adapter, e Environment, …)` and decompose only for the single
  adapter call. That keeps changeset diffs narrow without weakening the interface boundary.

- **`ResolveFeeAdapter` is the canonical multi-step lookup.** Token transfer configuration uses it
  for pre-v2 pool fee apply. Fee changesets (`SetTokenTransferFee`, `UpdateFeeQuoterDests`) still
  inline the same three steps in their apply loops today; behavior matches the helper, but the
  duplication is intentional deferral rather than a semantic fork.

- **Sequence behavior unchanged.** `SetTokenTransferFee` and `ApplyDestChainConfigUpdates` still
  build the same sequences; only the outer factory signature drops `Environment`. The fee ref is
  captured from the factory argument as before. Solana dest-chain updates pass `DataStore` into the
  sequence closure where off-ramp lookup needs it.

- **Soft-skip semantics narrowed in token configure.** `maybeApplyTokenTransferFeeConfig` still
  warn-skips when no fee resolver exists for the chain family. Other resolution failures—including
  a missing on-ramp-version adapter—now surface as errors via `ResolveFeeAdapter` instead of being
  silently skipped. That aligns optional fee apply with stricter failure modes elsewhere.

- **`SetTokenTransferFee(ds, fq)` carries DataStore even when unused.** Most EVM implementations do
  not read `ds` in the factory; the parameter exists for interface uniformity and for paths (e.g.
  Solana dest config) that do need datastore inside the sequence.

## Scope and non-goals

- **`TokenFeeAdapter` is unchanged.** Pool-level v2 fee configuration in `deployment/tokens` still
  uses `Environment`. That interface is a separate follow-up; this PR only covers the shared
  `fees.FeeAdapter` / `FeeResolver` product types.

- **No changes to fee semantics on-chain.** Bindings, sequence inputs, default configs, and
  version-specific validation (v1.5 on-ramp-as-fee-contract, v1.6/v2 fee quoter, v2 max-fee
  mapping) are preserved; only how dependencies are threaded changed.

## Relationship to prior work

The three-step fee resolution (on-ramp adapter → fee contract ref → fee-quoter-version adapter)
matches the lane inference fix that landed in #2149. This PR generalizes that pattern into
`ResolveFeeAdapter` and applies the dependency split consistently across EVM (v1.5, v1.6, v2) and
Solana (v1.6) implementations.
