### PR TITLE
fix: solana token expansion - stale pending admin read

### DIFF
--- a/chains/solana/deployment/v1_6_0/operations/router/router.go
+++ b/chains/solana/deployment/v1_6_0/operations/router/router.go
@@ -427,6 +427,9 @@ var RegisterTokenAdminRegistry = operations.NewOperation(
 		if err := chain.GetAccountDataBorshInto(b.GetContext(), tokenAdminRegistryPDA, &tokenAdminRegistryAccount); err == nil {
 			if input.Admin == tokenAdminRegistryAccount.Administrator {
 				b.Logger.Info("Token admin registry already registered with the given admin:", tokenAdminRegistryAccount)
+				// Return without PendingSigner: nothing changed on-chain, so callers must not
+				// sequence Accept (a leftover PendingAdministrator from an earlier register is
+				// unrelated and would cause Accept to validate against stale TAR state).
 				return TokenAdminRegistryOut{}, nil
 			}
 			pendingAdmin = tokenAdminRegistryAccount.PendingAdministrator
@@ -584,6 +587,8 @@ var AcceptTokenAdminRegistry = operations.NewOperation(
 			chain.Selector,
 			common_utils.CLLQualifier,
 		)
+		// Administrator already matches the caller's target; accept is unnecessary even if
+		// PendingAdministrator is stale (e.g. a third-party key from an earlier register).
 		if !currentAdmin.IsZero() && !input.Admin.IsZero() && currentAdmin == input.Admin {
 			b.Logger.Info("Token admin registry already has the requested admin, skipping accept admin role for token admin registry")
 			return sequences.OnChainOutput{}, nil
@@ -600,6 +605,10 @@ var AcceptTokenAdminRegistry = operations.NewOperation(
 			}
 			pendingAdmin = input.Admin
 		} else if pendingAdmin != timelockSigner && pendingAdmin != chain.DeployerKey.PublicKey() {
+			// MCMS batches don't execute immediately: Register may have queued an override to
+			// timelock/deployer while on-chain PendingAdministrator still shows a prior third
+			// party. Trust input.Admin (the intended accept signer from orchestration) when the
+			// admin slot is not yet settled.
 			if currentAdmin.IsZero() && !input.Admin.IsZero() && (input.Admin == timelockSigner || input.Admin == chain.DeployerKey.PublicKey()) {
 				pendingAdmin = input.Admin
 			} else {
@@ -665,6 +674,7 @@ var TransferTokenAdminRegistry = operations.NewOperation(
 		}
 		if currentAdmin == input.Admin {
 			b.Logger.Info("Token admin registry already registered with the given admin:", tokenAdminRegistryAccount)
+			// Same as Register no-op: do not set PendingSigner when no transfer was initiated.
 			return TokenAdminRegistryOut{}, nil
 		}
 		// sign as the current admin to transfer

--- a/chains/solana/deployment/v1_6_0/operations/router/router.go
+++ b/chains/solana/deployment/v1_6_0/operations/router/router.go
@@ -427,7 +427,7 @@ var RegisterTokenAdminRegistry = operations.NewOperation(
 		if err := chain.GetAccountDataBorshInto(b.GetContext(), tokenAdminRegistryPDA, &tokenAdminRegistryAccount); err == nil {
 			if input.Admin == tokenAdminRegistryAccount.Administrator {
 				b.Logger.Info("Token admin registry already registered with the given admin:", tokenAdminRegistryAccount)
-				return TokenAdminRegistryOut{PendingSigner: input.Admin}, nil
+				return TokenAdminRegistryOut{}, nil
 			}
 			pendingAdmin = tokenAdminRegistryAccount.PendingAdministrator
 			// there is already an admin registered, we need to transfer
@@ -584,6 +584,10 @@ var AcceptTokenAdminRegistry = operations.NewOperation(
 			chain.Selector,
 			common_utils.CLLQualifier,
 		)
+		if !currentAdmin.IsZero() && !input.Admin.IsZero() && currentAdmin == input.Admin {
+			b.Logger.Info("Token admin registry already has the requested admin, skipping accept admin role for token admin registry")
+			return sequences.OnChainOutput{}, nil
+		}
 		if pendingAdmin.IsZero() {
 			// if there is no pending admin, we assume the authority is timelock
 			// but we need to confirm that timelock is indeed the authority
@@ -596,7 +600,11 @@ var AcceptTokenAdminRegistry = operations.NewOperation(
 			}
 			pendingAdmin = input.Admin
 		} else if pendingAdmin != timelockSigner && pendingAdmin != chain.DeployerKey.PublicKey() {
-			return sequences.OnChainOutput{}, fmt.Errorf("pending admin %s does not match timelock signer %s or deployer %s", pendingAdmin.String(), timelockSigner.String(), chain.DeployerKey.PublicKey().String())
+			if currentAdmin.IsZero() && !input.Admin.IsZero() && (input.Admin == timelockSigner || input.Admin == chain.DeployerKey.PublicKey()) {
+				pendingAdmin = input.Admin
+			} else {
+				return sequences.OnChainOutput{}, fmt.Errorf("pending admin %s does not match timelock signer %s or deployer %s", pendingAdmin.String(), timelockSigner.String(), chain.DeployerKey.PublicKey().String())
+			}
 		}
 		// sign as the pending admin to accept
 		// when there is no pending admin, we assume the authority is timelock
@@ -657,7 +665,7 @@ var TransferTokenAdminRegistry = operations.NewOperation(
 		}
 		if currentAdmin == input.Admin {
 			b.Logger.Info("Token admin registry already registered with the given admin:", tokenAdminRegistryAccount)
-			return TokenAdminRegistryOut{PendingSigner: input.Admin}, nil
+			return TokenAdminRegistryOut{}, nil
 		}
 		// sign as the current admin to transfer
 		tempIx, err := ccip_router.NewTransferAdminRoleTokenAdminRegistryInstruction(

--- a/chains/solana/deployment/v1_6_0/sequences/tokens.go
+++ b/chains/solana/deployment/v1_6_0/sequences/tokens.go
@@ -105,8 +105,8 @@ func (a *SolanaAdapter) ConfigureTokenForTransfersSequence() *cldf_ops.Sequence[
 				result.BatchOps = append(result.BatchOps, atarOut.Output.BatchOps...)
 
 			// Case 2: the RegisterTokenAdminRegistry operation has MCMS batches and the proposed admin
-			// is timelock - in this case we bundle Register and Accept into the same MCMS batch.
-			case hasMCMSProposal && isTimelockPendingAdmin:
+			// is timelock or deployer - in this case we bundle Register and Accept into the same MCMS batch.
+			case hasMCMSProposal && (isTimelockPendingAdmin || isDeployerPendingAdmin):
 				atarIxn, err := routerops.BuildAcceptTokenAdminRegistrySolanaInstruction(routerPK, tokenMintPK, pendingSigner)
 				if err != nil {
 					return sequences.OnChainOutput{}, fmt.Errorf("failed to build accept token admin registry instruction: %w", err)


### PR DESCRIPTION
# Solana Token Admin Registry pending-admin hotfix

## Problem

Solana token expansion and configure-for-transfers flows can fail during MCMS proposal generation with:

`failed to accept token admin registry: pending admin <third-party> does not match timelock signer <timelock> or deployer <deployer>`

This blocked mainnet/testnet deployment pipelines when expanding tokens that previously had a non-CLL pending administrator on the Token Admin Registry (TAR).

## Background

TAR admin transfer is a two-step on-chain process: a pending administrator is proposed, then that key accepts to become the settled `Administrator`. Deployment tooling orchestrates register/override and accept across `RegisterTokenAdminRegistry`, `AcceptTokenAdminRegistry`, and `ConfigureTokenForTransfersSequence`.

MCMS proposals batch Solana instructions without executing them immediately. Any operation that reads live TAR state after a sibling operation has *queued* but not yet *applied* TAR changes can see a stale `PendingAdministrator`.

PR #2051 addressed part of this by bundling register and accept into the same MCMS batch when the intended pending admin is timelock (Case 2), and by exposing `ProposalInstructions` from register so accept could be appended without a separate chain read. The failure mode persisted in other paths.

## What this change adds

This is a minimal hotfix focused on making accept orchestration consistent with register orchestration when on-chain TAR state lags behind the intended final admin.

### Accept respects orchestration intent over stale chain state

`AcceptTokenAdminRegistry` receives `input.Admin` from the caller — the key Register determined should sign accept (`PendingSigner`). When the settled administrator is not yet assigned and the caller intends timelock or deployer, accept uses that intended signer rather than rejecting because on-chain `PendingAdministrator` still reflects an older third party.

This directly addresses the production error where a prior customer pending admin remained visible on-chain while the current changeset intended timelock.

### Accept skips when admin is already correct

If settled `Administrator` already equals the requested admin, accept returns without action. A leftover `PendingAdministrator` from an earlier incomplete flow must not force accept or cause validation failures when the desired end state is already satisfied.

### No-op register/transfer does not advertise a pending signer

When register or transfer determines the target admin is already the settled administrator, the operation returns without emitting instructions and without setting `PendingSigner`. Prior behavior (introduced in #2051) returned `PendingSigner: input.Admin` on these no-ops, which caused downstream configure logic to invoke accept even though nothing had changed — often hitting stale pending state.

### MCMS bundling symmetry for deployer

`ConfigureTokenForTransfersSequence` Case 2 now bundles register and accept in one MCMS batch when the pending signer is deployer as well as timelock. Previously only the timelock path avoided the separate accept call that re-read chain state.

## Intentional design choices

**Trust caller only under narrow conditions.** The stale-pending override applies only when `Administrator` is still unset and `input.Admin` is timelock or deployer — the keys CLL can actually sign accept with. Third-party pending admins that CLL does not control still defer to Case 3 (register only, accept later by the third party).

**Hotfix over refactor.** The broader orchestration problem — duplicated case logic, accept doing validation and execution, multiple sources of truth for pending signer — is acknowledged but intentionally not addressed here. A follow-up could centralize planning and make register/accept pure instruction builders.

**Revert part of #2051 no-op semantics.** Returning `PendingSigner` on no-op was meant to help callers sequence accept, but it conflated "target admin" with "accept still required." Empty no-op returns make the distinction explicit: no instruction emitted means no accept to sequence.

**Comments document MCMS timing invariant.** Inline comments in router operations explain why chain reads in accept can be wrong mid-batch, so future edits do not reintroduce validate-against-chain behavior without considering MCMS execution order.

## Relationship to on-chain TAR model

On Solana, `accept_admin_role_token_admin_registry` requires the transaction signer to match `pending_administrator`, then promotes that key to `administrator` and clears pending. Deployment tooling must align proposal instruction order and signer choice with that model. This change ensures off-chain orchestration does not reject valid proposal construction merely because an earlier pending slot was not yet overwritten on-chain.

## Out of scope

- Regression tests (deferred)
- Refactoring Case 1/2/3 into a single planner
- Extending the zero-pending accept branch to treat deployer symmetrically with timelock (deployer paths typically confirm register on-chain before accept runs)

## Downstream validation

After merging and pinning in chainlink-deployments, the token expansion cross-family durable pipeline completed and produced MCMS proposal PR #15834 without the pending-admin validation error. Solana batches in that proposal used timelock as authority; the stale third-party pending key did not appear.
