### PR TITLE
feat: reduce TTFC datastore lookups

### DIFF
--- a/chains/evm/deployment/v1_0_0/adapters/fees.go
+++ b/chains/evm/deployment/v1_0_0/adapters/fees.go
@@ -10,8 +10,10 @@ import (
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
 	evm_datastore_utils "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/datastore"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/type_and_version"
 	routerops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/operations/router"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/fees"
+	cciputils "github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 )
 
@@ -65,19 +67,29 @@ func (a *EVMFeeResolver) GetOnRampRef(b cldf_ops.Bundle, chains cldf_chain.Block
 	}
 
 	// NOTE: the OnRamp ContractType varies between v1.5 and v1.6. For v1.5 it's `EVM2EVMOnRamp` and
-	// for v1.6 it's `OnRamp`, so we should avoid filtering on the ContractType otherwise the search
-	// may be too restrictive and this call will incorrectly fail
+	// for v1.6 it's `OnRamp`, so we use `typeAndVersion()` to resolve the type and version directly
+	// from on-chain data rather than relying on the datastore.
 	b.Logger.Infof("Found OnRamp address %s for src %d and dst %d", onRampAddr.Hex(), src, dst)
-	onRampRef, err := datastore_utils.FindAndFormatRef(
-		ds,
-		datastore.AddressRef{ChainSelector: src, Address: onRampAddr.Hex()},
-		src,
-		datastore_utils.FullRef,
+	tvReport, err := cldf_ops.ExecuteOperation(
+		b,
+		type_and_version.GetTypeAndVersion,
+		srcChain,
+		contract.FunctionInput[struct{}]{
+			ChainSelector: src,
+			Address:       onRampAddr,
+		},
 	)
 	if err != nil {
-		return datastore.AddressRef{}, fmt.Errorf("failed to find OnRamp address ref for address %s on chain selector %d: %w", getOnRampReport.Output.Hex(), src, err)
+		return datastore.AddressRef{}, fmt.Errorf("failed to get typeAndVersion for OnRamp at %s on chain selector %d: %w", onRampAddr.Hex(), src, err)
 	}
 
+	onRampRef := datastore.AddressRef{
+		ChainSelector: src,
+		Qualifier:     cciputils.DefaultQualifier(onRampAddr.Hex(), tvReport.Output.Type),
+		Type:          datastore.ContractType(tvReport.Output.Type),
+		Version:       tvReport.Output.Version,
+		Address:       onRampAddr.Hex(),
+	}
 	b.Logger.Infof(
 		"OnRamp ref for src %d and dst %d: %s",
 		src, dst, datastore_utils.SprintRef(onRampRef),

--- a/chains/evm/deployment/v1_0_0/adapters/token_adapter.go
+++ b/chains/evm/deployment/v1_0_0/adapters/token_adapter.go
@@ -169,7 +169,7 @@ func (a *EVMTokenBase) ResolveTokenPoolRef(b cldf_ops.Bundle, chains cldf_chain.
 	// all versions (v1.5.x, v1.6.x, v2.x.x) so we use the v1.5.x generated bindings
 	// here for simplicity instead of overcomplicating the code with a switch on the
 	// pool version.
-	qualifier := fmt.Sprintf("%s-%s", poolAddress, tv.Output.Type)
+	qualifier := cciputils.DefaultQualifier(poolAddress.Hex(), tv.Output.Type)
 	if token, err := cldf_ops.ExecuteOperation(b,
 		token_pool.GetToken, chain,
 		contract.FunctionInput[any]{

--- a/chains/evm/deployment/v1_6_0/adapters/fees.go
+++ b/chains/evm/deployment/v1_6_0/adapters/fees.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	datastore_utils_evm "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/datastore"
 	adaptersV1_0_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/adapters"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/type_and_version"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/operations/fee_quoter"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/operations/onramp"
 	evmseqV1_6_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/sequences"
@@ -14,7 +15,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/deployment/fees"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/lanes"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
-	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
@@ -79,22 +79,31 @@ func (a *FeesAdapter) GetFeeContractRef(b operations.Bundle, chains cldf_chain.B
 		return datastore.AddressRef{}, fmt.Errorf("failed to execute GetDynamicConfig operation for OnRamp at %s on chain selector %d with dst %d: %w", onRampAddr.Hex(), src, dst, err)
 	}
 
-	// NOTE: version is omitted intentionally here - we could have a v1.6 OnRamp connected to a v2.0 FQ for example
-	fqRef, err := datastore_utils.FindAndFormatRef(
-		ds,
-		datastore.AddressRef{
-			ChainSelector: src,
-			Address:       report.Output.FeeQuoter.Hex(),
-			Type:          datastore.ContractType(fqops.ContractType),
-		},
-		src,
-		datastore_utils.FullRef,
-	)
-	if err != nil {
-		return datastore.AddressRef{}, fmt.Errorf("failed to find FeeQuoter address ref in datastore for address %s on chain selector %d: %w", report.Output.FeeQuoter.Hex(), src, err)
+	fqAddr := report.Output.FeeQuoter
+	if fqAddr == (common.Address{}) {
+		return datastore.AddressRef{}, fmt.Errorf("onRamp at %s on chain selector %d returned zero address for FeeQuoter for dst %d", onRampAddr.Hex(), src, dst)
 	}
 
-	return fqRef, nil
+	tvReport, err := operations.ExecuteOperation(
+		b,
+		type_and_version.GetTypeAndVersion,
+		chain,
+		contract.FunctionInput[struct{}]{
+			ChainSelector: src,
+			Address:       fqAddr,
+		},
+	)
+	if err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("failed to get typeAndVersion for FeeQuoter at %s on chain selector %d: %w", fqAddr.Hex(), src, err)
+	}
+
+	return datastore.AddressRef{
+		ChainSelector: src,
+		Qualifier:     utils.DefaultQualifier(fqAddr.Hex(), tvReport.Output.Type),
+		Type:          datastore.ContractType(tvReport.Output.Type),
+		Version:       tvReport.Output.Version,
+		Address:       fqAddr.Hex(),
+	}, nil
 }
 
 func (a *FeesAdapter) GetDefaultTokenTransferFeeConfig(src uint64, dst uint64) fees.TokenTransferFeeArgs {
@@ -208,7 +217,8 @@ func (a *FeesAdapter) SetTokenTransferFee(_ datastore.DataStore, feeRef datastor
 
 			var res sequences.OnChainOutput
 			for selector, updatesByChain := range args {
-				res, err = sequences.RunAndMergeSequence(b, chains,
+				res, err = sequences.RunAndMergeSequence(
+					b, chains,
 					evmseqV1_6_0.FeeQuoterApplyTokenTransferFeeConfigUpdatesSequence,
 					evmseqV1_6_0.FeeQuoterApplyTokenTransferFeeConfigUpdatesSequenceInput{
 						UpdatesByChain: updatesByChain,
@@ -306,7 +316,8 @@ func (a *FeesAdapter) ApplyDestChainConfigUpdates(_ datastore.DataStore, feeRef 
 
 			var res sequences.OnChainOutput
 			for selector, updates := range args {
-				res, err = sequences.RunAndMergeSequence(b, chains,
+				res, err = sequences.RunAndMergeSequence(
+					b, chains,
 					evmseqV1_6_0.FeeQuoterApplyDestChainConfigUpdatesSequence,
 					evmseqV1_6_0.FeeQuoterApplyDestChainConfigUpdatesSequenceInput{
 						Address:        fqAddr,

--- a/chains/evm/deployment/v2_0_0/adapters/fees.go
+++ b/chains/evm/deployment/v2_0_0/adapters/fees.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	datastore_utils_evm "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/datastore"
 	v1_0_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/adapters"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/type_and_version"
 	evmseqV1_6_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/sequences"
 	fqops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/fee_quoter"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/onramp"
@@ -14,7 +15,6 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/deployment/fees"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/lanes"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
-	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
@@ -79,22 +79,31 @@ func (a *FeesAdapter) GetFeeContractRef(b operations.Bundle, chains cldf_chain.B
 		return datastore.AddressRef{}, fmt.Errorf("failed to execute GetDynamicConfig operation for OnRamp at %s on chain selector %d with dst %d: %w", onRampAddr.Hex(), src, dst, err)
 	}
 
-	// NOTE: version is omitted intentionally here - we could have a v2.0 OnRamp connected to a v1.6 FQ for example
-	fqRef, err := datastore_utils.FindAndFormatRef(
-		ds,
-		datastore.AddressRef{
-			ChainSelector: src,
-			Address:       report.Output.FeeQuoter.Hex(),
-			Type:          datastore.ContractType(fqops.ContractType),
-		},
-		src,
-		datastore_utils.FullRef,
-	)
-	if err != nil {
-		return datastore.AddressRef{}, fmt.Errorf("failed to find FeeQuoter address ref in datastore for address %s on chain selector %d: %w", report.Output.FeeQuoter.Hex(), src, err)
+	fqAddr := report.Output.FeeQuoter
+	if fqAddr == (common.Address{}) {
+		return datastore.AddressRef{}, fmt.Errorf("onRamp at %s on chain selector %d returned zero address for FeeQuoter for dst %d", onRampAddr.Hex(), src, dst)
 	}
 
-	return fqRef, nil
+	tvReport, err := operations.ExecuteOperation(
+		b,
+		type_and_version.GetTypeAndVersion,
+		chain,
+		contract.FunctionInput[struct{}]{
+			ChainSelector: src,
+			Address:       fqAddr,
+		},
+	)
+	if err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("failed to get typeAndVersion for FeeQuoter at %s on chain selector %d: %w", fqAddr.Hex(), src, err)
+	}
+
+	return datastore.AddressRef{
+		ChainSelector: src,
+		Qualifier:     utils.DefaultQualifier(fqAddr.Hex(), tvReport.Output.Type),
+		Type:          datastore.ContractType(tvReport.Output.Type),
+		Version:       tvReport.Output.Version,
+		Address:       fqAddr.Hex(),
+	}, nil
 }
 
 func (a *FeesAdapter) GetDefaultTokenTransferFeeConfig(src uint64, dst uint64) fees.TokenTransferFeeArgs {
@@ -202,7 +211,8 @@ func (a *FeesAdapter) SetTokenTransferFee(_ datastore.DataStore, feeRef datastor
 
 			var res sequences.OnChainOutput
 			for selector, updatesByChain := range args {
-				res, err = sequences.RunAndMergeSequence(b, chains,
+				res, err = sequences.RunAndMergeSequence(
+					b, chains,
 					evmseq.SequenceFeeQuoterUpdate,
 					evmseq.FeeQuoterUpdate{
 						ExistingAddresses:             []datastore.AddressRef{feeRef},

--- a/deployment/utils/common.go
+++ b/deployment/utils/common.go
@@ -134,6 +134,13 @@ var (
 	Version_2_0_0 = semver.MustParse("2.0.0")
 )
 
+// DefaultQualifier returns a synthetic qualifier constructed from an address and
+// contract type. Used when a qualifier cannot be obtained from the datastore,
+// e.g. when resolving contract refs from on-chain data via typeAndVersion().
+func DefaultQualifier(address string, contractType cldf.ContractType) string {
+	return fmt.Sprintf("%s-%s", address, contractType)
+}
+
 // StripPatchVersion returns a copy of the version with the patch component set
 // to 0, preserving major and minor. Useful for adapter registry lookups where
 // patch versions should not affect compatibility.


### PR DESCRIPTION
# Reduce datastore lookups in SetTokenTransferFee (EVM)

## Background

The `SetTokenTransferFee` changeset resolves which fee contract to configure through a two-step version inference chain: the Router is queried on-chain to find the currently configured OnRamp, and then the OnRamp's dynamic config is queried to find the currently configured FeeQuoter. Both of these on-chain reads return bare addresses. Previously, the code then performed additional datastore lookups to enrich those bare addresses into fully-typed `AddressRef` values (with `Type`, `Version`, and `Qualifier` fields populated from stored metadata).

This created an implicit coupling between the fee configuration path and the accuracy of the datastore's address index — if the datastore was out of sync or the entry was missing, the operation would fail even though all the necessary information was already available on-chain.

## What this PR does

For EVM chains, the datastore-based address enrichment for the OnRamp and FeeQuoter is replaced with on-chain `typeAndVersion()` calls. Every CCIP contract implements `ITypeAndVersion`, which exposes a `typeAndVersion()` view function returning a string like `"OnRamp 1.6.0"` or `"FeeQuoter 1.6.3"`. This string contains all the information needed to construct a fully-typed `AddressRef` without touching the datastore.

The router lookup in `GetOnRampRef` remains datastore-backed. The Router is rarely re-deployed and the datastore is the appropriate canonical source for its address; this is the intended exception.

Solana adapters are unchanged. The Solana `FeeResolver` and `FeesAdapter` continue to use datastore lookups as before.

## Design choices

**Qualifier construction.** `AddressRef` has a `Qualifier` field that the datastore uses as part of its record key (`{ChainSelector, Type, Version, Qualifier}`). On-chain data has no notion of a qualifier, so one is synthesized as `"<address>-<contractType>"` — the same convention already used in `ResolveTokenPoolRef` for token pool refs. This produces a stable, unique qualifier per contract instance per chain.

**`DefaultQualifier` helper.** Rather than scattering the `fmt.Sprintf("%s-%s", addr, contractType)` format inline, a `DefaultQualifier(address string, contractType cldf.ContractType) string` helper was added to `deployment/utils/common.go` and all call sites (including the pre-existing one in `token_adapter.go`) were updated to use it. This makes the synthetic qualifier convention explicit, named, and findable.

**Operations caching.** The `typeAndVersion()` call goes through the operations framework's `ExecuteOperation`, which caches results within a bundle by (operation, input). For a given source chain with multiple destination chains, the OnRamp address is typically the same across all destinations, meaning `typeAndVersion()` is called at most once per unique contract address regardless of how many `(src, dst)` pairs are being processed.

**Zero address guard.** Both v1.6 and v2.0 `GetFeeContractRef` now validate that the FeeQuoter address returned by `GetDynamicConfig` is non-zero before calling `typeAndVersion()` on it, producing a clear error message rather than a confusing RPC failure against the zero address.

**Type casting.** `typeAndVersion()` returns `Type` as `deployment.ContractType` while `AddressRef.Type` is `datastore.ContractType`. These are distinct named string types from different packages requiring an explicit cast — `datastore.ContractType(tv.Output.Type)` — consistent with how `token_adapter.go` already handles this.
