### PR TITLE
CCTP changeset :  skip active pool supported chains check for CCTP-through-CCV pool

### DIFF
--- a/chains/evm/deployment/v2_0_0/sequences/cctp/configure_cctp_chain_for_lanes.go
+++ b/chains/evm/deployment/v2_0_0/sequences/cctp/configure_cctp_chain_for_lanes.go
@@ -283,6 +283,11 @@ var ConfigureCCTPChainForLanes = cldf_ops.NewSequence(
 			RegistryAddress:          refs.TokenAdminRegistry.Address,
 			AllowedFinalityConfig:    allowedFinality,
 			RemoteChains:             cctpThroughCCVRemoteChainConfigs,
+			// The CCTP-through-CCV pool is not a replacement for the USDCTokenPoolProxy; it is a
+			// separate pool that runs alongside the proxy. The upgrade-safety check would incorrectly
+			// require cctpThroughCCVRemoteChainConfigs to include lock-release chains, which the CCV
+			// pool intentionally does not handle.
+			SkipActivePoolSupportedChainsCheck: true,
 		})
 		if err != nil {
 			return sequences.OnChainOutput{}, fmt.Errorf("failed to configure token for transfers: %w", err)

--- a/chains/evm/deployment/v2_0_0/sequences/cctp/configure_cctp_chain_for_lanes.go
+++ b/chains/evm/deployment/v2_0_0/sequences/cctp/configure_cctp_chain_for_lanes.go
@@ -743,27 +743,76 @@ func applyUSDCTokenPoolProxyMechanismWrites(b cldf_ops.Bundle, chain evm.Chain, 
 	return []contract_utils.WriteOutput{report.Output}, nil
 }
 
-// applyCCTPVerifierWrites applies remote chain config and set-domains on the CCTPVerifier.
+// applyCCTPVerifierWrites applies remote chain config and set-domains on the CCTPVerifier,
+// skipping entries whose on-chain state already matches the desired config.
 func applyCCTPVerifierWrites(b cldf_ops.Bundle, chain evm.Chain, verifierAddress common.Address, setDomainArgs []cctp_verifier.SetDomainArgs, remoteChainConfigArgs []cctp_verifier.RemoteChainConfigArgs) ([]contract_utils.WriteOutput, error) {
 	writes := make([]contract_utils.WriteOutput, 0)
-	remoteConfigReport, err := cldf_ops.ExecuteOperation(b, cctp_verifier.ApplyRemoteChainConfigUpdates, chain, contract_utils.FunctionInput[[]cctp_verifier.RemoteChainConfigArgs]{
-		ChainSelector: chain.Selector,
-		Address:       verifierAddress,
-		Args:          remoteChainConfigArgs,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to apply remote chain config updates on CCTPVerifier: %w", err)
+
+	toUpdateConfigs := make([]cctp_verifier.RemoteChainConfigArgs, 0, len(remoteChainConfigArgs))
+	for _, arg := range remoteChainConfigArgs {
+		currentReport, err := cldf_ops.ExecuteOperation(b, cctp_verifier.GetRemoteChainConfig, chain, contract_utils.FunctionInput[uint64]{
+			ChainSelector: chain.Selector,
+			Address:       verifierAddress,
+			Args:          arg.RemoteChainSelector,
+		})
+		if err != nil {
+			// Not yet configured (RemoteChainNotSupported) or unreadable — include it.
+			toUpdateConfigs = append(toUpdateConfigs, arg)
+			continue
+		}
+		current := currentReport.Output.RemoteChainConfig
+		if current.Router != arg.Router ||
+			current.FeeUSDCents != arg.FeeUSDCents ||
+			current.GasForVerification != arg.GasForVerification ||
+			current.PayloadSizeBytes != arg.PayloadSizeBytes {
+			toUpdateConfigs = append(toUpdateConfigs, arg)
+		}
 	}
-	writes = append(writes, remoteConfigReport.Output)
-	domainsReport, err := cldf_ops.ExecuteOperation(b, cctp_verifier.SetDomains, chain, contract_utils.FunctionInput[[]cctp_verifier.SetDomainArgs]{
-		ChainSelector: chain.Selector,
-		Address:       verifierAddress,
-		Args:          setDomainArgs,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to set domains on CCTPVerifier: %w", err)
+	if len(toUpdateConfigs) > 0 {
+		remoteConfigReport, err := cldf_ops.ExecuteOperation(b, cctp_verifier.ApplyRemoteChainConfigUpdates, chain, contract_utils.FunctionInput[[]cctp_verifier.RemoteChainConfigArgs]{
+			ChainSelector: chain.Selector,
+			Address:       verifierAddress,
+			Args:          toUpdateConfigs,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to apply remote chain config updates on CCTPVerifier: %w", err)
+		}
+		writes = append(writes, remoteConfigReport.Output)
 	}
-	writes = append(writes, domainsReport.Output)
+
+	toUpdateDomains := make([]cctp_verifier.SetDomainArgs, 0, len(setDomainArgs))
+	for _, arg := range setDomainArgs {
+		currentReport, err := cldf_ops.ExecuteOperation(b, cctp_verifier.GetDomain, chain, contract_utils.FunctionInput[uint64]{
+			ChainSelector: chain.Selector,
+			Address:       verifierAddress,
+			Args:          arg.ChainSelector,
+		})
+		if err != nil {
+			// Not yet configured (UnknownDomain) or unreadable — include it.
+			toUpdateDomains = append(toUpdateDomains, arg)
+			continue
+		}
+		current := currentReport.Output
+		if current.AllowedCallerOnDest != arg.AllowedCallerOnDest ||
+			current.AllowedCallerOnSource != arg.AllowedCallerOnSource ||
+			current.MintRecipientOnDest != arg.MintRecipientOnDest ||
+			current.DomainIdentifier != arg.DomainIdentifier ||
+			current.Enabled != arg.Enabled {
+			toUpdateDomains = append(toUpdateDomains, arg)
+		}
+	}
+	if len(toUpdateDomains) > 0 {
+		domainsReport, err := cldf_ops.ExecuteOperation(b, cctp_verifier.SetDomains, chain, contract_utils.FunctionInput[[]cctp_verifier.SetDomainArgs]{
+			ChainSelector: chain.Selector,
+			Address:       verifierAddress,
+			Args:          toUpdateDomains,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to set domains on CCTPVerifier: %w", err)
+		}
+		writes = append(writes, domainsReport.Output)
+	}
+
 	return writes, nil
 }
 

--- a/chains/evm/deployment/v2_0_0/sequences/cctp/deploy_cctp_chain.go
+++ b/chains/evm/deployment/v2_0_0/sequences/cctp/deploy_cctp_chain.go
@@ -567,7 +567,8 @@ func applyCCTPAuthorizedCallerWrites(
 	return writes, nil
 }
 
-// setCCTPVerifierResolverInbound sets the CCTPVerifier as the inbound implementation on the resolver. Returns writes to append.
+// setCCTPVerifierResolverInbound sets the CCTPVerifier as the inbound implementation on the resolver,
+// skipping the write if the on-chain state already matches.
 func setCCTPVerifierResolverInbound(
 	b cldf_ops.Bundle,
 	chain evm.Chain,
@@ -580,12 +581,26 @@ func setCCTPVerifierResolverInbound(
 	if err != nil {
 		return nil, fmt.Errorf("failed to get version tag from CCTPVerifier: %w", err)
 	}
+	desired := versioned_verifier_resolver.InboundImplementationArgs{
+		Version:  versionTagReport.Output,
+		Verifier: cctpVerifierAddr,
+	}
+	currentReport, err := cldf_ops.ExecuteOperation(b, versioned_verifier_resolver.GetAllInboundImplementations, chain, contract_utils.FunctionInput[any]{
+		ChainSelector: chain.Selector,
+		Address:       resolverAddr,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get inbound implementations from CCTPVerifierResolver: %w", err)
+	}
+	for _, cur := range currentReport.Output {
+		if cur.Version == desired.Version && cur.Verifier == desired.Verifier {
+			return nil, nil
+		}
+	}
 	report, err := cldf_ops.ExecuteOperation(b, versioned_verifier_resolver.ApplyInboundImplementationUpdates, chain, contract_utils.FunctionInput[[]versioned_verifier_resolver.InboundImplementationArgs]{
 		ChainSelector: chain.Selector,
 		Address:       resolverAddr,
-		Args: []versioned_verifier_resolver.InboundImplementationArgs{
-			{Version: versionTagReport.Output, Verifier: cctpVerifierAddr},
-		},
+		Args:          []versioned_verifier_resolver.InboundImplementationArgs{desired},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to set inbound implementation on CCTPVerifierResolver: %w", err)

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_for_transfers.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_for_transfers.go
@@ -156,12 +156,13 @@ var ConfigureTokenForTransfers = cldf_ops.NewSequence(
 
 		// Configure token pool for all remote chains (validates active pool supported chains once when upgrading).
 		configureTokenPoolForRemoteChainsReport, err := cldf_ops.ExecuteSequence(b, ConfigureTokenPoolForRemoteChains, evmChain, ConfigureTokenPoolForRemoteChainsInput{
-			ChainSelector:     input.ChainSelector,
-			TokenPoolAddress:  tokenPoolAddress,
-			AdvancedPoolHooks: advancedPoolHooksAddress.Output,
-			RemoteChains:      input.RemoteChains,
-			RegistryAddress:   registryAddress,
-			TokenAddress:      tokenAddress,
+			ChainSelector:                      input.ChainSelector,
+			TokenPoolAddress:                   tokenPoolAddress,
+			AdvancedPoolHooks:                  advancedPoolHooksAddress.Output,
+			RemoteChains:                       input.RemoteChains,
+			RegistryAddress:                    registryAddress,
+			TokenAddress:                       tokenAddress,
+			SkipActivePoolSupportedChainsCheck: input.SkipActivePoolSupportedChainsCheck,
 		})
 		if err != nil {
 			return sequences.OnChainOutput{}, fmt.Errorf("failed to configure token pool for remote chains: %w", err)

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
@@ -25,6 +25,10 @@ type ConfigureTokenPoolForRemoteChainsInput struct {
 	RemoteChains      map[uint64]tokens.RemoteChainConfig[[]byte, string]
 	RegistryAddress   common.Address
 	TokenAddress      common.Address
+	// SkipActivePoolSupportedChainsCheck disables the upgrade-safety check that requires remoteChains
+	// to cover all chains the currently-registered pool supports. Set this when the pool being configured
+	// is not a direct replacement for the registered pool (e.g. CCTP-through-CCV alongside USDCTokenPoolProxy).
+	SkipActivePoolSupportedChainsCheck bool
 }
 
 // ConfigureTokenPoolForRemoteChains runs the supported-chains check once (when registry/token set) then calls
@@ -54,7 +58,7 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 					ChainSelector: input.ChainSelector,
 					Address:       activePool,
 				}, cldf_ops.WithForceExecute[evm_contract.FunctionInput[struct{}], evm.Chain]())
-				if err == nil {
+				if err == nil && !input.SkipActivePoolSupportedChainsCheck {
 					// Validate that remoteChains includes all chains the active pool already supports (upgrade safety).
 					supportedChains := supportedChainsReport.Output
 					for _, sel := range supportedChains {

--- a/deployment/tokens/product.go
+++ b/deployment/tokens/product.go
@@ -333,6 +333,10 @@ type ConfigureTokenForTransfersInput struct {
 	// TimelockAddress is the MCMS timelock address, resolved by the changeset from MCMS config.
 	// Required when a liquidity migration is triggered.
 	TimelockAddress string
+	// SkipActivePoolSupportedChainsCheck disables the upgrade-safety check that requires remoteChains
+	// to cover all chains the currently-registered pool supports. Set this when the pool being configured
+	// is not a direct replacement for the registered pool (e.g. CCTP-through-CCV alongside USDCTokenPoolProxy).
+	SkipActivePoolSupportedChainsCheck bool
 	// Below are not provided by the user and populated programmatically.
 	// ExistingDataStore is the datastore containing existing deployment data.
 	ExistingDataStore datastore.DataStore


### PR DESCRIPTION
 Description:
 
Summary
  - `ConfigureTokenPoolForRemoteChains` validates that remoteChains covers every chain the currently-registered (active) pool supports
  - `ConfigureCCTPChainForLanes` calls `ConfigureTokenForTransfers` for the CCTP-through-CCV pool passing only a subset of remote chains which intentionally excludes lock-release lanes + Solana. When the USDCTokenPoolProxy (or `HybirdUSDCTokenPool v1.6.2`, the registered pool) implements `getSupportedChains` and reports those lock-release chains,  the validation fires: `remoteChains must include all active pool supported chains.`
  - The check does not apply here: the CCTP-through-CCV pool is not a replacement for the USDCTokenPoolProxy it is a separate pool running alongside it. We have create post migration validation script to check the correct remote chain support for such pool
  
Changes
  - Added `SkipActivePoolSupportedChainsCheck` bool to `ConfigureTokenPoolForRemoteChainsInput` and `tokens.ConfigureTokenForTransfersInput`.
  - When the flag is set, the active-pool supported-chains validation is skipped entirely.
  - `ConfigureCCTPChainForLanes` sets the flag to true with an inline comment explaining why.

+ A few more idempotency check 