### PR TITLE
fix: allow migrate_chain_lanes_to_v2 to override prod-router OnRamp mappings

### DIFF
--- a/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2.go
+++ b/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2.go
@@ -149,6 +149,9 @@ func MigrateChainLanesToV2(
 				Lanes:      lanes,
 				MCMS:       cfg.MCMS,
 				TestRouter: cfg.TestRouter,
+				// A migration's whole purpose is to swap each lane's pre-2.0 OnRamp for the CCIP 2.0
+				// OnRamp on the (prod) router, so it must be allowed to overwrite the existing mapping.
+				AllowOnrampOverride: true,
 			},
 		}
 		if err := underlying.VerifyPreconditions(e, resolvedCfg); err != nil {

--- a/deployment/v2_0_0/changesets/build_lanes_cross_family.go
+++ b/deployment/v2_0_0/changesets/build_lanes_cross_family.go
@@ -43,6 +43,9 @@ type BuildLanesCrossFamilyConfig struct {
 	Lanes      []CrossFamilyLanePair `json:"lanes" yaml:"lanes"`
 	MCMS       mcms.Input            `json:"mcms" yaml:"mcms"`
 	TestRouter *bool                 `json:"testRouter,omitempty" yaml:"testRouter,omitempty"`
+	// AllowOnrampOverride permits replacing an existing OnRamp mapping in the production Router
+	// with a different OnRamp address. This should only be used for v2 migrations.
+	AllowOnrampOverride bool `json:"allowOnrampOverride,omitempty" yaml:"allowOnrampOverride,omitempty"`
 }
 
 // UseTestRouter reports whether the test router should be used instead of the production router.

--- a/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology.go
+++ b/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology.go
@@ -240,7 +240,7 @@ func ConfigureChainsForLanesFromTopology(
 			})
 		}
 
-		return applyConfigureChains(e, chainFamilyRegistry, mcmsRegistry, committeeVerifierContractRegistry, enriched, cfg.MCMS, cfg.UseTestRouter())
+		return applyConfigureChains(e, chainFamilyRegistry, mcmsRegistry, committeeVerifierContractRegistry, enriched, cfg.MCMS, cfg.UseTestRouter(), cfg.AllowOnrampOverride)
 	}
 
 	return deployment.CreateChangeSet(apply, validate)
@@ -265,6 +265,7 @@ func applyConfigureChains(
 	chains []enrichedChainConfig,
 	mcmsInput mcms.Input,
 	useTestRouter bool,
+	allowOnrampOverride bool,
 ) (deployment.ChangesetOutput, error) {
 	batchOps := make([]mcms_types.BatchOperation, 0)
 	reports := make([]cldf_ops.Report[any, any], 0)
@@ -344,8 +345,10 @@ func applyConfigureChains(
 
 		// ── Phase 3: Dispatch ──────────────────────────────────────────────
 		report, err := cldf_ops.ExecuteSequence(e.OperationsBundle, adapter.ConfigureChainForLanes(), e.BlockChains, adapters.ConfigureChainForLanesInput{
-			ChainSelector:       chainCfg.ChainSelector,
-			AllowOnrampOverride: useTestRouter,
+			ChainSelector: chainCfg.ChainSelector,
+			// Overriding an existing prod-router OnRamp mapping is allowed either implicitly on the
+			// test router or explicitly via AllowOnrampOverride (set by migrate_chain_lanes_to_v2).
+			AllowOnrampOverride: useTestRouter || allowOnrampOverride,
 			Router:              routerBytes,
 			OnRamp:              onRampBytes,
 			CommitteeVerifiers:  committeeVerifiers,

--- a/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology_test.go
+++ b/deployment/v2_0_0/changesets/configure_chains_for_lanes_from_topology_test.go
@@ -272,6 +272,12 @@ func withTestRouter(use bool) func(*changesets.ConfigureChainsForLanesFromTopolo
 	}
 }
 
+func withAllowOnrampOverride(allow bool) func(*changesets.ConfigureChainsForLanesFromTopologyConfig) {
+	return func(cfg *changesets.ConfigureChainsForLanesFromTopologyConfig) {
+		cfg.AllowOnrampOverride = allow
+	}
+}
+
 func newMockAdapter(prefix string, chainAddresses map[uint64]map[string][]byte, executors map[uint64]map[string]string) *mockChainFamilyAdapter {
 	return &mockChainFamilyAdapter{
 		addressPrefix: prefix,
@@ -749,6 +755,70 @@ func TestConfigureChainsForLanesFromTopology_SelectsStandardRouterWhenBothExist(
 		"with UseTestRouter=false and both routers in the datastore, the standard Router should be selected")
 	assert.False(t, evmAdapter.inputs[0].AllowOnrampOverride,
 		"UseTestRouter=false should set AllowOnrampOverride=false on sequence input")
+}
+
+// TestConfigureChainsForLanesFromTopology_AllowOnrampOverrideForcesOverrideOnProdRouter covers the
+// migrate_chain_lanes_to_v2 path: on the production router (UseTestRouter=false), setting
+// AllowOnrampOverride=true must still allow overwriting an existing OnRamp mapping so a lane can be
+// swapped from its pre-2.0 OnRamp to the CCIP 2.0 OnRamp.
+func TestConfigureChainsForLanesFromTopology_AllowOnrampOverrideForcesOverrideOnProdRouter(t *testing.T) {
+	localSelector := chainsel.TEST_90000001.Selector
+	remoteSelector := chainsel.TEST_90000002.Selector
+
+	env := newConfigureChainsTestEnv(t, []uint64{localSelector}, nil)
+	ds := datastore.NewMemoryDataStore()
+	addAddress(t, ds, testRef(localSelector, "0xverifier", "CommitteeVerifier"))
+	env.DataStore = ds.Seal()
+
+	committeeRegistry := adapters.NewCommitteeVerifierContractRegistry()
+	committeeRegistry.Register(chainsel.FamilyEVM, &mockCommitteeVerifierContractAdapter{
+		contractsByChainAndQualifier: map[string][]datastore.AddressRef{
+			fmt.Sprintf("%d:default", localSelector): {testRef(localSelector, "0xverifier", "CommitteeVerifier")},
+		},
+	})
+
+	evmAdapter := newMockAdapter("evm:", map[uint64]map[string][]byte{
+		localSelector: {
+			"Router": {0xaa, 0x01}, "TestRouter": {0xbb, 0x99},
+			"OnRamp": {0xaa, 0x02}, "FeeQuoter": {0xaa, 0x03}, "OffRamp": {0xaa, 0x04},
+		},
+		remoteSelector: {
+			"OnRamp": {0xcc, 0x01}, "OffRamp": {0xcc, 0x02},
+		},
+	}, map[uint64]map[string]string{
+		localSelector: {"default": "0xexecutor"},
+	})
+	registry := adapters.NewChainFamilyRegistry()
+	registry.RegisterChainFamily(chainsel.FamilyEVM, evmAdapter)
+
+	cs := changesets.ConfigureChainsForLanesFromTopology(committeeRegistry, registry, changesetscore.GetRegistry())
+	_, err := cs.Apply(env, lanesTopologyConfig(
+		&offchain.EnvironmentTopology{
+			NOPTopology: &offchain.NOPTopology{
+				NOPs: []offchain.NOPConfig{
+					{Alias: "nop-1", SignerAddressByFamily: map[string]string{chainsel.FamilyEVM: "0xsigner"}},
+				},
+				Committees: map[string]offchain.CommitteeConfig{
+					"default": {
+						Qualifier: "default",
+						ChainConfigs: map[string]offchain.ChainCommitteeConfig{
+							fmt.Sprintf("%d", remoteSelector): {NOPAliases: []string{"nop-1"}, Threshold: 1},
+							fmt.Sprintf("%d", localSelector):  {NOPAliases: []string{"nop-1"}, Threshold: 1},
+						},
+					},
+				},
+			},
+		},
+		[]changesets.CrossFamilyLanePair{{ChainA: localSelector, ChainB: remoteSelector}},
+		withTestRouter(false),
+		withAllowOnrampOverride(true),
+	))
+	require.NoError(t, err)
+	require.Len(t, evmAdapter.inputs, 1)
+	assert.Equal(t, []byte{0xaa, 0x01}, evmAdapter.inputs[0].Router,
+		"AllowOnrampOverride must not change router selection: the standard Router is still used")
+	assert.True(t, evmAdapter.inputs[0].AllowOnrampOverride,
+		"AllowOnrampOverride=true should force AllowOnrampOverride on the sequence input even on the prod router")
 }
 
 func TestConfigureChainsForLanesFromTopology_OnlyFetchesSigningKeysForCommitteeNOPs(t *testing.T) {


### PR DESCRIPTION
## Problem

`MigrateChainLanesToV2` delegates to `ConfigureChainsForLanesFromTopology`, which hardcoded `AllowOnrampOverride: useTestRouter`. 

On the production router the `configure-chain-for-lanes` sequence therefore refuses to replace an existing Router→OnRamp mapping with a different OnRamp address. However as part of the migrate_chain_lanes_to_v2 this is something we'd like to do.


## Fix
- Add an `AllowOnrampOverride` field to `BuildLanesCrossFamilyConfig`.
- Thread it into the sequence input as `useTestRouter || allowOnrampOverride`, leaving router selection unchanged.
- Set it `true` in `MigrateChainLanesToV2` (a migration's whole purpose is to re-point the router to the new OnRamp).

`build_lanes_cross_family` leaves the flag `false`, so accidental prod-router overwrites stay blocked.

## Tests
- New `TestConfigureChainsForLanesFromTopology_AllowOnrampOverrideForcesOverrideOnProdRouter`: verifies the override is forced on the prod router without changing router selection.
- Existing `useTestRouter` true/false assertions still pass (test-router behaviour unchanged; `build_lanes` default stays `false`).