### PR TITLE
fix: normalize addresses in xsfer ownership changeset

### DIFF
--- a/chains/solana/deployment/v1_0_0/adapters/address_normalizer.go
+++ b/chains/solana/deployment/v1_0_0/adapters/address_normalizer.go
@@ -1,11 +1,13 @@
 package adapters
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/gagliardetto/solana-go"
 
 	deployapi "github.com/smartcontractkit/chainlink-ccip/deployment/deploy"
+	mcms_solana "github.com/smartcontractkit/mcms/sdk/solana"
 )
 
 var _ deployapi.AddressNormalizer = (*SolanaAddressNormalizer)(nil)
@@ -14,11 +16,20 @@ var _ deployapi.AddressNormalizer = (*SolanaAddressNormalizer)(nil)
 type SolanaAddressNormalizer struct{}
 
 func (SolanaAddressNormalizer) NormalizeAddress(addr string) (string, error) {
-	pubKey, err := solana.PublicKeyFromBase58(addr)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse address '%s' as base58 Solana public key: %w", addr, err)
+	programID, seed, err := mcms_solana.ParseContractAddress(addr)
+	if err == nil {
+		return mcms_solana.ContractAddress(programID, seed), nil
 	}
-	return pubKey.String(), nil
+
+	if errors.Is(err, mcms_solana.ErrInvalidContractAddressFormat) {
+		if pubKey, err := solana.PublicKeyFromBase58(addr); err != nil {
+			return "", fmt.Errorf("failed to parse address '%s' as base58 Solana public key: %w", addr, err)
+		} else {
+			return pubKey.String(), nil
+		}
+	}
+
+	return "", fmt.Errorf("failed to normalize address '%s': %w", addr, err)
 }
 
 // BytesToString converts raw on-chain address bytes (a 32-byte public key) to its canonical base58 string.

--- a/deployment/deploy/address_normalizer.go
+++ b/deployment/deploy/address_normalizer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 )
 
-// TryNormalizeAddressRef attempts to normalize the given AddressRef.Address based on the provided chain selector.
+// TryNormalizeAddressRef normalizes the given AddressRef.Address based on the provided chain selector.
 func TryNormalizeAddressRef(sel uint64, ref datastore.AddressRef) (datastore.AddressRef, error) {
 	if datastore_utils.IsAddressRefEmpty(ref) {
 		return ref, nil

--- a/deployment/deploy/normalizer.go
+++ b/deployment/deploy/normalizer.go
@@ -1,0 +1,43 @@
+package deploy
+
+import (
+	"fmt"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+
+	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+)
+
+// TryNormalizeAddressRef attempts to normalize the given AddressRef.Address based on the provided chain selector.
+func TryNormalizeAddressRef(sel uint64, ref datastore.AddressRef) (datastore.AddressRef, error) {
+	if datastore_utils.IsAddressRefEmpty(ref) {
+		return ref, nil
+	} else {
+		// NOTE: `ref.ChainSelector` is intentionally ignored in favor of `sel`
+		ref.ChainSelector = sel
+	}
+
+	normalized := ref.Clone()
+	if normalized.Address == "" {
+		return normalized, nil
+	}
+
+	family, err := chainsel.GetSelectorFamily(sel)
+	if err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("invalid chain selector %d: %w", sel, err)
+	}
+
+	normalizer, ok := GetAddressNormalizerRegistry().GetAddressNormalizer(family)
+	if !ok {
+		return normalized, nil
+	}
+
+	normalized.Address, err = normalizer.NormalizeAddress(ref.Address)
+	if err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("failed to normalize address %s: %w", ref.Address, err)
+	}
+
+	return normalized, nil
+}

--- a/deployment/deploy/transfer_ownership.go
+++ b/deployment/deploy/transfer_ownership.go
@@ -47,7 +47,11 @@ func acceptOwnershipApply(cr *TransferOwnershipAdapterRegistry, mcmsRegistry *ch
 			}
 			// if partial refs are provided, resolve to full refs
 			for i, contractRef := range perChainInputs.ContractRef {
-				fullRef, err := datastore_utils.FindAndFormatRef(e.DataStore, contractRef, perChainInputs.ChainSelector, datastore_utils.FullRef)
+				normRef, err := TryNormalizeAddressRef(perChainInputs.ChainSelector, contractRef)
+				if err != nil {
+					return cldf.ChangesetOutput{}, fmt.Errorf("failed to normalize contract ref %s for chain %d: %w", datastore_utils.SprintRef(contractRef), perChainInputs.ChainSelector, err)
+				}
+				fullRef, err := datastore_utils.FindAndFormatRef(e.DataStore, normRef, perChainInputs.ChainSelector, datastore_utils.FullRef)
 				if err != nil {
 					return cldf.ChangesetOutput{}, err
 				}
@@ -88,7 +92,11 @@ func transferOwnershipApply(cr *TransferOwnershipAdapterRegistry, mcmsRegistry *
 			}
 			// if partial refs are provided, resolve to full refs
 			for i, contractRef := range perChainInputs.ContractRef {
-				fullRef, err := datastore_utils.FindAndFormatRef(e.DataStore, contractRef, perChainInputs.ChainSelector, datastore_utils.FullRef)
+				normRef, err := TryNormalizeAddressRef(perChainInputs.ChainSelector, contractRef)
+				if err != nil {
+					return cldf.ChangesetOutput{}, fmt.Errorf("failed to normalize contract ref %s for chain %d: %w", datastore_utils.SprintRef(contractRef), perChainInputs.ChainSelector, err)
+				}
+				fullRef, err := datastore_utils.FindAndFormatRef(e.DataStore, normRef, perChainInputs.ChainSelector, datastore_utils.FullRef)
 				if err != nil {
 					return cldf.ChangesetOutput{}, err
 				}
@@ -141,6 +149,18 @@ func TransferToTimelock(chainSel uint64, e cldf.Environment, mcmsInput mcms.Inpu
 	adapter, err := transferOwnershipReg.GetAdapterByChainSelector(chainSel, MCMSVersion)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get transfer ownership adapter for chain %d: %w", chainSel, err)
+	}
+
+	for i, contractRef := range addressRefs {
+		normRef, err := TryNormalizeAddressRef(chainSel, contractRef)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to normalize contract ref %s for chain %d: %w", datastore_utils.SprintRef(contractRef), chainSel, err)
+		}
+		fullRef, err := datastore_utils.FindAndFormatRef(e.DataStore, normRef, chainSel, datastore_utils.FullRef)
+		if err != nil {
+			return nil, nil, err
+		}
+		addressRefs[i] = fullRef
 	}
 
 	ownershipInput := TransferOwnershipPerChainInput{

--- a/deployment/deploy/transfer_ownership.go
+++ b/deployment/deploy/transfer_ownership.go
@@ -53,7 +53,7 @@ func acceptOwnershipApply(cr *TransferOwnershipAdapterRegistry, mcmsRegistry *ch
 				}
 				fullRef, err := datastore_utils.FindAndFormatRef(e.DataStore, normRef, perChainInputs.ChainSelector, datastore_utils.FullRef)
 				if err != nil {
-					return cldf.ChangesetOutput{}, err
+					return cldf.ChangesetOutput{}, fmt.Errorf("failed to resolve contract ref %s for chain %d: %w", datastore_utils.SprintRef(normRef), perChainInputs.ChainSelector, err)
 				}
 				perChainInputs.ContractRef[i] = fullRef
 			}

--- a/deployment/deploy/transfer_ownership.go
+++ b/deployment/deploy/transfer_ownership.go
@@ -98,7 +98,7 @@ func transferOwnershipApply(cr *TransferOwnershipAdapterRegistry, mcmsRegistry *
 				}
 				fullRef, err := datastore_utils.FindAndFormatRef(e.DataStore, normRef, perChainInputs.ChainSelector, datastore_utils.FullRef)
 				if err != nil {
-					return cldf.ChangesetOutput{}, err
+					return cldf.ChangesetOutput{}, fmt.Errorf("failed to resolve contract ref %s for chain %d: %w", datastore_utils.SprintRef(normRef), perChainInputs.ChainSelector, err)
 				}
 				perChainInputs.ContractRef[i] = fullRef
 			}

--- a/deployment/deploy/transfer_ownership.go
+++ b/deployment/deploy/transfer_ownership.go
@@ -151,18 +151,6 @@ func TransferToTimelock(chainSel uint64, e cldf.Environment, mcmsInput mcms.Inpu
 		return nil, nil, fmt.Errorf("failed to get transfer ownership adapter for chain %d: %w", chainSel, err)
 	}
 
-	for i, contractRef := range addressRefs {
-		normRef, err := TryNormalizeAddressRef(chainSel, contractRef)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to normalize contract ref %s for chain %d: %w", datastore_utils.SprintRef(contractRef), chainSel, err)
-		}
-		fullRef, err := datastore_utils.FindAndFormatRef(e.DataStore, normRef, chainSel, datastore_utils.FullRef)
-		if err != nil {
-			return nil, nil, err
-		}
-		addressRefs[i] = fullRef
-	}
-
 	ownershipInput := TransferOwnershipPerChainInput{
 		ChainSelector: chainSel,
 		ContractRef:   addressRefs,

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -138,7 +138,7 @@ func processTokenConfigForChain(e cldf.Environment, mcmsRegistry *changesets.MCM
 
 	var err error
 	for selector, token := range cfg {
-		token.RegistryRef, err = TryNormalizeAddressRef(selector, token.RegistryRef)
+		token.RegistryRef, err = deploy.TryNormalizeAddressRef(selector, token.RegistryRef)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("failed to normalize registry ref address for chain selector %d: %w", selector, err)
 		}
@@ -685,7 +685,7 @@ func convertRemoteChainConfig(
 		}
 	}
 	for _, ccvRef := range inCfg.OutboundCCVs {
-		ref, err := TryNormalizeAddressRef(chainSelector, ccvRef)
+		ref, err := deploy.TryNormalizeAddressRef(chainSelector, ccvRef)
 		if err != nil {
 			return outCfg, fmt.Errorf("failed to normalize outbound CCV ref address for chain selector %d: %w", chainSelector, err)
 		}
@@ -696,7 +696,7 @@ func convertRemoteChainConfig(
 		outCfg.OutboundCCVs = append(outCfg.OutboundCCVs, fullCCVRef.Address)
 	}
 	for _, ccvRef := range inCfg.InboundCCVs {
-		ref, err := TryNormalizeAddressRef(chainSelector, ccvRef)
+		ref, err := deploy.TryNormalizeAddressRef(chainSelector, ccvRef)
 		if err != nil {
 			return outCfg, fmt.Errorf("failed to normalize inbound CCV ref address for chain selector %d: %w", chainSelector, err)
 		}
@@ -707,7 +707,7 @@ func convertRemoteChainConfig(
 		outCfg.InboundCCVs = append(outCfg.InboundCCVs, fullCCVRef.Address)
 	}
 	for _, ccvRef := range inCfg.OutboundCCVsToAddAboveThreshold {
-		ref, err := TryNormalizeAddressRef(chainSelector, ccvRef)
+		ref, err := deploy.TryNormalizeAddressRef(chainSelector, ccvRef)
 		if err != nil {
 			return outCfg, fmt.Errorf("failed to normalize outbound CCV-above-threshold ref address for chain selector %d: %w", chainSelector, err)
 		}
@@ -718,7 +718,7 @@ func convertRemoteChainConfig(
 		outCfg.OutboundCCVsToAddAboveThreshold = append(outCfg.OutboundCCVsToAddAboveThreshold, fullCCVRef.Address)
 	}
 	for _, ccvRef := range inCfg.InboundCCVsToAddAboveThreshold {
-		ref, err := TryNormalizeAddressRef(chainSelector, ccvRef)
+		ref, err := deploy.TryNormalizeAddressRef(chainSelector, ccvRef)
 		if err != nil {
 			return outCfg, fmt.Errorf("failed to normalize inbound CCV-above-threshold ref address for chain selector %d: %w", chainSelector, err)
 		}

--- a/deployment/tokens/migrate_lock_release_pool_liquidity.go
+++ b/deployment/tokens/migrate_lock_release_pool_liquidity.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/deploy"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
 	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
@@ -97,7 +98,7 @@ func makeMigrationApply(_ *TokenAdapterRegistry, mcmsRegistry *changesets.MCMSRe
 
 			var setPoolConfig *MigrationSetPoolConfig
 			if migration.RegistryRef != nil && migration.TokenRef != nil {
-				regRef, err := TryNormalizeAddressRef(migration.ChainSelector, *migration.RegistryRef)
+				regRef, err := deploy.TryNormalizeAddressRef(migration.ChainSelector, *migration.RegistryRef)
 				if err != nil {
 					return cldf.ChangesetOutput{}, fmt.Errorf("migration[%d]: failed to normalize registry ref address: %w", i, err)
 				}

--- a/deployment/tokens/revoke_admin_role.go
+++ b/deployment/tokens/revoke_admin_role.go
@@ -8,6 +8,7 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	mcms_types "github.com/smartcontractkit/mcms/types"
 
+	"github.com/smartcontractkit/chainlink-ccip/deployment/deploy"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
 	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
@@ -134,9 +135,13 @@ func revokeTokenAdminRoleApply(tokenRegistry *TokenAdapterRegistry, mcmsRegistry
 			if !ok {
 				return cldf.ChangesetOutput{}, fmt.Errorf("revocation[%d]: token adapter for chain family '%s' and version '%v' does not support token admin role revocation", i, family, version)
 			}
-			tokenRef, err := datastore_utils.FindAndFormatRef(e.DataStore, revocation.TokenRef, revocation.ChainSelector, datastore_utils.FullRef)
+			cleanRef, err := deploy.TryNormalizeAddressRef(selector, revocation.TokenRef)
 			if err != nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("revocation[%d]: failed to resolve token ref: %w", i, err)
+				return cldf.ChangesetOutput{}, fmt.Errorf("revocation[%d]: failed to normalize token ref %s: %w", i, datastore_utils.SprintRef(revocation.TokenRef), err)
+			}
+			tokenRef, err := datastore_utils.FindAndFormatRef(e.DataStore, cleanRef, revocation.ChainSelector, datastore_utils.FullRef)
+			if err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("revocation[%d]: failed to resolve token ref %s: %w", i, datastore_utils.SprintRef(cleanRef), err)
 			}
 
 			// NOTE: if after resolution, the timelock address is still empty, the adapter should fall back to the deployer key

--- a/deployment/tokens/revoke_admin_role.go
+++ b/deployment/tokens/revoke_admin_role.go
@@ -139,7 +139,7 @@ func revokeTokenAdminRoleApply(tokenRegistry *TokenAdapterRegistry, mcmsRegistry
 			if err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("revocation[%d]: failed to normalize token ref %s: %w", i, datastore_utils.SprintRef(revocation.TokenRef), err)
 			}
-			tokenRef, err := datastore_utils.FindAndFormatRef(e.DataStore, cleanRef, revocation.ChainSelector, datastore_utils.FullRef)
+			tokenRef, err := datastore_utils.FindAndFormatRef(e.DataStore, cleanRef, selector, datastore_utils.FullRef)
 			if err != nil {
 				return cldf.ChangesetOutput{}, fmt.Errorf("revocation[%d]: failed to resolve token ref %s: %w", i, datastore_utils.SprintRef(cleanRef), err)
 			}

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -352,7 +352,7 @@ func tokenExpansionApply() func(cldf.Environment, TokenExpansionInput) (cldf.Cha
 				if err != nil {
 					return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge token pool refs for chain selector %d: %w", selector, err)
 				}
-				mergedPool, err = TryNormalizeAddressRef(selector, mergedPool)
+				mergedPool, err = ccipdeploy.TryNormalizeAddressRef(selector, mergedPool)
 				if err != nil {
 					return cldf.ChangesetOutput{}, fmt.Errorf("failed to normalize merged token pool ref address for chain selector %d: %w", selector, err)
 				}
@@ -364,7 +364,7 @@ func tokenExpansionApply() func(cldf.Environment, TokenExpansionInput) (cldf.Cha
 				if err != nil {
 					return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge token refs for chain selector %d: %w", selector, err)
 				}
-				mergedToken, err = TryNormalizeAddressRef(selector, mergedToken)
+				mergedToken, err = ccipdeploy.TryNormalizeAddressRef(selector, mergedToken)
 				if err != nil {
 					return cldf.ChangesetOutput{}, fmt.Errorf("failed to normalize merged token ref address for chain selector %d: %w", selector, err)
 				}
@@ -451,39 +451,6 @@ func ScaleTokenAmount(amount *big.Int, decimals uint8) *big.Int {
 	return new(big.Int).Mul(amount, new(big.Int).Exp(big.NewInt(10), new(big.Int).SetUint64(uint64(decimals)), nil))
 }
 
-// TryNormalizeAddressRef looks up AddressNormalizer registered for selector's chain family and canonicalizes ref.Address when set.
-func TryNormalizeAddressRef(chainSelector uint64, ref datastore.AddressRef) (datastore.AddressRef, error) {
-	if datastore_utils.IsAddressRefEmpty(ref) {
-		return ref, nil
-	} else {
-		// NOTE: `ref.ChainSelector` is intentionally ignored in favor of `chainSelector`
-		// which comes from the keys of `TokenExpansionInput.TokenExpansionInputPerChain`
-		ref.ChainSelector = chainSelector
-	}
-
-	normalized := ref.Clone()
-	if normalized.Address == "" {
-		return normalized, nil
-	}
-
-	family, err := chain_selectors.GetSelectorFamily(chainSelector)
-	if err != nil {
-		return datastore.AddressRef{}, fmt.Errorf("invalid chain selector %d: %w", chainSelector, err)
-	}
-
-	normalizer, ok := ccipdeploy.GetAddressNormalizerRegistry().GetAddressNormalizer(family)
-	if !ok {
-		return normalized, nil
-	}
-
-	normalized.Address, err = normalizer.NormalizeAddress(ref.Address)
-	if err != nil {
-		return datastore.AddressRef{}, fmt.Errorf("failed to normalize address %s: %w", ref.Address, err)
-	}
-
-	return normalized, nil
-}
-
 // ResolveAdapterAndRefs resolves the token adapter, token pool ref, and token ref for the given
 // chain selector and input refs. It first resolves the token pool ref, then uses that to resolve
 // the adapter, and finally uses the adapter to derive the token address and resolve the token ref.
@@ -526,7 +493,7 @@ func ResolveTokenPoolRef(e cldf.Environment, reg *TokenAdapterRegistry, sel uint
 	}
 
 	// Try to normalize ref.Address before doing any lookups
-	maybeNormalized, err := TryNormalizeAddressRef(sel, ref)
+	maybeNormalized, err := ccipdeploy.TryNormalizeAddressRef(sel, ref)
 	if err != nil {
 		return datastore.AddressRef{}, fmt.Errorf("failed to normalize address ref (%s) for chain selector %d: %w", datastore_utils.SprintRef(ref), sel, err)
 	}
@@ -568,7 +535,7 @@ func ResolveTokenRef(e cldf.Environment, reg *TokenAdapterRegistry, sel uint64, 
 	}
 
 	// Try to normalize ref.Address before doing any lookups
-	maybeNormalized, err := TryNormalizeAddressRef(sel, ref)
+	maybeNormalized, err := ccipdeploy.TryNormalizeAddressRef(sel, ref)
 	if err != nil {
 		return datastore.AddressRef{}, fmt.Errorf("failed to normalize address ref (%s) for chain selector %d: %w", datastore_utils.SprintRef(ref), sel, err)
 	}

--- a/integration-tests/deployment/tokens_and_token_pools_test.go
+++ b/integration-tests/deployment/tokens_and_token_pools_test.go
@@ -1383,7 +1383,7 @@ func TestTryNormalizeAddressRef(t *testing.T) {
 
 	t.Run("empty_address_returns_clone", func(t *testing.T) {
 		ref := datastore.AddressRef{ChainSelector: evmChainSel}
-		got, err := tokensapi.TryNormalizeAddressRef(evmChainSel, ref)
+		got, err := deployapi.TryNormalizeAddressRef(evmChainSel, ref)
 		require.NoError(t, err)
 		require.Empty(t, got.Address)
 	})
@@ -1393,7 +1393,7 @@ func TestTryNormalizeAddressRef(t *testing.T) {
 			Address:       "0xe939c02e92e9e66d1f0d8e4f099e7d3d269a8a11",
 			ChainSelector: 0,
 		}
-		_, err := tokensapi.TryNormalizeAddressRef(0, ref)
+		_, err := deployapi.TryNormalizeAddressRef(0, ref)
 		require.Error(t, err)
 	})
 
@@ -1403,7 +1403,7 @@ func TestTryNormalizeAddressRef(t *testing.T) {
 			Address:       lower,
 			ChainSelector: evmChainSel,
 		}
-		got, err := tokensapi.TryNormalizeAddressRef(evmChainSel, ref)
+		got, err := deployapi.TryNormalizeAddressRef(evmChainSel, ref)
 		require.NoError(t, err)
 		want := common.HexToAddress(lower).Hex()
 		require.Equal(t, want, got.Address)
@@ -1415,7 +1415,7 @@ func TestTryNormalizeAddressRef(t *testing.T) {
 			Address:       "not-valid-base58!!!",
 			ChainSelector: solChainSel,
 		}
-		_, err := tokensapi.TryNormalizeAddressRef(solChainSel, ref)
+		_, err := deployapi.TryNormalizeAddressRef(solChainSel, ref)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "failed to normalize address")
 	})
@@ -1426,7 +1426,7 @@ func TestTryNormalizeAddressRef(t *testing.T) {
 			Address:       canon,
 			ChainSelector: solChainSel,
 		}
-		got, err := tokensapi.TryNormalizeAddressRef(solChainSel, ref)
+		got, err := deployapi.TryNormalizeAddressRef(solChainSel, ref)
 		require.NoError(t, err)
 		require.Equal(t, canon, got.Address)
 	})


### PR DESCRIPTION
# Normalize address refs before ownership and datastore lookups

## Problem

Deployment changesets accept `datastore.AddressRef` values from YAML/config that may include a raw address string. Datastore lookups filter on exact address equality. On EVM chains, addresses in the datastore are stored EIP-55 checksummed; user input often arrives as all-lowercase hex. The same class of mismatch exists for Solana base58 canonicalization. A correct address in the wrong string form fails lookup with “expected exactly 1 ref, found 0” even though the contract is present.

Transfer ownership was particularly exposed: `ContractRef` inputs on the accept and transfer ownership changesets could include address-only or address-partial refs that never passed through the normalization path already used elsewhere in the tokens package.

## What this adds

A shared `TryNormalizeAddressRef` in `deployment/deploy`, colocated with the existing `AddressNormalizer` interface and family-keyed registry. Callers normalize an `AddressRef`’s `Address` field (when set) using the normalizer registered for the chain family derived from the caller-supplied chain selector, then proceed with existing datastore resolution.

The accept and transfer ownership changesets normalize before `FindAndFormatRef` when resolving `ContractRef` from config. The duplicate implementation that lived in `deployment/tokens` is removed; token changesets call into `deploy` instead. Revoke admin role applies the same pattern where it resolves token refs from config.

## Design choices

**Package ownership.** Normalization belongs in `deploy` because `AddressNormalizer`, its registry, and chain-family registration already live there. Token code was importing deploy only for the registry; owning the helper in tokens duplicated infrastructure and drifted from the documented model (family-keyed normalizers registered from adapter `init()` hooks).

**Opt-in, not built into `FindAndFormatRef`.** Normalization stays an explicit pre-step at call sites that accept user/config addresses. Not every `FindAndFormatRef` caller needs it—internal paths that produce refs from deployment sequences already emit canonical forms. Baking normalization into the datastore helper would change behavior broadly and hide which inputs are user-supplied vs machine-generated.

**`TransferToTimelock` left unchanged.** That helper is called programmatically from other changesets (FeeQuoter upgrade, deploy chain contracts) with refs produced by deployment sequences—already complete and canonical, and often not yet written to the datastore when ownership transfer runs. Adding normalize or `FindAndFormatRef` there would either be redundant or break pre-datastore refs. Config-driven ownership transfer goes through the accept/transfer ownership changesets instead, which is where normalization belongs.

**“Try” semantics.** When no normalizer is registered for a chain family, the function returns the ref unchanged rather than erroring. New or unsupported families can still flow through with raw strings until an adapter registers a normalizer. Invalid addresses for a family that *does* have a normalizer still fail hard.

**Chain selector from context, not from the ref.** The caller’s chain selector (map key, per-chain input field, etc.) wins over `ref.ChainSelector`. Config refs often omit or stale-populate the selector; the surrounding changeset context is authoritative.

**Partial refs unchanged.** Fully empty refs short-circuit with no mutation. Refs with type/version but no address skip address normalization and still resolve via non-address filters—the common case for “give me the Router at v1.6.0” style inputs.

**Inline duplication in transfer ownership changesets.** The normalize-then-resolve loop is repeated in accept and transfer apply paths rather than extracted to a shared helper. Each path keeps its error return shape and control flow local; the logic is small and identical by intent.

## Scope boundaries

This change does not alter adapter sequences, MCMS proposal construction, `TransferToTimelock`, or how refs are written to the datastore. It does not add normalizers for chain families that lack them. Other changesets that call `FindAndFormatRef` on user input without normalizing first are unchanged—same pre-existing gap, not expanded scope for this PR.
