### PR TITLE
Support CLLCCIP proposal to switch RMN proxy

### DIFF
--- a/chains/evm/deployment/v2_0_0/changesets/rmn_deploy_and_activate.go
+++ b/chains/evm/deployment/v2_0_0/changesets/rmn_deploy_and_activate.go
@@ -44,6 +44,9 @@ func validateActivateRMN(e cldf_deployment.Environment, input changesets.WithMCM
 	if err := validateActivateRMNCurseAdmins(input.Cfg.CurseAdmins, input.Cfg.ChainSels); err != nil {
 		return err
 	}
+	if input.Cfg.TimelockDelay < 0 {
+		return fmt.Errorf("TimelockDelay cannot be negative")
+	}
 	evmChains := e.BlockChains.EVMChains()
 	for _, sel := range input.Cfg.ChainSels {
 		if _, ok := evmChains[sel]; !ok {
@@ -216,7 +219,7 @@ func validateCLLCCIPForProxyProposal(e cldf_deployment.Environment, chainSels []
 			common_utils.CLLQualifier,
 		); ref.Address == "" {
 			return fmt.Errorf(
-				"ARMProxy setRMN requires CLLCCIP RBACTimelock (qualifier %q) in datastore for chain %d",
+				"RMNProxy.SetRMN requires CLLCCIP RBACTimelock (qualifier %q) in datastore for chain %d",
 				common_utils.CLLQualifier, sel,
 			)
 		}

--- a/chains/evm/deployment/v2_0_0/changesets/rmn_deploy_and_activate.go
+++ b/chains/evm/deployment/v2_0_0/changesets/rmn_deploy_and_activate.go
@@ -2,6 +2,7 @@ package changesets
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
@@ -14,6 +15,7 @@ import (
 	common_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
 	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
 )
 
 // ActivateRMNCfg configures the ActivateRMN changeset.
@@ -22,6 +24,8 @@ type ActivateRMNCfg struct {
 	// CurseAdmins are optional additional authorized callers (cursers) added at RMN deploy
 	// time, keyed by chain selector. The Ultra Fast Curse RBACTimelock is always included.
 	CurseAdmins map[uint64][]common.Address
+	// TimelockDelay is the schedule delay for RMNMCMS and CLLCCIP proposals. Zero means no delay.
+	TimelockDelay time.Duration
 }
 
 var ActivateRMN = func(mcmsRegistry *changesets.MCMSReaderRegistry) cldf_deployment.ChangeSetV2[changesets.WithMCMS[ActivateRMNCfg]] {
@@ -86,7 +90,8 @@ func applyDeployAndActivateRMN(
 ) (cldf_deployment.ChangesetOutput, error) {
 	evmChains := e.BlockChains.EVMChains()
 	outputDS := datastore.NewMemoryDataStore()
-	allBatchOps := make([]mcms_types.BatchOperation, 0, len(input.Cfg.ChainSels))
+	rmnBatchOps := make([]mcms_types.BatchOperation, 0, len(input.Cfg.ChainSels))
+	cllBatchOps := make([]mcms_types.BatchOperation, 0, len(input.Cfg.ChainSels))
 
 	for _, sel := range input.Cfg.ChainSels {
 		chain := evmChains[sel]
@@ -106,13 +111,70 @@ func applyDeployAndActivateRMN(
 				return cldf_deployment.ChangesetOutput{}, fmt.Errorf("failed to add address to datastore: %w", addErr)
 			}
 		}
-		allBatchOps = append(allBatchOps, report.Output.BatchOps...)
+		rmnBatchOps = append(rmnBatchOps, report.Output.RMNMCMSBatchOps...)
+		cllBatchOps = append(cllBatchOps, report.Output.CLLCCIPBatchOps...)
 	}
 
-	return changesets.NewOutputBuilder(e, mcmsRegistry).
-		WithDataStore(outputDS).
-		WithBatchOps(allBatchOps).
-		Build(input.MCMS)
+	var output cldf_deployment.ChangesetOutput
+	output.DataStore = outputDS
+	timelockDelay := mcms_types.NewDuration(input.Cfg.TimelockDelay)
+
+	if len(rmnBatchOps) > 0 {
+		rmnOut, err := changesets.NewOutputBuilder(e, mcmsRegistry).
+			WithDataStore(outputDS).
+			WithBatchOps(rmnBatchOps).
+			Build(mcmsInputForActivateRMN(
+				input.MCMS,
+				timelockDelay,
+				common_utils.RMNTimelockQualifier,
+				"Accept RMN 2.0 ownership on RMNMCMS timelock",
+			))
+		if err != nil {
+			return cldf_deployment.ChangesetOutput{}, fmt.Errorf("failed to build RMNMCMS proposal: %w", err)
+		}
+		output.MCMSTimelockProposals = append(output.MCMSTimelockProposals, rmnOut.MCMSTimelockProposals...)
+	}
+
+	// CLLCCIPBatchOps is only populated when SetRMN could not run on-chain (proxy not deployer-owned).
+	if len(cllBatchOps) > 0 {
+		cllChainSels := make([]uint64, 0, len(cllBatchOps))
+		for _, op := range cllBatchOps {
+			cllChainSels = append(cllChainSels, uint64(op.ChainSelector))
+		}
+		if err := validateCLLCCIPForProxyProposal(e, cllChainSels); err != nil {
+			return cldf_deployment.ChangesetOutput{}, err
+		}
+		cllOut, err := changesets.NewOutputBuilder(e, mcmsRegistry).
+			WithDataStore(outputDS).
+			WithBatchOps(cllBatchOps).
+			Build(mcmsInputForActivateRMN(
+				input.MCMS,
+				timelockDelay,
+				common_utils.CLLQualifier,
+				"Point RMNProxy at RMN 2.0 on CLLCCIP timelock",
+			))
+		if err != nil {
+			return cldf_deployment.ChangesetOutput{}, fmt.Errorf("failed to build CLLCCIP proposal: %w", err)
+		}
+		output.MCMSTimelockProposals = append(output.MCMSTimelockProposals, cllOut.MCMSTimelockProposals...)
+	}
+
+	return output, nil
+}
+
+func mcmsInputForActivateRMN(
+	base mcms.Input,
+	timelockDelay mcms_types.Duration,
+	qualifier, description string,
+) mcms.Input {
+	return mcms.Input{
+		OverridePreviousRoot: base.OverridePreviousRoot,
+		ValidUntil:             base.ValidUntil,
+		TimelockDelay:          timelockDelay,
+		TimelockAction:         mcms_types.TimelockActionSchedule,
+		Qualifier:              qualifier,
+		Description:            description,
+	}
 }
 
 func validateActivateRMNAddresses(addresses []datastore.AddressRef, chainSelector uint64) error {
@@ -139,6 +201,25 @@ func validateActivateRMNAddresses(addresses []datastore.AddressRef, chainSelecto
 			"Ultra Fast Curse RBACTimelock (qualifier %q) not found in datastore for chain %d",
 			common_utils.UltraFastCurseMCMSQualifier, chainSelector,
 		)
+	}
+	return nil
+}
+
+func validateCLLCCIPForProxyProposal(e cldf_deployment.Environment, chainSels []uint64) error {
+	for _, sel := range chainSels {
+		addresses := e.DataStore.Addresses().Filter(datastore.AddressRefByChainSelector(sel))
+		if ref := datastore_utils.GetAddressRef(
+			addresses,
+			sel,
+			common_utils.RBACTimelock,
+			mcms_ops.MCMSVersion,
+			common_utils.CLLQualifier,
+		); ref.Address == "" {
+			return fmt.Errorf(
+				"ARMProxy setRMN requires CLLCCIP RBACTimelock (qualifier %q) in datastore for chain %d",
+				common_utils.CLLQualifier, sel,
+			)
+		}
 	}
 	return nil
 }

--- a/chains/evm/deployment/v2_0_0/changesets/rmn_deploy_and_activate.go
+++ b/chains/evm/deployment/v2_0_0/changesets/rmn_deploy_and_activate.go
@@ -122,6 +122,9 @@ func applyDeployAndActivateRMN(
 	output.DataStore = outputDS
 	timelockDelay := mcms_types.NewDuration(input.Cfg.TimelockDelay)
 
+	if err := input.MCMS.PopulateDefaults(); err != nil {
+		return cldf_deployment.ChangesetOutput{}, fmt.Errorf("failed to populate MCMS defaults: %w", err)
+	}
 	if len(rmnBatchOps) > 0 {
 		rmnOut, err := changesets.NewOutputBuilder(e, mcmsRegistry).
 			WithDataStore(outputDS).

--- a/chains/evm/deployment/v2_0_0/changesets/rmn_deploy_and_activate_test.go
+++ b/chains/evm/deployment/v2_0_0/changesets/rmn_deploy_and_activate_test.go
@@ -3,6 +3,7 @@ package changesets_test
 import (
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	rmn_proxy_bind "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_0_0/rmn_proxy_contract"
@@ -216,6 +217,23 @@ func TestActivateRMN_ValidateCurseAdmins(t *testing.T) {
 		})
 		require.ErrorContains(t, err, "not in ChainSels")
 	})
+}
+
+func TestActivateRMN_ValidateCfgRejectsNegativeTimelockDelay(t *testing.T) {
+	chainSelector := uint64(5009297550715157269)
+	e, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{chainSelector}),
+	)
+	require.NoError(t, err)
+
+	mcmsRegistry := cs_core.GetRegistry()
+	err = changesets.ActivateRMN(mcmsRegistry).VerifyPreconditions(*e, cs_core.WithMCMS[changesets.ActivateRMNCfg]{
+		Cfg: changesets.ActivateRMNCfg{
+			ChainSels:     []uint64{chainSelector},
+			TimelockDelay: -time.Hour,
+		},
+	})
+	require.ErrorContains(t, err, "TimelockDelay cannot be negative")
 }
 
 func TestActivateRMN_AccumulatesBatchOpsAcrossChains(t *testing.T) {

--- a/chains/evm/deployment/v2_0_0/changesets/rmn_deploy_and_activate_test.go
+++ b/chains/evm/deployment/v2_0_0/changesets/rmn_deploy_and_activate_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	mcmslib "github.com/smartcontractkit/mcms"
 	mcms_types "github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/require"
 
@@ -313,6 +314,296 @@ func TestActivateRMN_MissingRMNMCMS(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.ErrorContains(t, err, common_utils.RMNTimelockQualifier)
+}
+
+func TestActivateRMN_CLLCCIPOwnedProxyEmitsDualProposals(t *testing.T) {
+	const (
+		chainSelector = uint64(5009297550715157269)
+		validUntil    = uint32(3759765795)
+	)
+	expectedDelay := mcms_types.NewDuration(0)
+
+	e, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{chainSelector}),
+	)
+	require.NoError(t, err)
+
+	chain := e.BlockChains.EVMChains()[chainSelector]
+	deployer := chain.DeployerKey.From
+	b := e.OperationsBundle
+
+	legacyARM := common.HexToAddress("0x2222222222222222222222222222222222222222")
+	proxyRef, err := contract.MaybeDeployContract(b, rmn_proxy.Deploy, chain, contract.DeployInput[rmn_proxy.ConstructorArgs]{
+		TypeAndVersion: deployment.NewTypeAndVersion(rmn_proxy.ContractType, *rmn_proxy.Version),
+		ChainSelector:  chainSelector,
+		Args:           rmn_proxy.ConstructorArgs{RMN: legacyARM},
+	}, nil)
+	require.NoError(t, err)
+
+	_, ultraFastAddrs := deployMCMSInstanceForTest(t, b, chain, deployer, common_utils.UltraFastCurseMCMSQualifier)
+	_, rmnMCMSAddrs := deployMCMSInstanceForTest(t, b, chain, deployer, common_utils.RMNTimelockQualifier)
+	cllTimelockAddr, cllAddrs := deployMCMSInstanceForTest(t, b, chain, deployer, common_utils.CLLQualifier)
+
+	ds := datastore.NewMemoryDataStore()
+	require.NoError(t, ds.Addresses().Add(proxyRef))
+	for _, ref := range ultraFastAddrs {
+		require.NoError(t, ds.Addresses().Add(ref))
+	}
+	for _, ref := range rmnMCMSAddrs {
+		require.NoError(t, ds.Addresses().Add(ref))
+	}
+	for _, ref := range cllAddrs {
+		require.NoError(t, ds.Addresses().Add(ref))
+	}
+	e.DataStore = ds.Seal()
+
+	transferProxyOwnershipToTimelockForTest(
+		t, b, chain, common.HexToAddress(proxyRef.Address), cllTimelockAddr, e, common_utils.CLLQualifier, validUntil,
+	)
+
+	mcmsRegistry := cs_core.GetRegistry()
+	out, err := changesets.ActivateRMN(mcmsRegistry).Apply(*e, cs_core.WithMCMS[changesets.ActivateRMNCfg]{
+		MCMS: mcms.Input{
+			OverridePreviousRoot: true,
+			ValidUntil:           validUntil,
+		},
+		Cfg: changesets.ActivateRMNCfg{
+			ChainSels: []uint64{chainSelector},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, out.MCMSTimelockProposals, 2)
+
+	rmnProposal, cllProposal := splitActivateRMNProposalsForTest(t, *e, chainSelector, out.MCMSTimelockProposals)
+	require.Equal(t, mcms_types.TimelockActionSchedule, rmnProposal.Action)
+	require.Equal(t, expectedDelay, rmnProposal.Delay)
+	require.Equal(t, mcms_types.TimelockActionSchedule, cllProposal.Action)
+	require.Equal(t, expectedDelay, cllProposal.Delay)
+	require.Len(t, rmnProposal.Operations, 1)
+	require.Len(t, rmnProposal.Operations[0].Transactions, 1)
+	require.Len(t, cllProposal.Operations, 1)
+	require.Len(t, cllProposal.Operations[0].Transactions, 1)
+
+	testhelpers.ProcessTimelockProposals(t, *e, out.MCMSTimelockProposals, false)
+
+	proxyC, err := rmn_proxy_bind.NewRMNProxy(common.HexToAddress(proxyRef.Address), chain.Client)
+	require.NoError(t, err)
+	require.Equal(t, cllTimelockAddr, common.HexToAddress(cllProposal.TimelockAddresses[mcms_types.ChainSelector(chainSelector)]))
+
+	rmnAddrs, err := out.DataStore.Addresses().Fetch()
+	require.NoError(t, err)
+	require.Len(t, rmnAddrs, 1)
+
+	armReport, err := operations.ExecuteOperation(b, rmn_proxy.GetRMN, chain, contract.FunctionInput[struct{}]{
+		ChainSelector: chainSelector,
+		Address:       common.HexToAddress(proxyRef.Address),
+	})
+	require.NoError(t, err)
+	require.Equal(t, common.HexToAddress(rmnAddrs[0].Address), armReport.Output)
+	require.NotEqual(t, legacyARM, armReport.Output)
+
+	proxyOwner, err := proxyC.Owner(nil)
+	require.NoError(t, err)
+	require.Equal(t, cllTimelockAddr, proxyOwner)
+}
+
+func TestActivateRMN_DualProposalsAccumulateBatchOpsAcrossChains(t *testing.T) {
+	const (
+		chainSelectorA = uint64(5009297550715157269)
+		chainSelectorB = uint64(4949039107694359620)
+		validUntil     = uint32(3759765795)
+	)
+
+	e, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{chainSelectorA, chainSelectorB}),
+	)
+	require.NoError(t, err)
+
+	ds := datastore.NewMemoryDataStore()
+	cllTimelocks := make(map[uint64]common.Address, 2)
+	for _, sel := range []uint64{chainSelectorA, chainSelectorB} {
+		chain := e.BlockChains.EVMChains()[sel]
+		deployer := chain.DeployerKey.From
+		b := e.OperationsBundle
+
+		proxyRef, deployErr := contract.MaybeDeployContract(b, rmn_proxy.Deploy, chain, contract.DeployInput[rmn_proxy.ConstructorArgs]{
+			TypeAndVersion: deployment.NewTypeAndVersion(rmn_proxy.ContractType, *rmn_proxy.Version),
+			ChainSelector:  sel,
+			Args:           rmn_proxy.ConstructorArgs{RMN: common.HexToAddress("0x3333333333333333333333333333333333333333")},
+		}, nil)
+		require.NoError(t, deployErr)
+		require.NoError(t, ds.Addresses().Add(proxyRef))
+
+		_, ultraFastAddrs := deployMCMSInstanceForTest(t, b, chain, deployer, common_utils.UltraFastCurseMCMSQualifier)
+		for _, ref := range ultraFastAddrs {
+			require.NoError(t, ds.Addresses().Add(ref))
+		}
+
+		_, rmnMCMSAddrs := deployMCMSInstanceForTest(t, b, chain, deployer, common_utils.RMNTimelockQualifier)
+		for _, ref := range rmnMCMSAddrs {
+			require.NoError(t, ds.Addresses().Add(ref))
+		}
+
+		cllTimelockAddr, cllAddrs := deployMCMSInstanceForTest(t, b, chain, deployer, common_utils.CLLQualifier)
+		cllTimelocks[sel] = cllTimelockAddr
+		for _, ref := range cllAddrs {
+			require.NoError(t, ds.Addresses().Add(ref))
+		}
+
+		e.DataStore = ds.Seal()
+		transferProxyOwnershipToTimelockForTest(
+			t, b, chain, common.HexToAddress(proxyRef.Address), cllTimelockAddr, e, common_utils.CLLQualifier, validUntil,
+		)
+	}
+	e.DataStore = ds.Seal()
+
+	mcmsRegistry := cs_core.GetRegistry()
+	out, err := changesets.ActivateRMN(mcmsRegistry).Apply(*e, cs_core.WithMCMS[changesets.ActivateRMNCfg]{
+		MCMS: mcms.Input{
+			OverridePreviousRoot: true,
+			ValidUntil:           validUntil,
+		},
+		Cfg: changesets.ActivateRMNCfg{
+			ChainSels: []uint64{chainSelectorA, chainSelectorB},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, out.MCMSTimelockProposals, 2)
+
+	rmnProposal, cllProposal := splitActivateRMNProposalsForTest(t, *e, chainSelectorA, out.MCMSTimelockProposals)
+	require.Len(t, rmnProposal.Operations, 2)
+	require.Len(t, cllProposal.Operations, 2)
+
+	rmnChainSelectors := make([]uint64, 0, len(rmnProposal.Operations))
+	for _, op := range rmnProposal.Operations {
+		rmnChainSelectors = append(rmnChainSelectors, uint64(op.ChainSelector))
+		require.Len(t, op.Transactions, 1)
+	}
+	require.ElementsMatch(t, []uint64{chainSelectorA, chainSelectorB}, rmnChainSelectors)
+
+	cllChainSelectors := make([]uint64, 0, len(cllProposal.Operations))
+	for _, op := range cllProposal.Operations {
+		cllChainSelectors = append(cllChainSelectors, uint64(op.ChainSelector))
+		require.Len(t, op.Transactions, 1)
+		require.Equal(t, cllTimelocks[uint64(op.ChainSelector)].Hex(), cllProposal.TimelockAddresses[op.ChainSelector])
+	}
+	require.ElementsMatch(t, []uint64{chainSelectorA, chainSelectorB}, cllChainSelectors)
+}
+
+func TestActivateRMN_MissingCLLCCIPWhenProxyNotDeployerOwned(t *testing.T) {
+	const validUntil = uint32(3759765795)
+
+	chainSelector := uint64(5009297550715157269)
+	e, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{chainSelector}),
+	)
+	require.NoError(t, err)
+
+	chain := e.BlockChains.EVMChains()[chainSelector]
+	deployer := chain.DeployerKey.From
+	b := e.OperationsBundle
+
+	proxyRef, err := contract.MaybeDeployContract(b, rmn_proxy.Deploy, chain, contract.DeployInput[rmn_proxy.ConstructorArgs]{
+		TypeAndVersion: deployment.NewTypeAndVersion(rmn_proxy.ContractType, *rmn_proxy.Version),
+		ChainSelector:  chainSelector,
+		Args:           rmn_proxy.ConstructorArgs{RMN: deployer},
+	}, nil)
+	require.NoError(t, err)
+
+	_, ultraFastAddrs := deployMCMSInstanceForTest(t, b, chain, deployer, common_utils.UltraFastCurseMCMSQualifier)
+	rmnTimelockAddr, rmnAddrs := deployMCMSInstanceForTest(t, b, chain, deployer, common_utils.RMNTimelockQualifier)
+
+	ds := datastore.NewMemoryDataStore()
+	require.NoError(t, ds.Addresses().Add(proxyRef))
+	for _, ref := range ultraFastAddrs {
+		require.NoError(t, ds.Addresses().Add(ref))
+	}
+	for _, ref := range rmnAddrs {
+		require.NoError(t, ds.Addresses().Add(ref))
+	}
+	e.DataStore = ds.Seal()
+
+	transferProxyOwnershipToTimelockForTest(
+		t, b, chain, common.HexToAddress(proxyRef.Address), rmnTimelockAddr, e, common_utils.RMNTimelockQualifier, validUntil,
+	)
+
+	mcmsRegistry := cs_core.GetRegistry()
+	_, err = changesets.ActivateRMN(mcmsRegistry).Apply(*e, cs_core.WithMCMS[changesets.ActivateRMNCfg]{
+		MCMS: mcms.Input{ValidUntil: validUntil},
+		Cfg:  changesets.ActivateRMNCfg{ChainSels: []uint64{chainSelector}},
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, common_utils.CLLQualifier)
+}
+
+func transferProxyOwnershipToTimelockForTest(
+	t *testing.T,
+	b operations.Bundle,
+	chain evm.Chain,
+	proxyAddr common.Address,
+	timelockAddr common.Address,
+	e *deployment.Environment,
+	mcmsQualifier string,
+	validUntil uint32,
+) {
+	t.Helper()
+
+	batchOps, err := mcms_seq.TransferAndAcceptOwnership(b, chain, []mcms_ops.OpTransferOwnershipInput{
+		{
+			ChainSelector:   chain.Selector,
+			Address:         proxyAddr,
+			ProposedOwner:   timelockAddr,
+			ContractType:    rmn_proxy.ContractType,
+			TimelockAddress: timelockAddr,
+		},
+	})
+	require.NoError(t, err)
+	if len(batchOps) == 0 {
+		return
+	}
+
+	mcmsRegistry := cs_core.GetRegistry()
+	out, err := cs_core.NewOutputBuilder(*e, mcmsRegistry).
+		WithBatchOps(batchOps).
+		Build(mcms.Input{
+			Qualifier:      mcmsQualifier,
+			TimelockAction: mcms_types.TimelockActionSchedule,
+			TimelockDelay:  mcms_types.MustParseDuration("0s"),
+			ValidUntil:     validUntil,
+		})
+	require.NoError(t, err)
+	testhelpers.ProcessTimelockProposals(t, *e, out.MCMSTimelockProposals, false)
+}
+
+func splitActivateRMNProposalsForTest(
+	t *testing.T,
+	e deployment.Environment,
+	chainSelector uint64,
+	proposals []mcmslib.TimelockProposal,
+) (rmnProposal, cllProposal mcmslib.TimelockProposal) {
+	t.Helper()
+	require.Len(t, proposals, 2)
+
+	mcmsReader, ok := cs_core.GetRegistry().GetMCMSReader("evm")
+	require.True(t, ok)
+
+	rmnTimelockRef, err := mcmsReader.GetTimelockRef(e, chainSelector, mcms.Input{Qualifier: common_utils.RMNTimelockQualifier})
+	require.NoError(t, err)
+	cllTimelockRef, err := mcmsReader.GetTimelockRef(e, chainSelector, mcms.Input{Qualifier: common_utils.CLLQualifier})
+	require.NoError(t, err)
+
+	for _, proposal := range proposals {
+		timelockAddr := proposal.TimelockAddresses[mcms_types.ChainSelector(chainSelector)]
+		switch timelockAddr {
+		case rmnTimelockRef.Address:
+			rmnProposal = proposal
+		case cllTimelockRef.Address:
+			cllProposal = proposal
+		default:
+			t.Fatalf("unexpected timelock address %s in proposal", timelockAddr)
+		}
+	}
+	return rmnProposal, cllProposal
 }
 
 func deployMCMSInstanceForTest(

--- a/chains/evm/deployment/v2_0_0/sequences/rmn.go
+++ b/chains/evm/deployment/v2_0_0/sequences/rmn.go
@@ -135,7 +135,7 @@ type ActivateRMNInput struct {
 
 // ActivateRMNOutput holds on-chain deploy results and MCMS batch ops split by owning timelock.
 type ActivateRMNOutput struct {
-	sequences.OnChainOutput
+	Addresses       []datastore.AddressRef
 	RMNMCMSBatchOps []mcms_types.BatchOperation
 	CLLCCIPBatchOps []mcms_types.BatchOperation
 }

--- a/chains/evm/deployment/v2_0_0/sequences/rmn.go
+++ b/chains/evm/deployment/v2_0_0/sequences/rmn.go
@@ -133,27 +133,34 @@ type ActivateRMNInput struct {
 	CurseAdmins []common.Address
 }
 
+// ActivateRMNOutput holds on-chain deploy results and MCMS batch ops split by owning timelock.
+type ActivateRMNOutput struct {
+	sequences.OnChainOutput
+	RMNMCMSBatchOps []mcms_types.BatchOperation
+	CLLCCIPBatchOps []mcms_types.BatchOperation
+}
+
 // DeployAndActivateRMN runs the RMN v2 activation flow on a single EVM chain.
 var DeployAndActivateRMN = cldf_ops.NewSequence(
 	"deploy-and-activate-rmn",
 	rmnops.Version,
 	"Deploy RMN 2.0.0 with Ultra Fast Curse MCMS as curse admin, transfer ownership to RMNMCMS, and point RMNProxy at the new RMN",
-	func(b cldf_ops.Bundle, chain evm.Chain, input ActivateRMNInput) (output sequences.OnChainOutput, err error) {
+	func(b cldf_ops.Bundle, chain evm.Chain, input ActivateRMNInput) (output ActivateRMNOutput, err error) {
 		if input.ChainSelector != chain.Selector {
-			return sequences.OnChainOutput{}, fmt.Errorf("input chain selector %d does not match chain %d",
+			return ActivateRMNOutput{}, fmt.Errorf("input chain selector %d does not match chain %d",
 				input.ChainSelector, chain.Selector)
 		}
 		var writes []contract.WriteOutput
 
 		rmnTimelock, err := resolveTimelockAddress(input.ExistingAddresses, chain.Selector, common_utils.RMNTimelockQualifier)
 		if err != nil {
-			return sequences.OnChainOutput{}, err
+			return ActivateRMNOutput{}, err
 		}
 
 		ultraFastCurseTimeLock, err := resolveTimelockAddress(
 			input.ExistingAddresses, chain.Selector, common_utils.UltraFastCurseMCMSQualifier)
 		if err != nil {
-			return sequences.OnChainOutput{}, err
+			return ActivateRMNOutput{}, err
 		}
 
 		// 1. Deploy RMN 2.0.0 with the Ultra Fast Curse RBACTimelock and any optional curse admins.
@@ -169,10 +176,10 @@ var DeployAndActivateRMN = cldf_ops.NewSequence(
 			},
 		}, input.ExistingAddresses)
 		if err != nil {
-			return sequences.OnChainOutput{}, fmt.Errorf("failed to deploy RMN on chain %d: %w", chain.Selector, err)
+			return ActivateRMNOutput{}, fmt.Errorf("failed to deploy RMN on chain %d: %w", chain.Selector, err)
 		}
 		if rmnRef.Address == "" {
-			return sequences.OnChainOutput{}, fmt.Errorf("RMN address is empty after deploy on chain %d", chain.Selector)
+			return ActivateRMNOutput{}, fmt.Errorf("RMN address is empty after deploy on chain %d", chain.Selector)
 		}
 		rmnAddr := common.HexToAddress(rmnRef.Address)
 		output.Addresses = append(output.Addresses, rmnRef)
@@ -188,23 +195,25 @@ var DeployAndActivateRMN = cldf_ops.NewSequence(
 			},
 		})
 		if err != nil {
-			return sequences.OnChainOutput{}, err
+			return ActivateRMNOutput{}, err
 		}
-		output.BatchOps = append(output.BatchOps, ownershipBatchOps...)
+		output.RMNMCMSBatchOps = append(output.RMNMCMSBatchOps, ownershipBatchOps...)
 
 		// 3. Point RMNProxy at the new RMN (makes the implementation live for CCIP).
 		rmnProxyWrites, err := pointRMNProxyAtRMN(b, chain, input.ExistingAddresses, rmnAddr)
 		if err != nil {
-			return sequences.OnChainOutput{}, err
+			return ActivateRMNOutput{}, err
 		}
 		writes = append(writes, rmnProxyWrites...)
 
 		if len(writes) > 0 {
 			batch, err := contract.NewBatchOperationFromWrites(writes)
 			if err != nil {
-				return sequences.OnChainOutput{}, fmt.Errorf("failed to create batch operation from writes: %w", err)
+				return ActivateRMNOutput{}, fmt.Errorf("failed to create batch operation from writes: %w", err)
 			}
-			output.BatchOps = append(output.BatchOps, batch)
+			if len(batch.Transactions) > 0 {
+				output.CLLCCIPBatchOps = append(output.CLLCCIPBatchOps, batch)
+			}
 		}
 
 		return output, nil


### PR DESCRIPTION
This pull request refactors and enhances the RMN deployment and activation flow to better support scenarios where RMNProxy is not deployer-owned, ensuring correct proposal generation and validation for both RMNMCMS and CLLCCIP timelocks. The changes introduce clearer separation of batch operations, improved error handling, and more robust tests for multi-chain and ownership edge cases.

**Deployment and Proposal Handling Improvements:**

* The deployment sequence now returns a new `ActivateRMNOutput` struct that separates `RMNMCMSBatchOps` and `CLLCCIPBatchOps`, instead of a single batch operation list. This enables the changeset to generate dual proposals when necessary [[1]](diffhunk://#diff-96577e558a6215635838632f2f4488651f11d9ec378ce7d622b0a2684e202d9cR136-R163) [[2]](diffhunk://#diff-96577e558a6215635838632f2f4488651f11d9ec378ce7d622b0a2684e202d9cL191-L207).
* The `applyDeployAndActivateRMN` function in the changeset now builds and accumulates separate MCMS proposals for RMNMCMS and CLLCCIP, applying the configured timelock delay and validating required addresses for proxy proposals [[1]](diffhunk://#diff-8932e9128a4632d3c44b024ffff17385e8de40dadfab6240f75a494c71c4e2e0L89-R94) [[2]](diffhunk://#diff-8932e9128a4632d3c44b024ffff17385e8de40dadfab6240f75a494c71c4e2e0L109-R177).

**Validation and Utility Additions:**

* Added `validateCLLCCIPForProxyProposal` to ensure CLLCCIP RBACTimelock is present in the datastore before building a proposal for non-deployer-owned proxies.
* Introduced a helper function to construct MCMS input objects for proposal generation, encapsulating common fields and logic.

**Testing Enhancements:**

* Added comprehensive tests to verify dual proposal emission, correct batch operation accumulation across multiple chains, and error handling when required timelocks are missing or proxies are not deployer-owned.

**Other Changes:**

* Updated imports to include new dependencies required for MCMS handling and testing [[1]](diffhunk://#diff-8932e9128a4632d3c44b024ffff17385e8de40dadfab6240f75a494c71c4e2e0R5) [[2]](diffhunk://#diff-8932e9128a4632d3c44b024ffff17385e8de40dadfab6240f75a494c71c4e2e0R18) [[3]](diffhunk://#diff-b3f1a29f152ba5e97ccd5680323e70af05888b8565d48f2fa028495e44c45219R14).
* Extended the `ActivateRMNCfg` struct to allow configuration of a timelock delay for proposals.

These changes collectively improve the reliability, clarity, and test coverage of the RMN deployment and activation process, especially in complex multi-chain and ownership scenarios.