### PR TITLE
Fix: OnRamp address lookup ambiguity in token verifier config

### DIFF
--- a/chains/evm/deployment/v2_0_0/adapters/token_verifier_config_adapter.go
+++ b/chains/evm/deployment/v2_0_0/adapters/token_verifier_config_adapter.go
@@ -3,10 +3,10 @@ package adapters
 import (
 	"fmt"
 
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/operations/rmn_remote"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/cctp_verifier"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/onramp"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/versioned_verifier_resolver"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/operations/rmn_remote"
 	dsutil "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	ccvadapters "github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/adapters"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
@@ -25,7 +25,8 @@ func (a *EVMTokenVerifierConfigAdapter) ResolveTokenVerifierAddresses(
 	toAddress := func(ref datastore.AddressRef) (string, error) { return ref.Address, nil }
 
 	onRampAddr, err := dsutil.FindAndFormatRef(ds, datastore.AddressRef{
-		Type: datastore.ContractType(onramp.ContractType),
+		Type:    datastore.ContractType(onramp.ContractType),
+		Version: onramp.Version,
 	}, chainSelector, toAddress)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get on ramp address for chain %d: %w", chainSelector, err)


### PR DESCRIPTION
The `generate-token-verifier-config` changeset was failing when a datastore contained both a v1.6 and v2.0 OnRamp for the same chain, because the lookup filtered only by Type + ChainSelector with no version constraint — matching both entries and violating the "exactly 1 ref" requirement.

Fix: add `Version: onramp.Version` (2.0.0) to the OnRamp lookup in `EVMTokenVerifierConfigAdapter` so the filter always resolves unambiguously to the v2 contract.