### PR TITLE
feat: Solana 1.6 pool support in ConfigureTokenPool

### DIFF
--- a/chains/evm/deployment/v1_0_0/adapters/pool_adapter.go
+++ b/chains/evm/deployment/v1_0_0/adapters/pool_adapter.go
@@ -207,10 +207,10 @@ func (a *EVMPoolAdapter) SetTokenPoolAdmins() *cldf_ops.Sequence[tokensapi.SetTo
 			if !ok {
 				return sequences.OnChainOutput{}, fmt.Errorf("chain with selector %d not defined", input.Selector)
 			}
-			if !common.IsHexAddress(input.PoolAddress) {
-				return sequences.OnChainOutput{}, fmt.Errorf("invalid pool address for chain %d: %s", input.Selector, input.PoolAddress)
+			if !common.IsHexAddress(input.TokenPoolRef.Address) {
+				return sequences.OnChainOutput{}, fmt.Errorf("invalid pool address for chain %d: %s", input.Selector, input.TokenPoolRef.Address)
 			}
-			poolAddr := common.HexToAddress(input.PoolAddress)
+			poolAddr := common.HexToAddress(input.TokenPoolRef.Address)
 
 			var rateLimitAdmin *common.Address
 			if input.RateLimitAdmin != nil {

--- a/chains/solana/deployment/v1_6_0/operations/token_pools/burnmint.go
+++ b/chains/solana/deployment/v1_6_0/operations/token_pools/burnmint.go
@@ -570,11 +570,13 @@ var UpdateRateLimitAdminBurnMint = operations.NewOperation(
 			b.Logger.Info("Rate limit admin already matches the desired value for burn mint token pool with token mint:", input.TokenMint.String())
 			return sequences.OnChainOutput{}, nil
 		}
-		authority, err := GetAuthorityBurnMint(chain, input.Program, input.TokenMint)
+		// err here is the error from the GetAccountDataBorshInto read above, which has already
+		// returned for every error except rpc.ErrNotFound — so err != nil at this point means
+		// exactly "account absent" (the pool config account may legitimately not exist yet:
+		// under MCMS the initialize op only queues a proposal, so this op must still build its
+		// instruction). Fall back to the program upgrade authority in that case.
+		authority := chainConfig.Config.Owner
 		if err != nil {
-			// The pool config account may legitimately not exist yet: under MCMS the initialize
-			// op only queues a proposal, so this op must still build its instruction. Fall back to
-			// the program upgrade authority in that case.
 			authority, err = utils.GetUpgradeAuthority(chain.Client, input.Program)
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to get upgrade authority for burn mint token pool: %w", err)

--- a/chains/solana/deployment/v1_6_0/operations/token_pools/burnmint.go
+++ b/chains/solana/deployment/v1_6_0/operations/token_pools/burnmint.go
@@ -3,9 +3,11 @@ package token_pools
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/utils"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/base_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/burnmint_token_pool"
@@ -556,27 +558,26 @@ var UpdateRateLimitAdminBurnMint = operations.NewOperation(
 	func(b operations.Bundle, chain cldf_solana.Chain, input TokenPoolTransferOwnershipInput) (sequences.OnChainOutput, error) {
 		burnmint_token_pool.SetProgramID(input.Program)
 		poolConfigPDA, _ := tokens.TokenPoolConfigAddress(input.TokenMint, input.Program)
+		// NOTE: input.NewOwner carries the desired rate limit admin — the input type is shared
+		// with the transfer-ownership ops. BnM pool state has the same wire layout as
+		// test_token_pool.State, which is why that type is used for decoding.
 		var chainConfig test_token_pool.State
 		err := chain.GetAccountDataBorshInto(b.GetContext(), poolConfigPDA, &chainConfig)
-		if err == nil {
-			if chainConfig.Config.RateLimitAdmin == input.NewOwner {
-				b.Logger.Info("New owner is the same as the current rate limit admin for burn mint token pool with token mint:", input.TokenMint.String())
-				return sequences.OnChainOutput{}, nil
-			}
+		if err != nil && !errors.Is(err, rpc.ErrNotFound) {
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to read burn mint token pool config for token mint %s: %w", input.TokenMint.String(), err)
+		}
+		if err == nil && chainConfig.Config.RateLimitAdmin == input.NewOwner {
+			b.Logger.Info("Rate limit admin already matches the desired value for burn mint token pool with token mint:", input.TokenMint.String())
+			return sequences.OnChainOutput{}, nil
 		}
 		authority, err := GetAuthorityBurnMint(chain, input.Program, input.TokenMint)
 		if err != nil {
-			// assume the authority is the upgrade authority if we fail to fetch the current authority, since the pool might not be initialized yet and there won't be an authority set on-chain yet (since the config account won't exist until initialization)
+			// The pool config account may legitimately not exist yet: under MCMS the initialize
+			// op only queues a proposal, so this op must still build its instruction. Fall back to
+			// the program upgrade authority in that case.
 			authority, err = utils.GetUpgradeAuthority(chain.Client, input.Program)
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to get upgrade authority for burn mint token pool: %w", err)
-			}
-			// if we had to assume the authority, then the pool isn't initialized yet and therefore
-			// there won't be an authority set on-chain yet, so we can skip the update since the initializer
-			// will be able to set the correct authority during initialization
-			if authority == input.NewOwner {
-				b.Logger.Info("New owner is the same as the current owner for burn mint token pool with token mint:", input.TokenMint.String())
-				return sequences.OnChainOutput{}, nil
 			}
 		}
 		ixn, err := burnmint_token_pool.NewSetRateLimitAdminInstruction(

--- a/chains/solana/deployment/v1_6_0/operations/token_pools/lockrelease.go
+++ b/chains/solana/deployment/v1_6_0/operations/token_pools/lockrelease.go
@@ -513,11 +513,13 @@ var UpdateRateLimitAdminLockRelease = operations.NewOperation(
 			b.Logger.Info("Rate limit admin already matches the desired value for lock release token pool with token mint:", input.TokenMint.String())
 			return sequences.OnChainOutput{}, nil
 		}
-		authority, err := GetAuthorityLockRelease(chain, input.Program, input.TokenMint)
+		// err here is the error from the GetAccountDataBorshInto read above, which has already
+		// returned for every error except rpc.ErrNotFound — so err != nil at this point means
+		// exactly "account absent" (the pool config account may legitimately not exist yet:
+		// under MCMS the initialize op only queues a proposal, so this op must still build its
+		// instruction). Fall back to the program upgrade authority in that case.
+		authority := chainConfig.Config.Owner
 		if err != nil {
-			// The pool config account may legitimately not exist yet: under MCMS the initialize
-			// op only queues a proposal, so this op must still build its instruction. Fall back to
-			// the program upgrade authority in that case.
 			authority, err = utils.GetUpgradeAuthority(chain.Client, input.Program)
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to get upgrade authority for lock release token pool: %w", err)

--- a/chains/solana/deployment/v1_6_0/operations/token_pools/lockrelease.go
+++ b/chains/solana/deployment/v1_6_0/operations/token_pools/lockrelease.go
@@ -3,9 +3,11 @@ package token_pools
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/utils"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/base_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/lockrelease_token_pool"
@@ -499,27 +501,26 @@ var UpdateRateLimitAdminLockRelease = operations.NewOperation(
 	func(b operations.Bundle, chain cldf_solana.Chain, input TokenPoolTransferOwnershipInput) (sequences.OnChainOutput, error) {
 		lockrelease_token_pool.SetProgramID(input.Program)
 		poolConfigPDA, _ := tokens.TokenPoolConfigAddress(input.TokenMint, input.Program)
+		// NOTE: input.NewOwner carries the desired rate limit admin — the input type is shared
+		// with the transfer-ownership ops. LnR pool state has the same wire layout as
+		// test_token_pool.State, which is why that type is used for decoding.
 		var chainConfig test_token_pool.State
 		err := chain.GetAccountDataBorshInto(b.GetContext(), poolConfigPDA, &chainConfig)
-		if err == nil {
-			if chainConfig.Config.RateLimitAdmin == input.NewOwner {
-				b.Logger.Info("New owner is the same as the current rate limit admin for lock release token pool with token mint:", input.TokenMint.String())
-				return sequences.OnChainOutput{}, nil
-			}
+		if err != nil && !errors.Is(err, rpc.ErrNotFound) {
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to read lock release token pool config for token mint %s: %w", input.TokenMint.String(), err)
+		}
+		if err == nil && chainConfig.Config.RateLimitAdmin == input.NewOwner {
+			b.Logger.Info("Rate limit admin already matches the desired value for lock release token pool with token mint:", input.TokenMint.String())
+			return sequences.OnChainOutput{}, nil
 		}
 		authority, err := GetAuthorityLockRelease(chain, input.Program, input.TokenMint)
 		if err != nil {
-			// assume the authority is the upgrade authority if we fail to fetch the current authority, since the pool might not be initialized yet and there won't be an authority set on-chain yet (since the config account won't exist until initialization)
+			// The pool config account may legitimately not exist yet: under MCMS the initialize
+			// op only queues a proposal, so this op must still build its instruction. Fall back to
+			// the program upgrade authority in that case.
 			authority, err = utils.GetUpgradeAuthority(chain.Client, input.Program)
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to get upgrade authority for lock release token pool: %w", err)
-			}
-			// if we had to assume the authority, then the pool isn't initialized yet and therefore
-			// there won't be an authority set on-chain yet, so we can skip the update since the initializer
-			// will be able to set the correct authority during initialization
-			if authority == input.NewOwner {
-				b.Logger.Info("New owner is the same as the current owner for lock release token pool with token mint:", input.TokenMint.String())
-				return sequences.OnChainOutput{}, nil
 			}
 		}
 		ixn, err := lockrelease_token_pool.NewSetRateLimitAdminInstruction(

--- a/chains/solana/deployment/v1_6_0/sequences/tokens.go
+++ b/chains/solana/deployment/v1_6_0/sequences/tokens.go
@@ -624,7 +624,7 @@ func (a *SolanaAdapter) SetTokenPoolAdmins() *cldf_ops.Sequence[tokenapi.SetToke
 
 			rlAdmin, err := solana.PublicKeyFromBase58(*input.RateLimitAdmin)
 			if err != nil {
-				return sequences.OnChainOutput{}, fmt.Errorf("invalid rate limit admin address for chain %d: %s", input.Selector, *input.RateLimitAdmin)
+				return sequences.OnChainOutput{}, fmt.Errorf("invalid rate limit admin address for chain %d: %s: %w", input.Selector, *input.RateLimitAdmin, err)
 			}
 
 			var op = tokenpoolops.UpdateRateLimitAdminBurnMint
@@ -639,11 +639,11 @@ func (a *SolanaAdapter) SetTokenPoolAdmins() *cldf_ops.Sequence[tokenapi.SetToke
 
 			tokenPool, err := solana.PublicKeyFromBase58(input.PoolAddress)
 			if err != nil {
-				return sequences.OnChainOutput{}, fmt.Errorf("invalid token pool address for chain %d: %s", input.Selector, input.PoolAddress)
+				return sequences.OnChainOutput{}, fmt.Errorf("invalid token pool address for chain %d: %s: %w", input.Selector, input.PoolAddress, err)
 			}
 			tokenMint, err := solana.PublicKeyFromBase58(input.TokenRef.Address)
 			if err != nil {
-				return sequences.OnChainOutput{}, fmt.Errorf("invalid token mint address for chain %d: %s", input.Selector, input.TokenRef.Address)
+				return sequences.OnChainOutput{}, fmt.Errorf("invalid token mint address for chain %d: %s: %w", input.Selector, input.TokenRef.Address, err)
 			}
 
 			rlOut, err := operations.ExecuteOperation(b, op, chain, tokenpoolops.TokenPoolTransferOwnershipInput{

--- a/chains/solana/deployment/v1_6_0/sequences/tokens.go
+++ b/chains/solana/deployment/v1_6_0/sequences/tokens.go
@@ -611,7 +611,7 @@ func (a *SolanaAdapter) SetTokenPoolAdmins() *cldf_ops.Sequence[tokenapi.SetToke
 		"Sets the rate limit admin on a Solana 1.6 token pool; no-op when the value already matches",
 		func(b operations.Bundle, chains cldf_chain.BlockChains, input tokenapi.SetTokenPoolAdminsSequenceInput) (sequences.OnChainOutput, error) {
 			if input.FeeAdmin != nil {
-				return sequences.OnChainOutput{}, fmt.Errorf("fee admin is not supported on Solana 1.6 token pools (pool %s on chain %d)", input.PoolAddress, input.Selector)
+				return sequences.OnChainOutput{}, fmt.Errorf("fee admin is not supported on Solana 1.6 token pools (pool %s on chain %d)", input.TokenPoolRef.Address, input.Selector)
 			}
 			if input.RateLimitAdmin == nil {
 				return sequences.OnChainOutput{}, nil
@@ -637,9 +637,9 @@ func (a *SolanaAdapter) SetTokenPoolAdmins() *cldf_ops.Sequence[tokenapi.SetToke
 				return sequences.OnChainOutput{}, fmt.Errorf("unsupported token pool type '%s' for Solana", input.TokenPoolRef.Type.String())
 			}
 
-			tokenPool, err := solana.PublicKeyFromBase58(input.PoolAddress)
+			tokenPool, err := solana.PublicKeyFromBase58(input.TokenPoolRef.Address)
 			if err != nil {
-				return sequences.OnChainOutput{}, fmt.Errorf("invalid token pool address for chain %d: %s: %w", input.Selector, input.PoolAddress, err)
+				return sequences.OnChainOutput{}, fmt.Errorf("invalid token pool address for chain %d: %s: %w", input.Selector, input.TokenPoolRef.Address, err)
 			}
 			tokenMint, err := solana.PublicKeyFromBase58(input.TokenRef.Address)
 			if err != nil {
@@ -652,7 +652,7 @@ func (a *SolanaAdapter) SetTokenPoolAdmins() *cldf_ops.Sequence[tokenapi.SetToke
 				NewOwner:  rlAdmin,
 			})
 			if err != nil {
-				return sequences.OnChainOutput{}, fmt.Errorf("failed to set rate limit admin on token pool %s on chain %d: %w", input.PoolAddress, input.Selector, err)
+				return sequences.OnChainOutput{}, fmt.Errorf("failed to set rate limit admin on token pool %s on chain %d: %w", input.TokenPoolRef.Address, input.Selector, err)
 			}
 
 			return sequences.OnChainOutput{BatchOps: rlOut.Output.BatchOps}, nil

--- a/chains/solana/deployment/v1_6_0/sequences/tokens.go
+++ b/chains/solana/deployment/v1_6_0/sequences/tokens.go
@@ -597,6 +597,69 @@ func (a *SolanaAdapter) SetTokenPoolRateLimits() *cldf_ops.Sequence[tokenapi.TPR
 	)
 }
 
+var _ tokenapi.TokenPoolAdminAdapter = (*SolanaAdapter)(nil)
+
+// SetTokenPoolAdmins updates the rate limit admin on a Solana 1.6 token pool. Solana pools
+// have no fee admin concept, so a non-nil FeeAdmin is rejected. The pool address is a program
+// ID shared across mints, so the token mint comes from input.TokenRef and the pool type from
+// input.TokenPoolRef. The underlying operation performs the read-compare no-op check and
+// emits an MCMS batch operation when the pool authority is not the deployer key.
+func (a *SolanaAdapter) SetTokenPoolAdmins() *cldf_ops.Sequence[tokenapi.SetTokenPoolAdminsSequenceInput, sequences.OnChainOutput, cldf_chain.BlockChains] {
+	return operations.NewSequence(
+		"SetTokenPoolAdmins",
+		common_utils.Version_1_6_0,
+		"Sets the rate limit admin on a Solana 1.6 token pool; no-op when the value already matches",
+		func(b operations.Bundle, chains cldf_chain.BlockChains, input tokenapi.SetTokenPoolAdminsSequenceInput) (sequences.OnChainOutput, error) {
+			if input.FeeAdmin != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("fee admin is not supported on Solana 1.6 token pools (pool %s on chain %d)", input.PoolAddress, input.Selector)
+			}
+			if input.RateLimitAdmin == nil {
+				return sequences.OnChainOutput{}, nil
+			}
+
+			chain, ok := chains.SolanaChains()[input.Selector]
+			if !ok {
+				return sequences.OnChainOutput{}, fmt.Errorf("solana chain with selector %d not defined", input.Selector)
+			}
+
+			rlAdmin, err := solana.PublicKeyFromBase58(*input.RateLimitAdmin)
+			if err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("invalid rate limit admin address for chain %d: %s", input.Selector, *input.RateLimitAdmin)
+			}
+
+			var op = tokenpoolops.UpdateRateLimitAdminBurnMint
+			switch input.TokenPoolRef.Type.String() {
+			case common_utils.BurnMintTokenPool.String():
+				op = tokenpoolops.UpdateRateLimitAdminBurnMint
+			case common_utils.LockReleaseTokenPool.String():
+				op = tokenpoolops.UpdateRateLimitAdminLockRelease
+			default:
+				return sequences.OnChainOutput{}, fmt.Errorf("unsupported token pool type '%s' for Solana", input.TokenPoolRef.Type.String())
+			}
+
+			tokenPool, err := solana.PublicKeyFromBase58(input.PoolAddress)
+			if err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("invalid token pool address for chain %d: %s", input.Selector, input.PoolAddress)
+			}
+			tokenMint, err := solana.PublicKeyFromBase58(input.TokenRef.Address)
+			if err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("invalid token mint address for chain %d: %s", input.Selector, input.TokenRef.Address)
+			}
+
+			rlOut, err := operations.ExecuteOperation(b, op, chain, tokenpoolops.TokenPoolTransferOwnershipInput{
+				Program:   tokenPool,
+				TokenMint: tokenMint,
+				NewOwner:  rlAdmin,
+			})
+			if err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("failed to set rate limit admin on token pool %s on chain %d: %w", input.PoolAddress, input.Selector, err)
+			}
+
+			return sequences.OnChainOutput{BatchOps: rlOut.Output.BatchOps}, nil
+		},
+	)
+}
+
 // GetOnchainRateLimits implements tokenapi.RateLimitReaderAdapter. It needs the token mint to
 // derive the remote-chain config PDA, so tokenRef must resolve to the token. Solana pools have a
 // single bucket per remote lane; fastFinality=true is not supported.

--- a/deployment/tokens/configure_token_pool.go
+++ b/deployment/tokens/configure_token_pool.go
@@ -184,7 +184,6 @@ func configureTokenPoolApply() func(cldf.Environment, ConfigureTokenPoolInput) (
 					}
 					report, err := cldf_ops.ExecuteSequence(e.OperationsBundle, adminAdapter.SetTokenPoolAdmins(), e.BlockChains, SetTokenPoolAdminsSequenceInput{
 						Selector:       selector,
-						PoolAddress:    fullPoolRef.Address,
 						RateLimitAdmin: pool.RateLimitAdmin,
 						FeeAdmin:       pool.FeeAdmin,
 						TokenPoolRef:   fullPoolRef,

--- a/deployment/tokens/configure_token_pool.go
+++ b/deployment/tokens/configure_token_pool.go
@@ -185,6 +185,8 @@ func configureTokenPoolApply() func(cldf.Environment, ConfigureTokenPoolInput) (
 						PoolAddress:    fullPoolRef.Address,
 						RateLimitAdmin: pool.RateLimitAdmin,
 						FeeAdmin:       pool.FeeAdmin,
+						TokenPoolRef:   fullPoolRef,
+						TokenRef:       fullTokenRef,
 					})
 					if err != nil {
 						return cldf.ChangesetOutput{}, fmt.Errorf("failed to set admin roles on pool %s: %w", fullPoolRef.Address, err)

--- a/deployment/tokens/configure_token_pool.go
+++ b/deployment/tokens/configure_token_pool.go
@@ -41,7 +41,9 @@ type ConfigureTokenPoolPerChain struct {
 // Every field other than TokenPoolRef is optional: absent fields leave on-chain state
 // untouched. To clear a value, provide it explicitly (e.g. the zero address).
 type PoolConfigUpdate struct {
-	// TokenPoolRef is a reference to the token pool in the datastore.
+	// TokenPoolRef is a reference to the token pool in the datastore. For Solana, this must be
+	// the pool's config PDA, not the pool program ID: a Solana pool address is a program ID
+	// shared across many mints, so it cannot alone identify the token being configured.
 	TokenPoolRef datastore.AddressRef `yaml:"tokenPoolRef" json:"tokenPoolRef"`
 	// FinalityConfig, if set, is the allowed finality config to set on the pool (v2+ only).
 	FinalityConfig *finality.Config `yaml:"finalityConfig,omitempty" json:"finalityConfig,omitempty"`

--- a/deployment/tokens/product.go
+++ b/deployment/tokens/product.go
@@ -56,10 +56,10 @@ type SetTokenPoolAdminsSequenceInput struct {
 	// TokenPoolRef is the fully resolved pool reference. EVM adapters ignore it; Solana
 	// needs Type to select the burnmint or lockrelease program, because a Solana pool
 	// address is a program ID shared across many token mints.
-	TokenPoolRef datastore.AddressRef `json:"tokenPoolRef,omitempty" yaml:"tokenPoolRef,omitempty"`
+	TokenPoolRef datastore.AddressRef `json:"tokenPoolRef" yaml:"tokenPoolRef"`
 	// TokenRef is the fully resolved token reference. EVM adapters ignore it; Solana needs
 	// Address as the token mint to derive the pool config PDA.
-	TokenRef datastore.AddressRef `json:"tokenRef,omitempty" yaml:"tokenRef,omitempty"`
+	TokenRef datastore.AddressRef `json:"tokenRef" yaml:"tokenRef"`
 }
 
 // TokenAdminRoleAdapter is an optional interface for chain families that support token admin role management.

--- a/deployment/tokens/product.go
+++ b/deployment/tokens/product.go
@@ -47,15 +47,14 @@ type TokenPoolAdminAdapter interface {
 type SetTokenPoolAdminsSequenceInput struct {
 	// Selector is the chain selector for the chain on which the pool lives.
 	Selector uint64 `json:"selector" yaml:"selector"`
-	// PoolAddress is the token pool address (family-specific string form).
-	PoolAddress string `json:"poolAddress" yaml:"poolAddress"`
 	// RateLimitAdmin, if non-nil, is the desired rate limit admin.
 	RateLimitAdmin *string `json:"rateLimitAdmin,omitempty" yaml:"rateLimitAdmin,omitempty"`
 	// FeeAdmin, if non-nil, is the desired fee admin.
 	FeeAdmin *string `json:"feeAdmin,omitempty" yaml:"feeAdmin,omitempty"`
-	// TokenPoolRef is the fully resolved pool reference. EVM adapters ignore it; Solana
-	// needs Type to select the burnmint or lockrelease program, because a Solana pool
-	// address is a program ID shared across many token mints.
+	// TokenPoolRef is the fully resolved pool reference. Address is the token pool address
+	// in family-specific string form. Solana additionally needs Type to select the burnmint
+	// or lockrelease program, because a Solana pool address is a program ID shared across
+	// many token mints.
 	TokenPoolRef datastore.AddressRef `json:"tokenPoolRef" yaml:"tokenPoolRef"`
 	// TokenRef is the fully resolved token reference. EVM adapters ignore it; Solana needs
 	// Address as the token mint to derive the pool config PDA.

--- a/deployment/tokens/product.go
+++ b/deployment/tokens/product.go
@@ -53,6 +53,13 @@ type SetTokenPoolAdminsSequenceInput struct {
 	RateLimitAdmin *string `json:"rateLimitAdmin,omitempty" yaml:"rateLimitAdmin,omitempty"`
 	// FeeAdmin, if non-nil, is the desired fee admin.
 	FeeAdmin *string `json:"feeAdmin,omitempty" yaml:"feeAdmin,omitempty"`
+	// TokenPoolRef is the fully resolved pool reference. EVM adapters ignore it; Solana
+	// needs Type to select the burnmint or lockrelease program, because a Solana pool
+	// address is a program ID shared across many token mints.
+	TokenPoolRef datastore.AddressRef `json:"tokenPoolRef,omitempty" yaml:"tokenPoolRef,omitempty"`
+	// TokenRef is the fully resolved token reference. EVM adapters ignore it; Solana needs
+	// Address as the token mint to derive the pool config PDA.
+	TokenRef datastore.AddressRef `json:"tokenRef,omitempty" yaml:"tokenRef,omitempty"`
 }
 
 // TokenAdminRoleAdapter is an optional interface for chain families that support token admin role management.

--- a/integration-tests/deployment/configure_token_pool_test.go
+++ b/integration-tests/deployment/configure_token_pool_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/gagliardetto/solana-go"
 	chainsel "github.com/smartcontractkit/chain-selectors"
 	"github.com/stretchr/testify/require"
 
@@ -17,6 +18,9 @@ import (
 	tokenpoolV1_5_1 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_1/token_pool"
 	tokenpoolV1_6_1 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_1/token_pool"
 	tokenpoolV2_0_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v2_0_0/token_pool"
+	solanautils "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/utils"
+	burnmint_token_pool "github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/burnmint_token_pool"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
 	deployapi "github.com/smartcontractkit/chainlink-ccip/deployment/deploy"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/fees"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/finality"
@@ -26,11 +30,14 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
 	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
+	solchain "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf_deployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 
 	_ "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/adapters"
+	_ "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_6_0/adapters"
+	_ "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_6_0/sequences"
 )
 
 func TestConfigureTokenPool_VerifyPreconditions(t *testing.T) {
@@ -728,4 +735,176 @@ func TestConfigureTokenPool_MCMSOwnedPool(t *testing.T) {
 	out2, err := tokensapi.ConfigureTokenPool().Apply(*tc.env, input)
 	require.NoError(t, err)
 	require.Empty(t, out2.MCMSTimelockProposals, "no-op re-apply must not emit an MCMS proposal")
+}
+
+// solanaPoolFixture identifies a deployed Solana token pool for use by ConfigureTokenPool tests.
+// Ref is the fully resolved pool reference (Address is the pool program ID, shared across every
+// mint that pool type serves); Mint is the specific token mint the pool was initialized for.
+type solanaPoolFixture struct {
+	Ref  datastore.AddressRef
+	Mint solana.PublicKey
+}
+
+// setupSolanaPoolsForConfigure stands up a Solana chain (plus a throwaway EVM chain, matching
+// the environment.New pattern used elsewhere in this package) with an initialized BurnMint pool
+// and an initialized LockRelease pool, ready for ConfigureTokenPool admin-role tests. Task 3
+// reuses this helper for the fee-admin-rejection and unsupported-pool-type tests.
+func setupSolanaPoolsForConfigure(t *testing.T) (env *cldf_deployment.Environment, bnm solanaPoolFixture, lnr solanaPoolFixture) {
+	t.Helper()
+
+	src := chainsel.SOLANA_DEVNET.Selector
+	dst := chainsel.TEST_90000002.Selector
+
+	programsPath, ds, err := PreloadSolanaEnvironment(t, src)
+	require.NoError(t, err)
+
+	env, err = environment.New(t.Context(),
+		environment.WithSolanaContainer(t, []uint64{src}, programsPath, solanaProgramIDs),
+		environment.WithEVMSimulated(t, []uint64{dst}),
+	)
+	require.NoError(t, err)
+	env.DataStore = ds.Seal()
+
+	solChain, ok := env.BlockChains.SolanaChains()[src]
+	require.True(t, ok, "Solana chain not found in environment")
+
+	deployRegistry := deployapi.GetRegistry()
+	deployOut, err := deployapi.DeployContracts(deployRegistry).Apply(*env, deployapi.ContractDeploymentConfig{
+		MCMS: mcms.Input{},
+		Chains: map[uint64]deployapi.ContractDeploymentConfigPerChain{
+			src: NewDefaultDeploymentConfigForSolana(cciputils.Version_1_6_0),
+		},
+	})
+	require.NoError(t, err)
+	MergeAddresses(t, env, deployOut.DataStore)
+
+	deployPool := func(symbol, poolType string) solanaPoolFixture {
+		expansionOut, err := tokensapi.TokenExpansion().Apply(*env, tokensapi.TokenExpansionInput{
+			ChainAdapterVersion: cciputils.Version_1_6_0,
+			MCMS:                NewDefaultInputForMCMS("Configure Token Pool test setup"),
+			TokenExpansionInputPerChain: map[uint64]tokensapi.TokenExpansionInputPerChain{
+				src: {
+					TokenPoolVersion: cciputils.Version_1_6_0,
+					DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
+						TokenPoolQualifier: "",
+						PoolType:           poolType,
+						RateLimitAdmin:     solana.NewWallet().PublicKey().String(),
+					},
+					DeployTokenInput: &tokensapi.DeployTokenInput{
+						Decimals:               9,
+						Symbol:                 symbol,
+						Name:                   symbol,
+						Type:                   solanautils.SPLTokens,
+						ExternalAdmin:          solana.NewWallet().PublicKey().String(),
+						DisableFreezeAuthority: true,
+						Senders:                []string{solChain.DeployerKey.PublicKey().String()},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		MergeAddresses(t, env, expansionOut.DataStore)
+		testhelpers.ProcessTimelockProposals(t, *env, expansionOut.MCMSTimelockProposals, false)
+
+		tokenRef, err := datastore_utils.FindAndFormatRef(
+			env.DataStore,
+			datastore.AddressRef{Qualifier: symbol},
+			src,
+			datastore_utils.FullRef,
+		)
+		require.NoError(t, err)
+
+		poolRef, err := datastore_utils.FindAndFormatRef(
+			env.DataStore,
+			datastore.AddressRef{
+				ChainSelector: src,
+				Qualifier:     "",
+				Type:          datastore.ContractType(poolType),
+				Version:       cciputils.Version_1_6_0,
+			},
+			src,
+			datastore_utils.FullRef,
+		)
+		require.NoError(t, err)
+
+		return solanaPoolFixture{Ref: poolRef, Mint: solana.MustPublicKeyFromBase58(tokenRef.Address)}
+	}
+
+	bnm = deployPool("CTP_SOL_BNM", cciputils.BurnMintTokenPool.String())
+	lnr = deployPool("CTP_SOL_LNR", cciputils.LockReleaseTokenPool.String())
+
+	return env, bnm, lnr
+}
+
+// solanaPoolRateLimitAdmin reads the on-chain rate limit admin for a Solana token pool.
+// BnM and LnR pools share the same state layout, so either binding decodes both.
+func solanaPoolRateLimitAdmin(t *testing.T, chain solchain.Chain, poolProgramID solana.PublicKey, tokenMint solana.PublicKey) solana.PublicKey {
+	t.Helper()
+	poolStatePDA, err := tokens.TokenPoolConfigAddress(tokenMint, poolProgramID)
+	require.NoError(t, err)
+	var poolState burnmint_token_pool.State
+	require.NoError(t, chain.GetAccountDataBorshInto(t.Context(), poolStatePDA, &poolState))
+	return poolState.Config.RateLimitAdmin
+}
+
+func TestConfigureTokenPool_Admins_Solana(t *testing.T) {
+	env, bnm, lnr := setupSolanaPoolsForConfigure(t) // helper from Step 6
+
+	for _, tc := range []struct {
+		name string
+		pool solanaPoolFixture // {Ref datastore.AddressRef, Mint solana.PublicKey}
+	}{
+		{"burnmint", bnm},
+		{"lockrelease", lnr},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			newAdmin := solana.NewWallet().PublicKey()
+			newAdminStr := newAdmin.String()
+
+			// A Solana pool program ID is shared across every mint that pool type serves, so it
+			// cannot alone identify "the pool for this mint" the way an EVM pool address can.
+			// The chain-agnostic ConfigureTokenPoolInput has no separate token field, so the
+			// mint-specific pool config PDA is what's passed as TokenPoolRef.Address here: the
+			// Solana adapter's ResolveTokenPoolRef (see chains/solana/deployment/v1_6_0/sequences/tokens.go)
+			// recognizes a PDA, reads its owner to recover the program ID, and tags the resolved
+			// ref with the PDA so DeriveTokenAddress can still identify the mint downstream.
+			solChain := env.BlockChains.SolanaChains()[tc.pool.Ref.ChainSelector]
+			poolProgramID := solana.MustPublicKeyFromBase58(tc.pool.Ref.Address)
+			poolConfigPDA, err := tokens.TokenPoolConfigAddress(tc.pool.Mint, poolProgramID)
+			require.NoError(t, err)
+			apiPoolRef := datastore.AddressRef{ChainSelector: tc.pool.Ref.ChainSelector, Address: poolConfigPDA.String()}
+
+			out, err := tokensapi.ConfigureTokenPool().Apply(*env, tokensapi.ConfigureTokenPoolInput{
+				Chains: []tokensapi.ConfigureTokenPoolPerChain{{
+					ChainSelector: tc.pool.Ref.ChainSelector,
+					Pools: []tokensapi.PoolConfigUpdate{{
+						TokenPoolRef:   apiPoolRef,
+						RateLimitAdmin: &newAdminStr,
+					}},
+				}},
+				MCMS: NewDefaultInputForMCMS("Configure Token Pool"),
+			})
+			require.NoError(t, err)
+			testhelpers.ProcessTimelockProposals(t, *env, out.MCMSTimelockProposals, false)
+
+			require.Equal(t, newAdmin, solanaPoolRateLimitAdmin(t, solChain, poolProgramID, tc.pool.Mint),
+				"rate limit admin should match the requested value")
+
+			// Re-applying the same value must produce no transactions.
+			out2, err := tokensapi.ConfigureTokenPool().Apply(*env, tokensapi.ConfigureTokenPoolInput{
+				Chains: []tokensapi.ConfigureTokenPoolPerChain{{
+					ChainSelector: tc.pool.Ref.ChainSelector,
+					Pools: []tokensapi.PoolConfigUpdate{{
+						TokenPoolRef:   apiPoolRef,
+						RateLimitAdmin: &newAdminStr,
+					}},
+				}},
+				MCMS: NewDefaultInputForMCMS("Configure Token Pool"),
+			})
+			require.NoError(t, err)
+			require.Empty(t, out2.MCMSTimelockProposals, "re-applying an unchanged admin must emit no proposals")
+			require.Equal(t, newAdmin, solanaPoolRateLimitAdmin(t, solChain, poolProgramID, tc.pool.Mint),
+				"rate limit admin must be unchanged after the no-op apply")
+		})
+	}
 }

--- a/integration-tests/deployment/configure_token_pool_test.go
+++ b/integration-tests/deployment/configure_token_pool_test.go
@@ -629,7 +629,6 @@ func TestConfigureTokenPool_FeeConfig(t *testing.T) {
 	require.Equal(t, before, after, "no-op fee update must not send transactions")
 }
 
-
 func TestConfigureTokenPool_CombinedUpdate(t *testing.T) {
 	tc := setupV2PoolsForConfigureImpl(t, "CTP_ALL", false)
 
@@ -747,8 +746,7 @@ type solanaPoolFixture struct {
 
 // setupSolanaPoolsForConfigure stands up a Solana chain (plus a throwaway EVM chain, matching
 // the environment.New pattern used elsewhere in this package) with an initialized BurnMint pool
-// and an initialized LockRelease pool, ready for ConfigureTokenPool admin-role tests. Task 3
-// reuses this helper for the fee-admin-rejection and unsupported-pool-type tests.
+// and an initialized LockRelease pool, ready for ConfigureTokenPool tests.
 func setupSolanaPoolsForConfigure(t *testing.T) (env *cldf_deployment.Environment, bnm solanaPoolFixture, lnr solanaPoolFixture) {
 	t.Helper()
 
@@ -758,7 +756,8 @@ func setupSolanaPoolsForConfigure(t *testing.T) (env *cldf_deployment.Environmen
 	programsPath, ds, err := PreloadSolanaEnvironment(t, src)
 	require.NoError(t, err)
 
-	env, err = environment.New(t.Context(),
+	env, err = environment.New(
+		t.Context(),
 		environment.WithSolanaContainer(t, []uint64{src}, programsPath, solanaProgramIDs),
 		environment.WithEVMSimulated(t, []uint64{dst}),
 	)

--- a/integration-tests/deployment/configure_token_pool_test.go
+++ b/integration-tests/deployment/configure_token_pool_test.go
@@ -870,9 +870,7 @@ func TestConfigureTokenPool_Admins_Solana(t *testing.T) {
 			// ref with the PDA so DeriveTokenAddress can still identify the mint downstream.
 			solChain := env.BlockChains.SolanaChains()[tc.pool.Ref.ChainSelector]
 			poolProgramID := solana.MustPublicKeyFromBase58(tc.pool.Ref.Address)
-			poolConfigPDA, err := tokens.TokenPoolConfigAddress(tc.pool.Mint, poolProgramID)
-			require.NoError(t, err)
-			apiPoolRef := datastore.AddressRef{ChainSelector: tc.pool.Ref.ChainSelector, Address: poolConfigPDA.String()}
+			apiPoolRef := solanaApiPoolRef(t, tc.pool)
 
 			out, err := tokensapi.ConfigureTokenPool().Apply(*env, tokensapi.ConfigureTokenPoolInput{
 				Chains: []tokensapi.ConfigureTokenPoolPerChain{{
@@ -890,7 +888,11 @@ func TestConfigureTokenPool_Admins_Solana(t *testing.T) {
 			require.Equal(t, newAdmin, solanaPoolRateLimitAdmin(t, solChain, poolProgramID, tc.pool.Mint),
 				"rate limit admin should match the requested value")
 
-			// Re-applying the same value must produce no transactions.
+			// Re-applying the same value must produce no transactions. Refresh the bundle's
+			// reporter first: ExecuteSequence memoizes on (sequence def, input) and would
+			// otherwise return the first apply's cached report without re-running the op,
+			// making this assertion vacuous. See TestConfigureTokenPool_MCMSOwnedPool above.
+			env.OperationsBundle = evm_testsetup.BundleWithFreshReporter(env.OperationsBundle)
 			out2, err := tokensapi.ConfigureTokenPool().Apply(*env, tokensapi.ConfigureTokenPoolInput{
 				Chains: []tokensapi.ConfigureTokenPoolPerChain{{
 					ChainSelector: tc.pool.Ref.ChainSelector,
@@ -907,4 +909,99 @@ func TestConfigureTokenPool_Admins_Solana(t *testing.T) {
 				"rate limit admin must be unchanged after the no-op apply")
 		})
 	}
+}
+
+// solanaApiPoolRef builds the API-facing TokenPoolRef for a Solana pool fixture: the pool
+// config PDA, not the bare pool program ID. Passing the program ID directly into
+// ConfigureTokenPool().Apply fails with "token derivation is only possible if a pool PDA is
+// provided" — the generic ResolveTokenPoolRef exact-matches the datastore by program ID and
+// short-circuits before the Solana PDA-normalizing resolver runs. See
+// TestConfigureTokenPool_Admins_Solana for the same pattern.
+func solanaApiPoolRef(t *testing.T, pool solanaPoolFixture) datastore.AddressRef {
+	t.Helper()
+	poolProgramID := solana.MustPublicKeyFromBase58(pool.Ref.Address)
+	poolConfigPDA, err := tokens.TokenPoolConfigAddress(pool.Mint, poolProgramID)
+	require.NoError(t, err)
+	return datastore.AddressRef{ChainSelector: pool.Ref.ChainSelector, Address: poolConfigPDA.String()}
+}
+
+func TestConfigureTokenPool_UnsupportedFields_Solana(t *testing.T) {
+	env, bnm, _ := setupSolanaPoolsForConfigure(t)
+	apiPoolRef := solanaApiPoolRef(t, bnm)
+	feeAdmin := solana.NewWallet().PublicKey().String()
+
+	t.Run("feeAdmin", func(t *testing.T) {
+		_, err := tokensapi.ConfigureTokenPool().Apply(*env, tokensapi.ConfigureTokenPoolInput{
+			Chains: []tokensapi.ConfigureTokenPoolPerChain{{
+				ChainSelector: bnm.Ref.ChainSelector,
+				Pools: []tokensapi.PoolConfigUpdate{{
+					TokenPoolRef: apiPoolRef,
+					FeeAdmin:     &feeAdmin,
+				}},
+			}},
+			MCMS: NewDefaultInputForMCMS("Configure Token Pool"),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "fee admin is not supported")
+	})
+
+	t.Run("finalityConfig", func(t *testing.T) {
+		_, err := tokensapi.ConfigureTokenPool().Apply(*env, tokensapi.ConfigureTokenPoolInput{
+			Chains: []tokensapi.ConfigureTokenPoolPerChain{{
+				ChainSelector: bnm.Ref.ChainSelector,
+				Pools: []tokensapi.PoolConfigUpdate{{
+					TokenPoolRef:   apiPoolRef,
+					FinalityConfig: &finality.Config{},
+				}},
+			}},
+			MCMS: NewDefaultInputForMCMS("Configure Token Pool"),
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does not support finality config updates")
+	})
+}
+
+func TestConfigureTokenPool_FeeConfig_Solana(t *testing.T) {
+	env, bnm, _ := setupSolanaPoolsForConfigure(t)
+	apiPoolRef := solanaApiPoolRef(t, bnm)
+	remote := chainsel.TEST_90000002.Selector // the EVM chain from the helper's env
+
+	out, err := tokensapi.ConfigureTokenPool().Apply(*env, tokensapi.ConfigureTokenPoolInput{
+		Chains: []tokensapi.ConfigureTokenPoolPerChain{{
+			ChainSelector: bnm.Ref.ChainSelector,
+			Pools: []tokensapi.PoolConfigUpdate{{
+				TokenPoolRef: apiPoolRef,
+				Remotes: []tokensapi.RemoteConfigUpdate{{
+					RemoteChainSelector: remote,
+					TokenTransferFeeConfig: &tokensapi.PartialTokenTransferFeeConfig{
+						IsEnabled:                  cciputils.NewOptional(true),
+						DefaultFinalityFeeUSDCents: cciputils.NewOptional(uint32(10)),
+						DestBytesOverhead:          cciputils.NewOptional(uint32(200_000)),
+					},
+				}},
+			}},
+		}},
+		MCMS: NewDefaultInputForMCMS("Configure Token Pool"),
+	})
+	require.NoError(t, err)
+	testhelpers.ProcessTimelockProposals(t, *env, out.MCMSTimelockProposals, false)
+
+	// Solana pools are below v2.0.0, so the fee config lands on the FeeQuoter. Read it back
+	// through the same resolution path the changeset used
+	// (deployment/tokens/configure_tokens_for_transfers.go:512).
+	feeAdapter, fqRef, err := fees.ResolveFeeAdapter(env.OperationsBundle, env.BlockChains, env.DataStore, bnm.Ref.ChainSelector, remote)
+	require.NoError(t, err)
+
+	onchain, err := feeAdapter.GetOnchainTokenTransferFeeConfig(
+		env.OperationsBundle,
+		env.BlockChains,
+		fqRef,
+		bnm.Ref.ChainSelector,
+		remote,
+		bnm.Mint.String(),
+	)
+	require.NoError(t, err)
+	require.True(t, onchain.IsEnabled, "fee config should be enabled on-chain")
+	require.Equal(t, uint32(200_000), onchain.DestBytesOverhead, "destBytesOverhead should match the requested value")
+	require.Equal(t, uint32(10), onchain.MinFeeUSDCents, "min fee USD cents should match the requested default finality fee")
 }


### PR DESCRIPTION
## What

Makes `ConfigureTokenPool`'s `rateLimitAdmin` field work for Solana 1.6 BurnMint and LockRelease token pools, and adds integration coverage proving the unsupported fields reject loudly and the `tokenTransferFeeConfig` path works for Solana.

Follows #2211, which did the equivalent EVM work.

`SolanaAdapter` joins the existing chain-agnostic `TokenPoolAdminAdapter` seam by type assertion — no new interface. Because a Solana pool address is a *program ID* shared across many token mints, `SetTokenPoolAdminsSequenceInput` gains `TokenPoolRef` and `TokenRef`, which the changeset already resolved and previously discarded. Both adapters read the pool address from `TokenPoolRef.Address` — `PoolAddress` was redundant and dropped in commit 5 (see below). The EVM adapter changes are trivial: `input.PoolAddress` → `input.TokenPoolRef.Address`.

## Commits

1. **`fix: correct idempotency and error handling in Solana rate limit admin ops`** — two defects in `UpdateRateLimitAdmin{BurnMint,LockRelease}`, which are already live in the Solana pool deploy path:
   - **Swallowed read error.** `if err == nil { compare }` made a transient RPC or decode failure indistinguishable from "account absent", and both fell through to writing — degrading the no-op guarantee to "always write". Now only `rpc.ErrNotFound` falls through; every other error is returned.
   - **Bogus comparison in the fallback.** `if authority == input.NewOwner { return nil }` compared the *program upgrade authority* against the *desired rate limit admin*. When the deployer key was both — normal in tests and single-operator deployments — the op reported success having done nothing.
2. **`feat: support rateLimitAdmin on Solana 1.6 token pools in ConfigureTokenPool`** — widens the sequence input, passes the already-resolved refs at the call site, and implements `SetTokenPoolAdmins()` on `SolanaAdapter`. `feeAdmin` is rejected (Solana pools have no fee admin concept); a nil `rateLimitAdmin` is a no-op.
3. **`test: cover Solana rejection paths and fee config in ConfigureTokenPool`** — `feeAdmin` and `finalityConfig` rejection, plus the `tokenTransferFeeConfig` path, which routes Solana pools to the FeeQuoter because their version is below 2.0.0. That path was believed to work but nothing verified it; it does, and the test reads the config back on-chain through the same resolution path the changeset uses.
4. **`fix: address review findings on the Solana rate limit admin path`** — see below.
5. **`refactor: drop redundant PoolAddress from SetTokenPoolAdminsSequenceInput`** — `PoolAddress` always carried the same value as `TokenPoolRef.Address`. Removed. EVM adapter switched from `input.PoolAddress` to `input.TokenPoolRef.Address`.

## Two things reviewers should know

**Solana callers must pass the pool config PDA as `TokenPoolRef`, not the pool program ID.** The generic `ResolveTokenPoolRef` does an exact-match datastore lookup by address *before* the family-specific resolver runs, and a bare Solana pool program ID is exactly what the datastore registers — so the lookup short-circuits and the Solana PDA-normalizing resolver never runs, and token derivation then fails with "token derivation is only possible if a pool PDA is provided". This is inherent rather than a workaround: a program ID is shared across mints and so cannot identify a token. The requirement is now documented on `PoolConfigUpdate.TokenPoolRef`, where it previously lived only in a test comment.

**Widening `SetTokenPoolAdminsSequenceInput` changes its report hash.** Any durable or resumable report store will no longer match previously-recorded `SetTokenPoolAdmins` reports and will re-execute them. That is safe — the operation reads on-chain state and no-ops before writing — but it is worth knowing.

## Review fixes folded into commit 4

- The **same swallowed-error pattern** fixed in commit 1 still existed six lines below it: any `GetAuthority*` failure, not just "account absent", fell back to the program upgrade authority, so a transient read failure could submit `SetRateLimitAdmin` signed by the wrong authority. Now reuses the pool config read the op already performed — which also removes a redundant RPC round-trip per pool — and keeps the upgrade-authority fallback for the account-absent case only. That fallback is load-bearing: under MCMS the initialize op only queues a proposal, so the pool config account genuinely does not exist yet when this op runs.
- A **Solana idempotency assertion that verified nothing.** The re-apply reused the same operations bundle with byte-identical input, so `ExecuteSequence`'s report memoization returned the first apply's cached report without running the handler — the read-compare no-op path was never exercised. Now refreshes the reporter first, matching the idiom every pre-existing EVM test in that file already uses.
- Dropped no-op `,omitempty` tags from the two struct-typed input fields (`encoding/json` never omits struct values), wrapped dropped address-parse errors with `%w`, and asserted the third fee-config value (`MinFeeUSDCents`) actually landed on-chain.

## Deliberately not changed

`UpdateRateLimitAdmin{BurnMint,LockRelease}` keep their signatures — the input type is shared with the transfer-ownership and accept-ownership ops, and these are exported vars in a public module, so a new input type would be source-breaking downstream. That is why `NewOwner` carries the desired rate limit admin, which reads oddly but is intended. The ops also keep decoding pool state as `test_token_pool.State`, which has the same wire layout.

## Testing

- `TestConfigureTokenPool` — 12 subtests pass, including every pre-existing EVM test
- `TestTokensAndTokenPools` — passes; this is the regression harness for the operation changes, and it deploys Solana BurnMint and LockRelease pools through MCMS
- `go build` and `go vet` clean in `chains/solana`, `chains/solana/deployment`, `deployment`, `integration-tests`, and `chains/evm`

## Follow-ups, not blockers

- The sequence's cheap validation branches (`feeAdmin` rejection, nil-admin no-op, unknown selector) all run before the chain lookup and are trivially unit-testable without a Solana container.
- `TestConfigureTokenPool_FeeConfig_Solana` and `TestConfigureTokenPool_UnsupportedFields_Solana` each stand up their own Solana container; they are read-mostly and could share one environment.

