### PR TITLE
feat(evm): support deploying SiloedLockReleaseTokenPool at v2.0.0

### DIFF
--- a/chains/evm/deployment/operations_gen_config.yaml
+++ b/chains/evm/deployment/operations_gen_config.yaml
@@ -162,6 +162,14 @@ contracts:
         access: owner
       - name: withdrawSiloedLiquidity
         access: owner
+      # provideLiquidity/provideSiloedLiquidity are rebalancer-gated on-chain rather than onlyOwner,
+      # and there is no rebalancer access alias, so they are declared public and rely on that check.
+      - name: provideLiquidity
+        access: public
+      - name: provideSiloedLiquidity
+        access: public
+      - name: updateSiloDesignations
+        access: owner
       - name: getToken
         access: public
 
@@ -412,6 +420,8 @@ contracts:
   - contract_name: SiloedLockReleaseTokenPool
     version: "2.0.0"
     functions:
+      - name: configureLockBoxes
+        access: owner
       - name: getLockBox
         access: public
       - name: getAllLockBoxConfigs

--- a/chains/evm/deployment/v1_6_1/operations/siloed_lock_release_token_pool/siloed_lock_release_token_pool.go
+++ b/chains/evm/deployment/v1_6_1/operations/siloed_lock_release_token_pool/siloed_lock_release_token_pool.go
@@ -137,6 +137,18 @@ func (c *SiloedLockReleaseTokenPoolContract) WithdrawSiloedLiquidity(opts *bind.
 	return c.contract.Transact(opts, "withdrawSiloedLiquidity", remoteChainSelector, amount)
 }
 
+func (c *SiloedLockReleaseTokenPoolContract) ProvideLiquidity(opts *bind.TransactOpts, args *big.Int) (*types.Transaction, error) {
+	return c.contract.Transact(opts, "provideLiquidity", args)
+}
+
+func (c *SiloedLockReleaseTokenPoolContract) ProvideSiloedLiquidity(opts *bind.TransactOpts, remoteChainSelector uint64, amount *big.Int) (*types.Transaction, error) {
+	return c.contract.Transact(opts, "provideSiloedLiquidity", remoteChainSelector, amount)
+}
+
+func (c *SiloedLockReleaseTokenPoolContract) UpdateSiloDesignations(opts *bind.TransactOpts, removes []uint64, adds []SiloConfigUpdate) (*types.Transaction, error) {
+	return c.contract.Transact(opts, "updateSiloDesignations", removes, adds)
+}
+
 func (c *SiloedLockReleaseTokenPoolContract) GetToken(opts *bind.CallOpts) (common.Address, error) {
 	var out []any
 	err := c.contract.Call(opts, &out, "getToken")
@@ -147,6 +159,11 @@ func (c *SiloedLockReleaseTokenPoolContract) GetToken(opts *bind.CallOpts) (comm
 	return *abi.ConvertType(out[0], new(common.Address)).(*common.Address), nil
 }
 
+type SiloConfigUpdate struct {
+	RemoteChainSelector uint64
+	Rebalancer          common.Address
+}
+
 type SetSiloRebalancerArgs struct {
 	RemoteChainSelector uint64
 	NewRebalancer       common.Address
@@ -155,6 +172,16 @@ type SetSiloRebalancerArgs struct {
 type WithdrawSiloedLiquidityArgs struct {
 	RemoteChainSelector uint64
 	Amount              *big.Int
+}
+
+type ProvideSiloedLiquidityArgs struct {
+	RemoteChainSelector uint64
+	Amount              *big.Int
+}
+
+type UpdateSiloDesignationsArgs struct {
+	Removes []uint64
+	Adds    []SiloConfigUpdate
 }
 
 type ConstructorArgs struct {
@@ -316,6 +343,60 @@ var WithdrawSiloedLiquidity = contract.NewWrite(contract.WriteParams[WithdrawSil
 		args WithdrawSiloedLiquidityArgs,
 	) (*types.Transaction, error) {
 		return c.WithdrawSiloedLiquidity(opts, args.RemoteChainSelector, args.Amount)
+	},
+})
+
+var ProvideLiquidity = contract.NewWrite(contract.WriteParams[*big.Int, *SiloedLockReleaseTokenPoolContract]{
+	Name:            "siloed-lock-release-token-pool:provide-liquidity",
+	Version:         Version,
+	Description:     "Calls provideLiquidity on the contract",
+	ContractType:    ContractType,
+	ContractABI:     SiloedLockReleaseTokenPoolABI,
+	NewContract:     NewSiloedLockReleaseTokenPoolContract,
+	IsAllowedCaller: contract.AllCallersAllowed[*SiloedLockReleaseTokenPoolContract, *big.Int],
+	Validate:        func(*big.Int) error { return nil },
+	CallContract: func(
+		c *SiloedLockReleaseTokenPoolContract,
+		opts *bind.TransactOpts,
+		args *big.Int,
+	) (*types.Transaction, error) {
+		return c.ProvideLiquidity(opts, args)
+	},
+})
+
+var ProvideSiloedLiquidity = contract.NewWrite(contract.WriteParams[ProvideSiloedLiquidityArgs, *SiloedLockReleaseTokenPoolContract]{
+	Name:            "siloed-lock-release-token-pool:provide-siloed-liquidity",
+	Version:         Version,
+	Description:     "Calls provideSiloedLiquidity on the contract",
+	ContractType:    ContractType,
+	ContractABI:     SiloedLockReleaseTokenPoolABI,
+	NewContract:     NewSiloedLockReleaseTokenPoolContract,
+	IsAllowedCaller: contract.AllCallersAllowed[*SiloedLockReleaseTokenPoolContract, ProvideSiloedLiquidityArgs],
+	Validate:        func(ProvideSiloedLiquidityArgs) error { return nil },
+	CallContract: func(
+		c *SiloedLockReleaseTokenPoolContract,
+		opts *bind.TransactOpts,
+		args ProvideSiloedLiquidityArgs,
+	) (*types.Transaction, error) {
+		return c.ProvideSiloedLiquidity(opts, args.RemoteChainSelector, args.Amount)
+	},
+})
+
+var UpdateSiloDesignations = contract.NewWrite(contract.WriteParams[UpdateSiloDesignationsArgs, *SiloedLockReleaseTokenPoolContract]{
+	Name:            "siloed-lock-release-token-pool:update-silo-designations",
+	Version:         Version,
+	Description:     "Calls updateSiloDesignations on the contract",
+	ContractType:    ContractType,
+	ContractABI:     SiloedLockReleaseTokenPoolABI,
+	NewContract:     NewSiloedLockReleaseTokenPoolContract,
+	IsAllowedCaller: contract.OnlyOwner[*SiloedLockReleaseTokenPoolContract, UpdateSiloDesignationsArgs],
+	Validate:        func(UpdateSiloDesignationsArgs) error { return nil },
+	CallContract: func(
+		c *SiloedLockReleaseTokenPoolContract,
+		opts *bind.TransactOpts,
+		args UpdateSiloDesignationsArgs,
+	) (*types.Transaction, error) {
+		return c.UpdateSiloDesignations(opts, args.Removes, args.Adds)
 	},
 })
 

--- a/chains/evm/deployment/v2_0_0/adapters/tokens_siloed_test.go
+++ b/chains/evm/deployment/v2_0_0/adapters/tokens_siloed_test.go
@@ -1,0 +1,126 @@
+package adapters_test
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+
+	evm_datastore_utils "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/datastore"
+	contract_utils "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
+	bnm_drip_v1_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/burn_mint_erc20_with_drip"
+	v2_0_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/changesets"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/create2_factory"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/erc20_lock_box"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/siloed_lock_release_token_pool"
+	evm_tokens_sequences "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences/tokens"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/testsetup"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
+	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
+)
+
+// TestTokenExpansion_SiloedLockReleaseTokenPool covers deploying a SiloedLockReleaseTokenPool through
+// TokenExpansion - the entry point external repos use. Before lockBoxGroups existed the siloed type
+// fell through to DeployLockReleaseTokenPool, whose bytecode map only holds LockReleaseTokenPool
+// 2.0.0, so this failed with "no bytecode defined for SiloedLockReleaseTokenPool 2.0.0".
+func TestTokenExpansion_SiloedLockReleaseTokenPool(t *testing.T) {
+	const (
+		symbol      = "TSILO"
+		remoteChain = uint64(4949039107694359620)
+	)
+	chainSel := uint64(5009297550715157269)
+
+	e, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{chainSel}),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, e)
+
+	ds := datastore.NewMemoryDataStore()
+	create2FactoryRef, err := contract_utils.MaybeDeployContract(e.OperationsBundle, create2_factory.Deploy, e.BlockChains.EVMChains()[chainSel], contract_utils.DeployInput[create2_factory.ConstructorArgs]{
+		TypeAndVersion: deployment.NewTypeAndVersion(create2_factory.ContractType, *semver.MustParse("2.0.0")),
+		ChainSelector:  chainSel,
+		Args: create2_factory.ConstructorArgs{
+			AllowList: []common.Address{e.BlockChains.EVMChains()[chainSel].DeployerKey.From},
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	deployChainOut, err := v2_0_0.DeployChainContracts(changesets.GetRegistry()).Apply(*e, changesets.WithMCMS[v2_0_0.DeployChainContractsCfg]{
+		Cfg: v2_0_0.DeployChainContractsCfg{
+			ChainSel:         chainSel,
+			CREATE2Factory:   common.HexToAddress(create2FactoryRef.Address),
+			Params:           testsetup.CreateBasicContractParams(),
+			DeployerKeyOwned: true,
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, ds.Merge(deployChainOut.DataStore.Seal()))
+	e.DataStore = ds.Seal()
+
+	deployer := e.BlockChains.EVMChains()[chainSel].DeployerKey.From
+	preMint := uint64(100_000)
+
+	output, err := tokens.TokenExpansion().Apply(*e, tokens.TokenExpansionInput{
+		ChainAdapterVersion: semver.MustParse("2.0.0"),
+		MCMS:                mcms.Input{},
+		TokenExpansionInputPerChain: map[uint64]tokens.TokenExpansionInputPerChain{
+			chainSel: {
+				TokenPoolVersion:      siloed_lock_release_token_pool.Version,
+				SkipOwnershipTransfer: true,
+				DeployTokenInput: &tokens.DeployTokenInput{
+					Name:          "Test Token " + symbol,
+					Symbol:        symbol,
+					Decimals:      18,
+					PreMint:       &preMint,
+					ExternalAdmin: deployer.Hex(),
+					CCIPAdmin:     deployer.Hex(),
+					Type:          bnm_drip_v1_0.ContractType,
+				},
+				DeployTokenPoolInput: &tokens.DeployTokenPoolInput{
+					PoolType:           string(siloed_lock_release_token_pool.ContractType),
+					TokenPoolQualifier: symbol,
+					LockBoxGroups:      [][]uint64{{remoteChain}},
+				},
+			},
+		},
+	})
+	require.NoError(t, err, "TokenExpansion should succeed for a siloed lock release pool")
+
+	require.NoError(t, ds.Merge(output.DataStore.Seal()))
+	e.DataStore = ds.Seal()
+
+	poolAddr, err := datastore_utils.FindAndFormatRef(e.DataStore, datastore.AddressRef{
+		ChainSelector: chainSel,
+		Type:          datastore.ContractType(siloed_lock_release_token_pool.ContractType),
+		Version:       siloed_lock_release_token_pool.Version,
+		Qualifier:     symbol,
+	}, chainSel, evm_datastore_utils.ToEVMAddress)
+	require.NoError(t, err, "Siloed token pool should exist in datastore")
+
+	// The lockbox is recorded under the group qualifier so re-runs and ownership transfer can find it.
+	lockBoxAddr, err := datastore_utils.FindAndFormatRef(e.DataStore, datastore.AddressRef{
+		ChainSelector: chainSel,
+		Type:          datastore.ContractType(erc20_lock_box.ContractType),
+		Version:       erc20_lock_box.Version,
+		Qualifier:     evm_tokens_sequences.LockBoxQualifier(symbol, []uint64{remoteChain}),
+	}, chainSel, evm_datastore_utils.ToEVMAddress)
+	require.NoError(t, err, "Per-silo lock box should exist in datastore")
+
+	poolContract, err := siloed_lock_release_token_pool.NewSiloedLockReleaseTokenPoolContract(
+		poolAddr, e.BlockChains.EVMChains()[chainSel].Client,
+	)
+	require.NoError(t, err)
+
+	onChainLockBox, err := poolContract.GetLockBox(&bind.CallOpts{Context: t.Context()}, remoteChain)
+	require.NoError(t, err, "getLockBox should resolve for the configured remote chain")
+	require.Equal(t, lockBoxAddr, onChainLockBox, "Expected the pool to point at the deployed lock box")
+}

--- a/chains/evm/deployment/v2_0_0/operations/siloed_lock_release_token_pool/siloed_lock_release_token_pool.go
+++ b/chains/evm/deployment/v2_0_0/operations/siloed_lock_release_token_pool/siloed_lock_release_token_pool.go
@@ -9,6 +9,8 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
 	cldf_deployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
@@ -55,6 +57,10 @@ func (c *SiloedLockReleaseTokenPoolContract) Owner(opts *bind.CallOpts) (common.
 		return common.Address{}, err
 	}
 	return *abi.ConvertType(out[0], new(common.Address)).(*common.Address), nil
+}
+
+func (c *SiloedLockReleaseTokenPoolContract) ConfigureLockBoxes(opts *bind.TransactOpts, args []LockBoxConfig) (*types.Transaction, error) {
+	return c.contract.Transact(opts, "configureLockBoxes", args)
 }
 
 func (c *SiloedLockReleaseTokenPoolContract) GetLockBox(opts *bind.CallOpts, args uint64) (common.Address, error) {
@@ -104,6 +110,24 @@ var Deploy = contract.NewDeploy(contract.DeployParams[ConstructorArgs]{
 		},
 	},
 	Validate: func(ConstructorArgs) error { return nil },
+})
+
+var ConfigureLockBoxes = contract.NewWrite(contract.WriteParams[[]LockBoxConfig, *SiloedLockReleaseTokenPoolContract]{
+	Name:            "siloed-lock-release-token-pool:configure-lock-boxes",
+	Version:         Version,
+	Description:     "Calls configureLockBoxes on the contract",
+	ContractType:    ContractType,
+	ContractABI:     SiloedLockReleaseTokenPoolABI,
+	NewContract:     NewSiloedLockReleaseTokenPoolContract,
+	IsAllowedCaller: contract.OnlyOwner[*SiloedLockReleaseTokenPoolContract, []LockBoxConfig],
+	Validate:        func([]LockBoxConfig) error { return nil },
+	CallContract: func(
+		c *SiloedLockReleaseTokenPoolContract,
+		opts *bind.TransactOpts,
+		args []LockBoxConfig,
+	) (*types.Transaction, error) {
+		return c.ConfigureLockBoxes(opts, args)
+	},
 })
 
 var GetLockBox = contract.NewRead(contract.ReadParams[uint64, common.Address, *SiloedLockReleaseTokenPoolContract]{

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/operations/token_admin_registry"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/siloed_lock_release_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
@@ -79,6 +80,41 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 				// If GetSupportedChains failed (e.g. active pool is USDCTokenPoolProxy and reverts), skip validation.
 			}
 		}
+		// A SiloedLockReleaseTokenPool holds no liquidity itself: lockOrBurn/releaseOrMint go through
+		// the ERC20LockBox mapped to the remote chain, and a chain with no lockbox reverts with
+		// LockBoxNotConfigured on its first transfer rather than at configuration time. Lockboxes are
+		// provisioned by DeploySiloedLockReleaseTokenPool from the pool's declared silo groups, so a
+		// chain missing here means it was configured without being covered by those groups. Fail with
+		// an actionable error instead of leaving a lane that looks wired up but cannot transfer.
+		//
+		// getAllLockBoxConfigs only exists on the siloed pool, so a failing call means this is some
+		// other pool type and the check does not apply.
+		lockBoxConfigsReport, err := cldf_ops.ExecuteOperation(b, siloed_lock_release_token_pool.GetAllLockBoxConfigs, chain, evm_contract.FunctionInput[struct{}]{
+			ChainSelector: input.ChainSelector,
+			Address:       input.TokenPoolAddress,
+		}, cldf_ops.WithForceExecute[evm_contract.FunctionInput[struct{}], evm.Chain]())
+		if err == nil {
+			withLockBox := make(map[uint64]struct{}, len(lockBoxConfigsReport.Output))
+			for _, cfg := range lockBoxConfigsReport.Output {
+				if cfg.LockBox != (common.Address{}) {
+					withLockBox[cfg.RemoteChainSelector] = struct{}{}
+				}
+			}
+			var missing []uint64
+			for remoteChainSelector := range input.RemoteChains {
+				if _, ok := withLockBox[remoteChainSelector]; !ok {
+					missing = append(missing, remoteChainSelector)
+				}
+			}
+			if len(missing) > 0 {
+				slices.Sort(missing)
+				return sequences.OnChainOutput{}, fmt.Errorf(
+					"siloed lock release pool %s on chain %d has no lock box configured for remote chains %v; add them to the pool's lockBoxGroups",
+					input.TokenPoolAddress, input.ChainSelector, missing,
+				)
+			}
+		}
+
 		ops := make([]mcms_types.BatchOperation, 0)
 		supportedChainsReport, err := cldf_ops.ExecuteOperation(b, token_pool.GetSupportedChains, chain, evm_contract.FunctionInput[struct{}]{
 			ChainSelector: input.ChainSelector,

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/deploy_siloed_lock_release_token_pool.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/deploy_siloed_lock_release_token_pool.go
@@ -1,0 +1,190 @@
+package tokens
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	mcms_types "github.com/smartcontractkit/mcms/types"
+
+	evm_contract "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
+
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/advanced_pool_hooks"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/erc20_lock_box"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/siloed_lock_release_token_pool"
+)
+
+// LockBoxQualifier builds the datastore qualifier for the lockbox backing one silo group. The
+// group's lowest remote chain selector identifies the group: a chain belongs to at most one group
+// (enforced by DeployTokenPoolInput.ValidateLockBoxGroups), so the minimum is unique across groups
+// and stays stable regardless of the order groups are listed in.
+func LockBoxQualifier(poolQualifier string, group []uint64) string {
+	return fmt.Sprintf("%s-silo(%d)", poolQualifier, slices.Min(group))
+}
+
+// DeploySiloedLockReleaseTokenPool deploys a SiloedLockReleaseTokenPool along with one ERC20LockBox
+// per silo group.
+//
+// Unlike the plain LockReleaseTokenPool - which takes a single lockbox in its constructor - the
+// siloed pool holds no liquidity itself and no internal accounting: lockOrBurn deposits into, and
+// releaseOrMint withdraws from, the lockbox mapped to that remote chain. Siloing is therefore
+// expressed purely by which chains share a lockbox, via configureLockBoxes.
+var DeploySiloedLockReleaseTokenPool = cldf_ops.NewSequence(
+	"deploy-siloed-lock-release-token-pool",
+	semver.MustParse("2.0.0"),
+	"Deploys a siloed lock release token pool and its per-silo lock boxes to an EVM chain",
+	func(b cldf_ops.Bundle, chain evm.Chain, input DeployTokenPoolInput) (output sequences.OnChainOutput, err error) {
+		if err := input.Validate(chain); err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("invalid input: %w", err)
+		}
+		if err := input.ValidateLockBoxGroups(); err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("invalid lock box groups: %w", err)
+		}
+
+		hooksDeployReport, err := cldf_ops.ExecuteOperation(b, advanced_pool_hooks.Deploy, chain, evm_contract.DeployInput[advanced_pool_hooks.ConstructorArgs]{
+			ChainSelector:  input.ChainSel,
+			TypeAndVersion: deployment.NewTypeAndVersion(advanced_pool_hooks.ContractType, *advanced_pool_hooks.Version),
+			Args: advanced_pool_hooks.ConstructorArgs{
+				Allowlist:                        input.AdvancedPoolHooksConfig.Allowlist,
+				ThresholdAmountForAdditionalCCVs: input.ThresholdAmountForAdditionalCCVs,
+				PolicyEngine:                     input.AdvancedPoolHooksConfig.PolicyEngine,
+				AuthorizedCallers:                input.AdvancedPoolHooksConfig.AuthorizedCallers,
+			},
+			Qualifier: &input.TokenSymbol,
+		})
+		if err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to deploy advanced pool hooks to %s: %w", chain, err)
+		}
+		hooksAddr := common.HexToAddress(hooksDeployReport.Output.Address)
+
+		typeAndVersion := deployment.NewTypeAndVersion(
+			deployment.ContractType(input.TokenPoolType),
+			*input.TokenPoolVersion,
+		)
+		tpDeployReport, err := cldf_ops.ExecuteOperation(b, siloed_lock_release_token_pool.Deploy, chain, evm_contract.DeployInput[siloed_lock_release_token_pool.ConstructorArgs]{
+			ChainSelector:  input.ChainSel,
+			TypeAndVersion: typeAndVersion,
+			Args: siloed_lock_release_token_pool.ConstructorArgs{
+				Token:              input.ConstructorArgs.Token,
+				LocalTokenDecimals: input.ConstructorArgs.Decimals,
+				AdvancedPoolHooks:  hooksAddr,
+				RmnProxy:           input.ConstructorArgs.RMNProxy,
+				Router:             input.ConstructorArgs.Router,
+			},
+			Qualifier: &input.TokenSymbol,
+		})
+		if err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to deploy %s to %s: %w", typeAndVersion, chain, err)
+		}
+		poolAddr := common.HexToAddress(tpDeployReport.Output.Address)
+
+		configureReport, err := cldf_ops.ExecuteSequence(b, ConfigureTokenPool, chain, ConfigureTokenPoolInput{
+			ChainSelector:                    input.ChainSel,
+			TokenPoolAddress:                 poolAddr,
+			RateLimitAdmin:                   input.RateLimitAdmin,
+			AdvancedPoolHooks:                hooksAddr,
+			RouterAddress:                    input.ConstructorArgs.Router,
+			ThresholdAmountForAdditionalCCVs: input.ThresholdAmountForAdditionalCCVs,
+		})
+		if err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to configure token pool with address %s on %s: %w", poolAddr, chain, err)
+		}
+
+		var writes []evm_contract.WriteOutput
+
+		// Add the newly deployed token pool as an authorized caller on the hooks.
+		getAuthorizedCallersReport, err := cldf_ops.ExecuteOperation(b, advanced_pool_hooks.GetAllAuthorizedCallers, chain, evm_contract.FunctionInput[struct{}]{
+			ChainSelector: input.ChainSel,
+			Address:       hooksAddr,
+		})
+		if err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to get authorized callers from advanced pool hooks %s on %s: %w", hooksAddr, chain, err)
+		}
+		if !slices.Contains(getAuthorizedCallersReport.Output, poolAddr) {
+			applyHooksCallersReport, err := cldf_ops.ExecuteOperation(b, advanced_pool_hooks.ApplyAuthorizedCallerUpdates, chain, evm_contract.FunctionInput[advanced_pool_hooks.AuthorizedCallerArgs]{
+				ChainSelector: input.ChainSel,
+				Address:       hooksAddr,
+				Args: advanced_pool_hooks.AuthorizedCallerArgs{
+					AddedCallers: []common.Address{poolAddr},
+				},
+			})
+			if err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("failed to authorize token pool %s on advanced pool hooks with address %s on %s: %w", poolAddr, hooksAddr, chain, err)
+			}
+			writes = append(writes, applyHooksCallersReport.Output)
+		}
+
+		// Deploy one lockbox per silo group and authorize the pool on each. Every remote chain in a
+		// group maps to that group's lockbox, so chains within a group share liquidity while chains
+		// in different groups are isolated.
+		// NOTE: Addresses[0] must remain the pool ref - DeployTokenPool relies on that convention.
+		addresses := []datastore.AddressRef{tpDeployReport.Output, hooksDeployReport.Output}
+		lockBoxConfigs := make([]siloed_lock_release_token_pool.LockBoxConfig, 0, len(input.LockBoxGroups))
+		for _, group := range input.LockBoxGroups {
+			qualifier := LockBoxQualifier(input.TokenSymbol, group)
+			lbDeployReport, err := cldf_ops.ExecuteOperation(b, erc20_lock_box.Deploy, chain, evm_contract.DeployInput[erc20_lock_box.ConstructorArgs]{
+				ChainSelector:  input.ChainSel,
+				TypeAndVersion: deployment.NewTypeAndVersion(erc20_lock_box.ContractType, *erc20_lock_box.Version),
+				Args: erc20_lock_box.ConstructorArgs{
+					Token: input.ConstructorArgs.Token,
+				},
+				Qualifier: &qualifier,
+			})
+			if err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("failed to deploy ERC20 lock box %q to %s: %w", qualifier, chain, err)
+			}
+			addresses = append(addresses, lbDeployReport.Output)
+			lockBoxAddr := common.HexToAddress(lbDeployReport.Output.Address)
+
+			for _, remoteChainSelector := range group {
+				lockBoxConfigs = append(lockBoxConfigs, siloed_lock_release_token_pool.LockBoxConfig{
+					RemoteChainSelector: remoteChainSelector,
+					LockBox:             lockBoxAddr,
+				})
+			}
+
+			applyLockBoxCallersReport, err := cldf_ops.ExecuteOperation(b, erc20_lock_box.ApplyAuthorizedCallerUpdates, chain, evm_contract.FunctionInput[erc20_lock_box.AuthorizedCallerArgs]{
+				ChainSelector: input.ChainSel,
+				Address:       lockBoxAddr,
+				Args: erc20_lock_box.AuthorizedCallerArgs{
+					AddedCallers: []common.Address{poolAddr},
+				},
+			})
+			if err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("failed to authorize token pool %s on lock box %s on %s: %w", poolAddr, lockBoxAddr, chain, err)
+			}
+			writes = append(writes, applyLockBoxCallersReport.Output)
+		}
+
+		// Map every remote chain to its lockbox in a single call.
+		configureLockBoxesReport, err := cldf_ops.ExecuteOperation(b, siloed_lock_release_token_pool.ConfigureLockBoxes, chain, evm_contract.FunctionInput[[]siloed_lock_release_token_pool.LockBoxConfig]{
+			ChainSelector: input.ChainSel,
+			Address:       poolAddr,
+			Args:          lockBoxConfigs,
+		})
+		if err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to configure lock boxes on token pool %s on %s: %w", poolAddr, chain, err)
+		}
+		writes = append(writes, configureLockBoxesReport.Output)
+
+		batchOps := configureReport.Output.BatchOps
+		if len(writes) > 0 {
+			batchOp, err := evm_contract.NewBatchOperationFromWrites(writes)
+			if err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("failed to create batch operation from writes: %w", err)
+			}
+			batchOps = append(batchOps, []mcms_types.BatchOperation{batchOp}...)
+		}
+
+		return sequences.OnChainOutput{
+			Addresses: addresses,
+			BatchOps:  batchOps,
+		}, nil
+	},
+)

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/deploy_siloed_lock_release_token_pool_test.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/deploy_siloed_lock_release_token_pool_test.go
@@ -1,0 +1,226 @@
+package tokens_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/rmn_proxy"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/operations/router"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/operations/burn_mint_erc20_with_drip"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/create2_factory"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/erc20_lock_box"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/siloed_lock_release_token_pool"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/token_pool"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences/tokens"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/testsetup"
+)
+
+// Arbitrary remote chain selectors; the pool only stores them as map keys.
+const (
+	siloedRemoteChainA = uint64(1111)
+	siloedRemoteChainB = uint64(2222)
+	siloedRemoteChainC = uint64(3333)
+)
+
+// setupSiloedPoolDeps stands up a simulated chain with the contracts the siloed pool constructor
+// needs, and returns the base input the tests then vary.
+func setupSiloedPoolDeps(t *testing.T, chainSel uint64) (*deployment.Environment, tokens.DeployTokenPoolInput) {
+	t.Helper()
+
+	e, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{chainSel}),
+	)
+	require.NoError(t, err, "Failed to create environment")
+	require.NotNil(t, e, "Environment should be created")
+
+	create2FactoryRef, err := contract.MaybeDeployContract(e.OperationsBundle, create2_factory.Deploy, e.BlockChains.EVMChains()[chainSel], contract.DeployInput[create2_factory.ConstructorArgs]{
+		TypeAndVersion: deployment.NewTypeAndVersion(create2_factory.ContractType, *semver.MustParse("2.0.0")),
+		ChainSelector:  chainSel,
+		Args: create2_factory.ConstructorArgs{
+			AllowList: []common.Address{e.BlockChains.EVMChains()[chainSel].DeployerKey.From},
+		},
+	}, nil)
+	require.NoError(t, err, "Failed to deploy CREATE2Factory")
+
+	chainReport, err := operations.ExecuteSequence(
+		e.OperationsBundle,
+		sequences.DeployChainContracts,
+		e.BlockChains.EVMChains()[chainSel],
+		sequences.DeployChainContractsInput{
+			ChainSelector:    chainSel,
+			CREATE2Factory:   common.HexToAddress(create2FactoryRef.Address),
+			ContractParams:   testsetup.CreateBasicContractParams(),
+			DeployerKeyOwned: true,
+		},
+	)
+	require.NoError(t, err, "ExecuteSequence should not error")
+
+	tokenReport, err := operations.ExecuteOperation(
+		e.OperationsBundle,
+		burn_mint_erc20_with_drip.Deploy,
+		e.BlockChains.EVMChains()[chainSel],
+		contract.DeployInput[burn_mint_erc20_with_drip.ConstructorArgs]{
+			ChainSelector:  chainSel,
+			TypeAndVersion: deployment.NewTypeAndVersion(burn_mint_erc20_with_drip.ContractType, *burn_mint_erc20_with_drip.Version),
+			Args: burn_mint_erc20_with_drip.ConstructorArgs{
+				Name:   "Test Token",
+				Symbol: "TEST",
+			},
+		},
+	)
+	require.NoError(t, err, "ExecuteOperation should not error")
+
+	var rmnProxyAddress, routerAddress common.Address
+	for _, addr := range chainReport.Output.Addresses {
+		if addr.Type == datastore.ContractType(rmn_proxy.ContractType) {
+			rmnProxyAddress = common.HexToAddress(addr.Address)
+		}
+		if addr.Type == datastore.ContractType(router.ContractType) {
+			routerAddress = common.HexToAddress(addr.Address)
+		}
+	}
+
+	return e, tokens.DeployTokenPoolInput{
+		ChainSel:                         chainSel,
+		TokenPoolType:                    datastore.ContractType(siloed_lock_release_token_pool.ContractType),
+		TokenPoolVersion:                 siloed_lock_release_token_pool.Version,
+		TokenSymbol:                      tokenReport.Input.Args.Symbol,
+		RateLimitAdmin:                   common.HexToAddress("0x01"),
+		ThresholdAmountForAdditionalCCVs: big.NewInt(1e18),
+		ConstructorArgs: tokens.ConstructorArgs{
+			Token:    common.HexToAddress(tokenReport.Output.Address),
+			Decimals: 18,
+			RMNProxy: rmnProxyAddress,
+			Router:   routerAddress,
+		},
+	}
+}
+
+func TestDeploySiloedLockReleaseTokenPool(t *testing.T) {
+	chainSel := uint64(5009297550715157269)
+
+	t.Run("happy path - chains A and B share a lock box, C is siloed", func(t *testing.T) {
+		e, input := setupSiloedPoolDeps(t, chainSel)
+		input.LockBoxGroups = [][]uint64{
+			{siloedRemoteChainA, siloedRemoteChainB},
+			{siloedRemoteChainC},
+		}
+
+		poolReport, err := operations.ExecuteSequence(
+			e.OperationsBundle,
+			tokens.DeploySiloedLockReleaseTokenPool,
+			e.BlockChains.EVMChains()[chainSel],
+			input,
+		)
+		require.NoError(t, err, "ExecuteSequence should not error")
+		require.Len(t, poolReport.Output.Addresses, 4, "Expected 4 addresses in output (pool, hooks, 2 lock boxes)")
+
+		poolAddress := common.HexToAddress(poolReport.Output.Addresses[0].Address)
+		sharedLockBox := common.HexToAddress(poolReport.Output.Addresses[2].Address)
+		siloedLockBox := common.HexToAddress(poolReport.Output.Addresses[3].Address)
+		require.NotEqual(t, sharedLockBox, siloedLockBox, "Expected a distinct lock box per silo group")
+
+		// The pool holds no liquidity of its own, so the token/router wiring plus the lock box
+		// mapping is what makes a lane usable.
+		getTokenReport, err := operations.ExecuteOperation(
+			testsetup.BundleWithFreshReporter(e.OperationsBundle),
+			token_pool.GetToken,
+			e.BlockChains.EVMChains()[chainSel],
+			contract.FunctionInput[struct{}]{ChainSelector: chainSel, Address: poolAddress},
+		)
+		require.NoError(t, err, "ExecuteOperation should not error")
+		require.Equal(t, input.ConstructorArgs.Token, getTokenReport.Output, "Expected the pool's token to be the deployed token")
+
+		// Every chain in a group must resolve to that group's lock box.
+		for chain, expected := range map[uint64]common.Address{
+			siloedRemoteChainA: sharedLockBox,
+			siloedRemoteChainB: sharedLockBox,
+			siloedRemoteChainC: siloedLockBox,
+		} {
+			getLockBoxReport, err := operations.ExecuteOperation(
+				testsetup.BundleWithFreshReporter(e.OperationsBundle),
+				siloed_lock_release_token_pool.GetLockBox,
+				e.BlockChains.EVMChains()[chainSel],
+				contract.FunctionInput[uint64]{ChainSelector: chainSel, Address: poolAddress, Args: chain},
+			)
+			require.NoError(t, err, "ExecuteOperation should not error for chain %d", chain)
+			require.Equal(t, expected, getLockBoxReport.Output, "Unexpected lock box for remote chain %d", chain)
+		}
+
+		getAllConfigsReport, err := operations.ExecuteOperation(
+			testsetup.BundleWithFreshReporter(e.OperationsBundle),
+			siloed_lock_release_token_pool.GetAllLockBoxConfigs,
+			e.BlockChains.EVMChains()[chainSel],
+			contract.FunctionInput[struct{}]{ChainSelector: chainSel, Address: poolAddress},
+		)
+		require.NoError(t, err, "ExecuteOperation should not error")
+		require.Len(t, getAllConfigsReport.Output, 3, "Expected one lock box config per remote chain")
+
+		// The pool must be able to deposit into and withdraw from each of its lock boxes.
+		for _, lockBox := range []common.Address{sharedLockBox, siloedLockBox} {
+			getCallersReport, err := operations.ExecuteOperation(
+				testsetup.BundleWithFreshReporter(e.OperationsBundle),
+				erc20_lock_box.GetAllAuthorizedCallers,
+				e.BlockChains.EVMChains()[chainSel],
+				contract.FunctionInput[struct{}]{ChainSelector: chainSel, Address: lockBox},
+			)
+			require.NoError(t, err, "ExecuteOperation should not error")
+			require.Equal(t, []common.Address{poolAddress}, getCallersReport.Output, "Expected only the pool to be authorized on lock box %s", lockBox)
+		}
+	})
+
+	t.Run("lock box groups not defined", func(t *testing.T) {
+		e, input := setupSiloedPoolDeps(t, chainSel)
+
+		_, err := operations.ExecuteSequence(
+			e.OperationsBundle,
+			tokens.DeploySiloedLockReleaseTokenPool,
+			e.BlockChains.EVMChains()[chainSel],
+			input,
+		)
+		require.Error(t, err, "ExecuteSequence should error")
+		require.Contains(t, err.Error(), "lock box groups must be defined")
+	})
+
+	t.Run("remote chain in more than one lock box group", func(t *testing.T) {
+		e, input := setupSiloedPoolDeps(t, chainSel)
+		input.LockBoxGroups = [][]uint64{
+			{siloedRemoteChainA, siloedRemoteChainB},
+			{siloedRemoteChainB},
+		}
+
+		_, err := operations.ExecuteSequence(
+			e.OperationsBundle,
+			tokens.DeploySiloedLockReleaseTokenPool,
+			e.BlockChains.EVMChains()[chainSel],
+			input,
+		)
+		require.Error(t, err, "ExecuteSequence should error")
+		require.Contains(t, err.Error(), "appears in lock box groups 0 and 1")
+	})
+
+	t.Run("empty lock box group", func(t *testing.T) {
+		e, input := setupSiloedPoolDeps(t, chainSel)
+		input.LockBoxGroups = [][]uint64{{siloedRemoteChainA}, {}}
+
+		_, err := operations.ExecuteSequence(
+			e.OperationsBundle,
+			tokens.DeploySiloedLockReleaseTokenPool,
+			e.BlockChains.EVMChains()[chainSel],
+			input,
+		)
+		require.Error(t, err, "ExecuteSequence should error")
+		require.Contains(t, err.Error(), "lock box group 1 is empty")
+	})
+}

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/deploy_token_pool.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/deploy_token_pool.go
@@ -221,11 +221,22 @@ var DeployTokenPool = cldf_ops.NewSequence(
 			AdvancedPoolHooksConfig: AdvancedPoolHooksConfig{
 				Allowlist: allowlist,
 			},
+			LockBoxGroups: input.LockBoxGroups,
 		}
 
 		// Deploy the desired pool contract
 		output := sequences.OnChainOutput{}
 		switch {
+		// NOTE: the siloed case must precede the lock-release case below, because
+		// utils.IsLockReleasePoolType deliberately reports true for the siloed type. The siloed pool
+		// has a distinct constructor (no lockbox argument) and needs one lockbox per silo group, so
+		// it cannot share DeployLockReleaseTokenPool.
+		case tokenPoolType == datastore.ContractType(utils.SiloedLockReleaseTokenPool):
+			if report, err := cldf_ops.ExecuteSequence(b, DeploySiloedLockReleaseTokenPool, chain, internalInput); err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("failed to deploy siloed lock release token pool on chain %d: %w", chain.Selector, err)
+			} else {
+				output = report.Output
+			}
 		case utils.IsLockReleasePoolType(tokenPoolType.String()):
 			if report, err := cldf_ops.ExecuteSequence(b, DeployLockReleaseTokenPool, chain, internalInput); err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to deploy lock release token pool on chain %d: %w", chain.Selector, err)

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/migrate_lock_release_pool_liquidity.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/migrate_lock_release_pool_liquidity.go
@@ -3,7 +3,7 @@ package tokens
 import (
 	"fmt"
 	"math/big"
-	"strings"
+	"slices"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
@@ -23,6 +23,7 @@ import (
 	siloed_lrtp_ops_v170 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/siloed_lock_release_token_pool"
 	token_pool_ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
 	evm_contract "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
 )
@@ -63,7 +64,9 @@ var MigrateLockReleasePoolLiquidity = cldf_ops.NewSequence(
 		}
 		tokenAddr := tokenReport.Output
 
-		isSiloed := strings.Contains(oldPoolType, "Siloed")
+		// Only the generic siloed lock-release pool is handled here. A substring match on "Siloed"
+		// would also catch SiloedUSDCTokenPool, which migrates through the CCTP hybrid path instead.
+		isSiloed := oldPoolType == utils.SiloedLockReleaseTokenPool.String()
 
 		if isSiloed {
 			if input.Amount != nil {
@@ -217,7 +220,45 @@ func migrateSiloedPool(
 
 	lockboxByChain := make(map[uint64]common.Address)
 	for _, config := range lockboxConfigsReport.Output {
+		if config.LockBox == (common.Address{}) {
+			continue
+		}
 		lockboxByChain[config.RemoteChainSelector] = config.LockBox
+	}
+
+	// Resolve which of the old pool's chains are siloed once; used both for the coverage check below
+	// and for the rebalancer handover further down.
+	isSiloedByChain := make(map[uint64]bool, len(supportedChains))
+	for _, remoteChain := range supportedChains {
+		isSiloedReport, err := cldf_ops.ExecuteOperation(b, siloed_ops_v161.IsSiloed, evmChain, evm_contract.FunctionInput[uint64]{
+			ChainSelector: chainSel,
+			Address:       oldPoolAddr,
+			Args:          remoteChain,
+		})
+		if err != nil {
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to check if chain %d is siloed on old pool %s: %w", remoteChain, oldPoolAddr, err)
+		}
+		isSiloedByChain[remoteChain] = isSiloedReport.Output
+	}
+
+	// Check lockbox coverage before emitting any writes. Without this the batch is built chain by
+	// chain and a gap surfaces partway through - after the rebalancer has already been repointed at
+	// the timelock - leaving the operator to work out which silo was missing.
+	var chainsWithoutLockBox []uint64
+	for _, remoteChain := range supportedChains {
+		if !isSiloedByChain[remoteChain] {
+			continue
+		}
+		if _, ok := lockboxByChain[remoteChain]; !ok {
+			chainsWithoutLockBox = append(chainsWithoutLockBox, remoteChain)
+		}
+	}
+	if len(chainsWithoutLockBox) > 0 {
+		slices.Sort(chainsWithoutLockBox)
+		return sequences.OnChainOutput{}, fmt.Errorf(
+			"new siloed pool %s has no lockbox configured for siloed chains %v of old pool %s; the new pool's lockBoxGroups must cover every siloed chain being migrated",
+			newPoolAddr, chainsWithoutLockBox, oldPoolAddr,
+		)
 	}
 
 	rebalancerReport, err := cldf_ops.ExecuteOperation(b, siloed_ops_v161.GetRebalancer, evmChain, evm_contract.FunctionInput[struct{}]{
@@ -247,16 +288,7 @@ func migrateSiloedPool(
 	var siloInfos []chainRebalancerInfo
 
 	for _, remoteChain := range supportedChains {
-		isSiloedReport, err := cldf_ops.ExecuteOperation(b, siloed_ops_v161.IsSiloed, evmChain, evm_contract.FunctionInput[uint64]{
-			ChainSelector: chainSel,
-			Address:       oldPoolAddr,
-			Args:          remoteChain,
-		})
-		if err != nil {
-			return sequences.OnChainOutput{}, fmt.Errorf("failed to check if chain %d is siloed on old pool %s: %w", remoteChain, oldPoolAddr, err)
-		}
-
-		if isSiloedReport.Output {
+		if isSiloedByChain[remoteChain] {
 			chainRebalancerReport, err := cldf_ops.ExecuteOperation(b, siloed_ops_v161.GetChainRebalancer, evmChain, evm_contract.FunctionInput[uint64]{
 				ChainSelector: chainSel,
 				Address:       oldPoolAddr,

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/migrate_lock_release_pool_liquidity_test.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/migrate_lock_release_pool_liquidity_test.go
@@ -727,19 +727,17 @@ func TestMigrateLockReleasePoolLiquidity_SiloedPool(t *testing.T) {
 	require.NoError(t, err)
 
 	// Mark chains as siloed and set silo rebalancers via updateSiloDesignations
-	type siloConfigUpdate struct {
-		RemoteChainSelector uint64
-		Rebalancer          common.Address
-	}
-	tx, err = oldPoolBound.Transact(chain.DeployerKey, "updateSiloDesignations",
-		[]uint64{},
-		[]siloConfigUpdate{
-			{RemoteChainSelector: remoteChain1, Rebalancer: deployer},
-			{RemoteChainSelector: remoteChain2, Rebalancer: deployer},
-		},
-	)
-	require.NoError(t, err)
-	_, err = chain.Confirm(tx)
+	_, err = operations.ExecuteOperation(e.OperationsBundle, old_siloed.UpdateSiloDesignations, chain,
+		evm_contract.FunctionInput[old_siloed.UpdateSiloDesignationsArgs]{
+			ChainSelector: chainSel, Address: oldPoolAddr,
+			Args: old_siloed.UpdateSiloDesignationsArgs{
+				Removes: []uint64{},
+				Adds: []old_siloed.SiloConfigUpdate{
+					{RemoteChainSelector: remoteChain1, Rebalancer: deployer},
+					{RemoteChainSelector: remoteChain2, Rebalancer: deployer},
+				},
+			},
+		})
 	require.NoError(t, err)
 
 	// Set deployer as the unsiloed rebalancer (for provideLiquidity)
@@ -766,19 +764,26 @@ func TestMigrateLockReleasePoolLiquidity_SiloedPool(t *testing.T) {
 		})
 	require.NoError(t, err)
 
-	tx, err = oldPoolBound.Transact(chain.DeployerKey, "provideSiloedLiquidity", remoteChain1, silo1Amount)
-	require.NoError(t, err)
-	_, err = chain.Confirm(tx)
-	require.NoError(t, err)
+	for _, silo := range []struct {
+		remoteChainSelector uint64
+		amount              *big.Int
+	}{
+		{remoteChain1, silo1Amount},
+		{remoteChain2, silo2Amount},
+	} {
+		_, err = operations.ExecuteOperation(e.OperationsBundle, old_siloed.ProvideSiloedLiquidity, chain,
+			evm_contract.FunctionInput[old_siloed.ProvideSiloedLiquidityArgs]{
+				ChainSelector: chainSel, Address: oldPoolAddr,
+				Args: old_siloed.ProvideSiloedLiquidityArgs{
+					RemoteChainSelector: silo.remoteChainSelector,
+					Amount:              silo.amount,
+				},
+			})
+		require.NoError(t, err)
+	}
 
-	tx, err = oldPoolBound.Transact(chain.DeployerKey, "provideSiloedLiquidity", remoteChain2, silo2Amount)
-	require.NoError(t, err)
-	_, err = chain.Confirm(tx)
-	require.NoError(t, err)
-
-	tx, err = oldPoolBound.Transact(chain.DeployerKey, "provideLiquidity", unsiloedAmount)
-	require.NoError(t, err)
-	_, err = chain.Confirm(tx)
+	_, err = operations.ExecuteOperation(e.OperationsBundle, old_siloed.ProvideLiquidity, chain,
+		evm_contract.FunctionInput[*big.Int]{ChainSelector: chainSel, Address: oldPoolAddr, Args: unsiloedAmount})
 	require.NoError(t, err)
 
 	// Deploy new v2.0 siloed pool via gobindings

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/types.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/types.go
@@ -61,6 +61,33 @@ type DeployTokenPoolInput struct {
 	ConstructorArgs ConstructorArgs
 	// AdvancedPoolHooksConfig contains optional configuration for AdvancedPoolHooks.
 	AdvancedPoolHooksConfig AdvancedPoolHooksConfig
+	// LockBoxGroups declares the liquidity topology for a SiloedLockReleaseTokenPool: each group is a
+	// set of remote chain selectors sharing one ERC20LockBox, so chains in different groups have
+	// isolated liquidity. Required for SiloedLockReleaseTokenPool, ignored by all other pool types.
+	LockBoxGroups [][]uint64
+}
+
+// ValidateLockBoxGroups checks that the declared silo topology is well formed: at least one group,
+// no empty groups, and no chain in more than one group (which would make the lockbox mapping
+// ambiguous, since configureLockBoxes is last-write-wins per chain).
+func (c DeployTokenPoolInput) ValidateLockBoxGroups() error {
+	if len(c.LockBoxGroups) == 0 {
+		return fmt.Errorf("lock box groups must be defined for pool type %s", c.TokenPoolType)
+	}
+	seen := make(map[uint64]int, len(c.LockBoxGroups))
+	for i, group := range c.LockBoxGroups {
+		if len(group) == 0 {
+			return fmt.Errorf("lock box group %d is empty", i)
+		}
+		for _, sel := range group {
+			if prev, dup := seen[sel]; dup {
+				return fmt.Errorf("remote chain selector %d appears in lock box groups %d and %d", sel, prev, i)
+			}
+			seen[sel] = i
+		}
+	}
+
+	return nil
 }
 
 func (c DeployTokenPoolInput) ChainSelector() uint64 {

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -147,6 +147,17 @@ type DeployTokenPoolInput struct {
 	// declarative setDynamicConfig reconcile (no-op if it already matches).
 	// EVM 2.0.0+ only.
 	FeeAggregator string `yaml:"feeAggregator,omitempty" json:"feeAggregator,omitempty"`
+	// LockBoxGroups declares the liquidity topology of a SiloedLockReleaseTokenPool. Each group is a
+	// set of remote chain selectors that share one ERC20LockBox; chains in different groups have
+	// isolated ("siloed") liquidity. One lockbox is deployed per group and mapped to every chain in
+	// it via the pool's configureLockBoxes.
+	//
+	// Required (and only meaningful) for SiloedLockReleaseTokenPool. The plain LockReleaseTokenPool
+	// takes a single lockbox in its constructor and ignores this field. A chain must not appear in
+	// more than one group, and every remote chain the pool will serve needs to be covered - a chain
+	// with no lockbox reverts with LockBoxNotConfigured on its first transfer.
+	// EVM 2.0.0+ only.
+	LockBoxGroups [][]uint64 `yaml:"lockBoxGroups,omitempty" json:"lockBoxGroups,omitempty"`
 	// below are not specified by the user, filled in by the deployment system to pass to chain operations
 	ChainSelector     uint64
 	ExistingDataStore datastore.DataStore


### PR DESCRIPTION
## Motivation

A `SiloedLockReleaseTokenPool` could not be deployed at v2.0.0 through the normal tooling, which blocked E2E token-pool-migration coverage for custom (non-BurnMint/LockRelease) pools in `chainlink-ccv`.

Four things were in the way:

1. `deploy_token_pool.go` routes every type matching `utils.IsLockReleasePoolType` — which deliberately returns `true` for the siloed type — into `DeployLockReleaseTokenPool`, which unconditionally calls `lock_release_token_pool.Deploy`. That op's `BytecodeByTypeAndVersion` map only holds `LockReleaseTokenPool 2.0.0`, so the deploy failed with `no bytecode defined for SiloedLockReleaseTokenPool 2.0.0`. (`DeployBurnMintTokenPool` *does* switch on pool type, which is why the burn-mint variants work.)
2. The v2 siloed pool keeps liquidity in per-remote-chain `ERC20LockBox` contracts and has no internal accounting at all — `_lockOrBurn` deposits into, and `_releaseOrMint` withdraws from, the lockbox mapped to that chain. Nothing deployed or configured those for a regular token; only the CCTP-specific `deploy_siloed_usdc_lock_release.go` did.
3. There was no generated `configureLockBoxes` write op for `SiloedLockReleaseTokenPool 2.0.0`, so the mapping could not be written even given lockboxes.
4. The v1.6.1 siloed pool had no `updateSiloDesignations` / `provideLiquidity` / `provideSiloedLiquidity` ops, so a legacy siloed pool could not be set up or funded through operations (a plain ERC20 transfer does not register as liquidity there).

## Changes

**Missing write ops** (`operations_gen_config.yaml` + regenerated packages, additive only)
- `SiloedLockReleaseTokenPool 2.0.0`: `configureLockBoxes` (owner)
- `SiloedLockReleaseTokenPool 1.6.1`: `updateSiloDesignations` (owner), `provideLiquidity` / `provideSiloedLiquidity` (declared `public` — they are rebalancer-gated on-chain rather than `onlyOwner`, and there is no rebalancer access alias)

**Silo topology as input** — new `LockBoxGroups [][]uint64` (yaml `lockBoxGroups`) on `deployment/tokens.DeployTokenPoolInput` and the v2 sequence input, with `ValidateLockBoxGroups` rejecting an empty set, empty groups, and any chain appearing in two groups. Each group is the set of remote chains sharing one lockbox, so chains in different groups have isolated liquidity. This mirrors the contract: siloing *is* which chains share a lockbox (`s_lockBoxes` is an explicitly many-to-one map), so there is no separate `isSiloed` flag to model.

**New `DeploySiloedLockReleaseTokenPool` sequence** — deploys hooks and the siloed pool (distinct constructor: no lockbox argument), one `ERC20LockBox` per group, authorizes the pool on each, then maps every chain in a single `configureLockBoxes` call. Lockboxes are recorded in the datastore under a stable per-group qualifier (`<pool>-silo(<lowest selector>)`) so the already-siloed-aware ownership transfer in `v2_0_0/adapters/tokens.go` picks them up. `deploy_token_pool.go` dispatches to it *before* the `IsLockReleasePoolType` case.

**Two robustness fixes**
- `ConfigureTokenPoolForRemoteChains` now fails with an actionable error naming the chains that have no lockbox, instead of leaving a lane that looks configured but reverts `LockBoxNotConfigured` on the first user transfer. Duck-typed on `getAllLockBoxConfigs`, so it is a no-op for other pool types.
- `migrate_lock_release_pool_liquidity.go`: `strings.Contains(oldPoolType, "Siloed")` also matched `SiloedUSDCTokenPool` (which migrates via the CCTP hybrid path), so it is now a type-constant comparison. Lockbox coverage is validated up front rather than surfacing mid-batch, after the rebalancer has already been repointed at the timelock. The resulting duplicate `IsSiloed` reads were collapsed into one pass.

## Testing

- Full test suites pass for `chains/evm/deployment/...` and `deployment/...`, including the existing siloed coverage in `migrate_lock_release_pool_liquidity_test.go`
- `go build` and `go vet` clean on both modules; `gofmt` clean on every touched file
- New `TestDeploySiloedLockReleaseTokenPool` — asserts on-chain that two chains in one group resolve to a shared lockbox while a third gets its own, one config per remote chain, only the pool authorized on each lockbox, plus the three validation errors
- New `TestTokenExpansion_SiloedLockReleaseTokenPool` — drives `TokenExpansion`, the entry point external repos use, and is the direct regression test for the `no bytecode defined` failure

## Notes for reviewers

- Regenerating the ops packages requires the gitignored `chains/evm/abi/` + `chains/evm/bytecode/` inputs. The tool the Makefile references (`gobindings/cmd/extract_bytecode`) is not in the tree, so I reconstructed those two contracts' inputs from the ABI/Bin constants already embedded in the generated files, after validating with a round-trip that reproduced the committed files byte-for-byte. Please re-run `make -C chains/evm operations` with the full foundry/pnpm toolchain to confirm.
- No changeset: `@chainlink/contracts-ccip` is unaffected, no `.sol` files changed.
- Follow-up: `chainlink-ccv` needs a dependency bump to add the SiloedLockRelease case to `build/devenv/tests/e2e/smoke_token_pool_migration_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
