### PR TITLE
fix: solana manual reg. - extend token pool LUT in token multisig flow

### DIFF
--- a/chains/solana/deployment/v1_6_0/operations/tokens/tokens.go
+++ b/chains/solana/deployment/v1_6_0/operations/tokens/tokens.go
@@ -257,7 +257,7 @@ var ExtendTokenPoolLookupTable = operations.NewOperation(
 
 		var tokenAdminRegistry ccip_common.TokenAdminRegistry
 		if err := chain.GetAccountDataBorshInto(ctx, tokenAdminRegistryPDA, &tokenAdminRegistry); err != nil {
-			return sequences.OnChainOutput{}, fmt.Errorf("failed to get token admin registry at '%s': %w", tokenAdminRegistryPDA.String(), err)
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to parse token admin registry account at '%s': %w", tokenAdminRegistryPDA.String(), err)
 		}
 
 		lookupTable := tokenAdminRegistry.LookupTable

--- a/chains/solana/deployment/v1_6_0/operations/tokens/tokens.go
+++ b/chains/solana/deployment/v1_6_0/operations/tokens/tokens.go
@@ -1,6 +1,7 @@
 package tokens
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
@@ -8,7 +9,9 @@ import (
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/utils"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/ccip_common"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
 	tokenapi "github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	common_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils"
@@ -219,6 +222,96 @@ var CreateTokenMultisig = operations.NewOperation(
 			},
 		}, nil
 	})
+
+type ExtendTokenPoolLookupTableParams struct {
+	Router    solana.PublicKey
+	TokenMint solana.PublicKey
+	Accounts  []solana.PublicKey
+}
+
+var ExtendTokenPoolLookupTable = operations.NewOperation(
+	"solana-token:extend-token-pool-lookup-table",
+	Version,
+	"Extends the token pool address lookup table with additional accounts",
+	func(b operations.Bundle, chain cldf_solana.Chain, input ExtendTokenPoolLookupTableParams) (sequences.OnChainOutput, error) {
+		ctx := b.GetContext()
+
+		if input.TokenMint.IsZero() {
+			return sequences.OnChainOutput{}, errors.New("token mint is zero")
+		}
+		if input.Router.IsZero() {
+			return sequences.OnChainOutput{}, errors.New("router is zero")
+		}
+		if len(input.Accounts) == 0 {
+			b.Logger.Info("no accounts provided - skipping token pool lookup table extension")
+			return sequences.OnChainOutput{}, nil
+		}
+		if chain.DeployerKey == nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("solana deployer key is nil for chain selector '%d'", chain.Selector)
+		}
+
+		tokenAdminRegistryPDA, _, err := state.FindTokenAdminRegistryPDA(input.TokenMint, input.Router)
+		if err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to find token admin registry PDA: %w", err)
+		}
+
+		var tokenAdminRegistry ccip_common.TokenAdminRegistry
+		if err := chain.GetAccountDataBorshInto(ctx, tokenAdminRegistryPDA, &tokenAdminRegistry); err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to get token admin registry at '%s': %w", tokenAdminRegistryPDA.String(), err)
+		}
+
+		lookupTable := tokenAdminRegistry.LookupTable
+		if lookupTable.IsZero() {
+			return sequences.OnChainOutput{}, fmt.Errorf(
+				"token pool lookup table is not set for token '%s' on router '%s'; run configure-for-transfers / set-pool first",
+				input.TokenMint.String(), input.Router.String(),
+			)
+		}
+
+		existingEntries, err := common.GetAddressLookupTable(ctx, chain.Client, lookupTable)
+		if err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to get token pool lookup table at '%s': %w", lookupTable.String(), err)
+		}
+
+		seen := make(map[solana.PublicKey]bool, len(existingEntries))
+		for _, entry := range existingEntries {
+			seen[entry] = true
+		}
+
+		toAdd := make([]solana.PublicKey, 0, len(input.Accounts))
+		for _, acct := range input.Accounts {
+			if acct.IsZero() {
+				return sequences.OnChainOutput{}, fmt.Errorf("account to add is zero")
+			}
+			if !seen[acct] {
+				toAdd = append(toAdd, acct)
+				seen[acct] = true
+			}
+		}
+
+		if len(toAdd) == 0 {
+			b.Logger.Infof(
+				"all %d account(s) already present in token pool lookup table at '%s' - nothing to extend",
+				len(input.Accounts), lookupTable.String(),
+			)
+			return sequences.OnChainOutput{}, nil
+		}
+
+		b.Logger.Infof(
+			"extending token pool lookup table at '%s' with %d account(s)",
+			lookupTable.String(), len(toAdd),
+		)
+
+		if err := common.ExtendLookupTable(ctx, chain.Client, lookupTable, *chain.DeployerKey, toAdd); err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to extend token pool lookup table at '%s': %w", lookupTable.String(), err)
+		}
+		if err := common.AwaitSlotChange(ctx, chain.Client); err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to await slot change after extending token pool lookup table: %w", err)
+		}
+
+		return sequences.OnChainOutput{}, nil
+	},
+)
 
 var UpsertTokenMetadata = operations.NewOperation(
 	"solana-token:upsert-metadata",

--- a/chains/solana/deployment/v1_6_0/operations/tokens/tokens.go
+++ b/chains/solana/deployment/v1_6_0/operations/tokens/tokens.go
@@ -270,7 +270,7 @@ var ExtendTokenPoolLookupTable = operations.NewOperation(
 
 		existingEntries, err := common.GetAddressLookupTable(ctx, chain.Client, lookupTable)
 		if err != nil {
-			return sequences.OnChainOutput{}, fmt.Errorf("failed to get token pool lookup table at '%s': %w", lookupTable.String(), err)
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to parse addresses from lookup table state at '%s': %w", lookupTable.String(), err)
 		}
 
 		seen := make(map[solana.PublicKey]bool, len(existingEntries))

--- a/chains/solana/deployment/v1_6_0/operations/tokens/tokens.go
+++ b/chains/solana/deployment/v1_6_0/operations/tokens/tokens.go
@@ -3,6 +3,7 @@ package tokens
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 	token_metadata "github.com/gagliardetto/metaplex-go/clients/token-metadata"
@@ -224,9 +225,15 @@ var CreateTokenMultisig = operations.NewOperation(
 	})
 
 type ExtendTokenPoolLookupTableParams struct {
-	Router    solana.PublicKey
-	TokenMint solana.PublicKey
-	Accounts  []solana.PublicKey
+	// AllowDuplicates indicates whether to allow duplicate accounts in the lookup
+	// table. When false (the default), then any duplicate account in the Accounts
+	// slice will be ignored AND any account that is already present in the lookup
+	// table will be ignored. If this is true, then *all* accounts in the Accounts
+	// slice will be added to the lookup table, even if they are already present.
+	AllowDuplicates bool
+	TokenMint       solana.PublicKey
+	Router          solana.PublicKey
+	Accounts        []solana.PublicKey
 }
 
 var ExtendTokenPoolLookupTable = operations.NewOperation(
@@ -268,24 +275,37 @@ var ExtendTokenPoolLookupTable = operations.NewOperation(
 			)
 		}
 
-		existingEntries, err := common.GetAddressLookupTable(ctx, chain.Client, lookupTable)
+		lutState, err := common.GetAddressLookupTableState(ctx, chain.Client, lookupTable)
 		if err != nil {
-			return sequences.OnChainOutput{}, fmt.Errorf("failed to get token pool lookup table at '%s': %w", lookupTable.String(), err)
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to get token pool lookup table at %q: %w", lookupTable.String(), err)
+		}
+		if !lutState.IsActive() {
+			return sequences.OnChainOutput{}, fmt.Errorf("token pool lookup table at %q is not active", lookupTable.String())
+		}
+		if lutState.Authority == nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("token pool lookup table at %q has no authority set", lookupTable.String())
+		}
+		if !lutState.Authority.Equals(chain.DeployerKey.PublicKey()) {
+			return sequences.OnChainOutput{}, fmt.Errorf("expected token pool lookup table at %q to have authority %q (deployer key), but it is %q", lookupTable.String(), chain.DeployerKey.PublicKey().String(), lutState.Authority.String())
 		}
 
-		seen := make(map[solana.PublicKey]bool, len(existingEntries))
-		for _, entry := range existingEntries {
-			seen[entry] = true
+		seen := make(map[solana.PublicKey]bool, len(lutState.Addresses))
+		if !input.AllowDuplicates {
+			for _, entry := range lutState.Addresses {
+				seen[entry] = true
+			}
 		}
 
-		toAdd := make([]solana.PublicKey, 0, len(input.Accounts))
-		for _, acct := range input.Accounts {
+		toAdd := make(solana.PublicKeySlice, 0, len(input.Accounts))
+		for i, acct := range input.Accounts {
 			if acct.IsZero() {
-				return sequences.OnChainOutput{}, fmt.Errorf("account to add is zero")
+				return sequences.OnChainOutput{}, fmt.Errorf("account at index %d is zero", i)
 			}
 			if !seen[acct] {
-				toAdd = append(toAdd, acct)
-				seen[acct] = true
+				toAdd.Append(acct)
+				if !input.AllowDuplicates {
+					seen[acct] = true
+				}
 			}
 		}
 
@@ -298,8 +318,8 @@ var ExtendTokenPoolLookupTable = operations.NewOperation(
 		}
 
 		b.Logger.Infof(
-			"extending token pool lookup table at '%s' with %d account(s)",
-			lookupTable.String(), len(toAdd),
+			"extending token pool lookup table at '%s' with account(s): %s",
+			lookupTable.String(), strings.Join(toAdd.ToBase58(), ", "),
 		)
 
 		if err := common.ExtendLookupTable(ctx, chain.Client, lookupTable, *chain.DeployerKey, toAdd); err != nil {

--- a/chains/solana/deployment/v1_6_0/sequences/tokens.go
+++ b/chains/solana/deployment/v1_6_0/sequences/tokens.go
@@ -485,6 +485,27 @@ func (a *SolanaAdapter) ManualRegistration() *cldf_ops.Sequence[tokenapi.ManualR
 				}
 				result.Addresses = append(result.Addresses, createTokenMultisigOutput.Output.Addresses...)
 				result.BatchOps = append(result.BatchOps, createTokenMultisigOutput.Output.BatchOps...)
+
+				var msigAddr string
+				if len(createTokenMultisigOutput.Output.Addresses) == 0 {
+					return sequences.OnChainOutput{}, fmt.Errorf("create token multisig did not return a multisig address")
+				} else {
+					msigAddr = createTokenMultisigOutput.Output.Addresses[0].Address
+				}
+
+				msigPubkey, err := solana.PublicKeyFromBase58(msigAddr)
+				if err != nil {
+					return sequences.OnChainOutput{}, fmt.Errorf("failed to parse multisig address '%s' as Solana public key: %w", msigAddr, err)
+				}
+
+				_, err = operations.ExecuteOperation(b, tokensops.ExtendTokenPoolLookupTable, chains.SolanaChains()[chain.Selector], tokensops.ExtendTokenPoolLookupTableParams{
+					Router:    solana.PublicKeyFromBytes(routerAddr),
+					TokenMint: tokenMint,
+					Accounts:  []solana.PublicKey{msigPubkey},
+				})
+				if err != nil {
+					return sequences.OnChainOutput{}, fmt.Errorf("failed to extend token pool lookup table with multisig: %w", err)
+				}
 			}
 
 			// Manual registration can be used on tokens that aren't in the datastore

--- a/chains/solana/utils/common/lookuptable.go
+++ b/chains/solana/utils/common/lookuptable.go
@@ -143,10 +143,19 @@ func SetupLookupTable(ctx context.Context, client *rpc.Client, admin solana.Priv
 	return table, nil
 }
 
-func GetAddressLookupTable(ctx context.Context, client *rpc.Client, lookupTablePublicKey solana.PublicKey) ([]solana.PublicKey, error) {
+func GetAddressLookupTableState(ctx context.Context, client *rpc.Client, lookupTablePublicKey solana.PublicKey) (*addresslookuptable.AddressLookupTableState, error) {
 	lookupTableState, err := addresslookuptable.GetAddressLookupTableStateWithOpts(ctx, client, lookupTablePublicKey, &rpc.GetAccountInfoOpts{
 		Commitment: rpc.CommitmentConfirmed,
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	return lookupTableState, nil
+}
+
+func GetAddressLookupTable(ctx context.Context, client *rpc.Client, lookupTablePublicKey solana.PublicKey) ([]solana.PublicKey, error) {
+	lookupTableState, err := GetAddressLookupTableState(ctx, client, lookupTablePublicKey)
 	if err != nil {
 		return []solana.PublicKey{}, err
 	}

--- a/integration-tests/deployment/tokens_and_token_pools_test.go
+++ b/integration-tests/deployment/tokens_and_token_pools_test.go
@@ -13,6 +13,7 @@ import (
 	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/ccip_common"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v1_6_0/burnmint_token_pool"
+	solcommon "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/fees"
@@ -69,7 +70,8 @@ func TestTokensAndTokenPools(t *testing.T) {
 	require.NoError(t, err)
 
 	// Setup test environment
-	env, err := environment.New(t.Context(),
+	env, err := environment.New(
+		t.Context(),
 		environment.WithSolanaContainer(t, []uint64{solChainSel}, programsPath, solanaProgramIDs),
 		environment.WithEVMSimulated(t, []uint64{evmChainSelA, evmChainSelB}),
 	)
@@ -878,7 +880,8 @@ func TestTokensAndTokenPools(t *testing.T) {
 				// Verify that DeriveTokenAddress can derive the token address if it is given the pool PDA instead of the pool program ID
 				svmTokenAdapter, adapterOk := tokensapi.GetTokenAdapterRegistry().GetTokenAdapter(chainsel.FamilySolana, cciputils.Version_1_6_0)
 				require.True(t, adapterOk, "v1.6.0 Solana token adapter should be registered")
-				derived, err := svmTokenAdapter.DeriveTokenAddress(*env,
+				derived, err := svmTokenAdapter.DeriveTokenAddress(
+					*env,
 					data.Chain.Selector,
 					datastore.AddressRef{Address: tokenPoolStatePDA.String()},
 				)
@@ -972,11 +975,6 @@ func TestTokensAndTokenPools(t *testing.T) {
 							TokenRef: datastore.AddressRef{
 								Qualifier: tokenSymbol,
 							},
-							SVMExtraArgs: &tokensapi.SVMExtraArgs{
-								CustomerMintAuthorities: []solana.PublicKey{
-									externalAdmin,
-								},
-							},
 						},
 					},
 				})
@@ -999,17 +997,6 @@ func TestTokensAndTokenPools(t *testing.T) {
 			require.Equal(t, tokenMint, tokenPoolStateAccountAfter.Config.Mint)
 			require.Equal(t, chain.DeployerKey.PublicKey(), tokenPoolStateAccountAfter.Config.RateLimitAdmin)
 
-			// Validate the Multisig is stored
-			multisigAdd, err := datastore_utils.FindAndFormatRef(env.DataStore, datastore.AddressRef{
-				ChainSelector: solbnm.Chain.Selector,
-				Version:       cciputils.Version_1_6_0,
-				Qualifier:     tokenSymbol,
-				Type:          "TOKEN_MULTISIG",
-			}, solbnm.Chain.Selector, datastore_utils.FullRef)
-			require.NoError(t, err)
-			multisigPublicKey := solana.MustPublicKeyFromBase58(multisigAdd.Address)
-			require.False(t, multisigPublicKey.IsZero())
-
 			// Run the changeset with a new admin, overriding the previous pending admin
 			newExternalAdmin, _ := solana.NewRandomPrivateKey()
 			output, err = tokensapi.
@@ -1028,11 +1015,6 @@ func TestTokensAndTokenPools(t *testing.T) {
 							TokenRef: datastore.AddressRef{
 								ChainSelector: solbnm.Chain.Selector,
 								Address:       tokenAddr.Address,
-							},
-							SVMExtraArgs: &tokensapi.SVMExtraArgs{
-								CustomerMintAuthorities: []solana.PublicKey{
-									newExternalAdmin.PublicKey(),
-								},
 							},
 						},
 					},
@@ -1314,6 +1296,81 @@ func TestTokensAndTokenPools(t *testing.T) {
 					require.Equal(t, uint32(math.MaxUint32), actualFee.MaxFeeUSDCents)
 				}
 			}
+		})
+
+		t.Run("Validate ManualRegistrationMultisigExtendsLookupTable", func(t *testing.T) {
+			solbnm := solTestData[0]
+			externalAdmin := solana.MustPublicKeyFromBase58(solbnm.Token.ExternalAdmin)
+			chain := env.BlockChains.SolanaChains()[solbnm.Chain.Selector]
+
+			tokenAddr, err := datastore_utils.FindAndFormatRef(env.DataStore, datastore.AddressRef{
+				ChainSelector: solbnm.Chain.Selector,
+				Qualifier:     solbnm.Token.Symbol,
+			}, solbnm.Chain.Selector, datastore_utils.FullRef)
+			require.NoError(t, err)
+
+			tokenPool, err := datastore_utils.FindAndFormatRef(env.DataStore, datastore.AddressRef{
+				ChainSelector: solbnm.Chain.Selector,
+				Type:          datastore.ContractType(cciputils.BurnMintTokenPool),
+				Version:       cciputils.Version_1_6_0,
+			}, solbnm.Chain.Selector, datastore_utils.FullRef)
+			require.NoError(t, err)
+
+			routerAdd, err := solAdapter.GetRouterAddress(env.DataStore, solbnm.Chain.Selector)
+			require.NoError(t, err)
+			routerProgramId := solana.PublicKeyFromBytes(routerAdd)
+
+			tokenMint := solana.MustPublicKeyFromBase58(tokenAddr.Address)
+			tokenAdminRegistryPDA, _, _ := state.FindTokenAdminRegistryPDA(tokenMint, routerProgramId)
+			var tar ccip_common.TokenAdminRegistry
+			require.NoError(t, chain.GetAccountDataBorshInto(t.Context(), tokenAdminRegistryPDA, &tar))
+			require.False(t, tar.LookupTable.IsZero(), "precondition: token pool lookup table must exist from ConfigureTokenForTransfers")
+
+			lutBefore, err := solcommon.GetAddressLookupTable(t.Context(), chain.Client, tar.LookupTable)
+			require.NoError(t, err)
+			lutLenBefore := len(lutBefore)
+
+			output, err := tokensapi.ManualRegistration().Apply(*env, tokensapi.ManualRegistrationInput{
+				ChainAdapterVersion: cciputils.Version_1_6_0,
+				MCMS:                NewDefaultInputForMCMS("Manual registration multisig LUT extension"),
+				Registrations: []tokensapi.RegisterTokenConfig{
+					{
+						ChainSelector: solbnm.Chain.Selector,
+						ProposedOwner: solbnm.Token.ExternalAdmin,
+						TokenPoolRef: datastore.AddressRef{
+							Address: tokenPool.Address,
+							Type:    datastore.ContractType(solbnm.TokenPoolType),
+						},
+						TokenRef: datastore.AddressRef{
+							Address: tokenAddr.Address,
+						},
+						SVMExtraArgs: &tokensapi.SVMExtraArgs{
+							SkipTokenPoolInit: true,
+							CustomerMintAuthorities: []solana.PublicKey{
+								externalAdmin,
+							},
+						},
+					},
+				},
+			})
+			require.NoError(t, err)
+			MergeAddresses(t, env, output.DataStore)
+			testhelpers.ProcessTimelockProposals(t, *env, output.MCMSTimelockProposals, false)
+
+			multisigRef, err := datastore_utils.FindAndFormatRef(env.DataStore, datastore.AddressRef{
+				ChainSelector: solbnm.Chain.Selector,
+				Version:       cciputils.Version_1_6_0,
+				Qualifier:     solbnm.Token.Symbol,
+				Type:          "TOKEN_MULTISIG",
+			}, solbnm.Chain.Selector, datastore_utils.FullRef)
+			require.NoError(t, err)
+
+			lutAfter, err := solcommon.GetAddressLookupTable(t.Context(), chain.Client, tar.LookupTable)
+			require.NoError(t, err)
+
+			multisigPubkey := solana.MustPublicKeyFromBase58(multisigRef.Address)
+			require.Contains(t, lutAfter, multisigPubkey, "multisig must be present in token pool lookup table entries")
+			require.GreaterOrEqual(t, len(lutAfter), lutLenBefore+1, "token pool lookup table should include the new multisig entry")
 		})
 	})
 }

--- a/integration-tests/deployment/tokens_and_token_pools_test.go
+++ b/integration-tests/deployment/tokens_and_token_pools_test.go
@@ -1299,6 +1299,8 @@ func TestTokensAndTokenPools(t *testing.T) {
 		})
 
 		t.Run("Validate ManualRegistrationMultisigExtendsLookupTable", func(t *testing.T) {
+			env.OperationsBundle = operations.NewBundle(t.Context(), env.OperationsBundle.Logger, operations.NewMemoryReporter())
+
 			solbnm := solTestData[0]
 			externalAdmin := solana.MustPublicKeyFromBase58(solbnm.Token.ExternalAdmin)
 			chain := env.BlockChains.SolanaChains()[solbnm.Chain.Selector]

--- a/integration-tests/deployment/tokens_and_token_pools_test.go
+++ b/integration-tests/deployment/tokens_and_token_pools_test.go
@@ -1299,7 +1299,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 		})
 
 		t.Run("Validate ManualRegistrationMultisigExtendsLookupTable", func(t *testing.T) {
-			env.OperationsBundle = operations.NewBundle(t.Context(), env.OperationsBundle.Logger, operations.NewMemoryReporter())
+			env.OperationsBundle = operations.NewBundle(t.Context, env.OperationsBundle.Logger, operations.NewMemoryReporter())
 
 			solbnm := solTestData[0]
 			externalAdmin := solana.MustPublicKeyFromBase58(solbnm.Token.ExternalAdmin)


### PR DESCRIPTION
# Solana manual registration: extend token pool LUT with SPL multisig

## Problem

Manual registration can create an SPL multisig for customer mint authority but did not add it to the token pool LUT. This is an issue because Solana token pools need to resolve the mint-authority multisig from LUT-supplied remaining accounts. If it is missing, execution fails with `InvalidMultisig` and operators previously had to extend the LUT in a separate step.

## What this adds

New operation `ExtendTokenPoolLookupTable`, called from manual registration after multisig creation when `customerMintAuthorities` is set. The multisig pubkey is appended to the on-chain token pool LUT (from token admin registry, not datastore).

## Design choices

- **On-chain LUT address, not datastore** — The operation resolves which lookup table to extend from the token admin registry account on-chain (`LookupTable` field), not from a datastore ref. That matches what the router and token pool programs use at execution time. If the field is unset, it fails with an explicit message to run configure-for-transfers / set-pool first.

- **Extend only when multisig path is active** — LUT extension runs inside the existing `customerMintAuthorities` branch, immediately after multisig creation. Manual registration without customer mint authorities is unchanged. No new YAML surface beyond what operators already pass for multisig setup.

- **Deployer key signs the extend transaction** — Token pool LUTs are created and extended with the chain deployer key as the Solana address lookup table authority, including during set-pool in configure-for-transfers. Timelock may administer the token admin registry via MCMS, but that is separate from ALT authority. This follows the same signing model as set-pool and existing offramp LUT extend helpers—not an MCMS batch for the extend instruction.

- **Dedup and idempotency** — Before extending, the operation loads current LUT entries and only submits accounts not already present. Duplicate pubkeys within the input list are collapsed so a single extend instruction never repeats the same address. Re-running manual registration when the multisig is already in the LUT is a no-op rather than an error.

- **Slot warmup after extend** — After a successful extend, the operation waits for a slot change before returning, consistent with initial token pool LUT setup during set-pool. New LUT entries are not reliably usable in the same slot they are added.

- **Non-atomic multisig + extend** — Multisig creation and LUT extension are separate confirmed transactions. If extend fails after multisig creation, the multisig still exists on-chain—the same partial state as before this change. Retry extend or fix LUT state before customer cutover.

## Operational prerequisites

Requires an existing token pool LUT (from configure-for-transfers / set-pool). Typical order: configure connectivity first, then manual registration with `skipTokenPoolInit` if the pool is already initialized, then customer `setAuthority` to the multisig.

## Integration test adjustments

Existing manual registration subtest no longer passes `customerMintAuthorities` (runs before configure-for-transfers, so no LUT yet).

New subtest after configure-for-transfers asserts manual registration with `customerMintAuthorities` adds the multisig to the on-chain LUT.
