### PR TITLE
deployment/v2_0_0: fix cross-family signer lookup

### DIFF
--- a/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology.go
+++ b/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology.go
@@ -157,7 +157,7 @@ func ConfigureChainsForLanesFromTopology(
 		// JD calls that could fail if those NOPs don't exist in the node registry.
 		targetFamilies := deriveFamiliesFromChains(chains)
 		committeeNOPs := filterNOPsToCommitteeMembers(cfg.Topology.NOPTopology, chains)
-		signingKeysByNOP, err := fetchSigningKeysForNOPsByFamilies(e, committeeNOPs, targetFamilies)
+		signingKeysByNOP, rawPubKeyByNOP, err := fetchSigningKeysForNOPsByFamilies(e, committeeNOPs, targetFamilies)
 		if err != nil {
 			return deployment.ChangesetOutput{}, fmt.Errorf("failed to fetch signing keys: %w", err)
 		}
@@ -186,6 +186,7 @@ func ConfigureChainsForLanesFromTopology(
 						chainCfg.ChainSelector,
 						remoteSelector,
 						signingKeysByNOP,
+						rawPubKeyByNOP,
 					)
 					if err != nil {
 						return deployment.ChangesetOutput{}, fmt.Errorf("failed to get signature config for lane local chain %d -> remote chain %d: %w", chainCfg.ChainSelector, remoteSelector, err)

--- a/deployment/v2_0_0/changesets/internal_functions_test.go
+++ b/deployment/v2_0_0/changesets/internal_functions_test.go
@@ -6,8 +6,11 @@ package changesets
 
 import (
 	"context"
+	"encoding/hex"
+	"strings"
 	"testing"
 
+	gethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -75,7 +78,7 @@ func TestSignerFromJDIfMissing_NotFoundInJD(t *testing.T) {
 
 func TestFetchSigningKeysForNOPsByFamilies_NilOffchain_ReturnsNil(t *testing.T) {
 	e := deployment.Environment{}
-	result, err := fetchSigningKeysForNOPsByFamilies(e, []offchain.NOPConfig{{Alias: "nop1"}}, []string{chainsel.FamilyEVM})
+	result, _, err := fetchSigningKeysForNOPsByFamilies(e, []offchain.NOPConfig{{Alias: "nop1"}}, []string{chainsel.FamilyEVM})
 	require.NoError(t, err)
 	assert.Nil(t, result)
 }
@@ -96,7 +99,7 @@ func TestFetchSigningKeysForNOPsByFamilies_AllSignersPresent_ReturnsNil(t *testi
 		{Alias: "nop1", SignerAddressByFamily: map[string]string{chainsel.FamilyEVM: "0xabc"}},
 		{Alias: "nop2", SignerAddressByFamily: map[string]string{chainsel.FamilyEVM: "0xdef"}},
 	}
-	result, err := fetchSigningKeysForNOPsByFamilies(e, nops, []string{chainsel.FamilyEVM})
+	result, _, err := fetchSigningKeysForNOPsByFamilies(e, nops, []string{chainsel.FamilyEVM})
 	require.NoError(t, err)
 	assert.Nil(t, result)
 }
@@ -157,7 +160,7 @@ func TestFetchSigningKeysForNOPsByFamilies_CallsJD_WhenSignerMissing(t *testing.
 		{Alias: "nop1"},
 	}
 
-	result, err := fetchSigningKeysForNOPsByFamilies(e, nops, []string{chainsel.FamilyEVM})
+	result, _, err := fetchSigningKeysForNOPsByFamilies(e, nops, []string{chainsel.FamilyEVM})
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Contains(t, result, "nop1")
@@ -203,7 +206,7 @@ func TestFetchSigningKeysForNOPsByFamilies_OnlyFetchesForNOPsMissingSigner(t *te
 		NodeIDs:          []string{"node-1", "node-2"},
 	}
 
-	result, err := fetchSigningKeysForNOPsByFamilies(e, []offchain.NOPConfig{
+	result, _, err := fetchSigningKeysForNOPsByFamilies(e, []offchain.NOPConfig{
 		{Alias: "nop1", SignerAddressByFamily: map[string]string{chainsel.FamilyEVM: "0xexisting"}},
 		{Alias: "nop2"},
 	}, []string{chainsel.FamilyEVM})
@@ -239,7 +242,7 @@ func TestSignerAddressForNOPAlias_TopologySignerTakesPrecedenceOverJD(t *testing
 		"nop1": {chainsel.FamilyEVM: jdSigner},
 	}
 
-	result, err := signerAddressForNOPAlias(e, topology, "nop1", chainsel.FamilyEVM, "test-committee", 1, jdKeys)
+	result, err := signerAddressForNOPAlias(e, topology, "nop1", chainsel.FamilyEVM, "test-committee", 1, jdKeys, "")
 	require.NoError(t, err)
 	assert.Equal(t, topologySigner, result, "topology signer must take precedence over JD-fetched key")
 }
@@ -262,9 +265,156 @@ func TestSignerAddressForNOPAlias_FallsBackToJDWhenTopologyMissing(t *testing.T)
 		"nop1": {chainsel.FamilyEVM: jdSigner},
 	}
 
-	result, err := signerAddressForNOPAlias(e, topology, "nop1", chainsel.FamilyEVM, "test-committee", 1, jdKeys)
+	result, err := signerAddressForNOPAlias(e, topology, "nop1", chainsel.FamilyEVM, "test-committee", 1, jdKeys, "")
 	require.NoError(t, err)
 	assert.Equal(t, jdSigner, result, "should fall back to JD key when topology signer is absent")
+}
+
+// ---- translateSignerAddress ----
+
+func TestTranslateSignerAddress_EVMToSolana(t *testing.T) {
+	// EVM and Solana addresses encode the identical 20 bytes; only string formatting differs.
+	translated, err := translateSignerAddress(chainsel.FamilyEVM, "0xAbC1230000000000000000000000000000000000", chainsel.FamilySolana)
+	require.NoError(t, err)
+	assert.Equal(t, "abc1230000000000000000000000000000000000", translated)
+}
+
+func TestTranslateSignerAddress_SolanaToEVM(t *testing.T) {
+	translated, err := translateSignerAddress(chainsel.FamilySolana, "abc1230000000000000000000000000000000000", chainsel.FamilyEVM)
+	require.NoError(t, err)
+	assert.Equal(t, "0xAbc1230000000000000000000000000000000000", translated)
+}
+
+func testRawPubKeyHex(t *testing.T) (hexKey string, evmAddress string) {
+	t.Helper()
+	privKey, err := gethcrypto.HexToECDSA(strings.Repeat("01", 32))
+	require.NoError(t, err)
+	pubKeyBytes := gethcrypto.FromECDSAPub(&privKey.PublicKey)
+	return hex.EncodeToString(pubKeyBytes), gethcrypto.PubkeyToAddress(privKey.PublicKey).Hex()
+}
+
+func TestTranslateSignerAddress_RawPubKeyFamiliesAreInterchangeable(t *testing.T) {
+	rawPubKey, _ := testRawPubKeyHex(t)
+	translated, err := translateSignerAddress(chainsel.FamilyAptos, rawPubKey, chainsel.FamilyStellar)
+	require.NoError(t, err)
+	assert.Equal(t, rawPubKey, translated)
+
+	translated, err = translateSignerAddress(chainsel.FamilyCanton, "0x"+rawPubKey, chainsel.FamilyAptos)
+	require.NoError(t, err)
+	assert.Equal(t, rawPubKey, translated, "0x prefix on a raw-pubkey-class value should be tolerated")
+}
+
+func TestTranslateSignerAddress_RawPubKeyToAddress(t *testing.T) {
+	// The derived address must match go-ethereum's own derivation so the destination
+	// contract can actually verify signatures produced by this key.
+	rawPubKey, wantAddress := testRawPubKeyHex(t)
+	translated, err := translateSignerAddress(chainsel.FamilyAptos, rawPubKey, chainsel.FamilyEVM)
+	require.NoError(t, err)
+	assert.Equal(t, wantAddress, translated)
+}
+
+func TestTranslateSignerAddress_AddressToRawPubKeyIsRejected(t *testing.T) {
+	_, err := translateSignerAddress(chainsel.FamilyEVM, "0xAbC1230000000000000000000000000000000000", chainsel.FamilyCanton)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not reversible")
+}
+
+// ---- translateFromKnownFamily / signerAddressForNOPAlias cross-family fallback ----
+
+func TestSignerAddressForNOPAlias_TranslatesFromSiblingFamily(t *testing.T) {
+	// Reproduces the reported bug: a standalone Solana verifier NOP only has a
+	// "solana" signer address in JD, but the lane's destination (local) chain is EVM.
+	lggr := logger.Test(t)
+	e := deployment.Environment{Logger: lggr}
+
+	topology := &offchain.EnvironmentTopology{
+		NOPTopology: &offchain.NOPTopology{
+			NOPs: []offchain.NOPConfig{
+				{Alias: "solana-verifier-1"},
+			},
+		},
+	}
+
+	jdKeys := fetch_signing_keys.SigningKeysByNOP{
+		"solana-verifier-1": {chainsel.FamilySolana: "abc1230000000000000000000000000000000000"},
+	}
+
+	result, err := signerAddressForNOPAlias(e, topology, "solana-verifier-1", chainsel.FamilyEVM, "default", 12463857294658392847, jdKeys, "")
+	require.NoError(t, err)
+	assert.Equal(t, "0xAbc1230000000000000000000000000000000000", result)
+}
+
+func TestSignerAddressForNOPAlias_TranslationFailureIsActionable(t *testing.T) {
+	// An EVM-only NOP with no raw public key on file cannot sign into a Canton-destination
+	// lane: an EVM address can't be un-hashed back into a raw public key.
+	lggr := logger.Test(t)
+	e := deployment.Environment{Logger: lggr}
+
+	topology := &offchain.EnvironmentTopology{
+		NOPTopology: &offchain.NOPTopology{
+			NOPs: []offchain.NOPConfig{
+				{
+					Alias:                 "evm-only-verifier",
+					SignerAddressByFamily: map[string]string{chainsel.FamilyEVM: "0xAbC1230000000000000000000000000000000000"},
+				},
+			},
+		},
+	}
+
+	_, err := signerAddressForNOPAlias(e, topology, "evm-only-verifier", chainsel.FamilyCanton, "default", 1, nil, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing signer_address for family canton")
+	assert.Contains(t, err.Error(), "not reversible")
+}
+
+func TestSignerAddressForNOPAlias_RawPubKeyUnblocksAddressToRawPubKeyDirection(t *testing.T) {
+	// Same setup as above, but the NOP's raw public key is now available — the previously
+	// unsupported EVM-address -> Canton-raw-pubkey direction is no longer needed because
+	// the raw key itself is on hand, so the lookup succeeds directly from it.
+	rawPubKey, _ := testRawPubKeyHex(t)
+	lggr := logger.Test(t)
+	e := deployment.Environment{Logger: lggr}
+
+	topology := &offchain.EnvironmentTopology{
+		NOPTopology: &offchain.NOPTopology{
+			NOPs: []offchain.NOPConfig{
+				{
+					Alias:                 "evm-only-verifier",
+					SignerAddressByFamily: map[string]string{chainsel.FamilyEVM: "0xAbC1230000000000000000000000000000000000"},
+				},
+			},
+		},
+	}
+
+	result, err := signerAddressForNOPAlias(e, topology, "evm-only-verifier", chainsel.FamilyCanton, "default", 1, nil, rawPubKey)
+	require.NoError(t, err)
+	assert.Equal(t, rawPubKey, result)
+}
+
+func TestSignerAddressForNOPAlias_RawPubKeyFromJDUnblocksSolanaToCanton(t *testing.T) {
+	// The scenario the user flagged: a solana-only NOP whose OnchainSigningAddress is
+	// EVM-style (un-hashable) needs to sign into a canton-destination lane. This only
+	// works because JD also carries the NOP's raw public key (RawPubKeyByNOP), pushed
+	// alongside every family bootstrap.go declares for the node.
+	rawPubKey, _ := testRawPubKeyHex(t)
+	lggr := logger.Test(t)
+	e := deployment.Environment{Logger: lggr}
+
+	topology := &offchain.EnvironmentTopology{
+		NOPTopology: &offchain.NOPTopology{
+			NOPs: []offchain.NOPConfig{
+				{Alias: "solana-verifier-1"},
+			},
+		},
+	}
+
+	jdKeys := fetch_signing_keys.SigningKeysByNOP{
+		"solana-verifier-1": {chainsel.FamilySolana: "abc1230000000000000000000000000000000000"},
+	}
+
+	result, err := signerAddressForNOPAlias(e, topology, "solana-verifier-1", chainsel.FamilyCanton, "default", 1, jdKeys, rawPubKey)
+	require.NoError(t, err)
+	assert.Equal(t, rawPubKey, result)
 }
 
 // ---- deriveFamiliesFromSelectors ----

--- a/deployment/v2_0_0/changesets/lane_signing_helpers.go
+++ b/deployment/v2_0_0/changesets/lane_signing_helpers.go
@@ -197,8 +197,8 @@ func signerAddressForNOPAlias(
 // identical bytes and differ only in string formatting, so they are freely
 // interconvertible in both directions.
 var addressClassFamilies = map[string]bool{
-	"evm":    true,
-	"solana": true,
+	chainsel.FamilyEVM:    true,
+	chainsel.FamilySolana: true,
 }
 
 // rawPubKeySourceFamily is a synthetic "family" tag used only as a translation source,
@@ -211,10 +211,10 @@ const rawPubKeySourceFamily = "xxx_notarealfamily_raw_pubkey"
 // whose signer identity is the full uncompressed secp256k1 public key, hex-encoded with
 // no per-family formatting differences. Members are interchangeable as-is.
 var rawPubKeyClassFamilies = map[string]bool{
-	"aptos":               true,
-	"stellar":             true,
-	"canton":              true,
-	rawPubKeySourceFamily: true,
+	chainsel.FamilyAptos:   true,
+	chainsel.FamilyStellar: true,
+	chainsel.FamilyCanton:  true,
+	rawPubKeySourceFamily:  true,
 }
 
 // translateFromKnownFamily tries to derive localFamily's signer address from whichever
@@ -327,9 +327,9 @@ func decodeAddressHex(s string) ([]byte, error) {
 // node's prior art in its Solana OCR2 keyring).
 func formatAddressForFamily(addr []byte, family string) (string, error) {
 	switch family {
-	case "evm":
+	case chainsel.FamilyEVM:
 		return gethcommon.BytesToAddress(addr).Hex(), nil
-	case "solana":
+	case chainsel.FamilySolana:
 		return strings.ToLower(hex.EncodeToString(addr)), nil
 	default:
 		return "", fmt.Errorf("unsupported address-class family %q", family)

--- a/deployment/v2_0_0/changesets/lane_signing_helpers.go
+++ b/deployment/v2_0_0/changesets/lane_signing_helpers.go
@@ -1,8 +1,14 @@
 package changesets
 
 import (
+	"encoding/hex"
 	"fmt"
+	"sort"
 	"strconv"
+	"strings"
+
+	gethcommon "github.com/ethereum/go-ethereum/common"
+	gethcrypto "github.com/ethereum/go-ethereum/crypto"
 
 	chainsel "github.com/smartcontractkit/chain-selectors"
 
@@ -31,7 +37,7 @@ func deriveFamiliesFromSelectors(selectors []uint64) []string {
 
 // fetchSigningKeysForNOPsByFamilies fetches JD signing keys for NOPs that are
 // missing a configured signer address for any of the given families.
-func fetchSigningKeysForNOPsByFamilies(e deployment.Environment, nops []offchain.NOPConfig, families []string) (fetch_signing_keys.SigningKeysByNOP, error) {
+func fetchSigningKeysForNOPsByFamilies(e deployment.Environment, nops []offchain.NOPConfig, families []string) (fetch_signing_keys.SigningKeysByNOP, map[string]string, error) {
 	return fetchSigningKeysForNOPsFiltered(e, nops, func(nop offchain.NOPConfig) bool {
 		for _, family := range families {
 			if nop.SignerAddressByFamily == nil || nop.SignerAddressByFamily[family] == "" {
@@ -46,9 +52,9 @@ func fetchSigningKeysForNOPsFiltered(
 	e deployment.Environment,
 	nops []offchain.NOPConfig,
 	include func(offchain.NOPConfig) bool,
-) (fetch_signing_keys.SigningKeysByNOP, error) {
+) (fetch_signing_keys.SigningKeysByNOP, map[string]string, error) {
 	if e.Offchain == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	aliases := make([]string, 0, len(nops))
@@ -59,7 +65,7 @@ func fetchSigningKeysForNOPsFiltered(
 	}
 
 	if len(aliases) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	report, err := operations.ExecuteOperation(
@@ -75,10 +81,10 @@ func fetchSigningKeysForNOPsFiltered(
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch signing keys from JD for NOPs %v: %w", aliases, err)
+		return nil, nil, fmt.Errorf("failed to fetch signing keys from JD for NOPs %v: %w", aliases, err)
 	}
 
-	return report.Output.SigningKeysByNOP, nil
+	return report.Output.SigningKeysByNOP, report.Output.RawPubKeyByNOP, nil
 }
 
 // getSignatureConfigForLane builds the committee verifier signature quorum
@@ -90,6 +96,7 @@ func getSignatureConfigForLane(
 	localSelector uint64,
 	remoteSelector uint64,
 	signingKeysByNOP fetch_signing_keys.SigningKeysByNOP,
+	rawPubKeyByNOP map[string]string,
 ) (*adapters.CommitteeVerifierSignatureQuorumConfig, error) {
 	committee, ok := topology.NOPTopology.Committees[committeeQualifier]
 	if !ok {
@@ -108,7 +115,7 @@ func getSignatureConfigForLane(
 
 	signers := make([]string, 0, len(chainCfg.NOPAliases))
 	for _, alias := range chainCfg.NOPAliases {
-		signer, err := signerAddressForNOPAlias(e, topology, alias, localFamily, committeeQualifier, remoteSelector, signingKeysByNOP)
+		signer, err := signerAddressForNOPAlias(e, topology, alias, localFamily, committeeQualifier, remoteSelector, signingKeysByNOP, rawPubKeyByNOP[alias])
 		if err != nil {
 			return nil, err
 		}
@@ -129,6 +136,7 @@ func signerAddressForNOPAlias(
 	committeeQualifier string,
 	remoteSelector uint64,
 	signingKeysByNOP fetch_signing_keys.SigningKeysByNOP,
+	rawPubKey string,
 ) (string, error) {
 	nop, ok := topology.NOPTopology.GetNOP(alias)
 	if !ok {
@@ -158,10 +166,174 @@ func signerAddressForNOPAlias(
 		return signer, nil
 	}
 
+	// No exact match for localFamily. A standalone (bootstrap-based) NOP signs with a
+	// secp256k1 key that may be registered under a different family.
+	// This key can often be translated into localFamily's representation without any new data.
+	if signer, sourceFamily, translateErr := translateFromKnownFamily(
+		nop.SignerAddressByFamily, signingKeysByNOP[alias], rawPubKey, localFamily,
+	); signer != "" {
+		e.Logger.Debugw("Translated signing address from a different chain family",
+			"nopAlias", alias,
+			"sourceFamily", sourceFamily,
+			"targetFamily", localFamily,
+			"signerAddress", signer,
+		)
+		return signer, nil
+	} else if translateErr != nil {
+		return "", fmt.Errorf(
+			"NOP %q missing signer_address for family %s on committee %q chain %d: %w",
+			alias, localFamily, committeeQualifier, remoteSelector, translateErr,
+		)
+	}
+
 	return "", fmt.Errorf(
 		"NOP %q missing signer_address for family %s on committee %q chain %d",
 		alias, localFamily, committeeQualifier, remoteSelector,
 	)
+}
+
+// addressClassFamilies are chain families whose signer identity is a 20-byte address
+// derived via secp256k1 -> keccak256 (EVM-style, e.g. ecrecover). Members encode the
+// identical bytes and differ only in string formatting, so they are freely
+// interconvertible in both directions.
+var addressClassFamilies = map[string]bool{
+	"evm":    true,
+	"solana": true,
+}
+
+// rawPubKeySourceFamily is a synthetic "family" tag used only as a translation source,
+// standing for a NOP's raw public key fetched directly from JD rather than derived from
+// any one chain family's own address representation (see FetchSigningKeysOutput.RawPubKeyByNOP).
+// It is never a real chain family and must never be passed as a translation target.
+const rawPubKeySourceFamily = "xxx_notarealfamily_raw_pubkey"
+
+// rawPubKeyClassFamilies are chain families (plus the synthetic rawPubKeySourceFamily)
+// whose signer identity is the full uncompressed secp256k1 public key, hex-encoded with
+// no per-family formatting differences. Members are interchangeable as-is.
+var rawPubKeyClassFamilies = map[string]bool{
+	"aptos":               true,
+	"stellar":             true,
+	"canton":              true,
+	rawPubKeySourceFamily: true,
+}
+
+// translateFromKnownFamily tries to derive localFamily's signer address from whichever
+// family(ies) the NOP does have a signer address for (static topology, JD, and/or the
+// NOP's raw public key), preferring a deterministic order when more than one is
+// available.
+//
+// It returns the derived address and the family it came from on success. If a
+// candidate was found but translation into localFamily isn't possible (e.g. deriving a
+// raw public key back out of an already-hashed address), err explains why, so the caller
+// can surface something more actionable than a generic "missing" error.
+func translateFromKnownFamily(
+	staticByFamily map[string]string,
+	jdByFamily map[string]string,
+	rawPubKey string,
+	localFamily string,
+) (address string, sourceFamily string, err error) {
+	candidates := make(map[string]string, len(staticByFamily)+len(jdByFamily)+1)
+	for family, addr := range staticByFamily {
+		if addr != "" {
+			candidates[family] = addr
+		}
+	}
+	for family, addr := range jdByFamily {
+		if addr != "" {
+			if _, exists := candidates[family]; !exists {
+				candidates[family] = addr
+			}
+		}
+	}
+	if rawPubKey != "" {
+		candidates[rawPubKeySourceFamily] = rawPubKey
+	}
+	delete(candidates, localFamily)
+
+	families := make([]string, 0, len(candidates))
+	for family := range candidates {
+		families = append(families, family)
+	}
+	sort.Strings(families) // deterministic when a NOP declares more than one other family
+
+	var lastErr error
+	for _, family := range families {
+		translated, tErr := translateSignerAddress(family, candidates[family], localFamily)
+		if tErr == nil {
+			return translated, family, nil
+		}
+		lastErr = tErr
+	}
+	return "", "", lastErr
+}
+
+// translateSignerAddress converts a signer identity stored under sourceFamily into the
+// representation targetFamily expects, valid only when both families sign with the same
+// underlying secp256k1 key.
+//
+// Address-class families (evm, solana) store the same 20 bytes and translate in both
+// directions. Raw-pubkey-class families (aptos, stellar, canton) store the same
+// hex-encoded public key and translate in both directions. Deriving an address-class
+// value from a raw public key is one-directional: an address is a keccak256 hash of the
+// public key, so recovering the public key from an address is not possible — that
+// direction returns an error instead of a wrong answer.
+func translateSignerAddress(sourceFamily, value, targetFamily string) (string, error) {
+	switch {
+	case addressClassFamilies[sourceFamily] && addressClassFamilies[targetFamily]:
+		addrBytes, err := decodeAddressHex(value)
+		if err != nil {
+			return "", fmt.Errorf("decode %s signer address: %w", sourceFamily, err)
+		}
+		return formatAddressForFamily(addrBytes, targetFamily)
+	case rawPubKeyClassFamilies[sourceFamily] && rawPubKeyClassFamilies[targetFamily]:
+		return strings.ToLower(strings.TrimPrefix(value, "0x")), nil
+	case rawPubKeyClassFamilies[sourceFamily] && addressClassFamilies[targetFamily]:
+		pubKeyBytes, err := hex.DecodeString(strings.TrimPrefix(strings.ToLower(value), "0x"))
+		if err != nil {
+			return "", fmt.Errorf("decode %s raw public key: %w", sourceFamily, err)
+		}
+		pubKey, err := gethcrypto.UnmarshalPubkey(pubKeyBytes)
+		if err != nil {
+			return "", fmt.Errorf("unmarshal %s public key: %w", sourceFamily, err)
+		}
+		return formatAddressForFamily(gethcrypto.PubkeyToAddress(*pubKey).Bytes(), targetFamily)
+	case addressClassFamilies[sourceFamily] && rawPubKeyClassFamilies[targetFamily]:
+		return "", fmt.Errorf(
+			"cannot derive a %s raw public key from a %s address: address derivation (keccak256) is not "+
+				"reversible; register the node's raw public key for family %s directly",
+			targetFamily, sourceFamily, targetFamily)
+	default:
+		return "", fmt.Errorf("no signer address translation defined from family %s to family %s", sourceFamily, targetFamily)
+	}
+}
+
+// decodeAddressHex parses a 20-byte address from hex, tolerating an optional 0x prefix
+// and either case (JD-fetched addresses are lowercased and 0x-prefixed unconditionally;
+// statically-configured ones may be EIP-55 checksummed or, for solana, bare lowercase).
+func decodeAddressHex(s string) ([]byte, error) {
+	s = strings.TrimPrefix(strings.TrimPrefix(s, "0x"), "0X")
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return nil, err
+	}
+	if len(b) != 20 {
+		return nil, fmt.Errorf("expected 20-byte address, got %d bytes", len(b))
+	}
+	return b, nil
+}
+
+// formatAddressForFamily renders a 20-byte address per family convention: EIP-55
+// checksummed with 0x for evm, lowercase without 0x for solana (matching the chainlink
+// node's prior art in its Solana OCR2 keyring).
+func formatAddressForFamily(addr []byte, family string) (string, error) {
+	switch family {
+	case "evm":
+		return gethcommon.BytesToAddress(addr).Hex(), nil
+	case "solana":
+		return strings.ToLower(hex.EncodeToString(addr)), nil
+	default:
+		return "", fmt.Errorf("unsupported address-class family %q", family)
+	}
 }
 
 func signerFromJDIfMissing(

--- a/deployment/v2_0_0/offchain/operations/fetch_signing_keys/fetch_signing_keys.go
+++ b/deployment/v2_0_0/offchain/operations/fetch_signing_keys/fetch_signing_keys.go
@@ -22,6 +22,13 @@ type FetchSigningKeysInput struct {
 
 type FetchSigningKeysOutput struct {
 	SigningKeysByNOP SigningKeysByNOP
+	// RawPubKeyByNOP maps NOP alias -> raw uncompressed secp256k1 public key (hex, no
+	// 0x prefix). A standalone (bootstrap-based) node pushes the same key for every
+	// chain family it declares (which is always 1 family at most),
+	// so lane-config code can derive a signer address for a
+	// family the NOP never declared directly from this, rather than only being able to
+	// translate between families the NOP already has an OnchainSigningAddress for.
+	RawPubKeyByNOP map[string]string
 }
 
 type FetchSigningKeysDeps struct {
@@ -40,6 +47,7 @@ var FetchNOPSigningKeys = operations.NewOperation(
 
 		output := FetchSigningKeysOutput{
 			SigningKeysByNOP: make(SigningKeysByNOP),
+			RawPubKeyByNOP:   make(map[string]string),
 		}
 
 		if len(input.NOPAliases) == 0 {
@@ -115,6 +123,14 @@ var FetchNOPSigningKeys = operations.NewOperation(
 				"nodeId", chainConfig.NodeId,
 				"chainFamily", chainFamily,
 				"signerAddress", signerAddress)
+
+			if rawPubKey := chainConfig.Ocr2Config.OcrKeyBundle.OnchainSigningPubKey; rawPubKey != "" {
+				normalized := strings.ToLower(strings.TrimPrefix(rawPubKey, "0x"))
+				if existing, ok := output.RawPubKeyByNOP[nopAlias]; ok && existing != normalized {
+					return output, fmt.Errorf("NOP %q has conflicting raw public keys across chain configs: %s vs %s — a standalone node registers one key for every chain it declares", nopAlias, existing, normalized)
+				}
+				output.RawPubKeyByNOP[nopAlias] = normalized
+			}
 		}
 
 		return output, nil


### PR DESCRIPTION
## Description

Related PR: https://github.com/smartcontractkit/chainlink-ccv/pull/1223

Fixes a production bug where committee verifier lane configuration failed for any lane whose source and destination chains are in different families. A Solana verifier NOP configuring a `solana -> evm` lane failed with:

```
NOP "solana-verifier-1" missing signer_address for family evm on committee "default" chain <selector>
```

Root cause: `signerAddressForNOPAlias` looks up a NOP's signer address keyed by the *destination* chain's family (`localFamily`), but JD only ever stores it keyed by the *NOP's own declared* chain family (from `chainConfig.Chain.Type`). Those coincided for every lane in production so far because every deployed NOP was EVM-only. Solana NOPs are the first to expose the mismatch.

The fix adds a translation fallback for when the exact-family lookup misses:
- `evm` and `solana` signer addresses are the same 20 bytes (secp256k1 -> keccak256), differing only in string format, so they translate freely in both directions.
- `aptos`/`stellar`/`canton` all store the same raw uncompressed public key hex, so they translate freely among themselves, and one-directionally into `evm`/`solana` (deriving an address from a public key is possible; the reverse is not, since it's a hash).
- To also support the reverse direction (e.g. `evm`/`solana` -> `canton`), JD's `OnchainSigningPubKey` field is now captured (`RawPubKeyByNOP`) and used as an additional translation source, once the paired chainlink-ccv change starts pushing it for every declared chain family, not just EVM.

The exact-match lookup path (static topology, then JD) is untouched and always takes precedence, so `evm <-> evm` lanes, the entire currently-deployed fleet, see byte-identical behavior; the new fallback code is unreachable for a NOP that already has a direct match.

## Testing

- Ran `go test ./v2_0_0/...` in the `deployment` module
