### PR TITLE
fix(commit): make observations non-blocking on stuck ops (#2193)

### DIFF
--- a/commit/chainfee/observation.go
+++ b/commit/chainfee/observation.go
@@ -36,29 +36,26 @@ func (p *processor) Observation(
 		p.obs.invalidateCaches(ctx, lggr)
 	}
 
-	var (
-		feeComponents     map[cciptypes.ChainSelector]types.ChainFeeComponents
-		nativeTokenPrices map[cciptypes.ChainSelector]cciptypes.BigInt
-		chainFeeUpdates   map[cciptypes.ChainSelector]Update
-		fChain            map[cciptypes.ChainSelector]int
-	)
-
 	operations := asynclib.AsyncNoErrOperationsMap{
-		"getChainsFeeComponents": func(ctx context.Context, l logger.Logger) {
-			feeComponents = p.obs.getChainsFeeComponents(ctx, l)
+		"getChainsFeeComponents": func(ctx context.Context, l logger.Logger) any {
+			return p.obs.getChainsFeeComponents(ctx, l)
 		},
-		"getNativeTokenPrices": func(ctx context.Context, l logger.Logger) {
-			nativeTokenPrices = p.obs.getNativeTokenPrices(ctx, l)
+		"getNativeTokenPrices": func(ctx context.Context, l logger.Logger) any {
+			return p.obs.getNativeTokenPrices(ctx, l)
 		},
-		"getChainFeePriceUpdates": func(ctx context.Context, l logger.Logger) {
-			chainFeeUpdates = p.obs.getChainFeePriceUpdates(ctx, l)
+		"getChainFeePriceUpdates": func(ctx context.Context, l logger.Logger) any {
+			return p.obs.getChainFeePriceUpdates(ctx, l)
 		},
-		"observeFChain": func(_ context.Context, l logger.Logger) {
-			fChain = p.observeFChain(l)
+		"observeFChain": func(_ context.Context, l logger.Logger) any {
+			return p.observeFChain(l)
 		},
 	}
 
-	asynclib.WaitForAllNoErrOperations(ctx, p.cfg.ChainFeeAsyncObserverSyncTimeout, operations, lggr)
+	results := p.runner.WaitForAll(ctx, p.cfg.ChainFeeAsyncObserverSyncTimeout, operations, lggr)
+	feeComponents, _ := results["getChainsFeeComponents"].(map[cciptypes.ChainSelector]types.ChainFeeComponents)
+	nativeTokenPrices, _ := results["getNativeTokenPrices"].(map[cciptypes.ChainSelector]cciptypes.BigInt)
+	chainFeeUpdates, _ := results["getChainFeePriceUpdates"].(map[cciptypes.ChainSelector]Update)
+	fChain, _ := results["observeFChain"].(map[cciptypes.ChainSelector]int)
 	now := time.Now().UTC()
 
 	chainsWithNativeTokenPrices := mapset.NewSet(slices.Collect(maps.Keys(feeComponents))...).

--- a/commit/chainfee/observation_test.go
+++ b/commit/chainfee/observation_test.go
@@ -20,11 +20,13 @@ import (
 
 	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
+	"github.com/smartcontractkit/chainlink-ccip/internal/libs/asynclib"
 	plugincommon2 "github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
 	"github.com/smartcontractkit/chainlink-ccip/mocks/internal_/plugincommon"
 	reader2 "github.com/smartcontractkit/chainlink-ccip/mocks/internal_/reader"
 	"github.com/smartcontractkit/chainlink-ccip/mocks/pkg/reader"
 	reader3 "github.com/smartcontractkit/chainlink-ccip/pkg/reader"
+	"github.com/smartcontractkit/chainlink-ccip/pluginconfig"
 )
 
 func Test_processor_Observation(t *testing.T) {
@@ -133,6 +135,10 @@ func Test_processor_Observation(t *testing.T) {
 				homeChain:       homeChain,
 				metricsReporter: plugincommon2.NoopReporter{},
 				obs:             newBaseObserver(ccipReader, tc.dstChain, oracleID, cs),
+				runner:          asynclib.NewRunner(),
+				// Non-zero so the async runner's per-round timeout doesn't fire before the (fast)
+				// mock ops complete; production applies this default in config validation.
+				cfg: pluginconfig.CommitOffchainConfig{ChainFeeAsyncObserverSyncTimeout: 10 * time.Second},
 			}
 
 			supportedSet := mapset.NewSet(tc.supportedChains...)
@@ -344,6 +350,10 @@ func Test_unique_chain_filter_in_Observation(t *testing.T) {
 				homeChain:       homeChain,
 				metricsReporter: plugincommon2.NoopReporter{},
 				obs:             newBaseObserver(ccipReader, tc.dstChain, oracleID, cs),
+				runner:          asynclib.NewRunner(),
+				// Non-zero so the async runner's per-round timeout doesn't fire before the (fast)
+				// mock ops complete; production applies this default in config validation.
+				cfg: pluginconfig.CommitOffchainConfig{ChainFeeAsyncObserverSyncTimeout: 10 * time.Second},
 			}
 
 			supportedSet := mapset.NewSet(tc.supportedChains...)

--- a/commit/chainfee/processor.go
+++ b/commit/chainfee/processor.go
@@ -8,6 +8,7 @@ import (
 
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
+	"github.com/smartcontractkit/chainlink-ccip/internal/libs/asynclib"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
 	"github.com/smartcontractkit/chainlink-ccip/internal/reader"
 	readerpkg "github.com/smartcontractkit/chainlink-ccip/pkg/reader"
@@ -26,6 +27,7 @@ type processor struct {
 	metricsReporter plugincommon.MetricsReporter
 	fRoleDON        int
 	obs             observer
+	runner          *asynclib.Runner
 }
 
 func NewProcessor(
@@ -68,6 +70,7 @@ func NewProcessor(
 		cfg:             offChainConfig,
 		metricsReporter: metricsReporter,
 		obs:             obs,
+		runner:          asynclib.NewRunner(),
 	}
 	return plugincommon.NewTrackedProcessor(lggr, p, processorLabel, metricsReporter)
 }

--- a/commit/plugin_e2e_test.go
+++ b/commit/plugin_e2e_test.go
@@ -1007,7 +1007,12 @@ func defaultNodeParams(t *testing.T) SetupNodeParams {
 		MerkleRootAsyncObserverDisabled: true, // we want to keep it disabled since this test is deterministic
 		ChainFeeAsyncObserverDisabled:   true,
 		TokenPriceAsyncObserverDisabled: true,
-		DonBreakingChangesVersion:       pluginconfig.DonBreakingChangesVersion1RoleDonSupport,
+		// Non-zero per-round observation timeouts so the async runner doesn't time out before the
+		// (synchronous, mocked) observers complete; production applies these defaults in config
+		// validation.
+		ChainFeeAsyncObserverSyncTimeout:   10 * time.Second,
+		TokenPriceAsyncObserverSyncTimeout: *commonconfig.MustNewDuration(10 * time.Second),
+		DonBreakingChangesVersion:          pluginconfig.DonBreakingChangesVersion1RoleDonSupport,
 	}
 
 	reportingCfg := ocr3types.ReportingPluginConfig{F: 1, ConfigDigest: digest}

--- a/commit/plugin_roledon_e2e_test.go
+++ b/commit/plugin_roledon_e2e_test.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"slices"
 	"testing"
+	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	chainsel "github.com/smartcontractkit/chain-selectors"
@@ -16,6 +17,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/types/ccip/consts"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
@@ -411,7 +413,12 @@ func (s roleDonTestSetup) newRoleDonTestPlugin(oracleID commontypes.OracleID, in
 			MerkleRootAsyncObserverDisabled: true,
 			ChainFeeAsyncObserverDisabled:   true,
 			TokenPriceAsyncObserverDisabled: true,
-			DonBreakingChangesVersion:       pluginconfig.DonBreakingChangesVersion1RoleDonSupport,
+			// Non-zero per-round observation timeouts so the async runner doesn't time out before
+			// the (synchronous, mocked) observers complete; production defaults these in config
+			// validation.
+			ChainFeeAsyncObserverSyncTimeout:   10 * time.Second,
+			TokenPriceAsyncObserverSyncTimeout: *commonconfig.MustNewDuration(10 * time.Second),
+			DonBreakingChangesVersion:          pluginconfig.DonBreakingChangesVersion1RoleDonSupport,
 		},
 		s.destChain,
 		deps.ccipReader,

--- a/commit/tokenprice/observation.go
+++ b/commit/tokenprice/observation.go
@@ -31,25 +31,23 @@ func (p *processor) Observation(
 		p.obs.invalidateCaches(ctx, lggr)
 	}
 
-	var (
-		fChain           map[cciptypes.ChainSelector]int
-		feedTokenPrices  cciptypes.TokenPriceMap
-		feeQuoterUpdates map[cciptypes.UnknownEncodedAddress]cciptypes.TimestampedBig
-	)
-
 	operations := asynclib.AsyncNoErrOperationsMap{
-		"observeFeedTokenPrices": func(ctx context.Context, l logger.Logger) {
-			feedTokenPrices = p.obs.observeFeedTokenPrices(ctx, l)
+		"observeFeedTokenPrices": func(ctx context.Context, l logger.Logger) any {
+			return p.obs.observeFeedTokenPrices(ctx, l)
 		},
-		"observeFeeQuoterTokenUpdates": func(ctx context.Context, l logger.Logger) {
-			feeQuoterUpdates = p.obs.observeFeeQuoterTokenUpdates(ctx, l)
+		"observeFeeQuoterTokenUpdates": func(ctx context.Context, l logger.Logger) any {
+			return p.obs.observeFeeQuoterTokenUpdates(ctx, l)
 		},
-		"observeFChain": func(_ context.Context, l logger.Logger) {
-			fChain = p.observeFChain(l)
+		"observeFChain": func(_ context.Context, l logger.Logger) any {
+			return p.observeFChain(l)
 		},
 	}
 
-	asynclib.WaitForAllNoErrOperations(ctx, p.offChainCfg.TokenPriceAsyncObserverSyncTimeout.Duration(), operations, lggr)
+	results := p.runner.WaitForAll(ctx, p.offChainCfg.TokenPriceAsyncObserverSyncTimeout.Duration(), operations, lggr)
+	feedTokenPrices, _ := results["observeFeedTokenPrices"].(cciptypes.TokenPriceMap)
+	feeQuoterUpdatesRaw := results["observeFeeQuoterTokenUpdates"]
+	feeQuoterUpdates, _ := feeQuoterUpdatesRaw.(map[cciptypes.UnknownEncodedAddress]cciptypes.TimestampedBig)
+	fChain, _ := results["observeFChain"].(map[cciptypes.ChainSelector]int)
 	now := time.Now().UTC()
 
 	lggr.Infow(

--- a/commit/tokenprice/observation_test.go
+++ b/commit/tokenprice/observation_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
+
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -190,4 +192,7 @@ var defaultCfg = pluginconfig.CommitOffchainConfig{
 	PriceFeedChainSelector: feedChainSel,
 	// Have this disabled for testing purposes
 	TokenPriceAsyncObserverDisabled: true,
+	// Non-zero so the async runner's per-round timeout doesn't fire before the (fast) mock ops
+	// complete; production applies this default in config validation.
+	TokenPriceAsyncObserverSyncTimeout: *commonconfig.MustNewDuration(10 * time.Second),
 }

--- a/commit/tokenprice/processor.go
+++ b/commit/tokenprice/processor.go
@@ -10,6 +10,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types/ccip/consts"
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
+	"github.com/smartcontractkit/chainlink-ccip/internal/libs/asynclib"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
 	"github.com/smartcontractkit/chainlink-ccip/internal/reader"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/logutil"
@@ -29,6 +30,7 @@ type processor struct {
 	metricsReporter  plugincommon.MetricsReporter
 	fRoleDON         int
 	obs              observer
+	runner           *asynclib.Runner
 }
 
 func NewProcessor(
@@ -71,6 +73,7 @@ func NewProcessor(
 		fRoleDON:         fRoleDON,
 		metricsReporter:  metricsReporter,
 		obs:              obs,
+		runner:           asynclib.NewRunner(),
 	}
 	return plugincommon.NewTrackedProcessor(lggr, p, processorsLabel, metricsReporter)
 }

--- a/internal/libs/asynclib/goroutines.go
+++ b/internal/libs/asynclib/goroutines.go
@@ -2,39 +2,126 @@ package asynclib
 
 import (
 	"context"
+	"maps"
 	"sync"
 	"time"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
-type AsyncNoErrOperationsMap map[string]func(ctx context.Context, l logger.Logger)
+// AsyncNoErrOperationsMap maps an operation name to a function that performs the operation and
+// returns its result. Operations must not return an error; recoverable failures should be handled
+// internally (e.g. by returning an empty/zero result and logging).
+type AsyncNoErrOperationsMap map[string]func(ctx context.Context, l logger.Logger) any
 
-// WaitForAllNoErrOperations spawns goroutines for each operation in the map and waits for
-// all of them to finish. It creates a child context with a timeout to ensure that the operations
-// do not run indefinitely.
-func WaitForAllNoErrOperations(
+// Runner executes a set of named operations concurrently on each call to WaitForAll. It bounds the
+// number of goroutines it spawns: it never starts a second goroutine for an operation whose previous
+// invocation is still running. A still-running operation is treated as stuck and skipped
+// for the current round, so a wedged dependency (i.e. stuck LOOP plugin)
+// cannot cause goroutines to accumulate across rounds.
+//
+// A Runner is safe for concurrent use and is intended to be created once and reused across rounds
+// so that its in-flight tracking persists between calls.
+type Runner struct {
+	mu       sync.Mutex
+	inFlight map[string]bool
+}
+
+// NewRunner returns a ready-to-use Runner.
+func NewRunner() *Runner {
+	return &Runner{inFlight: make(map[string]bool)}
+}
+
+// WaitForAll runs each operation in its own goroutine under a child context bounded by timeout, and
+// returns a map of the results of the operations that COMPLETED within the timeout. Operations that
+// do not complete in time (or whose previous invocation is still running) are absent from the
+// returned map, so callers should treat a missing key as "no fresh result this round" (its zero
+// value) rather than blocking on it.
+//
+// WaitForAll never blocks past the timeout, even if an operation ignores context cancellation. Such
+// an operation's goroutine is abandoned (it keeps running until it returns on its own), but:
+//   - it is not re-spawned on subsequent rounds while it remains in flight, so goroutines do not
+//     accumulate; and
+//   - its late result is discarded rather than served, so consensus never acts on stale data.
+//
+// This trades a bounded, loudly-logged goroutine leak in the rare stuck case for guaranteed
+// liveness of the caller.
+func (r *Runner) WaitForAll(
 	ctx context.Context,
 	timeout time.Duration,
 	operations AsyncNoErrOperationsMap,
 	lggr logger.Logger,
-) {
+) map[string]any {
 	callCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	lggr.Debugw("spawning goroutines", "timeout", timeout)
+	lggr.Debugw("spawning operation goroutines", "timeout", timeout)
 
-	var wg sync.WaitGroup
-	wg.Add(len(operations))
+	// results is scoped to this round: the returned snapshot is cloned from it, and any late write
+	// from an abandoned goroutine lands here (never in a future round's map), so stale results are
+	// never served.
+	var (
+		resMu   sync.Mutex
+		results = make(map[string]any)
+	)
+	// Buffered to the number of operations so a late-finishing (abandoned) goroutine can always
+	// signal completion without blocking, even after we have stopped waiting.
+	doneCh := make(chan struct{}, len(operations))
 
+	spawned := 0
 	for opName, op := range operations {
-		go func(opName string, op func(context.Context, logger.Logger)) {
-			defer wg.Done()
+		r.mu.Lock()
+		if r.inFlight[opName] {
+			r.mu.Unlock()
+			// A goroutine from a previous round is still running for this op: don't pile on.
+			lggr.Warnw("skipping operation: previous invocation still running (likely stuck)", "opID", opName)
+			continue
+		}
+		r.inFlight[opName] = true
+		r.mu.Unlock()
+
+		spawned++
+		go func(opName string, op func(context.Context, logger.Logger) any) {
+			defer func() { doneCh <- struct{}{} }()
+			defer func() {
+				r.mu.Lock()
+				r.inFlight[opName] = false
+				r.mu.Unlock()
+			}()
+
 			tStart := time.Now()
-			op(callCtx, logger.With(lggr, "opID", opName))
-			lggr.Debugw("observing goroutine finished", "opID", opName, "duration", time.Since(tStart))
+			res := op(callCtx, logger.With(lggr, "opID", opName))
+			resMu.Lock()
+			results[opName] = res
+			resMu.Unlock()
+			lggr.Debugw("operation goroutine finished", "opID", opName, "duration", time.Since(tStart))
 		}(opName, op)
 	}
 
-	wg.Wait()
+	// Wait for the spawned operations to finish, or the timeout to elapse, whichever comes first.
+	timedOut := false
+waitLoop:
+	for range spawned {
+		select {
+		case <-doneCh:
+		case <-callCtx.Done():
+			timedOut = true
+			break waitLoop
+		}
+	}
+	if timedOut {
+		lggr.Errorw(
+			"timed out waiting for async operations; proceeding with completed results only",
+			"timeout", timeout,
+			"err", context.Cause(callCtx),
+		)
+	}
+
+	resMu.Lock()
+	defer resMu.Unlock()
+
+	// Clone to avoid a data race: a late-finishing (abandoned) goroutine
+	// may still write to results after we return it, so the
+	// returned map must be a snapshot of the results at this point in time.
+	return maps.Clone(results)
 }

--- a/internal/libs/asynclib/goroutines_test.go
+++ b/internal/libs/asynclib/goroutines_test.go
@@ -2,89 +2,140 @@ package asynclib
 
 import (
 	"context"
-	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
-func TestWaitForAllNoErrOperations_AllOpsRun(t *testing.T) {
-	ctx := context.Background()
-	lggr := logger.Test(t)
-	var mu sync.Mutex
-	var calledOps []string
-
-	ops := AsyncNoErrOperationsMap{
-		"op1": func(_ context.Context, _ logger.Logger) {
-			mu.Lock()
-			defer mu.Unlock()
-			calledOps = append(calledOps, "op1")
-		},
-		"op2": func(_ context.Context, _ logger.Logger) {
-			mu.Lock()
-			defer mu.Unlock()
-			calledOps = append(calledOps, "op2")
-		},
-	}
-
-	WaitForAllNoErrOperations(ctx, 2*time.Second, ops, lggr)
-
-	mu.Lock()
-	defer mu.Unlock()
-	assert.ElementsMatch(t, []string{"op1", "op2"}, calledOps)
-}
-
-func TestWaitForAllNoErrOperations_ContextTimeoutRespected(t *testing.T) {
-	ctx := context.Background()
-	lggr := logger.Test(t)
-	start := time.Now()
-
-	ops := AsyncNoErrOperationsMap{
-		"slowOp": func(ctx context.Context, _ logger.Logger) {
-			select {
-			case <-ctx.Done():
-			case <-time.After(24 * time.Hour):
-			}
-		},
-	}
-
-	timeout := 100 * time.Millisecond
-	WaitForAllNoErrOperations(ctx, timeout, ops, lggr)
-
-	elapsed := time.Since(start)
-	assert.LessOrEqual(t, elapsed.Milliseconds(), int64(500), "timeout not respected")
-}
-
-func TestWaitForAllNoErrOperations_ContextIsPropagated(t *testing.T) {
+func TestRunner_AllOpsRun(t *testing.T) {
 	ctx := context.Background()
 	lggr := logger.Test(t)
 
-	done := make(chan struct{})
-
 	ops := AsyncNoErrOperationsMap{
-		"checkCtx": func(ctx context.Context, _ logger.Logger) {
-			_, ok := ctx.Deadline()
-			assert.True(t, ok, "context should have a deadline")
-			close(done)
-		},
+		"op1": func(_ context.Context, _ logger.Logger) any { return 1 },
+		"op2": func(_ context.Context, _ logger.Logger) any { return "two" },
 	}
 
-	WaitForAllNoErrOperations(ctx, 500*time.Millisecond, ops, lggr)
+	results := NewRunner().WaitForAll(ctx, 2*time.Second, ops, lggr)
 
-	select {
-	case <-done:
-	case <-time.After(24 * time.Hour):
-		t.Fatal("operation did not complete")
-	}
+	require.Len(t, results, 2)
+	assert.Equal(t, 1, results["op1"])
+	assert.Equal(t, "two", results["op2"])
 }
 
-func TestWaitForAllNoErrOperations_NoOps(t *testing.T) {
+func TestRunner_NoOps(t *testing.T) {
 	ctx := context.Background()
 	lggr := logger.Test(t)
 
 	// should not panic or block
-	WaitForAllNoErrOperations(ctx, 500*time.Millisecond, AsyncNoErrOperationsMap{}, lggr)
+	results := NewRunner().WaitForAll(ctx, 500*time.Millisecond, AsyncNoErrOperationsMap{}, lggr)
+	assert.Empty(t, results)
+}
+
+func TestRunner_ContextIsPropagated(t *testing.T) {
+	ctx := context.Background()
+	lggr := logger.Test(t)
+
+	ops := AsyncNoErrOperationsMap{
+		"checkCtx": func(ctx context.Context, _ logger.Logger) any {
+			_, ok := ctx.Deadline()
+			assert.True(t, ok, "context should have a deadline")
+			return ok
+		},
+	}
+
+	results := NewRunner().WaitForAll(ctx, 500*time.Millisecond, ops, lggr)
+	require.Contains(t, results, "checkCtx")
+}
+
+func TestRunner_ContextHonoringOpReturnsOnTimeout(t *testing.T) {
+	ctx := context.Background()
+	// Nop logger: the op's goroutine finishes right as the timeout fires, so it may log after the
+	// test returns, which the zap test logger treats as a fatal error.
+	lggr := logger.Nop()
+	start := time.Now()
+
+	ops := AsyncNoErrOperationsMap{
+		"slowOp": func(ctx context.Context, _ logger.Logger) any {
+			select {
+			case <-ctx.Done():
+			case <-time.After(24 * time.Hour):
+			}
+			return ctx.Err()
+		},
+	}
+
+	results := NewRunner().WaitForAll(ctx, 100*time.Millisecond, ops, lggr)
+
+	assert.LessOrEqual(t, time.Since(start).Milliseconds(), int64(500), "timeout not respected")
+	// The op returns as the context is cancelled, so it may or may not be recorded; either way the
+	// call must not have blocked past the timeout, which the assertion above checks.
+	_ = results
+}
+
+// TestRunner_CtxIgnoringOpDoesNotBlock is the case that would hang the old helper: an operation that
+// ignores context cancellation. WaitForAll must still return within the timeout, and the stuck op
+// must be absent from the results (so the caller degrades to a zero value rather than blocking).
+func TestRunner_CtxIgnoringOpDoesNotBlock(t *testing.T) {
+	ctx := context.Background()
+	// Nop logger: the abandoned goroutine is released in cleanup and logs after the test returns.
+	lggr := logger.Nop()
+
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) }) // let the abandoned goroutine exit at test end
+
+	ops := AsyncNoErrOperationsMap{
+		"fastOp": func(_ context.Context, _ logger.Logger) any { return "done" },
+		"stuckOp": func(_ context.Context, _ logger.Logger) any {
+			<-release // deliberately ignores ctx
+			return "too late"
+		},
+	}
+
+	start := time.Now()
+	results := NewRunner().WaitForAll(ctx, 100*time.Millisecond, ops, lggr)
+
+	assert.LessOrEqual(t, time.Since(start).Milliseconds(), int64(500), "did not return within timeout")
+	assert.Equal(t, "done", results["fastOp"], "fast op result should be present")
+	assert.NotContains(t, results, "stuckOp", "stuck op must not appear in results")
+}
+
+// TestRunner_StuckOpNotRespawned verifies that an operation still running from a previous round is
+// not spawned again, so a wedged dependency cannot make goroutines accumulate across rounds.
+func TestRunner_StuckOpNotRespawned(t *testing.T) {
+	ctx := context.Background()
+	// Nop logger: the abandoned goroutine is released in cleanup and logs after the test returns.
+	lggr := logger.Nop()
+
+	var calls atomic.Int32
+	started := make(chan struct{}, 8)
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) })
+
+	ops := AsyncNoErrOperationsMap{
+		"stuckOp": func(_ context.Context, _ logger.Logger) any {
+			n := calls.Add(1)
+			started <- struct{}{}
+			<-release // ignores ctx: stays in flight across rounds
+			return n
+		},
+	}
+
+	r := NewRunner()
+
+	// Round 1: spawns the op, which starts and then blocks past the timeout.
+	round1 := r.WaitForAll(ctx, 50*time.Millisecond, ops, lggr)
+	<-started // ensure the op actually began
+	assert.Equal(t, int32(1), calls.Load())
+	assert.NotContains(t, round1, "stuckOp")
+
+	// Round 2: the op is still in flight, so it must be skipped (not re-spawned).
+	round2 := r.WaitForAll(ctx, 50*time.Millisecond, ops, lggr)
+	assert.Equal(t, int32(1), calls.Load(), "stuck op should not be spawned a second time")
+	assert.NotContains(t, round2, "stuckOp")
 }


### PR DESCRIPTION
* fix(commit): make observations non-blocking on stuck ops

- Replace the free WaitForAllNoErrOperations (which ended in an unconditional wg.Wait) with a stateful asynclib.Runner whose WaitForAll returns on timeout, so one operation that ignores its context can no longer hang the whole Observation / OCR round.
- Add a per-operation in-flight guard: an op whose previous invocation is still running is skipped rather than re-spawned, bounding goroutines to the number of distinct ops instead of accumulating one stuck goroutine per round.
- Return only operations that completed this round; a missing result degrades to its zero value (empty), and a late result from an abandoned goroutine is discarded rather than served, so consensus never acts on stale data.

* lint