### PR TITLE
Fix setPath logic in configure_lombard_chain_for_lanes.go

### DIFF
--- a/chains/evm/deployment/v2_0_0/adapters/lombard_chain.go
+++ b/chains/evm/deployment/v2_0_0/adapters/lombard_chain.go
@@ -82,3 +82,15 @@ func (c *LombardChainAdapter) RemoteTokenPoolAddress(ds datastore.DataStore, cha
 	}
 	return c.AddressRefToBytes(tokenPool)
 }
+
+// RemoteBridgeSender returns the address of the Bridge/AssetRouter on the remote chain.
+func (c *LombardChainAdapter) RemoteBridgeSender(ds datastore.DataStore, chains chain.BlockChains, selector uint64) ([]byte, error) {
+	bridgeRef, err := datastore_utils.FindAndFormatRef(ds, datastore.AddressRef{
+		Type:    datastore.ContractType("LombardBridge"),
+		Version: lombard_verifier.Version,
+	}, selector, datastore_utils.FullRef)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find Lombard Bridge address on chain %d: %w", selector, err)
+	}
+	return common.FromHex(bridgeRef.Address), nil
+}

--- a/chains/evm/deployment/v2_0_0/sequences/lombard/configure_lombard_chain_for_lanes.go
+++ b/chains/evm/deployment/v2_0_0/sequences/lombard/configure_lombard_chain_for_lanes.go
@@ -201,12 +201,14 @@ var ConfigureLombardChainForLanes = cldf_ops.NewSequence(
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to convert lombardChainID to bytes32: %w", err)
 			}
-			if remoteChain.RemoteBridgeSender == "" {
-				return sequences.OnChainOutput{}, fmt.Errorf("remote bridge sender is required for remote chain %d", remoteChainSelector)
-			}
-			remoteBridgeSender, err := parseLombardIdentifier(remoteChain.RemoteBridgeSender)
+			// Fetch the remote bridge sender from the datastore instead of requiring it in the input
+			remoteBridgeSenderBytes, err := dep.RemoteChains[remoteChainSelector].RemoteBridgeSender(dep.DataStore, dep.BlockChains, remoteChainSelector)
 			if err != nil {
-				return sequences.OnChainOutput{}, fmt.Errorf("failed to parse remote bridge sender for remote chain %d: %w", remoteChainSelector, err)
+				return sequences.OnChainOutput{}, fmt.Errorf("failed to get remote bridge sender for remote chain %d: %w", remoteChainSelector, err)
+			}
+			remoteBridgeSender, err := toBytes32LeftPad(remoteBridgeSenderBytes)
+			if err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("failed to convert remote bridge sender to bytes32 for chain %d: %w", remoteChainSelector, err)
 			}
 
 			tokenPoolPathArgs = append(tokenPoolPathArgs, lombard_token_pool.SetPathArgs{

--- a/chains/evm/deployment/v2_0_0/sequences/lombard/deploy_lombard_chain.go
+++ b/chains/evm/deployment/v2_0_0/sequences/lombard/deploy_lombard_chain.go
@@ -102,6 +102,15 @@ var DeployLombardChain = cldf_ops.NewSequence(
 		addresses = append(addresses, lombardVerifierRef)
 		lombardVerifierAddress := common.HexToAddress(lombardVerifierRef.Address)
 
+		// Save the Bridge address to the datastore for use in configure_lombard_chain_for_lanes
+		bridgeRef := datastore.AddressRef{
+			Type:          datastore.ContractType("LombardBridge"),
+			ChainSelector: input.ChainSelector,
+			Address:       lombardBridgeAddress.Hex(),
+			Version:       lombard_verifier.Version,
+		}
+		addresses = append(addresses, bridgeRef)
+
 		_, err = cldf_ops.ExecuteOperation(b, lombard_verifier.UpdateSupportedTokens, chain, contract_utils.FunctionInput[lombard_verifier.UpdateSupportedTokensArgs]{
 			ChainSelector: input.ChainSelector,
 			Address:       lombardVerifierAddress,

--- a/deployment/v2_0_0/adapters/lombard.go
+++ b/deployment/v2_0_0/adapters/lombard.go
@@ -64,10 +64,6 @@ type RemoteLombardChainConfig struct {
 	// RemoteAdapter is the optional remote token identifier accepted by Lombard bridge.
 	// Accepts either an EVM address hex string or a 32-byte hex string. Leave empty to disable adapter override.
 	RemoteAdapter string
-	// RemoteBridgeSender is the BridgeV2/AssetRouter on the remote chain expected to have sent the GMP envelope.
-	// Accepts either an EVM address hex string or a 32-byte hex string. Required: the LombardVerifier rejects a
-	// zero value, and inbound messages whose envelope sender does not match it.
-	RemoteBridgeSender string
 	FeeUSDCents        uint16
 	GasForVerification uint32
 	PayloadSizeBytes   uint16
@@ -101,6 +97,9 @@ type RemoteLombardChain interface {
 	RemoteTokenAddress(bundle cldf_ops.Bundle, ds datastore.DataStore, chains cldf_chain.BlockChains, selector uint64, tokenQualifier string) ([]byte, error)
 
 	RemoteTokenPoolAddress(ds datastore.DataStore, chains cldf_chain.BlockChains, selector uint64, tokenQualifier string) ([]byte, error)
+
+	// RemoteBridgeSender returns the address of the Bridge/AssetRouter on the remote chain.
+	RemoteBridgeSender(ds datastore.DataStore, chains cldf_chain.BlockChains, selector uint64) ([]byte, error)
 }
 
 // LombardChainRegistry maintains a registry of Lombard chains.

--- a/deployment/v2_0_0/changesets/deploy_lombard_chains_test.go
+++ b/deployment/v2_0_0/changesets/deploy_lombard_chains_test.go
@@ -214,6 +214,9 @@ func (m *mockLombardAdapter) RemoteTokenAddress(_ cldf_ops.Bundle, _ datastore.D
 func (m *mockLombardAdapter) RemoteTokenPoolAddress(_ datastore.DataStore, _ cldf_chain.BlockChains, _ uint64, _ string) ([]byte, error) {
 	return []byte("pool"), nil
 }
+func (m *mockLombardAdapter) RemoteBridgeSender(_ datastore.DataStore, _ cldf_chain.BlockChains, _ uint64) ([]byte, error) {
+	return []byte("bridge"), nil
+}
 func (m *mockLombardAdapter) AddressRefToBytes(_ datastore.AddressRef) ([]byte, error) {
 	return []byte("bytes"), nil
 }


### PR DESCRIPTION
LombardVerifier.setPath() was changed to require a non-zero remoteBridgeSender argument — the address of the Bridge/AssetRouter contract on the remote chain — and reverts with ZeroRemoteBridgeSender() if it's missing. This validation was added to close a real security gap: without it, a lane could be configured with wildcard-style permissions to submit transfers on-chain-B without pinning who's actually allowed to route the message, since the messaging-layer sender was never checked.

The problem: when chainlink-ccip's deployment code calls setPath() (in configure_lombard_chain_for_lanes.go), it builds SetPathArgs but never fills in RemoteBridgeSender — so every call reverts. The contract-level fix was shipped, but the deployment code that drives it wasn't updated to actually supply the new required value.

The tricky bit is there was no plumbing to know "What is chain B's bridge address?" from chain A's deployment sequence. To get around this each chain's bridge address is recorded in the datastore at deploy time. An alternative would be to read the bridge address using an rpc call.

I explored using an RPC call, overall it added about 30 more lines of code, and required regenerating lombard_verifier operations. I dont think thats worth it. The main downside is an already deployed Lombard Verifier won't have the datastore entry created, so the bridge address will need to be manually added. But this is a one off addition. Future deployments of the LombardVerifier will automatically add the bridge address to the datastore.