### PR TITLE
fix(ccv): derive Lombard verifier adapter lookup from the padded token form

### DIFF
--- a/chains/evm/contracts/ccvs/LombardVerifier.sol
+++ b/chains/evm/contracts/ccvs/LombardVerifier.sol
@@ -387,7 +387,11 @@ contract LombardVerifier is BaseVerifier, Ownable2StepMsgSender {
       bytes32 expected = Internal._leftPadBytesToBytes32(expectedToken);
       // When a local adapter is configured, the bridge payload encodes the adapter address
       // instead of the local token address.
-      address localToken = address(bytes20(expectedToken));
+      // Derive the lookup key from the padded form: explicit bytes20() conversion keeps the
+      // FIRST 20 bytes, so a 32-byte left-padded address would truncate to the padding and
+      // silently skip the adapter override while the identity comparison below still uses
+      // the full padded value.
+      address localToken = address(uint160(uint256(expected)));
       if (s_supportedTokens.contains(localToken)) {
         address localAdapter = s_supportedTokens.get(localToken);
         if (localAdapter != address(0)) {

--- a/chains/evm/contracts/test/ccvs/LombardVerifier/LombardVerifier.verifyMessage.t.sol
+++ b/chains/evm/contracts/test/ccvs/LombardVerifier/LombardVerifier.verifyMessage.t.sol
@@ -44,6 +44,39 @@ contract LombardVerifier_verifyMessage is LombardVerifierSetup {
     s_lombardVerifier.verifyMessage(message, messageId, ccvData);
   }
 
+  function test_verifyMessage_32ByteEncodedTokenWithAdapter() public {
+    // Register the dest token with a local adapter: the bridge payload then
+    // encodes the adapter address as toToken. s_destToken is a makeAddr label,
+    // so mock the approve calls that updateSupportedTokens triggers.
+    address adapter = makeAddr("32byteAdapter");
+    vm.mockCall(s_destToken, abi.encodeWithSignature("approve(address,uint256)"), abi.encode(true));
+    LombardVerifier.SupportedTokenArgs[] memory tokensToAdd = new LombardVerifier.SupportedTokenArgs[](1);
+    tokensToAdd[0] = LombardVerifier.SupportedTokenArgs({localToken: s_destToken, localAdapter: adapter});
+    s_lombardVerifier.updateSupportedTokens(new address[](0), tokensToAdd);
+
+    (MessageV1Codec.MessageV1 memory message, bytes32 messageId) =
+      _createForwardMessage(address(s_testToken), address(12));
+    // Canonical CCIP encoding for EVM addresses is the 32-byte abi.encode form.
+    message.tokenTransfer[0].destTokenAddress = abi.encode(s_destToken);
+
+    // The bridge payload carries the adapter address, as forwardToVerifier would have deposited it.
+    bytes memory rawPayload = _generateValidRawPayload(
+      abi.encodePacked(adapter),
+      message.sender,
+      message.tokenTransfer[0].tokenReceiver,
+      message.tokenTransfer[0].amount,
+      messageId
+    );
+    bytes memory ccvData = _encodeCcvData(rawPayload, "");
+    s_mockMailbox.setMessageId(abi.encodePacked(VERSION_TAG_V2_0_0, messageId));
+
+    vm.startPrank(s_offRamp);
+
+    // Must not revert: the adapter override has to resolve from the 32-byte padded form.
+    s_lombardVerifier.verifyMessage(message, messageId, ccvData);
+  }
+
+
   function test_verifyMessage_RevertWhen_InvalidMessageId() public {
     (MessageV1Codec.MessageV1 memory message, bytes32 messageId) =
       _createForwardMessage(address(s_testToken), address(12));


### PR DESCRIPTION
## Summary

In `LombardVerifier._validatePayload`, the supported-token lookup key is derived with an explicit `bytes20()` conversion, while the token-identity comparison two lines below uses `Internal._leftPadBytesToBytes32`:

```solidity
bytes32 expected = Internal._leftPadBytesToBytes32(expectedToken);  // whole value, left-padded
address localToken = address(bytes20(expectedToken));               // FIRST 20 bytes
```

An explicit `bytes20()` conversion of a dynamic `bytes` value keeps the leftmost 20 bytes. For a 32-byte left-padded address (the canonical `abi.encode(address)` form CCIP uses for EVM addresses) that yields 12 zero bytes plus the first 8 bytes of the real address, so:

- the adapter lookup silently misses,
- `expected` stays the padded *token* address,
- but `forwardToVerifier` deposited through the *adapter*, so the bridge payload's `toToken` is the adapter,
- and verification reverts with `InvalidToken`.

Net effect: valid transfers for adapter-configured tokens cannot be verified when `destTokenAddress` arrives in the 32-byte form, with no length guard on the field to rule that representation out.

## Fix

Derive the lookup key from the already-padded `bytes32`:

```solidity
address localToken = address(uint160(uint256(expected)));
```

so the adapter lookup and the identity comparison resolve the same address for every input length up to 32 bytes.

## Test plan

- [x] New regression test `test_verifyMessage_32ByteEncodedTokenWithAdapter`: 32-byte `abi.encode`d `destTokenAddress` with a configured adapter; reverts with `InvalidToken` before this change, passes after
- [x] Full LombardVerifier suite green: 68/68 (`forge test --match-path "*LombardVerifier*"`)

Made with Cursor

Made with [Cursor](https://cursor.com)