### PR TITLE
fix: reuse existing CREATE2Factory when deployer nonce is not 0

### DIFF
--- a/chains/evm/deployment/v2_0_0/changesets/create2_factory/deploy_create2_factory.go
+++ b/chains/evm/deployment/v2_0_0/changesets/create2_factory/deploy_create2_factory.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/create2_factory"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/create2_factory"
+	create2_factory_bindings "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v2_0_0/create2_factory"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldf_deployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -26,18 +28,61 @@ func applyDeployCREATE2Factory(e cldf_deployment.Environment, cfg DeployCREATE2F
 		return cldf_deployment.ChangesetOutput{}, fmt.Errorf("chain with selector %d not found in environment", cfg.ChainSel)
 	}
 
-	// Require that the nonce of the deployer key is 0
+	tv := deployment.NewTypeAndVersion(create2_factory.ContractType, *create2_factory.Version)
+
+	// The CREATE2Factory is expected to be the very first contract deployed by the
+	// deployer key, so it is deployed at the address derived from the deployer key
+	// and nonce 0. This makes the factory address deterministic across chains.
 	nonce, err := evmChain.Client.PendingNonceAt(e.GetContext(), evmChain.DeployerKey.From)
 	if err != nil {
 		return cldf_deployment.ChangesetOutput{}, fmt.Errorf("failed to get nonce of deployer key: %w", err)
 	}
+
+	// If the deployer key has already sent transactions, the factory may already have
+	// been deployed by a previous run of this changeset. Rather than failing, look up
+	// the contract that was deployed at nonce 0 and, if it is the CREATE2Factory,
+	// record its address in the datastore instead of deploying a new one.
 	if nonce != 0 {
-		return cldf_deployment.ChangesetOutput{}, fmt.Errorf("nonce of the deployer key must be 0, got %d", nonce)
+		factoryAddr := crypto.CreateAddress(evmChain.DeployerKey.From, 0)
+
+		code, err := evmChain.Client.CodeAt(e.GetContext(), factoryAddr, nil)
+		if err != nil {
+			return cldf_deployment.ChangesetOutput{}, fmt.Errorf("failed to get code at expected create2 factory address %s: %w", factoryAddr, err)
+		}
+		if len(code) == 0 {
+			return cldf_deployment.ChangesetOutput{}, fmt.Errorf("deployer key nonce is %d but no contract is deployed at the expected create2 factory address %s", nonce, factoryAddr)
+		}
+
+		factory, err := create2_factory_bindings.NewCREATE2Factory(factoryAddr, evmChain.Client)
+		if err != nil {
+			return cldf_deployment.ChangesetOutput{}, fmt.Errorf("failed to bind create2 factory at %s: %w", factoryAddr, err)
+		}
+		gotTV, err := factory.TypeAndVersion(nil)
+		if err != nil {
+			return cldf_deployment.ChangesetOutput{}, fmt.Errorf("failed to get type and version of contract at %s: %w", factoryAddr, err)
+		}
+		if gotTV != tv.String() {
+			return cldf_deployment.ChangesetOutput{}, fmt.Errorf("contract at expected create2 factory address %s is not a %s, got %q", factoryAddr, tv, gotTV)
+		}
+
+		ds := datastore.NewMemoryDataStore()
+		if err := ds.Addresses().Add(datastore.AddressRef{
+			Address:       factoryAddr.Hex(),
+			ChainSelector: cfg.ChainSel,
+			Type:          datastore.ContractType(tv.Type),
+			Version:       &tv.Version,
+		}); err != nil {
+			return cldf_deployment.ChangesetOutput{}, fmt.Errorf("failed to add existing create2 factory address to datastore: %w", err)
+		}
+
+		return cldf_deployment.ChangesetOutput{
+			DataStore: ds,
+		}, nil
 	}
 
 	deployReport, err := cldf_ops.ExecuteOperation(e.OperationsBundle, create2_factory.Deploy, evmChain, contract.DeployInput[create2_factory.ConstructorArgs]{
 		ChainSelector:  cfg.ChainSel,
-		TypeAndVersion: deployment.NewTypeAndVersion(create2_factory.ContractType, *create2_factory.Version),
+		TypeAndVersion: tv,
 		Args: create2_factory.ConstructorArgs{
 			AllowList: cfg.AllowList,
 		},

--- a/chains/evm/deployment/v2_0_0/changesets/create2_factory/deploy_create2_factory_test.go
+++ b/chains/evm/deployment/v2_0_0/changesets/create2_factory/deploy_create2_factory_test.go
@@ -94,13 +94,23 @@ func TestDeployCREATE2Factory_NonceNotZero(t *testing.T) {
 	// Update environment with the deployed contract
 	e.DataStore = out1.DataStore.Seal()
 
-	// Second deployment (should fail because nonce is not 0)
-	_, err = create2_factory.DeployCREATE2Factory.Apply(*e, create2_factory.DeployCREATE2FactoryCfg{
+	// Second deployment: the deployer key nonce is no longer 0, so instead of
+	// re-deploying the changeset should discover the already-deployed factory and
+	// record it in the datastore.
+	out2, err := create2_factory.DeployCREATE2Factory.Apply(*e, create2_factory.DeployCREATE2FactoryCfg{
 		ChainSel:  chainSel,
 		AllowList: allowList,
 	})
-	require.Error(t, err, "Should fail when deploying with nonce not 0")
-	require.ErrorContains(t, err, "nonce of the deployer key must be 0, got 1", "Error should mention nonce is not 0")
+	require.NoError(t, err, "Should discover the existing factory when nonce is not 0")
+
+	addrs2, err := out2.DataStore.Addresses().Fetch()
+	require.NoError(t, err, "Failed to fetch addresses from datastore")
+	require.Len(t, addrs2, 1, "Should have recorded one contract")
+
+	// The discovered address must match the originally deployed factory.
+	require.Equal(t, addrs1[0].Address, addrs2[0].Address, "Discovered address should match the originally deployed factory")
+	require.Equal(t, datastore.ContractType(create2_factory_ops.ContractType), addrs2[0].Type, "Contract type should match")
+	require.Equal(t, chainSel, addrs2[0].ChainSelector, "Chain selector should match")
 }
 
 func TestDeployCREATE2Factory_VerifyPreconditions(t *testing.T) {


### PR DESCRIPTION
## Motivation

The `deploy_create2_factory` changeset previously returned an error if the deployer key's nonce was not 0. This meant re-running the changeset (e.g. after a partial or previous deployment) would fail rather than reconcile with the on-chain state.

## Changes

When the deployer key nonce is not 0, instead of erroring the changeset now:

1. Computes the address the factory would have been deployed at — `crypto.CreateAddress(deployerKey, 0)`. The factory is always the deployer key's first transaction (nonce 0), so this address is deterministic.
2. Verifies contract code exists at that address.
3. Binds the `CREATE2Factory` and calls `typeAndVersion()`, checking it matches the expected `CREATE2Factory 2.0.0`.
4. Records the discovered `AddressRef` in the datastore instead of re-deploying.

The nonce == 0 path deploys as before. Errors are returned if there is no code at the expected address or if the contract there is not the CREATE2Factory, to avoid mislabeling an unrelated contract.

## Testing

Updated `TestDeployCREATE2Factory_NonceNotZero` to assert the changeset now discovers the already-deployed factory (matching address, type, and chain selector) on a second apply, rather than failing.

Part of epic [CCIP-12109](https://smartcontract-it.atlassian.net/browse/CCIP-12109)

[CCIP-12109]: https://smartcontract-it.atlassian.net/browse/CCIP-12109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ