### PR TITLE
TON smoke - clear vcs cache at runtime

### DIFF
--- a/.github/actions/build-cl/action.yml
+++ b/.github/actions/build-cl/action.yml
@@ -50,8 +50,16 @@ runs:
       shell: bash
       run: |
         export GOPRIVATE=github.com/smartcontractkit/*
+        # Drop any stale shallow-clone VCS cache that the Go module cache restore may have
+        # left behind.  A restored shallow clone causes "fatal: shallow file has changed
+        # since we read it" when go get --unshallow races against it.
+        rm -rf "$(go env GOMODCACHE)/cache/vcs" || true
         if [ -n "${{ inputs.ton_ref }}" ]; then
-          go get github.com/smartcontractkit/chainlink-ton@${{ inputs.ton_ref }}
+          for i in 1 2 3; do
+            go get github.com/smartcontractkit/chainlink-ton@${{ inputs.ton_ref }} && break
+            echo "retry $i – unshallow race on chainlink-ton; sleeping 5s"
+            sleep 5
+          done
         fi
         if [ -n "${{ inputs.solana_ref }}" ]; then
           go get github.com/smartcontractkit/chainlink-solana@${{ inputs.solana_ref }}

--- a/.github/actions/build-cl/action.yml
+++ b/.github/actions/build-cl/action.yml
@@ -51,13 +51,12 @@ runs:
       run: |
         export GOPRIVATE=github.com/smartcontractkit/*
         # Drop any stale shallow-clone VCS cache that the Go module cache restore may have
-        # left behind.  A restored shallow clone causes "fatal: shallow file has changed
-        # since we read it" when go get --unshallow races against it.
+        # left behind.
         rm -rf "$(go env GOMODCACHE)/cache/vcs" || true
         if [ -n "${{ inputs.ton_ref }}" ]; then
           for i in 1 2 3; do
             go get github.com/smartcontractkit/chainlink-ton@${{ inputs.ton_ref }} && break
-            echo "retry $i – unshallow race on chainlink-ton; sleeping 5s"
+            echo "retry $i - unshallow race on chainlink-ton, sleeping 5s"
             sleep 5
           done
         fi

--- a/.github/workflows/test_smoke.yml
+++ b/.github/workflows/test_smoke.yml
@@ -112,14 +112,14 @@ jobs:
           export GOPRIVATE=github.com/smartcontractkit/*
           if [ -n "${{ inputs.ton_ref }}" ]; then
             # Clear any stale shallow VCS cache restored by setup-go to avoid
-            # "fatal: shallow file has changed since we read it" races.
+            # "fatal: shallow file has changed since we read it" races. Retry max 3 times
             rm -rf "$(go env GOMODCACHE)/cache/vcs" || true
             for i in 1 2 3; do
               go get github.com/smartcontractkit/chainlink-ton/devenv@${{ inputs.ton_ref }} \
                 && go get github.com/smartcontractkit/chainlink-ton/deployment@${{ inputs.ton_ref }} \
                 && go get github.com/smartcontractkit/chainlink-ton@${{ inputs.ton_ref }} \
                 && break
-              echo "retry $i – unshallow race on chainlink-ton; sleeping 5s"
+              echo "retry $i - unshallow race on chainlink-ton, sleeping 5s"
               sleep 5
             done
             go mod tidy

--- a/.github/workflows/test_smoke.yml
+++ b/.github/workflows/test_smoke.yml
@@ -111,9 +111,17 @@ jobs:
         run: |
           export GOPRIVATE=github.com/smartcontractkit/*
           if [ -n "${{ inputs.ton_ref }}" ]; then
-            go get github.com/smartcontractkit/chainlink-ton/devenv@${{ inputs.ton_ref }}
-            go get github.com/smartcontractkit/chainlink-ton/deployment@${{ inputs.ton_ref }}
-            go get github.com/smartcontractkit/chainlink-ton@${{ inputs.ton_ref }}
+            # Clear any stale shallow VCS cache restored by setup-go to avoid
+            # "fatal: shallow file has changed since we read it" races.
+            rm -rf "$(go env GOMODCACHE)/cache/vcs" || true
+            for i in 1 2 3; do
+              go get github.com/smartcontractkit/chainlink-ton/devenv@${{ inputs.ton_ref }} \
+                && go get github.com/smartcontractkit/chainlink-ton/deployment@${{ inputs.ton_ref }} \
+                && go get github.com/smartcontractkit/chainlink-ton@${{ inputs.ton_ref }} \
+                && break
+              echo "retry $i – unshallow race on chainlink-ton; sleeping 5s"
+              sleep 5
+            done
             go mod tidy
           fi
           go mod download


### PR DESCRIPTION
- clear VCS cache before `go get` to evict stale shallow clone that `setup-go` leaves behind
- wrap `go get cl-ton` in a retry loop 