### PR TITLE
fix(ci): run CCIPReader integration tests serially

### DIFF
--- a/.github/workflows/ccip-integration-test.yml
+++ b/.github/workflows/ccip-integration-test.yml
@@ -98,6 +98,7 @@ jobs:
           - name: "CCIPReader Test"
             run: "TestCCIPReader|Test_GetChainFeePriceUpdates|Test_GetWrappedNativeTokenPriceUSD"
             timeout: 12m
+            go_parallel: 1
           - name: "Test_CCIPTopologies_EVM2EVM_RoleDON_AllSupportSource_SomeSupportDest"
             run: "^Test_CCIPTopologies_EVM2EVM_RoleDON_AllSupportSource_SomeSupportDest$"
             timeout: 20m
@@ -267,8 +268,12 @@ jobs:
             echo "No tests matched -run '$run'"
             exit 1
           fi
-          echo "gotestsum --junitfile=test-results.xml --format=github-actions -- . -timeout ${{ matrix.type.timeout }} -run '${run}'"
-          gotestsum --junitfile=test-results.xml --format=github-actions -- . -timeout ${{ matrix.type.timeout }} -run "$run"
+          parallel_flag=""
+          if [ -n "${{ matrix.type.go_parallel }}" ]; then
+            parallel_flag="-parallel=${{ matrix.type.go_parallel }}"
+          fi
+          echo "gotestsum --junitfile=test-results.xml --format=github-actions -- . -timeout ${{ matrix.type.timeout }} ${parallel_flag} -run '${run}'"
+          gotestsum --junitfile=test-results.xml --format=github-actions -- . -timeout ${{ matrix.type.timeout }} ${parallel_flag} -run "$run"
         env:
           CL_DATABASE_URL: ${{ env.DB_URL }}
 


### PR DESCRIPTION
This PR updates CCIPReader integration tests to run with `-parallel=1` and match how it is run in [the chainlink repo](https://github.com/smartcontractkit/chainlink/blob/develop/.github/integration-in-memory-tests.yml#L286).
This should avoid flakes from multiple `TestCCIPReader_*` tests running concurrently via `t.Parallel()`.