### PR TITLE
ci: harden workflow inputs before shell use

### DIFF
--- a/.github/actions/build-cl/action.yml
+++ b/.github/actions/build-cl/action.yml
@@ -48,23 +48,27 @@ runs:
     - name: Upgrade relayer dependencies to specified commit
       working-directory: ${{ github.workspace }}/chainlink-repo
       shell: bash
+      env:
+        TON_REF: ${{ inputs.ton_ref }}
+        SOLANA_REF: ${{ inputs.solana_ref }}
+        CCIP_REF: ${{ inputs.ccip_ref }}
       run: |
         export GOPRIVATE=github.com/smartcontractkit/*
         # Drop any stale shallow-clone VCS cache that the Go module cache restore may have
         # left behind.
         rm -rf "$(go env GOMODCACHE)/cache/vcs" || true
-        if [ -n "${{ inputs.ton_ref }}" ]; then
+        if [ -n "$TON_REF" ]; then
           for i in 1 2 3; do
-            go get github.com/smartcontractkit/chainlink-ton@${{ inputs.ton_ref }} && break
+            go get "github.com/smartcontractkit/chainlink-ton@${TON_REF}" && break
             echo "retry $i - unshallow race on chainlink-ton, sleeping 5s"
             sleep 5
           done
         fi
-        if [ -n "${{ inputs.solana_ref }}" ]; then
-          go get github.com/smartcontractkit/chainlink-solana@${{ inputs.solana_ref }}
+        if [ -n "$SOLANA_REF" ]; then
+          go get "github.com/smartcontractkit/chainlink-solana@${SOLANA_REF}"
         fi
-        if [ -n "${{ inputs.ccip_ref }}" ]; then
-          go get github.com/smartcontractkit/chainlink-ccip@${{ inputs.ccip_ref }}
-          go get github.com/smartcontractkit/chainlink-ccip/chains/evm@${{ inputs.ccip_ref }}
+        if [ -n "$CCIP_REF" ]; then
+          go get "github.com/smartcontractkit/chainlink-ccip@${CCIP_REF}"
+          go get "github.com/smartcontractkit/chainlink-ccip/chains/evm@${CCIP_REF}"
         fi
         make gomodtidy

--- a/.github/workflows/test_smoke.yml
+++ b/.github/workflows/test_smoke.yml
@@ -108,16 +108,18 @@ jobs:
           cache-dependency-path: |
             devenv/go.sum
       - name: Download Go dependencies
+        env:
+          TON_REF: ${{ inputs.ton_ref }}
         run: |
           export GOPRIVATE=github.com/smartcontractkit/*
-          if [ -n "${{ inputs.ton_ref }}" ]; then
+          if [ -n "$TON_REF" ]; then
             # Clear any stale shallow VCS cache restored by setup-go to avoid
             # "fatal: shallow file has changed since we read it" races. Retry max 3 times
             rm -rf "$(go env GOMODCACHE)/cache/vcs" || true
             for i in 1 2 3; do
-              go get github.com/smartcontractkit/chainlink-ton/devenv@${{ inputs.ton_ref }} \
-                && go get github.com/smartcontractkit/chainlink-ton/deployment@${{ inputs.ton_ref }} \
-                && go get github.com/smartcontractkit/chainlink-ton@${{ inputs.ton_ref }} \
+              go get "github.com/smartcontractkit/chainlink-ton/devenv@${TON_REF}" \
+                && go get "github.com/smartcontractkit/chainlink-ton/deployment@${TON_REF}" \
+                && go get "github.com/smartcontractkit/chainlink-ton@${TON_REF}" \
                 && break
               echo "retry $i - unshallow race on chainlink-ton, sleeping 5s"
               sleep 5


### PR DESCRIPTION
## Summary
- CI hygiene for `.github/actions/build-cl` and `test_smoke.yml`.
- Bind free-string inputs (`ton_ref`, `solana_ref`, `ccip_ref`) under `env:` before `run:` script use (quoted `$TON_REF` / `$SOLANA_REF` / `$CCIP_REF`).
- `with:` / `ref:` expressions left as-is (not shell script text).
- Defense-in-depth for Actions composites — not framed as a vulnerability ticket.

## Test plan
- [ ] Workflow YAML review
- [ ] Existing callers of `build-cl` / `test_smoke` with optional `ton_ref` / `solana_ref` / `ccip_ref` still resolve the same module versions
