### PR TITLE
always have new timelocks be owned by CLLCCIP

### DIFF
--- a/chains/evm/deployment/v1_0_0/adapters/deployer.go
+++ b/chains/evm/deployment/v1_0_0/adapters/deployer.go
@@ -257,12 +257,12 @@ func (d *EVMDeployer) DeployMCMS() *cldf_ops.Sequence[ccipapi.MCMSDeploymentConf
 				evmChain,
 				seq.OwnershipInputsFromRefs(
 					in.ChainSelector,
-					common.HexToAddress(timelockAddr.Address),
+					finalAdmin,
 					[]cldf_datastore.AddressRef{proposerAddr, bypasserAddr, cancellerAddr},
 				),
 			)
 			if err != nil {
-				return sequtil.OnChainOutput{}, fmt.Errorf("failed to transfer MCM ownership to timelock on chain %d: %w", in.ChainSelector, err)
+				return sequtil.OnChainOutput{}, fmt.Errorf("failed to transfer MCM ownership to CLLCCIP timelock on chain %d: %w", in.ChainSelector, err)
 			}
 			output.BatchOps = append(output.BatchOps, mcmOwnershipBatchOps...)
 

--- a/chains/evm/deployment/v1_0_0/adapters/transfer_ownership_test.go
+++ b/chains/evm/deployment/v1_0_0/adapters/transfer_ownership_test.go
@@ -80,9 +80,10 @@ func TestTransferOwnership(t *testing.T) {
 	env.DataStore = ds.Seal()
 
 	// Deploy a second MCMS set (RMNMCMS) so we can transfer ownership to it later.
+	// MCM multisigs are owned by the CLLCCIP timelock, so accept-ownership proposals use CLLCCIP.
 	output, err = deployMCMS.Apply(*env, deploy.MCMSDeploymentConfig{
 		AdapterVersion: semver.MustParse("1.0.0"),
-		MCMS:           testhelpers.MCMSInputForQualifier(deploymentutils.RMNTimelockQualifier),
+		MCMS:           testhelpers.MCMSInputForQualifier(deploymentutils.CLLQualifier),
 		Chains: map[uint64]deploy.MCMSDeploymentConfigPerChain{
 			selector1: {
 				Canceller:        testhelpers.SingleGroupMCMS(),

--- a/chains/evm/deployment/v1_0_0/transfer_ownership_test.go
+++ b/chains/evm/deployment/v1_0_0/transfer_ownership_test.go
@@ -79,9 +79,10 @@ func TestTransferOwnership(t *testing.T) {
 	env.DataStore = ds.Seal()
 
 	// Deploy a second MCMS set (RMNMCMS) so we can transfer ownership to it later.
+	// MCM multisigs are owned by the CLLCCIP timelock, so accept-ownership proposals use CLLCCIP.
 	output, err = deployMCMS.Apply(*env, deploy.MCMSDeploymentConfig{
 		AdapterVersion: deploy.MCMSVersion,
-		MCMS:           testhelpers.MCMSInputForQualifier(deploymentutils.RMNTimelockQualifier),
+		MCMS:           testhelpers.MCMSInputForQualifier(deploymentutils.CLLQualifier),
 		Chains: map[uint64]deploy.MCMSDeploymentConfigPerChain{
 			selector1: {
 				Canceller:        testhelpers.SingleGroupMCMS(),

--- a/deployment/deploy/mcms.go
+++ b/deployment/deploy/mcms.go
@@ -364,7 +364,7 @@ func mcmsRegistryForDeploy(registry *changesets.MCMSReaderRegistry) *changesets.
 
 // mcmsInputForDeployment returns MCMS proposal input for deploy output. When ownership
 // accept batch operations are produced and the caller did not supply MCMS config, a
-// schedule proposal is built using the deployed MCMS timelock qualifier from chain config.
+// schedule proposal is built using the CLLCCIP MCMS qualifier.
 func mcmsInputForDeployment(cfg MCMSDeploymentConfig, batchOps []mcmstypes.BatchOperation) (mcms.Input, error) {
 	if len(batchOps) == 0 {
 		return cfg.MCMS, nil
@@ -376,38 +376,10 @@ func mcmsInputForDeployment(cfg MCMSDeploymentConfig, batchOps []mcmstypes.Batch
 		input.TimelockDelay = mcmstypes.MustParseDuration("0s")
 	}
 	if input.Qualifier == "" {
-		qualifier, err := deploymentQualifier(cfg)
-		if err != nil {
-			return mcms.Input{}, err
-		}
-		input.Qualifier = qualifier
+		input.Qualifier = utils.CLLQualifier
 	}
 	if input.Description == "" {
-		input.Description = "Accept MCM contract ownership on timelock"
+		input.Description = "Accept MCM contract ownership on CLLCCIP timelock"
 	}
 	return input, nil
-}
-
-func deploymentQualifier(cfg MCMSDeploymentConfig) (string, error) {
-	var qualifier string
-	for _, chainCfg := range cfg.Chains {
-		if chainCfg.Qualifier == nil || *chainCfg.Qualifier == "" {
-			continue
-		}
-		if qualifier == "" {
-			qualifier = *chainCfg.Qualifier
-			continue
-		}
-		if qualifier != *chainCfg.Qualifier {
-			return "", fmt.Errorf(
-				"all chains in MCMS deployment must share the same qualifier when MCMS input is omitted",
-			)
-		}
-	}
-	if qualifier == "" {
-		return "", errors.New(
-			"MCMS qualifier is required when deploy produces ownership transfer operations and cannot be inferred from chain config",
-		)
-	}
-	return qualifier, nil
 }


### PR DESCRIPTION
Ownership of MCM and admin role of timelock should ALL be given to CLLCCIP