### PR TITLE
fix : update CCTP and Lombard verifier tag to use 2.1.0

### DIFF
--- a/chains/evm/deployment/v2_0_0/verifier_tags/tags.go
+++ b/chains/evm/deployment/v2_0_0/verifier_tags/tags.go
@@ -2,9 +2,9 @@ package verifier_tags
 
 // TODO potentially update schema with 2-byte prefix + 2 byte version.
 var (
-	cctpVerifierV2      = [4]byte{0x35, 0xa2, 0x58, 0x38} // bytes4(keccak256("CCTPVerifier 2.0.0"))
+	cctpVerifierV2      = [4]byte{0x91, 0xb3, 0x33, 0x8e} // bytes4(keccak256("CCTPVerifier 2.1.0"))
 	committeeVerifierV2 = [4]byte{0xe9, 0xa0, 0x5a, 0x20} // bytes4(keccak256("CommitteeVerifier 2.0.0"))
-	lombardVerifierV2   = [4]byte{0xeb, 0xa5, 0x55, 0x88} // bytes4(keccak256("LombardVerifier 2.0.0"))
+	lombardVerifierV2   = [4]byte{0x5b, 0x92, 0x53, 0xce} // bytes4(keccak256("LombardVerifier 2.1.0"))
 )
 
 func CCTPVerifierV2() [4]byte {


### PR DESCRIPTION
<img width="711" height="156" alt="image" src="https://github.com/user-attachments/assets/6e16ce46-2b5f-4549-b301-3133a77f171f" />


https://github.com/smartcontractkit/chainlink-ccip/pull/2235 will update the tags in ccv repo once this is merged
