### PR TITLE
Various minor CLD fixes & code dedup

### DIFF
--- a/chains/evm/deployment/fastcurse_test.go
+++ b/chains/evm/deployment/fastcurse_test.go
@@ -299,6 +299,12 @@ func TestFastCurse(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, isCursed, "subject on chain1 should be uncursed on rmnremote in chain2")
 	t.Logf("Subjects successfully uncursed %x on chain1 %d and %x on chain2 %d", adv1_5_0.SelectorToSubject(chain2), chain1, adv1_6_0.SelectorToSubject(chain1), chain2)
+
+	// Uncursing again should fail because nothing is cursed on chain.
+	env.OperationsBundle = cldf_ops.NewBundle(env.GetContext, env.Logger, cldf_ops.NewMemoryReporter())
+	_, err = uncurseChangeset.Apply(*env, curseCfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "uncurse skipped all actions")
 }
 
 func TestFastCurseGlobalCurseOnChain(t *testing.T) {

--- a/chains/evm/deployment/fastcurse_test.go
+++ b/chains/evm/deployment/fastcurse_test.go
@@ -156,6 +156,7 @@ func TestFastCurse(t *testing.T) {
 	evmChain2 := env.BlockChains.EVMChains()[chain2]
 	output, err := cs.Apply(*env, deploy.MCMSDeploymentConfig{
 		AdapterVersion: semver.MustParse("1.0.0"),
+		MCMS:           testhelpers.MCMSInputForQualifier(deploymentutils.CLLQualifier),
 		Chains: map[uint64]deploy.MCMSDeploymentConfigPerChain{
 			chain1: {
 				Canceller:        testhelpers.SingleGroupMCMS(),
@@ -456,6 +457,7 @@ func TestFastCurseGlobalCurseOnChain(t *testing.T) {
 	}
 	output, err := cs.Apply(*env, deploy.MCMSDeploymentConfig{
 		AdapterVersion: semver.MustParse("1.0.0"),
+		MCMS:           testhelpers.MCMSInputForQualifier(deploymentutils.CLLQualifier),
 		Chains:         mcmsChainInput,
 	})
 	require.NoError(t, err)

--- a/chains/evm/deployment/utils/rmn.go
+++ b/chains/evm/deployment/utils/rmn.go
@@ -1,0 +1,83 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+
+	evmds "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/datastore"
+	rmnproxyops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/rmn_proxy"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_0_0/rmn_proxy_contract"
+	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
+)
+
+const (
+	rmnContractType       = "RMN"
+	rmnRemoteContractType = "RMNRemote"
+)
+
+// ActiveRMNVersion returns the version of the active RMN on the given chain.
+// It reads the address from RMNProxy when available, otherwise falls back to RMN/RMNRemote in the datastore.
+func ActiveRMNVersion(e cldf.Environment, selector uint64) (*semver.Version, error) {
+	chain, ok := e.BlockChains.EVMChains()[selector]
+	if !ok {
+		return nil, fmt.Errorf("no EVM chain found for selector %d", selector)
+	}
+
+	if version, err := activeRMNVersionFromProxy(e, selector, chain); err == nil {
+		return version, nil
+	}
+
+	return activeRMNVersionFromDatastore(e, selector, chain)
+}
+
+func activeRMNVersionFromProxy(e cldf.Environment, selector uint64, chain cldf_evm.Chain) (*semver.Version, error) {
+	rmnProxyRef := datastore.AddressRef{
+		Type:    datastore.ContractType(rmnproxyops.ContractType),
+		Version: semver.MustParse("1.0.0"),
+	}
+	rmnProxyAddr, err := datastore_utils.FindAndFormatRef(e.DataStore, rmnProxyRef, selector, evmds.ToEVMAddress)
+	if err != nil {
+		return nil, err
+	}
+	rmnProxyC, err := rmn_proxy_contract.NewRMNProxy(rmnProxyAddr, chain.Client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to instantiate RMNProxy contract at %s on chain %d: %w", rmnProxyAddr, selector, err)
+	}
+	rmnAddr, err := rmnProxyC.GetARM(&bind.CallOpts{Context: e.GetContext()})
+	if err != nil {
+		return nil, err
+	}
+	if rmnAddr == (common.Address{}) {
+		return nil, fmt.Errorf("RMNProxy on chain %d has no active RMN set", selector)
+	}
+	_, version, err := TypeAndVersion(rmnAddr, chain.Client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get type and version from RMN at %s on chain %d: %w", rmnAddr, selector, err)
+	}
+	return version, nil
+}
+
+func activeRMNVersionFromDatastore(e cldf.Environment, selector uint64, chain cldf_evm.Chain) (*semver.Version, error) {
+	for _, contractType := range []string{rmnRemoteContractType, rmnContractType} {
+		refs := e.DataStore.Addresses().Filter(
+			datastore.AddressRefByChainSelector(selector),
+			datastore.AddressRefByType(datastore.ContractType(contractType)),
+		)
+		if len(refs) == 0 {
+			continue
+		}
+		addr := common.HexToAddress(refs[0].Address)
+		_, version, err := TypeAndVersion(addr, chain.Client)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get type and version from %s at %s on chain %d: %w", contractType, addr, selector, err)
+		}
+		return version, nil
+	}
+	return nil, fmt.Errorf("no active RMN found on chain %d", selector)
+}

--- a/chains/evm/deployment/v1_0_0/adapters/deployer.go
+++ b/chains/evm/deployment/v1_0_0/adapters/deployer.go
@@ -267,12 +267,14 @@ func (d *EVMDeployer) DeployMCMS() *cldf_ops.Sequence[ccipapi.MCMSDeploymentConf
 				b.Logger.Infof("Deployer renounced Admin role on Timelock %s on chain %s", timelockAddr.Address, evmChain.Name)
 			}
 
-			mcmOwnershipBatchOps, err := seq.TransferDeployedMCMsToTimelock(
+			mcmOwnershipBatchOps, err := seq.TransferAndAcceptOwnership(
 				b,
 				evmChain,
-				in.ChainSelector,
-				common.HexToAddress(timelockAddr.Address),
-				[]cldf_datastore.AddressRef{proposerAddr, bypasserAddr, cancellerAddr},
+				seq.OwnershipInputsFromRefs(
+					in.ChainSelector,
+					common.HexToAddress(timelockAddr.Address),
+					[]cldf_datastore.AddressRef{proposerAddr, bypasserAddr, cancellerAddr},
+				),
 			)
 			if err != nil {
 				return sequtil.OnChainOutput{}, fmt.Errorf("failed to transfer MCM ownership to timelock on chain %d: %w", in.ChainSelector, err)

--- a/chains/evm/deployment/v1_0_0/adapters/deployer.go
+++ b/chains/evm/deployment/v1_0_0/adapters/deployer.go
@@ -241,30 +241,15 @@ func (d *EVMDeployer) DeployMCMS() *cldf_ops.Sequence[ccipapi.MCMSDeploymentConf
 			//   "transfer" = grantRole(ADMIN_ROLE, finalAdmin)
 			//   "accept"   = renounceRole(ADMIN_ROLE) by the deployer — both happen in the same changeset.
 			if finalAdmin != evmChain.DeployerKey.From {
-				_, err = cldf_ops.ExecuteOperation(b, ops.OpGrantRoleTimelock, evmChain, contract.FunctionInput[ops.OpGrantRoleTimelockInput]{
-					ChainSelector: in.ChainSelector,
-					Address:       common.HexToAddress(timelockAddr.Address),
-					Args: ops.OpGrantRoleTimelockInput{
-						RoleID:  ops.ADMIN_ROLE.ID,
-						Account: finalAdmin,
-					},
-				})
-				if err != nil {
-					return sequtil.OnChainOutput{}, fmt.Errorf("failed to grant admin role to %s on timelock on chain %d: %w", finalAdmin, in.ChainSelector, err)
+				if err := seq.TransferTimelockAdminTo(
+					b,
+					evmChain,
+					in.ChainSelector,
+					common.HexToAddress(timelockAddr.Address),
+					finalAdmin,
+				); err != nil {
+					return sequtil.OnChainOutput{}, fmt.Errorf("failed to transfer timelock admin on chain %d: %w", in.ChainSelector, err)
 				}
-				b.Logger.Infof("Granted Admin role on Timelock %s to %s on chain %s", timelockAddr.Address, finalAdmin, evmChain.Name)
-
-				_, err = cldf_ops.ExecuteOperation(b, ops.OpRenounceRoleTimelock, evmChain, contract.FunctionInput[ops.OpRenounceRoleTimelockInput]{
-					ChainSelector: in.ChainSelector,
-					Address:       common.HexToAddress(timelockAddr.Address),
-					Args: ops.OpRenounceRoleTimelockInput{
-						RoleID: ops.ADMIN_ROLE.ID,
-					},
-				})
-				if err != nil {
-					return sequtil.OnChainOutput{}, fmt.Errorf("failed to renounce admin role on timelock on chain %d: %w", in.ChainSelector, err)
-				}
-				b.Logger.Infof("Deployer renounced Admin role on Timelock %s on chain %s", timelockAddr.Address, evmChain.Name)
 			}
 
 			mcmOwnershipBatchOps, err := seq.TransferAndAcceptOwnership(

--- a/chains/evm/deployment/v1_0_0/adapters/deployer.go
+++ b/chains/evm/deployment/v1_0_0/adapters/deployer.go
@@ -267,6 +267,18 @@ func (d *EVMDeployer) DeployMCMS() *cldf_ops.Sequence[ccipapi.MCMSDeploymentConf
 				b.Logger.Infof("Deployer renounced Admin role on Timelock %s on chain %s", timelockAddr.Address, evmChain.Name)
 			}
 
+			mcmOwnershipBatchOps, err := seq.TransferDeployedMCMsToTimelock(
+				b,
+				evmChain,
+				in.ChainSelector,
+				common.HexToAddress(timelockAddr.Address),
+				[]cldf_datastore.AddressRef{proposerAddr, bypasserAddr, cancellerAddr},
+			)
+			if err != nil {
+				return sequtil.OnChainOutput{}, fmt.Errorf("failed to transfer MCM ownership to timelock on chain %d: %w", in.ChainSelector, err)
+			}
+			output.BatchOps = append(output.BatchOps, mcmOwnershipBatchOps...)
+
 			return output, nil
 		})
 }

--- a/chains/evm/deployment/v1_0_0/adapters/deployer_test.go
+++ b/chains/evm/deployment/v1_0_0/adapters/deployer_test.go
@@ -11,6 +11,7 @@ import (
 	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf_deployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 	"github.com/smartcontractkit/mcms/sdk/evm/bindings"
 	mcms_types "github.com/smartcontractkit/mcms/types"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/adapters"
 	ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations"
+	seq "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/sequences"
 	deployops "github.com/smartcontractkit/chainlink-ccip/deployment/deploy"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/testhelpers"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
@@ -25,6 +27,21 @@ import (
 	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
 )
+
+func applyDeployMCMSAndAcceptOwnership(
+	t *testing.T,
+	env *cldf_deployment.Environment,
+	cs cldf_deployment.ChangeSetV2[deployops.MCMSDeploymentConfig],
+	cfg deployops.MCMSDeploymentConfig,
+) cldf_deployment.ChangesetOutput {
+	t.Helper()
+	output, err := cs.Apply(*env, cfg)
+	require.NoError(t, err)
+	if len(output.MCMSTimelockProposals) > 0 {
+		testhelpers.ProcessTimelockProposals(t, *env, output.MCMSTimelockProposals, false)
+	}
+	return output
+}
 
 func TestDeployMCMS(t *testing.T) {
 	t.Parallel()
@@ -42,7 +59,7 @@ func TestDeployMCMS(t *testing.T) {
 	dReg.RegisterDeployer(chainsel.FamilyEVM, deployops.MCMSVersion, evmDeployer)
 	cs := deployops.DeployMCMS(dReg, nil)
 
-	output, err := cs.Apply(*env, deployops.MCMSDeploymentConfig{
+	output := applyDeployMCMSAndAcceptOwnership(t, env, cs, deployops.MCMSDeploymentConfig{
 		AdapterVersion: deployops.MCMSVersion,
 		Chains: map[uint64]deployops.MCMSDeploymentConfigPerChain{
 			selector1: {
@@ -62,7 +79,6 @@ func TestDeployMCMS(t *testing.T) {
 		},
 	})
 
-	require.NoError(t, err)
 	require.Greater(t, len(output.Reports), 0)
 	env.DataStore = output.DataStore.Seal()
 	// filter addresses for the test chain selector
@@ -131,6 +147,12 @@ func TestDeployMCMS(t *testing.T) {
 	selfAdmin, err := timelockC.HasRole(&bind.CallOpts{Context: t.Context()}, adminRoleAdmin, timelockAddr)
 	require.NoError(t, err)
 	require.True(t, selfAdmin, "CLLCCIP timelock should be self-governed")
+
+	for _, ref := range [][]datastore.AddressRef{proposerRef, bypasserRef, cancellerRef} {
+		owner, _, err := seq.LoadOwnableContract(common.HexToAddress(ref[0].Address), evmChain1.Client)
+		require.NoError(t, err)
+		require.Equal(t, timelockAddr, owner, "MCM %s should be owned by CLLCCIP timelock", ref[0].Type)
+	}
 }
 
 // TestDeployMCMS_TimelockAdminRoleTransfer verifies the admin-role logic inside DeployMCMS:
@@ -169,7 +191,7 @@ func TestDeployMCMS_TimelockAdminRoleTransfer(t *testing.T) {
 	})
 
 	t.Run("CLLCCIP bootstrap is self-governed", func(t *testing.T) {
-		output, err := cs.Apply(*env, deployops.MCMSDeploymentConfig{
+		output := applyDeployMCMSAndAcceptOwnership(t, env, cs, deployops.MCMSDeploymentConfig{
 			AdapterVersion: deployops.MCMSVersion,
 			Chains: map[uint64]deployops.MCMSDeploymentConfigPerChain{
 				selector: {
@@ -181,7 +203,6 @@ func TestDeployMCMS_TimelockAdminRoleTransfer(t *testing.T) {
 				},
 			},
 		})
-		require.NoError(t, err)
 		env.DataStore = output.DataStore.Seal()
 
 		timelockRef := env.DataStore.Addresses().Filter(
@@ -227,7 +248,7 @@ func TestDeployMCMS_DefaultsToExistingCLLCCIPTimelock(t *testing.T) {
 	cs := deployops.DeployMCMS(dReg, nil)
 
 	// Step 1: deploy the CLLCCIP MCMS instance
-	cllOutput, err := cs.Apply(*env, deployops.MCMSDeploymentConfig{
+	cllOutput := applyDeployMCMSAndAcceptOwnership(t, env, cs, deployops.MCMSDeploymentConfig{
 		AdapterVersion: deployops.MCMSVersion,
 		Chains: map[uint64]deployops.MCMSDeploymentConfigPerChain{
 			selector: {
@@ -239,7 +260,6 @@ func TestDeployMCMS_DefaultsToExistingCLLCCIPTimelock(t *testing.T) {
 			},
 		},
 	})
-	require.NoError(t, err)
 	require.NoError(t, cllOutput.DataStore.Merge(env.DataStore))
 	env.DataStore = cllOutput.DataStore.Seal()
 
@@ -254,7 +274,7 @@ func TestDeployMCMS_DefaultsToExistingCLLCCIPTimelock(t *testing.T) {
 
 	// Step 2: deploy a second (non-CLLCCIP) MCMS instance.
 	// The deployer should automatically pick the CLLCCIP timelock as the admin.
-	rmnOutput, err := cs.Apply(*env, deployops.MCMSDeploymentConfig{
+	rmnOutput := applyDeployMCMSAndAcceptOwnership(t, env, cs, deployops.MCMSDeploymentConfig{
 		AdapterVersion: deployops.MCMSVersion,
 		Chains: map[uint64]deployops.MCMSDeploymentConfigPerChain{
 			selector: {
@@ -266,7 +286,6 @@ func TestDeployMCMS_DefaultsToExistingCLLCCIPTimelock(t *testing.T) {
 			},
 		},
 	})
-	require.NoError(t, err)
 	require.NoError(t, rmnOutput.DataStore.Merge(env.DataStore))
 	env.DataStore = rmnOutput.DataStore.Seal()
 
@@ -311,7 +330,7 @@ func TestUpdateMCMSConfig(t *testing.T) {
 
 	// deploy one set of timelock and MCMS contracts on each chain
 	deployMCMS := deployops.DeployMCMS(dReg, nil)
-	output, err := deployMCMS.Apply(*env, deployops.MCMSDeploymentConfig{
+	output := applyDeployMCMSAndAcceptOwnership(t, env, deployMCMS, deployops.MCMSDeploymentConfig{
 		AdapterVersion: semver.MustParse("1.0.0"),
 		Chains: map[uint64]deployops.MCMSDeploymentConfigPerChain{
 			selector1: {
@@ -330,7 +349,6 @@ func TestUpdateMCMSConfig(t *testing.T) {
 			},
 		},
 	})
-	require.NoError(t, err)
 	require.Greater(t, len(output.Reports), 0)
 	env.DataStore = output.DataStore.Seal()
 
@@ -412,6 +430,8 @@ func TestUpdateMCMSConfig(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Greater(t, len(output.Reports), 0)
+	require.NotEmpty(t, output.MCMSTimelockProposals)
+	testhelpers.ProcessTimelockProposals(t, *env, output.MCMSTimelockProposals, false)
 
 	// check that MCMS configs are updated correctly
 	for _, sel := range []uint64{selector1, selector2} {
@@ -450,7 +470,7 @@ func TestDeployMCMS_CLLCCIPAutoAdminMultiChain(t *testing.T) {
 	deployMCMS := deployops.DeployMCMS(dReg, nil)
 
 	// Step 1: deploy CLLCCIP on both chains (bootstrap — each self-governed).
-	cllOutput, err := deployMCMS.Apply(*env, deployops.MCMSDeploymentConfig{
+	cllOutput := applyDeployMCMSAndAcceptOwnership(t, env, deployMCMS, deployops.MCMSDeploymentConfig{
 		AdapterVersion: deployops.MCMSVersion,
 		Chains: map[uint64]deployops.MCMSDeploymentConfigPerChain{
 			selector1: {
@@ -469,7 +489,6 @@ func TestDeployMCMS_CLLCCIPAutoAdminMultiChain(t *testing.T) {
 			},
 		},
 	})
-	require.NoError(t, err)
 	require.Greater(t, len(cllOutput.Reports), 0)
 	require.NoError(t, cllOutput.DataStore.Merge(env.DataStore))
 	env.DataStore = cllOutput.DataStore.Seal()
@@ -488,7 +507,7 @@ func TestDeployMCMS_CLLCCIPAutoAdminMultiChain(t *testing.T) {
 
 	// Step 2: deploy a second MCMS set (testQual) with CLLCCIP already in datastore.
 	// DeployMCMS should automatically use CLLCCIP timelock as admin.
-	testOutput, err := deployMCMS.Apply(*env, deployops.MCMSDeploymentConfig{
+	testOutput := applyDeployMCMSAndAcceptOwnership(t, env, deployMCMS, deployops.MCMSDeploymentConfig{
 		AdapterVersion: deployops.MCMSVersion,
 		Chains: map[uint64]deployops.MCMSDeploymentConfigPerChain{
 			selector1: {
@@ -507,7 +526,6 @@ func TestDeployMCMS_CLLCCIPAutoAdminMultiChain(t *testing.T) {
 			},
 		},
 	})
-	require.NoError(t, err)
 	require.Greater(t, len(testOutput.Reports), 0)
 	require.NoError(t, testOutput.DataStore.Merge(env.DataStore))
 	env.DataStore = testOutput.DataStore.Seal()

--- a/chains/evm/deployment/v1_0_0/adapters/deployer_test.go
+++ b/chains/evm/deployment/v1_0_0/adapters/deployer_test.go
@@ -173,6 +173,24 @@ func TestDeployMCMS_TimelockAdminRoleTransfer(t *testing.T) {
 	dReg.RegisterDeployer(chainsel.FamilyEVM, deployops.MCMSVersion, evmDeployer)
 	cs := deployops.DeployMCMS(dReg, nil)
 
+	t.Run("defaults to schedule proposal using chain qualifier", func(t *testing.T) {
+		output, err := cs.Apply(*env, deployops.MCMSDeploymentConfig{
+			AdapterVersion: deployops.MCMSVersion,
+			Chains: map[uint64]deployops.MCMSDeploymentConfigPerChain{
+				selector: {
+					Canceller:        testhelpers.SingleGroupMCMS(),
+					Bypasser:         testhelpers.SingleGroupMCMS(),
+					Proposer:         testhelpers.SingleGroupMCMS(),
+					TimelockMinDelay: big.NewInt(0),
+					Qualifier:        ptr.String(utils.CLLQualifier),
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, output.MCMSTimelockProposals, 1)
+		require.Equal(t, mcms_types.TimelockActionSchedule, output.MCMSTimelockProposals[0].Action)
+	})
+
 	t.Run("non-CLLCCIP with no CLLCCIP deployed fails", func(t *testing.T) {
 		_, err := cs.Apply(*env, deployops.MCMSDeploymentConfig{
 			AdapterVersion: deployops.MCMSVersion,

--- a/chains/evm/deployment/v1_0_0/adapters/transfer_ownership_test.go
+++ b/chains/evm/deployment/v1_0_0/adapters/transfer_ownership_test.go
@@ -71,6 +71,9 @@ func TestTransferOwnership(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Greater(t, len(output.Reports), 0)
+	if len(output.MCMSTimelockProposals) > 0 {
+		testhelpers.ProcessTimelockProposals(t, *env, output.MCMSTimelockProposals, false)
+	}
 	ds := output.DataStore
 	require.NoError(t, ds.Merge(env.DataStore))
 	env.DataStore = ds.Seal()
@@ -97,12 +100,11 @@ func TestTransferOwnership(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Greater(t, len(output.Reports), 0)
-	addresses, err := output.DataStore.Addresses().Fetch()
-	require.NoError(t, err)
-	for _, addr := range addresses {
-		t.Logf("Adding address %s of type %s on chain %d to datastore", addr.Address, addr.Type, addr.ChainSelector)
-		require.NoError(t, ds.Addresses().Add(addr))
+	if len(output.MCMSTimelockProposals) > 0 {
+		testhelpers.ProcessTimelockProposals(t, *env, output.MCMSTimelockProposals, false)
 	}
+	require.NoError(t, ds.Merge(output.DataStore.Seal()))
+	env.DataStore = ds.Seal()
 
 	// deploy router on both chains, then transfer ownership to the timelock
 	routerAddrs := make(map[uint64]common.Address)

--- a/chains/evm/deployment/v1_0_0/adapters/transfer_ownership_test.go
+++ b/chains/evm/deployment/v1_0_0/adapters/transfer_ownership_test.go
@@ -52,6 +52,7 @@ func TestTransferOwnership(t *testing.T) {
 	// Deploy CLLCCIP (bootstrap).
 	output, err := deployMCMS.Apply(*env, deploy.MCMSDeploymentConfig{
 		AdapterVersion: semver.MustParse("1.0.0"),
+		MCMS:           testhelpers.MCMSInputForQualifier(deploymentutils.CLLQualifier),
 		Chains: map[uint64]deploy.MCMSDeploymentConfigPerChain{
 			selector1: {
 				Canceller:        testhelpers.SingleGroupMCMS(),
@@ -81,6 +82,7 @@ func TestTransferOwnership(t *testing.T) {
 	// Deploy a second MCMS set (RMNMCMS) so we can transfer ownership to it later.
 	output, err = deployMCMS.Apply(*env, deploy.MCMSDeploymentConfig{
 		AdapterVersion: semver.MustParse("1.0.0"),
+		MCMS:           testhelpers.MCMSInputForQualifier(deploymentutils.RMNTimelockQualifier),
 		Chains: map[uint64]deploy.MCMSDeploymentConfigPerChain{
 			selector1: {
 				Canceller:        testhelpers.SingleGroupMCMS(),

--- a/chains/evm/deployment/v1_0_0/sequences/mcms.go
+++ b/chains/evm/deployment/v1_0_0/sequences/mcms.go
@@ -6,7 +6,9 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
@@ -18,7 +20,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
 
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
 	ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations"
 )
 
@@ -298,6 +299,56 @@ var SeqAcceptMCMOwnershipFromTimelock = cldf_ops.NewSequence(
 		}
 		return output, nil
 	})
+
+// TransferDeployedMCMsToTimelock transfers Ownable2Step ownership of deployed MCM contracts
+// from the deployer to the given timelock. Transfer is executed on-chain immediately;
+// accept ownership is returned as MCMS batch operations for the timelock to execute.
+func TransferDeployedMCMsToTimelock(
+	b cldf_ops.Bundle,
+	chain cldf_evm.Chain,
+	chainSelector uint64,
+	timelock common.Address,
+	mcmContracts []datastore.AddressRef,
+) ([]types.BatchOperation, error) {
+	var batchOps []types.BatchOperation
+	for _, ref := range mcmContracts {
+		addr := common.HexToAddress(ref.Address)
+		owner, ownable, err := LoadOwnableContract(addr, chain.Client)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load MCM contract %s (%s): %w", ref.Address, ref.Type, err)
+		}
+		if owner == timelock {
+			b.Logger.Infof("MCM %s at %s is already owned by timelock %s, skipping ownership transfer",
+				ref.Type, ref.Address, timelock.Hex())
+			continue
+		}
+
+		ownershipInput := ops.OpTransferOwnershipInput{
+			ChainSelector:   chainSelector,
+			Address:         addr,
+			ProposedOwner:   timelock,
+			ContractType:    cldf.ContractType(ref.Type),
+			TimelockAddress: timelock,
+		}
+		deps := ops.OpEVMOwnershipDeps{Chain: chain, OwnableC: ownable}
+
+		transferReport, err := cldf_ops.ExecuteOperation(b, ops.OpTransferOwnership, deps, ownershipInput)
+		if err != nil {
+			return nil, fmt.Errorf("failed to transfer MCM %s ownership to timelock on chain %d: %w", ref.Type, chainSelector, err)
+		}
+		acceptReport, err := cldf_ops.ExecuteOperation(b, ops.OpAcceptOwnership, deps, ownershipInput)
+		if err != nil {
+			return nil, fmt.Errorf("failed to accept MCM %s ownership on timelock on chain %d: %w", ref.Type, chainSelector, err)
+		}
+
+		batch, err := contract.NewBatchOperationFromWrites([]contract.WriteOutput{transferReport.Output, acceptReport.Output})
+		if err != nil {
+			return nil, fmt.Errorf("failed to create batch operation from MCM ownership writes: %w", err)
+		}
+		batchOps = append(batchOps, batch)
+	}
+	return batchOps, nil
+}
 
 func LoadOwnableContract(addr common.Address, client bind.ContractBackend) (common.Address, ops.OwnershipTranferable, error) {
 	// Just using the ownership interface from here.

--- a/chains/evm/deployment/v1_0_0/sequences/mcms.go
+++ b/chains/evm/deployment/v1_0_0/sequences/mcms.go
@@ -168,42 +168,9 @@ var SeqGrantAdminRoleOfTimelockToTimelock = cldf_ops.NewSequence(
 			return output, fmt.Errorf("caller %s is not admin on timelock contract %s: %w", chain.DeployerKey.From, in.TimelockAddress, err)
 		}
 
-		newAdminTimelockHasRole, err := timelock.HasRole(nil, ops.ADMIN_ROLE.ID, in.NewAdminTimelockAddress)
-		if err != nil {
-			b.Logger.Errorf("failed to check whether new timelock owner %s is admin on timelock contract %s: %v", in.NewAdminTimelockAddress, in.TimelockAddress, err)
-			return output, fmt.Errorf("failed to check whether new timelock owner %s is admin on timelock contract %s: %w", in.NewAdminTimelockAddress, in.TimelockAddress, err)
+		if err := TransferTimelockAdminTo(b, chain, in.ChainSelector, in.TimelockAddress, in.NewAdminTimelockAddress); err != nil {
+			return sequences.OnChainOutput{}, err
 		}
-
-		// Grant admin role to new admin Timelock
-		if !newAdminTimelockHasRole {
-			_, err = cldf_ops.ExecuteOperation(b, ops.OpGrantRoleTimelock, chain, contract.FunctionInput[ops.OpGrantRoleTimelockInput]{
-				ChainSelector: in.ChainSelector,
-				Address:       in.TimelockAddress,
-				Args: ops.OpGrantRoleTimelockInput{
-					RoleID:  ops.ADMIN_ROLE.ID,
-					Account: in.NewAdminTimelockAddress,
-				},
-			})
-			if err != nil {
-				return sequences.OnChainOutput{}, fmt.Errorf("failed to grant admin role to new admin timelock on chain %d: %w", in.ChainSelector, err)
-			}
-			b.Logger.Infof("Granted Admin role on Timelock %s to Timelock %s on chain %s", in.TimelockAddress, in.NewAdminTimelockAddress, chain)
-		} else {
-			b.Logger.Infof("Timelock %s is already admin on Timelock %s on chain %s", in.NewAdminTimelockAddress, in.TimelockAddress, chain)
-		}
-
-		// Renounce admin role from Deployer EOA
-		_, err = cldf_ops.ExecuteOperation(b, ops.OpRenounceRoleTimelock, chain, contract.FunctionInput[ops.OpRenounceRoleTimelockInput]{
-			ChainSelector: in.ChainSelector,
-			Address:       in.TimelockAddress,
-			Args: ops.OpRenounceRoleTimelockInput{
-				RoleID: ops.ADMIN_ROLE.ID,
-			},
-		})
-		if err != nil {
-			return sequences.OnChainOutput{}, fmt.Errorf("failed to renounce admin role on timelock contract on chain %d: %w", in.ChainSelector, err)
-		}
-		b.Logger.Infof("Renounced Admin role on Timelock %s on chain %s", in.TimelockAddress, chain)
 
 		return sequences.OnChainOutput{}, nil
 	})

--- a/chains/evm/deployment/v1_0_0/sequences/mcms.go
+++ b/chains/evm/deployment/v1_0_0/sequences/mcms.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 
 	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
@@ -12,9 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
-	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/burn_mint_erc677"
 	"github.com/smartcontractkit/mcms/sdk"
-	"github.com/smartcontractkit/mcms/sdk/evm/bindings"
 	"github.com/smartcontractkit/mcms/types"
 
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
@@ -30,11 +27,6 @@ type SeqMCMSDeploymentCfg struct {
 	Label             *string
 	Qualifier         *string
 	ExistingAddresses []datastore.AddressRef
-}
-
-type SeqTransferMCMOwnershipToTimelockInput struct {
-	ChainSelector uint64
-	Contracts     []ops.OpTransferOwnershipInput
 }
 
 type SeqGrantAdminRoleOfTimelockToTimelockInput struct {
@@ -221,41 +213,11 @@ var SeqTransferMCMOwnershipToTimelock = cldf_ops.NewSequence(
 	semver.MustParse("1.0.0"),
 	"Transfers ownership of MCM contract to the specified timelock",
 	func(b cldf_ops.Bundle, chain cldf_evm.Chain, in SeqTransferMCMOwnershipToTimelockInput) (output sequences.OnChainOutput, err error) {
-		for _, contractInput := range in.Contracts {
-			contractAddr := contractInput.Address.Hex()
-			owner, c, err := LoadOwnableContract(contractInput.Address, chain.Client)
-			if err != nil {
-				b.Logger.Errorf("failed to load ownable contract %s: %v", contractAddr, err)
-				return output, fmt.Errorf("error loading ownable contract %s: %w", contractAddr, err)
-			}
-			if owner == contractInput.ProposedOwner {
-				b.Logger.Infof("ownership of contract %s on chain %s is already set to %s, skipping transfer",
-					contractAddr, chain.Name(), contractInput.ProposedOwner.Hex())
-				continue
-			}
-			deps := ops.OpEVMOwnershipDeps{
-				Chain:    chain,
-				OwnableC: c,
-			}
-			report, err := cldf_ops.ExecuteOperation(b, ops.OpTransferOwnership, deps,
-				ops.OpTransferOwnershipInput{
-					ChainSelector:   in.ChainSelector,
-					Address:         contractInput.Address,
-					ProposedOwner:   contractInput.ProposedOwner,
-					ContractType:    contractInput.ContractType,
-					TimelockAddress: contractInput.TimelockAddress,
-				})
-			if err != nil {
-				b.Logger.Errorf("failed to transfer ownership of contract %s on chain %s: %v", contractAddr, chain.Name(), err)
-				return output, fmt.Errorf("error transferring ownership of contract %s on chain %s: %w", contractAddr, chain.Name(), err)
-			}
-			batchOp, err := contract.NewBatchOperationFromWrites([]contract.WriteOutput{report.Output})
-			if err != nil {
-				return sequences.OnChainOutput{}, fmt.Errorf("failed to create batch operation from writes: %w", err)
-			}
-			output.BatchOps = append(output.BatchOps, batchOp)
+		batchOps, err := TransferOwnership(b, chain, in.Contracts)
+		if err != nil {
+			return sequences.OnChainOutput{}, err
 		}
-		return output, nil
+		return sequences.OnChainOutput{BatchOps: batchOps}, nil
 	})
 
 var SeqAcceptMCMOwnershipFromTimelock = cldf_ops.NewSequence(
@@ -263,112 +225,9 @@ var SeqAcceptMCMOwnershipFromTimelock = cldf_ops.NewSequence(
 	semver.MustParse("1.0.0"),
 	"Accepts ownership of MCM contract from the specified timelock",
 	func(b cldf_ops.Bundle, chain cldf_evm.Chain, in SeqTransferMCMOwnershipToTimelockInput) (output sequences.OnChainOutput, err error) {
-		for _, contractInput := range in.Contracts {
-			contractAddr := contractInput.Address.Hex()
-			owner, c, err := LoadOwnableContract(contractInput.Address, chain.Client)
-			if err != nil {
-				b.Logger.Errorf("failed to load ownable contract %s: %v", contractAddr, err)
-				return output, fmt.Errorf("error loading ownable contract %s: %w", contractAddr, err)
-			}
-			if owner == contractInput.ProposedOwner {
-				b.Logger.Infof("ownership of contract %s on chain %s is already set to %s, skipping acceptance",
-					contractAddr, chain.Name(), contractInput.ProposedOwner.Hex())
-				continue
-			}
-			deps := ops.OpEVMOwnershipDeps{
-				Chain:    chain,
-				OwnableC: c,
-			}
-			report, err := cldf_ops.ExecuteOperation(b, ops.OpAcceptOwnership, deps,
-				ops.OpTransferOwnershipInput{
-					ChainSelector:   in.ChainSelector,
-					Address:         contractInput.Address,
-					ProposedOwner:   contractInput.ProposedOwner,
-					ContractType:    contractInput.ContractType,
-					TimelockAddress: contractInput.TimelockAddress,
-				})
-			if err != nil {
-				b.Logger.Errorf("failed to accept ownership of contract %s on chain %s: %v", contractAddr, chain.Name(), err)
-				return output, fmt.Errorf("error accepting ownership of contract %s on chain %s: %w", contractAddr, chain.Name(), err)
-			}
-			batchOp, err := contract.NewBatchOperationFromWrites([]contract.WriteOutput{report.Output})
-			if err != nil {
-				return sequences.OnChainOutput{}, fmt.Errorf("failed to create batch operation from writes: %w", err)
-			}
-			output.BatchOps = append(output.BatchOps, batchOp)
+		batchOps, err := AcceptOwnership(b, chain, in.Contracts)
+		if err != nil {
+			return sequences.OnChainOutput{}, err
 		}
-		return output, nil
+		return sequences.OnChainOutput{BatchOps: batchOps}, nil
 	})
-
-// TransferDeployedMCMsToTimelock transfers Ownable2Step ownership of deployed MCM contracts
-// from the deployer to the given timelock. Transfer is executed on-chain immediately;
-// accept ownership is returned as MCMS batch operations for the timelock to execute.
-func TransferDeployedMCMsToTimelock(
-	b cldf_ops.Bundle,
-	chain cldf_evm.Chain,
-	chainSelector uint64,
-	timelock common.Address,
-	mcmContracts []datastore.AddressRef,
-) ([]types.BatchOperation, error) {
-	var batchOps []types.BatchOperation
-	for _, ref := range mcmContracts {
-		addr := common.HexToAddress(ref.Address)
-		owner, ownable, err := LoadOwnableContract(addr, chain.Client)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load MCM contract %s (%s): %w", ref.Address, ref.Type, err)
-		}
-		if owner == timelock {
-			b.Logger.Infof("MCM %s at %s is already owned by timelock %s, skipping ownership transfer",
-				ref.Type, ref.Address, timelock.Hex())
-			continue
-		}
-
-		ownershipInput := ops.OpTransferOwnershipInput{
-			ChainSelector:   chainSelector,
-			Address:         addr,
-			ProposedOwner:   timelock,
-			ContractType:    cldf.ContractType(ref.Type),
-			TimelockAddress: timelock,
-		}
-		deps := ops.OpEVMOwnershipDeps{Chain: chain, OwnableC: ownable}
-
-		transferReport, err := cldf_ops.ExecuteOperation(b, ops.OpTransferOwnership, deps, ownershipInput)
-		if err != nil {
-			return nil, fmt.Errorf("failed to transfer MCM %s ownership to timelock on chain %d: %w", ref.Type, chainSelector, err)
-		}
-		acceptReport, err := cldf_ops.ExecuteOperation(b, ops.OpAcceptOwnership, deps, ownershipInput)
-		if err != nil {
-			return nil, fmt.Errorf("failed to accept MCM %s ownership on timelock on chain %d: %w", ref.Type, chainSelector, err)
-		}
-
-		batch, err := contract.NewBatchOperationFromWrites([]contract.WriteOutput{transferReport.Output, acceptReport.Output})
-		if err != nil {
-			return nil, fmt.Errorf("failed to create batch operation from MCM ownership writes: %w", err)
-		}
-		batchOps = append(batchOps, batch)
-	}
-	return batchOps, nil
-}
-
-func LoadOwnableContract(addr common.Address, client bind.ContractBackend) (common.Address, ops.OwnershipTranferable, error) {
-	// Just using the ownership interface from here.
-	c, err := burn_mint_erc677.NewBurnMintERC677(addr, client)
-	if err != nil {
-		return common.Address{}, nil, fmt.Errorf("failed to create contract: %w", err)
-	}
-	owner, err := c.Owner(nil)
-	if err != nil {
-		return common.Address{}, nil, fmt.Errorf("failed to get owner of contract %s: %w", c.Address(), err)
-	}
-
-	return owner, c, nil
-}
-
-func LoadTimelockContract(addr common.Address, client bind.ContractBackend) (*bindings.RBACTimelock, error) {
-	c, err := bindings.NewRBACTimelock(addr, client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load timelock contract: %w", err)
-	}
-
-	return c, nil
-}

--- a/chains/evm/deployment/v1_0_0/sequences/ownership.go
+++ b/chains/evm/deployment/v1_0_0/sequences/ownership.go
@@ -1,0 +1,154 @@
+package sequences
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/burn_mint_erc677"
+	"github.com/smartcontractkit/mcms/sdk/evm/bindings"
+	"github.com/smartcontractkit/mcms/types"
+
+	ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations"
+)
+
+// OwnableContractsInput describes one or more ownable contracts whose ownership should be updated.
+type OwnableContractsInput struct {
+	ChainSelector uint64
+	Contracts     []ops.OpTransferOwnershipInput
+}
+
+// SeqTransferMCMOwnershipToTimelockInput is kept for backward compatibility.
+type SeqTransferMCMOwnershipToTimelockInput = OwnableContractsInput
+
+type ownershipStep uint8
+
+const (
+	ownershipStepTransfer ownershipStep = 1 << iota
+	ownershipStepAccept
+)
+
+// OwnershipInputsFromRefs builds ownership inputs for transferring contract ownership to a timelock.
+func OwnershipInputsFromRefs(
+	chainSelector uint64,
+	timelock common.Address,
+	refs []datastore.AddressRef,
+) []ops.OpTransferOwnershipInput {
+	inputs := make([]ops.OpTransferOwnershipInput, 0, len(refs))
+	for _, ref := range refs {
+		inputs = append(inputs, ops.OpTransferOwnershipInput{
+			ChainSelector:   chainSelector,
+			Address:         common.HexToAddress(ref.Address),
+			ProposedOwner:   timelock,
+			ContractType:    cldf.ContractType(ref.Type),
+			TimelockAddress: timelock,
+		})
+	}
+	return inputs
+}
+
+// TransferOwnership transfers Ownable2Step ownership of the given contracts.
+func TransferOwnership(
+	b cldf_ops.Bundle,
+	chain cldf_evm.Chain,
+	contracts []ops.OpTransferOwnershipInput,
+) ([]types.BatchOperation, error) {
+	return executeOwnershipSteps(b, chain, contracts, ownershipStepTransfer)
+}
+
+// AcceptOwnership accepts Ownable2Step ownership of the given contracts.
+func AcceptOwnership(
+	b cldf_ops.Bundle,
+	chain cldf_evm.Chain,
+	contracts []ops.OpTransferOwnershipInput,
+) ([]types.BatchOperation, error) {
+	return executeOwnershipSteps(b, chain, contracts, ownershipStepAccept)
+}
+
+// TransferAndAcceptOwnership transfers then accepts ownership for the given contracts.
+// Transfer is executed on-chain when the deployer is the current owner; accept is returned
+// as MCMS batch operations for the timelock when the proposed owner is the timelock.
+func TransferAndAcceptOwnership(
+	b cldf_ops.Bundle,
+	chain cldf_evm.Chain,
+	contracts []ops.OpTransferOwnershipInput,
+) ([]types.BatchOperation, error) {
+	return executeOwnershipSteps(b, chain, contracts, ownershipStepTransfer|ownershipStepAccept)
+}
+
+func executeOwnershipSteps(
+	b cldf_ops.Bundle,
+	chain cldf_evm.Chain,
+	contracts []ops.OpTransferOwnershipInput,
+	steps ownershipStep,
+) ([]types.BatchOperation, error) {
+	var batchOps []types.BatchOperation
+	for _, contractInput := range contracts {
+		contractAddr := contractInput.Address.Hex()
+		owner, ownable, err := LoadOwnableContract(contractInput.Address, chain.Client)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load ownable contract %s: %w", contractAddr, err)
+		}
+		if owner == contractInput.ProposedOwner {
+			b.Logger.Infof("ownership of contract %s (%s) on chain %s is already set to %s, skipping",
+				contractAddr, contractInput.ContractType, chain.Name(), contractInput.ProposedOwner.Hex())
+			continue
+		}
+
+		deps := ops.OpEVMOwnershipDeps{Chain: chain, OwnableC: ownable}
+		var writes []contract.WriteOutput
+
+		if steps&ownershipStepTransfer != 0 {
+			report, err := cldf_ops.ExecuteOperation(b, ops.OpTransferOwnership, deps, contractInput)
+			if err != nil {
+				b.Logger.Errorf("failed to transfer ownership of contract %s on chain %s: %v", contractAddr, chain.Name(), err)
+				return nil, fmt.Errorf("error transferring ownership of contract %s on chain %s: %w", contractAddr, chain.Name(), err)
+			}
+			writes = append(writes, report.Output)
+		}
+		if steps&ownershipStepAccept != 0 {
+			report, err := cldf_ops.ExecuteOperation(b, ops.OpAcceptOwnership, deps, contractInput)
+			if err != nil {
+				b.Logger.Errorf("failed to accept ownership of contract %s on chain %s: %v", contractAddr, chain.Name(), err)
+				return nil, fmt.Errorf("error accepting ownership of contract %s on chain %s: %w", contractAddr, chain.Name(), err)
+			}
+			writes = append(writes, report.Output)
+		}
+		if len(writes) == 0 {
+			continue
+		}
+		batch, err := contract.NewBatchOperationFromWrites(writes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create batch operation from ownership writes: %w", err)
+		}
+		batchOps = append(batchOps, batch)
+	}
+	return batchOps, nil
+}
+
+func LoadOwnableContract(addr common.Address, client bind.ContractBackend) (common.Address, ops.OwnershipTranferable, error) {
+	c, err := burn_mint_erc677.NewBurnMintERC677(addr, client)
+	if err != nil {
+		return common.Address{}, nil, fmt.Errorf("failed to create contract: %w", err)
+	}
+	owner, err := c.Owner(nil)
+	if err != nil {
+		return common.Address{}, nil, fmt.Errorf("failed to get owner of contract %s: %w", c.Address(), err)
+	}
+
+	return owner, c, nil
+}
+
+func LoadTimelockContract(addr common.Address, client bind.ContractBackend) (*bindings.RBACTimelock, error) {
+	c, err := bindings.NewRBACTimelock(addr, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load timelock contract: %w", err)
+	}
+
+	return c, nil
+}

--- a/chains/evm/deployment/v1_0_0/sequences/timelock_admin.go
+++ b/chains/evm/deployment/v1_0_0/sequences/timelock_admin.go
@@ -1,0 +1,92 @@
+package sequences
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
+	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations"
+)
+
+// GrantTimelockAdminRole grants ADMIN_ROLE to account on timelock if it does not already hold it.
+func GrantTimelockAdminRole(
+	b cldf_ops.Bundle,
+	chain cldf_evm.Chain,
+	chainSelector uint64,
+	timelockAddr, account common.Address,
+) error {
+	timelock, err := LoadTimelockContract(timelockAddr, chain.Client)
+	if err != nil {
+		return fmt.Errorf("failed to load timelock contract %s: %w", timelockAddr, err)
+	}
+	hasRole, err := timelock.HasRole(nil, ops.ADMIN_ROLE.ID, account)
+	if err != nil {
+		return fmt.Errorf("failed to check whether %s is admin on timelock %s: %w", account, timelockAddr, err)
+	}
+	if hasRole {
+		b.Logger.Infof("Timelock %s is already admin on Timelock %s on chain %s", account, timelockAddr, chain.Name)
+		return nil
+	}
+	_, err = cldf_ops.ExecuteOperation(b, ops.OpGrantRoleTimelock, chain, contract.FunctionInput[ops.OpGrantRoleTimelockInput]{
+		ChainSelector: chainSelector,
+		Address:       timelockAddr,
+		Args: ops.OpGrantRoleTimelockInput{
+			RoleID:  ops.ADMIN_ROLE.ID,
+			Account: account,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to grant admin role to %s on timelock %s on chain %d: %w", account, timelockAddr, chainSelector, err)
+	}
+	b.Logger.Infof("Granted Admin role on Timelock %s to %s on chain %s", timelockAddr, account, chain.Name)
+	return nil
+}
+
+// RenounceDeployerTimelockAdmin renounces ADMIN_ROLE from the deployer on timelock if held.
+func RenounceDeployerTimelockAdmin(
+	b cldf_ops.Bundle,
+	chain cldf_evm.Chain,
+	chainSelector uint64,
+	timelockAddr common.Address,
+) error {
+	timelock, err := LoadTimelockContract(timelockAddr, chain.Client)
+	if err != nil {
+		return fmt.Errorf("failed to load timelock contract %s: %w", timelockAddr, err)
+	}
+	hasRole, err := timelock.HasRole(nil, ops.ADMIN_ROLE.ID, chain.DeployerKey.From)
+	if err != nil {
+		return fmt.Errorf("failed to check whether deployer %s is admin on timelock %s: %w", chain.DeployerKey.From, timelockAddr, err)
+	}
+	if !hasRole {
+		b.Logger.Infof("Deployer is not admin on Timelock %s on chain %s, skipping renounce", timelockAddr, chain.Name)
+		return nil
+	}
+	_, err = cldf_ops.ExecuteOperation(b, ops.OpRenounceRoleTimelock, chain, contract.FunctionInput[ops.OpRenounceRoleTimelockInput]{
+		ChainSelector: chainSelector,
+		Address:       timelockAddr,
+		Args: ops.OpRenounceRoleTimelockInput{
+			RoleID: ops.ADMIN_ROLE.ID,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to renounce admin role on timelock %s on chain %d: %w", timelockAddr, chainSelector, err)
+	}
+	b.Logger.Infof("Renounced Admin role on Timelock %s on chain %s", timelockAddr, chain.Name)
+	return nil
+}
+
+// TransferTimelockAdminTo grants ADMIN_ROLE to newAdmin and renounces it from the deployer.
+func TransferTimelockAdminTo(
+	b cldf_ops.Bundle,
+	chain cldf_evm.Chain,
+	chainSelector uint64,
+	timelockAddr, newAdmin common.Address,
+) error {
+	if err := GrantTimelockAdminRole(b, chain, chainSelector, timelockAddr, newAdmin); err != nil {
+		return err
+	}
+	return RenounceDeployerTimelockAdmin(b, chain, chainSelector, timelockAddr)
+}

--- a/chains/evm/deployment/v1_0_0/transfer_ownership_test.go
+++ b/chains/evm/deployment/v1_0_0/transfer_ownership_test.go
@@ -70,6 +70,9 @@ func TestTransferOwnership(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Greater(t, len(output.Reports), 0)
+	if len(output.MCMSTimelockProposals) > 0 {
+		testhelpers.ProcessTimelockProposals(t, *env, output.MCMSTimelockProposals, false)
+	}
 	ds := output.DataStore
 	require.NoError(t, ds.Merge(env.DataStore))
 	env.DataStore = ds.Seal()
@@ -96,12 +99,11 @@ func TestTransferOwnership(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Greater(t, len(output.Reports), 0)
-	addresses, err := output.DataStore.Addresses().Fetch()
-	require.NoError(t, err)
-	for _, addr := range addresses {
-		t.Logf("Adding address %s of type %s on chain %d to datastore", addr.Address, addr.Type, addr.ChainSelector)
-		require.NoError(t, ds.Addresses().Add(addr))
+	if len(output.MCMSTimelockProposals) > 0 {
+		testhelpers.ProcessTimelockProposals(t, *env, output.MCMSTimelockProposals, false)
 	}
+	require.NoError(t, ds.Merge(output.DataStore.Seal()))
+	env.DataStore = ds.Seal()
 
 	// deploy router on both chains, then transfer ownership to the timelock
 	routerAddrs := make(map[uint64]common.Address)

--- a/chains/evm/deployment/v1_0_0/transfer_ownership_test.go
+++ b/chains/evm/deployment/v1_0_0/transfer_ownership_test.go
@@ -51,6 +51,7 @@ func TestTransferOwnership(t *testing.T) {
 	// Deploy CLLCCIP (bootstrap).
 	output, err := deployMCMS.Apply(*env, deploy.MCMSDeploymentConfig{
 		AdapterVersion: deploy.MCMSVersion,
+		MCMS:           testhelpers.MCMSInputForQualifier(deploymentutils.CLLQualifier),
 		Chains: map[uint64]deploy.MCMSDeploymentConfigPerChain{
 			selector1: {
 				Canceller:        testhelpers.SingleGroupMCMS(),
@@ -80,6 +81,7 @@ func TestTransferOwnership(t *testing.T) {
 	// Deploy a second MCMS set (RMNMCMS) so we can transfer ownership to it later.
 	output, err = deployMCMS.Apply(*env, deploy.MCMSDeploymentConfig{
 		AdapterVersion: deploy.MCMSVersion,
+		MCMS:           testhelpers.MCMSInputForQualifier(deploymentutils.RMNTimelockQualifier),
 		Chains: map[uint64]deploy.MCMSDeploymentConfigPerChain{
 			selector1: {
 				Canceller:        testhelpers.SingleGroupMCMS(),

--- a/chains/evm/deployment/v1_5_0/adapters/fastcurse.go
+++ b/chains/evm/deployment/v1_5_0/adapters/fastcurse.go
@@ -17,11 +17,9 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils"
 	evmds "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/datastore"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
-	rmnproxyops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/rmn_proxy"
 	routerops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/operations/router"
 	ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/operations/rmn"
 	rmnsequences "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/sequences"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_0_0/rmn_proxy_contract"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/rmn_contract"
 	api "github.com/smartcontractkit/chainlink-ccip/deployment/fastcurse"
@@ -259,35 +257,7 @@ func (ca *CurseAdapter) ListConnectedChains(e cldf.Environment, selector uint64)
 }
 
 func (ca *CurseAdapter) DeriveCurseAdapterVersion(e cldf.Environment, selector uint64) (*semver.Version, error) {
-	// fetch RMNProxy address on chain
-	rmnProxyRef := datastore.AddressRef{
-		Type:          datastore.ContractType(rmnproxyops.ContractType),
-		Version:       semver.MustParse("1.0.0"),
-		ChainSelector: selector,
-	}
-	rmnProxyAddr, err := datastore_utils.FindAndFormatRef(e.DataStore, rmnProxyRef, selector, evmds.ToEVMAddress)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve RMNProxy ref on chain with selector %d: %w", selector, err)
-	}
-	chain, ok := e.BlockChains.EVMChains()[selector]
-	if !ok {
-		return nil, fmt.Errorf("no EVM chain found for selector %d", selector)
-	}
-	rmnProxyC, err := rmn_proxy_contract.NewRMNProxy(rmnProxyAddr, chain.Client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to instantiate RMNProxy contract at %s on chain %d: %w", rmnProxyAddr.String(), chain.Selector, err)
-	}
-	rmnAddr, err := rmnProxyC.GetARM(&bind.CallOpts{
-		Context: e.GetContext(),
-	})
-	if err != nil {
-		return nil, err
-	}
-	_, version, err := utils.TypeAndVersion(rmnAddr, chain.Client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get type and version from RMN at %s on chain %d: %w", rmnAddr.String(), chain.Selector, err)
-	}
-	return version, nil
+	return utils.ActiveRMNVersion(e, selector)
 }
 
 func generateCurseID(cfgVersion uint32, subjects [][16]byte) ([16]byte, error) {

--- a/chains/evm/deployment/v1_6_0/adapters/fastcurse.go
+++ b/chains/evm/deployment/v1_6_0/adapters/fastcurse.go
@@ -15,11 +15,9 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils"
 	evmds "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/datastore"
-	rmnproxyops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/rmn_proxy"
 	routerops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/operations/router"
 	ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/operations/rmn_remote"
 	rmnsequences "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/sequences"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_0_0/rmn_proxy_contract"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_0/rmn_remote"
 	api "github.com/smartcontractkit/chainlink-ccip/deployment/fastcurse"
@@ -244,33 +242,5 @@ func (ca *CurseAdapter) ListConnectedChains(e cldf.Environment, selector uint64)
 }
 
 func (ca *CurseAdapter) DeriveCurseAdapterVersion(e cldf.Environment, selector uint64) (*semver.Version, error) {
-	// fetch RMNProxy address on chain
-	rmnProxyRef := datastore.AddressRef{
-		Type:          datastore.ContractType(rmnproxyops.ContractType),
-		Version:       semver.MustParse("1.0.0"),
-		ChainSelector: selector,
-	}
-	rmnProxyAddr, err := datastore_utils.FindAndFormatRef(e.DataStore, rmnProxyRef, selector, evmds.ToEVMAddress)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve RMNProxy ref on chain with selector %d: %w", selector, err)
-	}
-	chain, ok := e.BlockChains.EVMChains()[selector]
-	if !ok {
-		return nil, fmt.Errorf("no EVM chain found for selector %d", selector)
-	}
-	rmnProxyC, err := rmn_proxy_contract.NewRMNProxy(rmnProxyAddr, chain.Client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to instantiate RMNProxy contract at %s on chain %d: %w", rmnProxyAddr.String(), chain.Selector, err)
-	}
-	rmnAddr, err := rmnProxyC.GetARM(&bind.CallOpts{
-		Context: e.GetContext(),
-	})
-	if err != nil {
-		return nil, err
-	}
-	_, version, err := utils.TypeAndVersion(rmnAddr, chain.Client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get type and version from RMN at %s on chain %d: %w", rmnAddr.String(), chain.Selector, err)
-	}
-	return version, nil
+	return utils.ActiveRMNVersion(e, selector)
 }

--- a/chains/evm/deployment/v2_0_0/adapters/chain_family.go
+++ b/chains/evm/deployment/v2_0_0/adapters/chain_family.go
@@ -30,7 +30,7 @@ import (
 )
 
 // minProductionChainNOPs is the minimum number of NOPs we must have for a production chain.
-const minProductionChainNOPs = 15
+const minProductionChainNOPs = 9
 
 // ChainFamilyAdapter is the adapter for chains of the EVM family.
 type ChainFamilyAdapter struct{}

--- a/chains/evm/deployment/v2_0_0/adapters/chain_family_test.go
+++ b/chains/evm/deployment/v2_0_0/adapters/chain_family_test.go
@@ -455,12 +455,12 @@ func TestChainFamilyAdapter_ValidateNOPsTopology(t *testing.T) {
 	}{
 		{
 			name:     "fewer than the minimum is rejected",
-			nopCount: 14,
-			wantErr:  `chain "5009297550715157269" requires at least 15 unique NOPs for production environments, got 14`,
+			nopCount: 8,
+			wantErr:  `chain "5009297550715157269" requires at least 9 unique NOPs for production environments, got 8`,
 		},
 		{
 			name:     "exactly the minimum is allowed",
-			nopCount: 15,
+			nopCount: 9,
 		},
 		{
 			name:     "more than the minimum is allowed",

--- a/chains/evm/deployment/v2_0_0/adapters/fastcurse.go
+++ b/chains/evm/deployment/v2_0_0/adapters/fastcurse.go
@@ -15,11 +15,9 @@ import (
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils"
 	evmds "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/datastore"
-	rmnproxyops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/rmn_proxy"
 	routerops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/operations/router"
 	ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/rmn"
 	rmnsequences "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_0_0/rmn_proxy_contract"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_2_0/router"
 	api "github.com/smartcontractkit/chainlink-ccip/deployment/fastcurse"
 	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
@@ -236,32 +234,5 @@ func (ca *CurseAdapter) ListConnectedChains(e cldf.Environment, selector uint64)
 }
 
 func (ca *CurseAdapter) DeriveCurseAdapterVersion(e cldf.Environment, selector uint64) (*semver.Version, error) {
-	rmnProxyRef := datastore.AddressRef{
-		Type:          datastore.ContractType(rmnproxyops.ContractType),
-		Version:       semver.MustParse("1.0.0"),
-		ChainSelector: selector,
-	}
-	rmnProxyAddr, err := datastore_utils.FindAndFormatRef(e.DataStore, rmnProxyRef, selector, evmds.ToEVMAddress)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve RMNProxy ref on chain with selector %d: %w", selector, err)
-	}
-	chain, ok := e.BlockChains.EVMChains()[selector]
-	if !ok {
-		return nil, fmt.Errorf("no EVM chain found for selector %d", selector)
-	}
-	rmnProxyC, err := rmn_proxy_contract.NewRMNProxy(rmnProxyAddr, chain.Client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to instantiate RMNProxy contract at %s on chain %d: %w", rmnProxyAddr.String(), chain.Selector, err)
-	}
-	rmnAddr, err := rmnProxyC.GetARM(&bind.CallOpts{
-		Context: e.GetContext(),
-	})
-	if err != nil {
-		return nil, err
-	}
-	_, version, err := utils.TypeAndVersion(rmnAddr, chain.Client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get type and version from RMN at %s on chain %d: %w", rmnAddr.String(), chain.Selector, err)
-	}
-	return version, nil
+	return utils.ActiveRMNVersion(e, selector)
 }

--- a/chains/evm/deployment/v2_0_0/changesets/rmn_deploy_and_activate.go
+++ b/chains/evm/deployment/v2_0_0/changesets/rmn_deploy_and_activate.go
@@ -3,6 +3,7 @@ package changesets
 import (
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf_deployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
@@ -18,6 +19,9 @@ import (
 // ActivateRMNCfg configures the ActivateRMN changeset.
 type ActivateRMNCfg struct {
 	ChainSels []uint64
+	// CurseAdmins are optional additional authorized callers (cursers) added at RMN deploy
+	// time, keyed by chain selector. The Ultra Fast Curse RBACTimelock is always included.
+	CurseAdmins map[uint64][]common.Address
 }
 
 var ActivateRMN = func(mcmsRegistry *changesets.MCMSReaderRegistry) cldf_deployment.ChangeSetV2[changesets.WithMCMS[ActivateRMNCfg]] {
@@ -33,6 +37,9 @@ func validateActivateRMN(e cldf_deployment.Environment, input changesets.WithMCM
 	if len(input.Cfg.ChainSels) == 0 {
 		return fmt.Errorf("at least one chain selector is required")
 	}
+	if err := validateActivateRMNCurseAdmins(input.Cfg.CurseAdmins, input.Cfg.ChainSels); err != nil {
+		return err
+	}
 	evmChains := e.BlockChains.EVMChains()
 	for _, sel := range input.Cfg.ChainSels {
 		if _, ok := evmChains[sel]; !ok {
@@ -41,6 +48,32 @@ func validateActivateRMN(e cldf_deployment.Environment, input changesets.WithMCM
 		addresses := e.DataStore.Addresses().Filter(datastore.AddressRefByChainSelector(sel))
 		if err := validateActivateRMNAddresses(addresses, sel); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+func validateActivateRMNCurseAdmins(curseAdmins map[uint64][]common.Address, chainSels []uint64) error {
+	if len(curseAdmins) == 0 {
+		return nil
+	}
+	chainSet := make(map[uint64]struct{}, len(chainSels))
+	for _, sel := range chainSels {
+		chainSet[sel] = struct{}{}
+	}
+	for sel, addrs := range curseAdmins {
+		if _, ok := chainSet[sel]; !ok {
+			return fmt.Errorf("curse admins configured for chain %d which is not in ChainSels", sel)
+		}
+		seen := make(map[common.Address]struct{}, len(addrs))
+		for _, addr := range addrs {
+			if addr == (common.Address{}) {
+				return fmt.Errorf("curse admin address cannot be zero for chain %d", sel)
+			}
+			if _, dup := seen[addr]; dup {
+				return fmt.Errorf("duplicate curse admin %s for chain %d", addr.Hex(), sel)
+			}
+			seen[addr] = struct{}{}
 		}
 	}
 	return nil
@@ -62,6 +95,7 @@ func applyDeployAndActivateRMN(
 		report, err := cldf_ops.ExecuteSequence(e.OperationsBundle, sequences.DeployAndActivateRMN, chain, sequences.ActivateRMNInput{
 			ChainSelector:     sel,
 			ExistingAddresses: addresses,
+			CurseAdmins:       input.Cfg.CurseAdmins[sel],
 		})
 		if err != nil {
 			return cldf_deployment.ChangesetOutput{}, fmt.Errorf("failed to activate RMN on chain %d: %w", sel, err)

--- a/chains/evm/deployment/v2_0_0/changesets/rmn_deploy_and_activate_test.go
+++ b/chains/evm/deployment/v2_0_0/changesets/rmn_deploy_and_activate_test.go
@@ -107,6 +107,116 @@ func TestActivateRMN_Apply(t *testing.T) {
 	require.NotEqual(t, legacyARM, armReport.Output)
 }
 
+func TestActivateRMN_WithAdditionalCurseAdmins(t *testing.T) {
+	chainSelector := uint64(5009297550715157269)
+	e, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{chainSelector}),
+	)
+	require.NoError(t, err)
+
+	chain := e.BlockChains.EVMChains()[chainSelector]
+	deployer := chain.DeployerKey.From
+	b := e.OperationsBundle
+	additionalCurser := common.HexToAddress("0x1111111111111111111111111111111111111111")
+
+	proxyRef, err := contract.MaybeDeployContract(b, rmn_proxy.Deploy, chain, contract.DeployInput[rmn_proxy.ConstructorArgs]{
+		TypeAndVersion: deployment.NewTypeAndVersion(rmn_proxy.ContractType, *rmn_proxy.Version),
+		ChainSelector:  chainSelector,
+		Args:           rmn_proxy.ConstructorArgs{RMN: deployer},
+	}, nil)
+	require.NoError(t, err)
+
+	ultraFastTimelockAddr, ultraFastAddrs := deployMCMSInstanceForTest(t, b, chain, deployer, common_utils.UltraFastCurseMCMSQualifier)
+	_, rmnMCMSAddrs := deployMCMSInstanceForTest(t, b, chain, deployer, common_utils.RMNTimelockQualifier)
+
+	ds := datastore.NewMemoryDataStore()
+	require.NoError(t, ds.Addresses().Add(proxyRef))
+	for _, ref := range ultraFastAddrs {
+		require.NoError(t, ds.Addresses().Add(ref))
+	}
+	for _, ref := range rmnMCMSAddrs {
+		require.NoError(t, ds.Addresses().Add(ref))
+	}
+	e.DataStore = ds.Seal()
+
+	mcmsRegistry := cs_core.GetRegistry()
+	out, err := changesets.ActivateRMN(mcmsRegistry).Apply(*e, cs_core.WithMCMS[changesets.ActivateRMNCfg]{
+		MCMS: mcms.Input{
+			Qualifier:      common_utils.RMNTimelockQualifier,
+			TimelockAction: mcms_types.TimelockActionSchedule,
+			TimelockDelay:  mcms_types.MustParseDuration("0s"),
+			ValidUntil:     3759765795,
+		},
+		Cfg: changesets.ActivateRMNCfg{
+			ChainSels: []uint64{chainSelector},
+			CurseAdmins: map[uint64][]common.Address{
+				chainSelector: {additionalCurser},
+			},
+		},
+	})
+	require.NoError(t, err)
+	testhelpers.ProcessTimelockProposals(t, *e, out.MCMSTimelockProposals, false)
+
+	rmnAddrs, err := out.DataStore.Addresses().Fetch()
+	require.NoError(t, err)
+	require.Len(t, rmnAddrs, 1)
+
+	rmnC, err := rmnops.NewRMNContract(common.HexToAddress(rmnAddrs[0].Address), chain.Client)
+	require.NoError(t, err)
+	callers, err := rmnC.GetAllAuthorizedCallers(nil)
+	require.NoError(t, err)
+	require.Contains(t, callers, ultraFastTimelockAddr, "Ultra Fast Curse timelock must be a curse admin")
+	require.Contains(t, callers, additionalCurser, "configured curse admin must be authorized at deploy time")
+}
+
+func TestActivateRMN_ValidateCurseAdmins(t *testing.T) {
+	chainSelector := uint64(5009297550715157269)
+	e, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{chainSelector}),
+	)
+	require.NoError(t, err)
+
+	mcmsRegistry := cs_core.GetRegistry()
+	changeset := changesets.ActivateRMN(mcmsRegistry)
+
+	t.Run("zero address", func(t *testing.T) {
+		err := changeset.VerifyPreconditions(*e, cs_core.WithMCMS[changesets.ActivateRMNCfg]{
+			Cfg: changesets.ActivateRMNCfg{
+				ChainSels: []uint64{chainSelector},
+				CurseAdmins: map[uint64][]common.Address{
+					chainSelector: {common.Address{}},
+				},
+			},
+		})
+		require.ErrorContains(t, err, "curse admin address cannot be zero")
+	})
+
+	t.Run("duplicate address", func(t *testing.T) {
+		addr := common.HexToAddress("0x1111111111111111111111111111111111111111")
+		err := changeset.VerifyPreconditions(*e, cs_core.WithMCMS[changesets.ActivateRMNCfg]{
+			Cfg: changesets.ActivateRMNCfg{
+				ChainSels: []uint64{chainSelector},
+				CurseAdmins: map[uint64][]common.Address{
+					chainSelector: {addr, addr},
+				},
+			},
+		})
+		require.ErrorContains(t, err, "duplicate curse admin")
+	})
+
+	t.Run("chain not in ChainSels", func(t *testing.T) {
+		err := changeset.VerifyPreconditions(*e, cs_core.WithMCMS[changesets.ActivateRMNCfg]{
+			Cfg: changesets.ActivateRMNCfg{
+				ChainSels: []uint64{chainSelector},
+				CurseAdmins: map[uint64][]common.Address{
+					99999: {common.HexToAddress("0x1111111111111111111111111111111111111111")},
+				},
+			},
+		})
+		require.ErrorContains(t, err, "not in ChainSels")
+	})
+}
+
 func TestActivateRMN_AccumulatesBatchOpsAcrossChains(t *testing.T) {
 	const (
 		chainSelectorA = uint64(5009297550715157269)

--- a/chains/evm/deployment/v2_0_0/sequences/deploy_chain_contracts.go
+++ b/chains/evm/deployment/v2_0_0/sequences/deploy_chain_contracts.go
@@ -914,33 +914,12 @@ func ensureTimelockSelfGoverned(
 	}
 
 	if !adminHasRole {
-		_, err = cldf_ops.ExecuteOperation(b, mcms_ops.OpGrantRoleTimelock, chain, contract_utils.FunctionInput[mcms_ops.OpGrantRoleTimelockInput]{
-			ChainSelector: chain.Selector,
-			Address:       timelockAddr,
-			Args: mcms_ops.OpGrantRoleTimelockInput{
-				RoleID:  mcms_ops.ADMIN_ROLE.ID,
-				Account: newAdmin,
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("failed to grant ADMIN_ROLE to %s on timelock %s: %w", newAdmin, timelockAddr, err)
+		if err := mcms_seq.GrantTimelockAdminRole(b, chain, chain.Selector, timelockAddr, newAdmin); err != nil {
+			return err
 		}
-		b.Logger.Infof("Granted ADMIN_ROLE on timelock %s to %s", timelockAddr, newAdmin)
 	}
 
-	_, err = cldf_ops.ExecuteOperation(b, mcms_ops.OpRenounceRoleTimelock, chain, contract_utils.FunctionInput[mcms_ops.OpRenounceRoleTimelockInput]{
-		ChainSelector: chain.Selector,
-		Address:       timelockAddr,
-		Args: mcms_ops.OpRenounceRoleTimelockInput{
-			RoleID: mcms_ops.ADMIN_ROLE.ID,
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("failed to renounce deployer ADMIN_ROLE on timelock %s: %w", timelockAddr, err)
-	}
-	b.Logger.Infof("Renounced deployer ADMIN_ROLE on timelock %s", timelockAddr)
-
-	return nil
+	return mcms_seq.RenounceDeployerTimelockAdmin(b, chain, chain.Selector, timelockAddr)
 }
 
 // getMockReceiverVerifiers finds the required and optional verifier addresses given the mock receiver

--- a/chains/evm/deployment/v2_0_0/sequences/rmn.go
+++ b/chains/evm/deployment/v2_0_0/sequences/rmn.go
@@ -171,7 +171,15 @@ var DeployAndActivateRMN = cldf_ops.NewSequence(
 		output.Addresses = append(output.Addresses, rmnRef)
 
 		// 2. Transfer RMN ownership to RMNMCMS timelock.
-		ownershipBatchOps, err := transferRMNOwnershipToTimelock(b, chain, rmnAddr, rmnTimelock)
+		ownershipBatchOps, err := mcms_seq.TransferAndAcceptOwnership(b, chain, []mcms_ops.OpTransferOwnershipInput{
+			{
+				ChainSelector:   chain.Selector,
+				Address:         rmnAddr,
+				ProposedOwner:   rmnTimelock,
+				ContractType:    rmnops.ContractType,
+				TimelockAddress: rmnTimelock,
+			},
+		})
 		if err != nil {
 			return sequences.OnChainOutput{}, err
 		}
@@ -215,46 +223,6 @@ func pointRMNProxyAtRMN(
 		return nil, fmt.Errorf("failed to set RMN on RMNProxy on chain %d: %w", chain.Selector, err)
 	}
 	return []contract.WriteOutput{setRMNReport.Output}, nil
-}
-
-func transferRMNOwnershipToTimelock(
-	b cldf_ops.Bundle,
-	chain evm.Chain,
-	rmnAddr, rmnTimelock common.Address,
-) ([]mcms_types.BatchOperation, error) {
-	owner, ownable, err := mcms_seq.LoadOwnableContract(rmnAddr, chain.Client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load RMN ownable contract %s: %w", rmnAddr.Hex(), err)
-	}
-	if owner == rmnTimelock {
-		b.Logger.Infof("RMN %s on chain %d is already owned by RMNMCMS timelock %s",
-			rmnAddr.Hex(), chain.Selector, rmnTimelock.Hex())
-		return nil, nil
-	}
-
-	ownershipInput := mcms_ops.OpTransferOwnershipInput{
-		ChainSelector:   chain.Selector,
-		Address:         rmnAddr,
-		ProposedOwner:   rmnTimelock,
-		ContractType:    rmnops.ContractType,
-		TimelockAddress: rmnTimelock,
-	}
-	deps := mcms_ops.OpEVMOwnershipDeps{Chain: chain, OwnableC: ownable}
-
-	transferReport, err := cldf_ops.ExecuteOperation(b, mcms_ops.OpTransferOwnership, deps, ownershipInput)
-	if err != nil {
-		return nil, fmt.Errorf("failed to transfer RMN ownership to RMNMCMS on chain %d: %w", chain.Selector, err)
-	}
-	acceptReport, err := cldf_ops.ExecuteOperation(b, mcms_ops.OpAcceptOwnership, deps, ownershipInput)
-	if err != nil {
-		return nil, fmt.Errorf("failed to accept RMN ownership on RMNMCMS timelock on chain %d: %w", chain.Selector, err)
-	}
-
-	batch, err := contract.NewBatchOperationFromWrites([]contract.WriteOutput{transferReport.Output, acceptReport.Output})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create batch operation from RMN ownership writes: %w", err)
-	}
-	return []mcms_types.BatchOperation{batch}, nil
 }
 
 func resolveTimelockAddress(refs []datastore.AddressRef, chainSelector uint64, qualifier string) (common.Address, error) {

--- a/chains/evm/deployment/v2_0_0/sequences/rmn.go
+++ b/chains/evm/deployment/v2_0_0/sequences/rmn.go
@@ -128,6 +128,9 @@ var RmnUncurse = cldf_ops.NewSequence(
 type ActivateRMNInput struct {
 	ChainSelector     uint64
 	ExistingAddresses []datastore.AddressRef
+	// CurseAdmins are optional additional authorized callers added at deploy time.
+	// The Ultra Fast Curse RBACTimelock is always included.
+	CurseAdmins []common.Address
 }
 
 // DeployAndActivateRMN runs the RMN v2 activation flow on a single EVM chain.
@@ -153,12 +156,16 @@ var DeployAndActivateRMN = cldf_ops.NewSequence(
 			return sequences.OnChainOutput{}, err
 		}
 
-		// 1. Deploy RMN 2.0.0 with the Ultra Fast Curse RBACTimelock as an initial curse admin.
+		// 1. Deploy RMN 2.0.0 with the Ultra Fast Curse RBACTimelock and any optional curse admins.
+		curseAdmins := make([]common.Address, 0, 1+len(input.CurseAdmins))
+		curseAdmins = append(curseAdmins, ultraFastCurseTimeLock)
+		curseAdmins = append(curseAdmins, input.CurseAdmins...)
+
 		rmnRef, err := contract.MaybeDeployContract(b, rmnops.Deploy, chain, contract.DeployInput[rmnops.ConstructorArgs]{
 			TypeAndVersion: deployment.NewTypeAndVersion(rmnops.ContractType, *rmnops.Version),
 			ChainSelector:  chain.Selector,
 			Args: rmnops.ConstructorArgs{
-				CurseAdmins: []common.Address{ultraFastCurseTimeLock},
+				CurseAdmins: curseAdmins,
 			},
 		}, input.ExistingAddresses)
 		if err != nil {

--- a/deployment/deploy/mcms.go
+++ b/deployment/deploy/mcms.go
@@ -167,7 +167,7 @@ func updateMCMSConfigApply(d *DeployerRegistry, mcmsRegistry *changesets.MCMSRea
 			reports = append(reports, report.ExecutionReports...)
 		}
 
-		return changesets.NewOutputBuilder(e, mcmsRegistry).
+		return changesets.NewOutputBuilder(e, mcmsRegistryForDeploy(mcmsRegistry)).
 			WithReports(reports).
 			WithBatchOps(batchOps).
 			Build(cfg.MCMS)
@@ -336,10 +336,49 @@ func deployMCMSApply(
 			reports = append(reports, deployReport.ExecutionReports...)
 		}
 
-		return changesets.NewOutputBuilder(e, mcmsRegistry).
+		if err := ds.Merge(e.DataStore); err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge existing datastore into MCMS deployment output: %w", err)
+		}
+		buildEnv := e
+		buildEnv.DataStore = ds.Seal()
+
+		return changesets.NewOutputBuilder(buildEnv, mcmsRegistryForDeploy(mcmsRegistry)).
 			WithReports(reports).
 			WithDataStore(ds).
 			WithBatchOps(batchOps).
-			Build(cfg.MCMS)
+			Build(mcmsInputForDeployment(cfg, batchOps))
 	}
+}
+
+func mcmsRegistryForDeploy(registry *changesets.MCMSReaderRegistry) *changesets.MCMSReaderRegistry {
+	if registry != nil {
+		return registry
+	}
+	return changesets.GetRegistry()
+}
+
+// mcmsInputForDeployment returns MCMS proposal input for deploy output. When ownership
+// accept batch operations are produced and the caller did not supply MCMS config, a
+// default bypass proposal is used so timelock can accept MCM contract ownership.
+func mcmsInputForDeployment(cfg MCMSDeploymentConfig, batchOps []mcmstypes.BatchOperation) mcms.Input {
+	if len(batchOps) == 0 || cfg.MCMS.TimelockAction != "" {
+		return cfg.MCMS
+	}
+
+	mcmsInput := cfg.MCMS
+	mcmsInput.TimelockAction = mcmstypes.TimelockActionBypass
+	mcmsInput.TimelockDelay = mcmstypes.MustParseDuration("0s")
+	mcmsInput.ValidUntil = 3759765795
+	if mcmsInput.Qualifier == "" {
+		for _, chainCfg := range cfg.Chains {
+			if chainCfg.Qualifier != nil {
+				mcmsInput.Qualifier = *chainCfg.Qualifier
+				break
+			}
+		}
+	}
+	if mcmsInput.Description == "" {
+		mcmsInput.Description = "Accept MCM contract ownership on timelock"
+	}
+	return mcmsInput
 }

--- a/deployment/deploy/mcms.go
+++ b/deployment/deploy/mcms.go
@@ -342,11 +342,16 @@ func deployMCMSApply(
 		buildEnv := e
 		buildEnv.DataStore = ds.Seal()
 
+		mcmsInput, err := mcmsInputForDeployment(cfg, batchOps)
+		if err != nil {
+			return cldf.ChangesetOutput{}, err
+		}
+
 		return changesets.NewOutputBuilder(buildEnv, mcmsRegistryForDeploy(mcmsRegistry)).
 			WithReports(reports).
 			WithDataStore(ds).
 			WithBatchOps(batchOps).
-			Build(mcmsInputForDeployment(cfg, batchOps))
+			Build(mcmsInput)
 	}
 }
 
@@ -359,26 +364,50 @@ func mcmsRegistryForDeploy(registry *changesets.MCMSReaderRegistry) *changesets.
 
 // mcmsInputForDeployment returns MCMS proposal input for deploy output. When ownership
 // accept batch operations are produced and the caller did not supply MCMS config, a
-// default bypass proposal is used so timelock can accept MCM contract ownership.
-func mcmsInputForDeployment(cfg MCMSDeploymentConfig, batchOps []mcmstypes.BatchOperation) mcms.Input {
-	if len(batchOps) == 0 || cfg.MCMS.TimelockAction != "" {
-		return cfg.MCMS
+// schedule proposal is built using the deployed MCMS timelock qualifier from chain config.
+func mcmsInputForDeployment(cfg MCMSDeploymentConfig, batchOps []mcmstypes.BatchOperation) (mcms.Input, error) {
+	if len(batchOps) == 0 {
+		return cfg.MCMS, nil
 	}
 
-	mcmsInput := cfg.MCMS
-	mcmsInput.TimelockAction = mcmstypes.TimelockActionBypass
-	mcmsInput.TimelockDelay = mcmstypes.MustParseDuration("0s")
-	mcmsInput.ValidUntil = 3759765795
-	if mcmsInput.Qualifier == "" {
-		for _, chainCfg := range cfg.Chains {
-			if chainCfg.Qualifier != nil {
-				mcmsInput.Qualifier = *chainCfg.Qualifier
-				break
-			}
+	input := cfg.MCMS
+	if input.TimelockAction == "" {
+		input.TimelockAction = mcmstypes.TimelockActionSchedule
+		input.TimelockDelay = mcmstypes.MustParseDuration("0s")
+	}
+	if input.Qualifier == "" {
+		qualifier, err := deploymentQualifier(cfg)
+		if err != nil {
+			return mcms.Input{}, err
+		}
+		input.Qualifier = qualifier
+	}
+	if input.Description == "" {
+		input.Description = "Accept MCM contract ownership on timelock"
+	}
+	return input, nil
+}
+
+func deploymentQualifier(cfg MCMSDeploymentConfig) (string, error) {
+	var qualifier string
+	for _, chainCfg := range cfg.Chains {
+		if chainCfg.Qualifier == nil || *chainCfg.Qualifier == "" {
+			continue
+		}
+		if qualifier == "" {
+			qualifier = *chainCfg.Qualifier
+			continue
+		}
+		if qualifier != *chainCfg.Qualifier {
+			return "", fmt.Errorf(
+				"all chains in MCMS deployment must share the same qualifier when MCMS input is omitted",
+			)
 		}
 	}
-	if mcmsInput.Description == "" {
-		mcmsInput.Description = "Accept MCM contract ownership on timelock"
+	if qualifier == "" {
+		return "", errors.New(
+			"MCMS qualifier is required when deploy produces ownership transfer operations and cannot be inferred from chain config",
+		)
 	}
-	return mcmsInput
+	return qualifier, nil
 }

--- a/deployment/fastcurse/fastcurse.go
+++ b/deployment/fastcurse/fastcurse.go
@@ -249,6 +249,7 @@ func applyUncurse(cr *CurseRegistry, mcmsRegistry *changesets.MCMSReaderRegistry
 
 		batchOps := make([]mcms_types.BatchOperation, 0)
 		reports := make([]cldf_ops.Report[any, any], 0)
+		performedUncurse := false
 		// Group curse actions by chain selector
 		grouped, err := cr.groupRMNSubjectBySelector(e, cfg.CurseActions)
 		if err != nil {
@@ -286,8 +287,12 @@ func applyUncurse(cr *CurseRegistry, mcmsRegistry *changesets.MCMSReaderRegistry
 			if err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("failed to curse subjects on chain with selector %d: %w", selector, err)
 			}
+			performedUncurse = true
 			batchOps = append(batchOps, unCurseReport.Output.BatchOps...)
 			reports = append(reports, unCurseReport.ExecutionReports...)
+		}
+		if len(cfg.CurseActions) > 0 && !performedUncurse {
+			return cldf.ChangesetOutput{}, fmt.Errorf("uncurse skipped all actions: no subjects are currently cursed on chain")
 		}
 		return changesets.NewOutputBuilder(e, mcmsRegistry).
 			WithReports(reports).

--- a/deployment/fastcurse/fastcurse.go
+++ b/deployment/fastcurse/fastcurse.go
@@ -31,8 +31,6 @@ type RMNCurseConfig struct {
 	MCMS mcms.Input
 }
 
-// CurseActionInput represent a curse action to be applied on a chain (ChainSelector) with a specific SubjectToCurse derived from the SubjectChainSelector
-// The curse action will by applied by calling the Curse method on the RMNRemote contract on the chain (ChainSelector)
 type CurseActionInput struct {
 	IsGlobalCurse        bool
 	ChainSelector        uint64

--- a/deployment/fastcurse/product.go
+++ b/deployment/fastcurse/product.go
@@ -127,6 +127,9 @@ func (cr *CurseRegistry) groupRMNSubjectBySelector(e cldf.Environment, rmnSubjec
 		if err != nil {
 			return nil, err
 		}
+		if s.Version == nil {
+			return nil, fmt.Errorf("lane curse action missing version: chain %d -> %d", s.ChainSelector, s.SubjectChainSelector)
+		}
 		adapter, ok := cr.GetCurseAdapter(family, s.Version)
 		if !ok {
 			return nil, fmt.Errorf("no curse adapter registered for chain family '%s' and RMN version '%s'",

--- a/deployment/testhelpers/proposal.go
+++ b/deployment/testhelpers/proposal.go
@@ -27,6 +27,8 @@ import (
 	mcmstypes "github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	mcms_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
 )
 
 var (
@@ -60,6 +62,17 @@ func SingleGroupMCMS() mcmstypes.Config {
 		panic(err)
 	}
 	return c
+}
+
+// MCMSInputForQualifier returns a schedule-based MCMS input suitable for test deployments.
+func MCMSInputForQualifier(qualifier string) mcms_utils.Input {
+	return mcms_utils.Input{
+		Qualifier:      qualifier,
+		TimelockAction: mcmstypes.TimelockActionSchedule,
+		TimelockDelay:  mcmstypes.MustParseDuration("0s"),
+		ValidUntil:     3759765795,
+		Description:    "Accept MCM contract ownership on timelock",
+	}
 }
 
 func SingleGroupMCMSTwoSigners() mcmstypes.Config {

--- a/deployment/v2_0_0/offchain/topology.go
+++ b/deployment/v2_0_0/offchain/topology.go
@@ -16,7 +16,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/offchain/shared"
 )
 
-const minProductionChainNOPs = 15
+const minProductionChainNOPs = 9
 
 // EnvironmentTopology holds all environment-specific configuration that cannot be inferred
 // from the datastore. This serves as the single source of truth for the desired state of both off-chain

--- a/devenv/common/implcommon.go
+++ b/devenv/common/implcommon.go
@@ -181,6 +181,13 @@ func DeployContractsForSelector(ctx context.Context, env *deployment.Environment
 	fcs := deployops.FinalizeDeployMCMS(dReg, nil)
 	output, err := cs.Apply(*env, deployops.MCMSDeploymentConfig{
 		AdapterVersion: version,
+		MCMS: mcms.Input{
+			Qualifier:      qualifier,
+			TimelockAction: mcms_types.TimelockActionSchedule,
+			TimelockDelay:  mcms_types.MustParseDuration("0s"),
+			ValidUntil:     math.MaxUint32,
+			Description:    "Accept MCM contract ownership on timelock",
+		},
 		Chains: map[uint64]deployops.MCMSDeploymentConfigPerChain{
 			selector: {
 				Canceller:        SingleGroupMCMS(),

--- a/integration-tests/deployment/fastcurse_test.go
+++ b/integration-tests/deployment/fastcurse_test.go
@@ -212,6 +212,7 @@ func TestFastCurseSolanaAndEVM(t *testing.T) {
 	cs := deploy.DeployMCMS(dReg, nil)
 	output, err := cs.Apply(*env, deploy.MCMSDeploymentConfig{
 		AdapterVersion: semver.MustParse("1.0.0"),
+		MCMS:           testhelpers.MCMSInputForQualifier(deploymentutils.CLLQualifier),
 		Chains: map[uint64]deploy.MCMSDeploymentConfigPerChain{
 			chain1: {
 				Canceller:        testhelpers.SingleGroupMCMS(),

--- a/integration-tests/deployment/helpers.go
+++ b/integration-tests/deployment/helpers.go
@@ -67,6 +67,9 @@ func DeployMCMS(t *testing.T, e *cldf_deployment.Environment, selector uint64, q
 		})
 		require.NoError(t, err)
 		require.Greater(t, len(output.Reports), 0)
+		if len(output.MCMSTimelockProposals) > 0 {
+			testhelpers.ProcessTimelockProposals(t, *e, output.MCMSTimelockProposals, false)
+		}
 		require.NoError(t, output.DataStore.Merge(e.DataStore))
 		e.DataStore = output.DataStore.Seal()
 		finalizeOutput, err := fcs.Apply(*e, mcmsapi.MCMSDeploymentConfig{

--- a/integration-tests/deployment/helpers.go
+++ b/integration-tests/deployment/helpers.go
@@ -55,6 +55,7 @@ func DeployMCMS(t *testing.T, e *cldf_deployment.Environment, selector uint64, q
 	for _, qualifier := range qualifiers {
 		output, err := cs.Apply(*e, mcmsapi.MCMSDeploymentConfig{
 			AdapterVersion: version,
+			MCMS:           testhelpers.MCMSInputForQualifier(qualifier),
 			Chains: map[uint64]mcmsapi.MCMSDeploymentConfigPerChain{
 				selector: {
 					Canceller:        testhelpers.SingleGroupMCMS(),


### PR DESCRIPTION
- Set min nops to 9 (threshold for v2)
- Transfer MCM ownership on deploy
- Extract shared logic to reduce code dup
- Allow passing in extra RMN cursers on deployment