### PR TITLE
feat(commit): add beholder metrics for commit plugin visibility

### DIFF
--- a/commit/merkleroot/observation.go
+++ b/commit/merkleroot/observation.go
@@ -63,6 +63,27 @@ var allOffRampLaneStatuses = []string{
 	laneStatusLive, laneStatusSkippedNotALane, laneStatusSkippedDisabled, laneStatusRMNMisconfigured,
 }
 
+// Reasons passed to MetricsReporter.TrackObservationError. Named here, rather than left as inline
+// literals, because these are effectively a stable label-value contract for dashboards/runbooks/alerts
+// (see docs/runbooks/uncommitted-message.md's metric reference table) with no test asserting on the
+// literal spelling -- a typo at a call site would silently create an unmonitored label value instead of
+// failing to compile.
+const (
+	obsErrNoBindings         = "no_bindings"
+	obsErrTimeout            = "timeout"
+	obsErrRPCError           = "rpc_error"
+	obsErrMsgCountMismatch   = "msg_count_mismatch"
+	obsErrSeqNumMismatch     = "seq_num_mismatch"
+	obsErrHashError          = "hash_error"
+	obsErrAddressLookupError = "address_lookup_error"
+)
+
+// Curse-type labels used with MetricsReporter.TrackRmnCurseActive.
+const (
+	curseTypeGlobal      = "global"
+	curseTypeDestination = "destination"
+)
+
 // offRampLaneClassification buckets source chains by their offramp lane status.
 type offRampLaneClassification struct {
 	// live lanes are enabled, have an onRamp, and have RMN verification disabled (queryable).
@@ -597,8 +618,8 @@ func (o observerImpl) ObserveOffRampNextSeqNums(ctx context.Context) []plugintyp
 
 	// Report curse state unconditionally (including "not cursed") so the gauges reflect the current
 	// round rather than sticking at a stale "1" from a curse that has since cleared.
-	o.metricsReporter.TrackRmnCurseActive("global", curseInfo.GlobalCurse)
-	o.metricsReporter.TrackRmnCurseActive("destination", curseInfo.CursedDestination)
+	o.metricsReporter.TrackRmnCurseActive(curseTypeGlobal, curseInfo.GlobalCurse)
+	o.metricsReporter.TrackRmnCurseActive(curseTypeDestination, curseInfo.CursedDestination)
 	for _, sourceChain := range allSourceChains {
 		o.metricsReporter.TrackSourceChainCursed(sourceChain, curseInfo.CursedSourceChains[sourceChain])
 	}
@@ -714,13 +735,13 @@ func (o observerImpl) ObserveLatestOnRampSeqNums(ctx context.Context) []pluginty
 					// when a source chain is disabled there will not be a binding for the onRamp contract
 					// we don't want to log this as an error.
 					lggr.Debugw("no bindings for source chain, ignore if chain is disabled", "sourceChain", sourceChain)
-					o.metricsReporter.TrackObservationError(sourceChain, "no_bindings")
+					o.metricsReporter.TrackObservationError(sourceChain, obsErrNoBindings)
 				} else if errors.Is(err, context.DeadlineExceeded) {
 					lggr.Warnw("timed out getting latest msg seq num for source chain", logutil.FieldSourceChain, sourceChain)
-					o.metricsReporter.TrackObservationError(sourceChain, "timeout")
+					o.metricsReporter.TrackObservationError(sourceChain, obsErrTimeout)
 				} else {
 					lggr.Errorw("failed to get latest msg seq num for source chain", logutil.FieldSourceChain, sourceChain, "err", err)
-					o.metricsReporter.TrackObservationError(sourceChain, "rpc_error")
+					o.metricsReporter.TrackObservationError(sourceChain, obsErrRPCError)
 				}
 				return
 			}
@@ -771,10 +792,10 @@ func (o observerImpl) ObserveMerkleRoots(
 							logutil.FieldSourceChain, chainRange.ChainSel,
 							logutil.FieldSeqNumRange, chainRange.SeqNumRange,
 						)
-						o.metricsReporter.TrackObservationError(chainRange.ChainSel, "timeout")
+						o.metricsReporter.TrackObservationError(chainRange.ChainSel, obsErrTimeout)
 					} else {
 						lggr.Warnw("call to MsgsBetweenSeqNums failed", "err", err)
-						o.metricsReporter.TrackObservationError(chainRange.ChainSel, "rpc_error")
+						o.metricsReporter.TrackObservationError(chainRange.ChainSel, obsErrRPCError)
 					}
 					return
 				}
@@ -786,7 +807,7 @@ func (o observerImpl) ObserveMerkleRoots(
 						"expected", chainRange.SeqNumRange.End()-chainRange.SeqNumRange.Start()+1,
 						"actual", len(msgs),
 					)
-					o.metricsReporter.TrackObservationError(chainRange.ChainSel, "msg_count_mismatch")
+					o.metricsReporter.TrackObservationError(chainRange.ChainSel, obsErrMsgCountMismatch)
 					return
 				}
 
@@ -802,7 +823,7 @@ func (o observerImpl) ObserveMerkleRoots(
 							"msgSeqNum", msgSeqNum,
 							logutil.FieldSeqNumRange, chainRange.SeqNumRange,
 						)
-						o.metricsReporter.TrackObservationError(chainRange.ChainSel, "seq_num_mismatch")
+						o.metricsReporter.TrackObservationError(chainRange.ChainSel, obsErrSeqNumMismatch)
 						return
 					}
 					msgIdx++
@@ -811,7 +832,7 @@ func (o observerImpl) ObserveMerkleRoots(
 				root, err := o.computeMerkleRoot(ctx, lggr, msgs)
 				if err != nil {
 					lggr.Warnw("call to computeMerkleRoot failed", "err", err)
-					o.metricsReporter.TrackObservationError(chainRange.ChainSel, "hash_error")
+					o.metricsReporter.TrackObservationError(chainRange.ChainSel, obsErrHashError)
 					return
 				}
 
@@ -822,7 +843,7 @@ func (o observerImpl) ObserveMerkleRoots(
 						"err", err,
 						logutil.FieldSourceChain, chainRange.ChainSel,
 					)
-					o.metricsReporter.TrackObservationError(chainRange.ChainSel, "address_lookup_error")
+					o.metricsReporter.TrackObservationError(chainRange.ChainSel, obsErrAddressLookupError)
 					return
 				}
 

--- a/commit/merkleroot/observation.go
+++ b/commit/merkleroot/observation.go
@@ -50,6 +50,19 @@ func isLiveOffRampSourceLane(cfg readerpkg.StaticSourceChainConfig, exists bool)
 	return exists && cfg.IsEnabled && len(cfg.OnRamp) > 0
 }
 
+// Offramp lane status labels used with MetricsReporter.TrackOffRampLaneStatus. Mutually exclusive: a
+// source chain is in exactly one of these buckets every round.
+const (
+	laneStatusLive             = "live"
+	laneStatusSkippedNotALane  = "skipped_not_a_lane"
+	laneStatusSkippedDisabled  = "skipped_disabled"
+	laneStatusRMNMisconfigured = "rmn_misconfigured"
+)
+
+var allOffRampLaneStatuses = []string{
+	laneStatusLive, laneStatusSkippedNotALane, laneStatusSkippedDisabled, laneStatusRMNMisconfigured,
+}
+
 // offRampLaneClassification buckets source chains by their offramp lane status.
 type offRampLaneClassification struct {
 	// live lanes are enabled, have an onRamp, and have RMN verification disabled (queryable).
@@ -60,6 +73,25 @@ type offRampLaneClassification struct {
 	skippedDisabled []cciptypes.ChainSelector
 	// rmnMisconfigured are live lanes that unexpectedly have RMN verification enabled.
 	rmnMisconfigured []cciptypes.ChainSelector
+}
+
+// statusByChain returns the single status bucket each source chain landed in.
+func (c offRampLaneClassification) statusByChain() map[cciptypes.ChainSelector]string {
+	statuses := make(map[cciptypes.ChainSelector]string,
+		len(c.live)+len(c.skippedNotALane)+len(c.skippedDisabled)+len(c.rmnMisconfigured))
+	for _, chain := range c.live {
+		statuses[chain] = laneStatusLive
+	}
+	for _, chain := range c.skippedNotALane {
+		statuses[chain] = laneStatusSkippedNotALane
+	}
+	for _, chain := range c.skippedDisabled {
+		statuses[chain] = laneStatusSkippedDisabled
+	}
+	for _, chain := range c.rmnMisconfigured {
+		statuses[chain] = laneStatusRMNMisconfigured
+	}
+	return statuses
 }
 
 // classifyOffRampSourceLanes buckets the supported source chains based on their offramp source chain
@@ -643,6 +675,14 @@ func (o observerImpl) ObserveLatestOnRampSeqNums(ctx context.Context) []pluginty
 	}
 
 	classification := classifyOffRampSourceLanes(supportedSourceChains, sourceChainsCfg)
+
+	// Report unconditionally (all four statuses, active and inactive) so the gauge can't get stuck
+	// showing an old status as "still active" once a chain moves to a different bucket.
+	for chain, actualStatus := range classification.statusByChain() {
+		for _, status := range allOffRampLaneStatuses {
+			o.metricsReporter.TrackOffRampLaneStatus(chain, status, status == actualStatus)
+		}
+	}
 
 	if len(classification.skippedNotALane) > 0 || len(classification.skippedDisabled) > 0 {
 		logutil.LogWhenExceedFrequency(&lastSkippedLanesLog, skippedLanesLogFrequency, func() {

--- a/commit/merkleroot/observation.go
+++ b/commit/merkleroot/observation.go
@@ -642,6 +642,8 @@ func (o observerImpl) ObserveOffRampNextSeqNums(ctx context.Context) []plugintyp
 }
 
 // ObserveLatestOnRampSeqNums observes the latest onRamp sequence numbers for each configured source chain.
+//
+//nolint:gocyclo
 func (o observerImpl) ObserveLatestOnRampSeqNums(ctx context.Context) []plugintypes.SeqNumChain {
 	lggr := logutil.WithContextValues(ctx, o.lggr)
 

--- a/commit/merkleroot/observation.go
+++ b/commit/merkleroot/observation.go
@@ -501,12 +501,13 @@ func (o *asyncObserver) Close() error {
 }
 
 type observerImpl struct {
-	lggr         logger.Logger
-	homeChain    reader.HomeChain
-	oracleID     commontypes.OracleID
-	chainSupport plugincommon.ChainSupport
-	ccipReader   readerpkg.CCIPReader
-	msgHasher    cciptypes.MessageHasher
+	lggr            logger.Logger
+	homeChain       reader.HomeChain
+	oracleID        commontypes.OracleID
+	chainSupport    plugincommon.ChainSupport
+	ccipReader      readerpkg.CCIPReader
+	msgHasher       cciptypes.MessageHasher
+	metricsReporter MetricsReporter
 }
 
 func newObserverImpl(
@@ -516,14 +517,16 @@ func newObserverImpl(
 	chainSupport plugincommon.ChainSupport,
 	ccipReader readerpkg.CCIPReader,
 	msgHasher cciptypes.MessageHasher,
+	metricsReporter MetricsReporter,
 ) observerImpl {
 	return observerImpl{
-		lggr:         lggr,
-		homeChain:    homeChain,
-		oracleID:     oracleID,
-		chainSupport: chainSupport,
-		ccipReader:   ccipReader,
-		msgHasher:    msgHasher,
+		lggr:            lggr,
+		homeChain:       homeChain,
+		oracleID:        oracleID,
+		chainSupport:    chainSupport,
+		ccipReader:      ccipReader,
+		msgHasher:       msgHasher,
+		metricsReporter: metricsReporter,
 	}
 }
 
@@ -559,6 +562,15 @@ func (o observerImpl) ObserveOffRampNextSeqNums(ctx context.Context) []plugintyp
 		)
 		return nil
 	}
+
+	// Report curse state unconditionally (including "not cursed") so the gauges reflect the current
+	// round rather than sticking at a stale "1" from a curse that has since cleared.
+	o.metricsReporter.TrackRmnCurseActive("global", curseInfo.GlobalCurse)
+	o.metricsReporter.TrackRmnCurseActive("destination", curseInfo.CursedDestination)
+	for _, sourceChain := range allSourceChains {
+		o.metricsReporter.TrackSourceChainCursed(sourceChain, curseInfo.CursedSourceChains[sourceChain])
+	}
+
 	if curseInfo.GlobalCurse || curseInfo.CursedDestination {
 		lggr.Warnw("nothing to observe: rmn curse", "curseInfo", curseInfo)
 		return nil
@@ -590,6 +602,7 @@ func (o observerImpl) ObserveOffRampNextSeqNums(ctx context.Context) []plugintyp
 	result := make([]plugintypes.SeqNumChain, 0, len(sourceChains))
 	for chainSelector, seqNum := range offRampNextSeqNums {
 		result = append(result, plugintypes.NewSeqNumChain(chainSelector, seqNum))
+		o.metricsReporter.TrackOffRampNextSeqNum(chainSelector, seqNum)
 	}
 
 	sort.Slice(result, func(i, j int) bool { return result[i].ChainSel < result[j].ChainSel })
@@ -659,14 +672,18 @@ func (o observerImpl) ObserveLatestOnRampSeqNums(ctx context.Context) []pluginty
 					// when a source chain is disabled there will not be a binding for the onRamp contract
 					// we don't want to log this as an error.
 					lggr.Debugw("no bindings for source chain, ignore if chain is disabled", "sourceChain", sourceChain)
+					o.metricsReporter.TrackObservationError(sourceChain, "no_bindings")
 				} else if errors.Is(err, context.DeadlineExceeded) {
 					lggr.Warnw("timed out getting latest msg seq num for source chain", logutil.FieldSourceChain, sourceChain)
+					o.metricsReporter.TrackObservationError(sourceChain, "timeout")
 				} else {
 					lggr.Errorw("failed to get latest msg seq num for source chain", logutil.FieldSourceChain, sourceChain, "err", err)
+					o.metricsReporter.TrackObservationError(sourceChain, "rpc_error")
 				}
 				return
 			}
 
+			o.metricsReporter.TrackOnRampMaxSeqNum(sourceChain, latestOnRampSeqNum)
 			mu.Lock()
 			latestOnRampSeqNums = append(
 				latestOnRampSeqNums,
@@ -712,8 +729,10 @@ func (o observerImpl) ObserveMerkleRoots(
 							logutil.FieldSourceChain, chainRange.ChainSel,
 							logutil.FieldSeqNumRange, chainRange.SeqNumRange,
 						)
+						o.metricsReporter.TrackObservationError(chainRange.ChainSel, "timeout")
 					} else {
 						lggr.Warnw("call to MsgsBetweenSeqNums failed", "err", err)
+						o.metricsReporter.TrackObservationError(chainRange.ChainSel, "rpc_error")
 					}
 					return
 				}
@@ -725,6 +744,7 @@ func (o observerImpl) ObserveMerkleRoots(
 						"expected", chainRange.SeqNumRange.End()-chainRange.SeqNumRange.Start()+1,
 						"actual", len(msgs),
 					)
+					o.metricsReporter.TrackObservationError(chainRange.ChainSel, "msg_count_mismatch")
 					return
 				}
 
@@ -740,6 +760,7 @@ func (o observerImpl) ObserveMerkleRoots(
 							"msgSeqNum", msgSeqNum,
 							logutil.FieldSeqNumRange, chainRange.SeqNumRange,
 						)
+						o.metricsReporter.TrackObservationError(chainRange.ChainSel, "seq_num_mismatch")
 						return
 					}
 					msgIdx++
@@ -748,6 +769,7 @@ func (o observerImpl) ObserveMerkleRoots(
 				root, err := o.computeMerkleRoot(ctx, lggr, msgs)
 				if err != nil {
 					lggr.Warnw("call to computeMerkleRoot failed", "err", err)
+					o.metricsReporter.TrackObservationError(chainRange.ChainSel, "hash_error")
 					return
 				}
 
@@ -758,6 +780,7 @@ func (o observerImpl) ObserveMerkleRoots(
 						"err", err,
 						logutil.FieldSourceChain, chainRange.ChainSel,
 					)
+					o.metricsReporter.TrackObservationError(chainRange.ChainSel, "address_lookup_error")
 					return
 				}
 
@@ -864,8 +887,8 @@ func (o observerImpl) ObserveFChain(ctx context.Context) map[cciptypes.ChainSele
 
 	fChain, err := o.homeChain.GetFChain()
 	if err != nil {
-		// TODO: metrics
 		lggr.Errorw("call to GetFChain failed", "err", err)
+		o.metricsReporter.TrackFChainReadError()
 		return map[cciptypes.ChainSelector]int{}
 	}
 	return fChain

--- a/commit/merkleroot/observation_test.go
+++ b/commit/merkleroot/observation_test.go
@@ -377,6 +377,7 @@ func Test_ObserveOffRampNextSeqNums(t *testing.T) {
 				chainSupport,
 				ccipReader,
 				mocks.NewMessageHasher(),
+				NoopMetrics{},
 			)
 
 			assert.Equal(t, tc.expResult, o.ObserveOffRampNextSeqNums(ctx))
@@ -589,6 +590,7 @@ func Test_ObserveOnRampNextSeqNums(t *testing.T) {
 				chainSupport,
 				ccipReader,
 				mocks.NewMessageHasher(),
+				NoopMetrics{},
 			)
 
 			assert.Equal(t, tc.expResult, o.ObserveLatestOnRampSeqNums(ctx))
@@ -634,6 +636,7 @@ func Test_ObserveOnRampNextSeqNums(t *testing.T) {
 			chainSupport,
 			ccipReader,
 			mocks.NewMessageHasher(),
+			NoopMetrics{},
 		)
 
 		result := o.ObserveLatestOnRampSeqNums(ctx)
@@ -939,6 +942,7 @@ func Test_ObserveMerkleRoots(t *testing.T) {
 				chainSupport,
 				mockCCIPReader,
 				mocks.NewMessageHasher(),
+				NoopMetrics{},
 			)
 
 			roots := o.ObserveMerkleRoots(ctx, tc.ranges)
@@ -1003,6 +1007,7 @@ func Test_ObserveMerkleRoots(t *testing.T) {
 			chainSupport,
 			mockCCIPReader,
 			mocks.NewMessageHasher(),
+			NoopMetrics{},
 		)
 
 		roots := o.ObserveMerkleRoots(ctx, ranges)

--- a/commit/merkleroot/outcome.go
+++ b/commit/merkleroot/outcome.go
@@ -88,12 +88,14 @@ func (p *Processor) getOutcome(
 	consObservation, err := getConsensusObservation(lggr, p.reportingCfg.F, p.destChain, aos)
 	if err != nil {
 		lggr.Warnw(ConsensusObservationFailed, "err", err)
+		p.metricsReporter.TrackConsensusObservationFailed()
 		return Outcome{}, nextState, nil
 	}
 
 	switch nextState {
 	case selectingRangesForReport:
-		return reportRangesOutcome(q, lggr, consObservation, p.offchainCfg.MaxMerkleTreeSize, p.destChain),
+		return reportRangesOutcome(
+				q, lggr, consObservation, p.offchainCfg.MaxMerkleTreeSize, p.destChain, p.metricsReporter),
 			nextState,
 			nil
 	case buildingReport:
@@ -115,7 +117,8 @@ func (p *Processor) getOutcome(
 	case waitingForReportTransmission:
 		attempts := p.offchainCfg.MaxReportTransmissionCheckAttempts
 		multipleReports := p.offchainCfg.MultipleReportsEnabled
-		outcome := checkForReportTransmission(lggr, attempts, multipleReports, previousOutcome, consObservation)
+		outcome := checkForReportTransmission(
+			lggr, attempts, multipleReports, previousOutcome, consObservation, p.metricsReporter)
 		return outcome, nextState, nil
 	default:
 		return Outcome{}, nextState, fmt.Errorf("unexpected next state in Outcome: %v", nextState)
@@ -129,6 +132,7 @@ func reportRangesOutcome(
 	consObservation consensusObservation,
 	maxMerkleTreeSize uint64,
 	dstChain cciptypes.ChainSelector,
+	metricsReporter MetricsReporter,
 ) Outcome {
 	rangesToReport := make([]plugintypes.ChainRange, 0)
 
@@ -148,6 +152,12 @@ func reportRangesOutcome(
 		if !exists {
 			continue
 		}
+
+		var pending uint64
+		if onRampMaxSeqNum >= offRampNextSeqNum {
+			pending = uint64(onRampMaxSeqNum-offRampNextSeqNum) + 1
+		}
+		metricsReporter.TrackPendingMessages(chainSel, pending)
 
 		if onRampMaxSeqNum < offRampNextSeqNum-1 {
 			if onRampMaxSeqNum == 0 {
@@ -397,6 +407,7 @@ func checkForReportTransmission(
 	multipleReports bool,
 	previousOutcome Outcome,
 	consensusObservation consensusObservation,
+	metricsReporter MetricsReporter,
 ) Outcome {
 	// Check that all sources have been updates using a set initialized from the previous outcome.
 	// Check that all have been updated in case there were multiple reports generated in the previous round.
@@ -405,11 +416,15 @@ func checkForReportTransmission(
 		pendingSources[root.ChainSel] = struct{}{}
 	}
 
+	// Attempts consumed as of, and including, this check.
+	checksSoFar := previousOutcome.ReportTransmissionCheckAttempts + 1
+
 	for _, previousSeqNumChain := range previousOutcome.OffRampNextSeqNums {
 		if currentSeqNum, exists := consensusObservation.OffRampNextSeqNums[previousSeqNumChain.ChainSel]; exists {
 			if previousSeqNumChain.SeqNum < currentSeqNum {
 				// if there is only one report, any single update means the report has been transmitted.
 				if !multipleReports {
+					metricsReporter.TrackReportTransmissionAttempts(checksSoFar, true)
 					return Outcome{
 						OutcomeType: ReportTransmitted,
 					}
@@ -431,17 +446,22 @@ func checkForReportTransmission(
 
 	// All pending sources have been updated, we can move to the next state.
 	if len(pendingSources) == 0 {
+		metricsReporter.TrackReportTransmissionAttempts(checksSoFar, true)
 		return Outcome{
 			OutcomeType: ReportTransmitted,
 		}
 	}
 
-	if previousOutcome.ReportTransmissionCheckAttempts+1 >= maxReportTransmissionCheckAttempts {
+	if checksSoFar >= maxReportTransmissionCheckAttempts {
 		lggr.Warnw(
 			ReportTransmissionGaveUp,
 			"maxReportTransmissionCheckAttempts", maxReportTransmissionCheckAttempts,
 			"abandonedSourceChains", slices.Collect(maps.Keys(pendingSources)),
 		)
+		for chainSel := range pendingSources {
+			metricsReporter.TrackReportTransmissionGaveUp(chainSel)
+		}
+		metricsReporter.TrackReportTransmissionAttempts(checksSoFar, false)
 		return Outcome{
 			OutcomeType: ReportTransmissionFailed,
 		}

--- a/commit/merkleroot/outcome.go
+++ b/commit/merkleroot/outcome.go
@@ -85,7 +85,7 @@ func (p *Processor) getOutcome(
 ) (Outcome, processorState, error) {
 	nextState := previousOutcome.nextState()
 
-	consObservation, err := getConsensusObservation(lggr, p.reportingCfg.F, p.destChain, aos)
+	consObservation, err := getConsensusObservation(lggr, p.reportingCfg.F, p.destChain, aos, p.metricsReporter)
 	if err != nil {
 		lggr.Warnw(ConsensusObservationFailed, "err", err)
 		p.metricsReporter.TrackConsensusObservationFailed()
@@ -164,10 +164,12 @@ func reportRangesOutcome(
 				lggr.Infow(OnRampMaxSeqNumZero,
 					logutil.FieldChain, chainSel,
 					"note", "not necessarily an issue, but if it persists without progress investigate why oracles observe 0")
+				metricsReporter.TrackSeqNumInvariantViolation(chainSel, "onramp_max_zero")
 			} else {
 				lggr.Errorw(ImpossibleSeqNumsOnOffRamp,
 					"detail", "offRamp latest executed sequence number is greater than onRamp latest executed sequence number",
 					logutil.FieldChain, chainSel, "onRampMaxSeqNum", onRampMaxSeqNum, "offRampNextSeqNum", offRampNextSeqNum)
+				metricsReporter.TrackSeqNumInvariantViolation(chainSel, "offramp_ahead_of_onramp")
 			}
 		}
 
@@ -183,6 +185,7 @@ func reportRangesOutcome(
 
 			if rng.End() != chainRange.SeqNumRange.End() { // Check if the range was truncated.
 				lggr.Debugf("Range for chain %d: %s (before truncate: %v)", chainSel, chainRange.SeqNumRange, rng)
+				metricsReporter.TrackRangeTruncated(chainSel)
 			} else {
 				lggr.Debugf("Range for chain %d: %s", chainSel, chainRange.SeqNumRange)
 			}
@@ -440,6 +443,7 @@ func checkForReportTransmission(
 					logutil.FieldSeqNum, previousSeqNumChain.SeqNum,
 					"currentSeqNum", currentSeqNum,
 				)
+				metricsReporter.TrackSeqNumInvariantViolation(previousSeqNumChain.ChainSel, "offramp_seqnum_regression")
 			}
 		}
 	}
@@ -483,6 +487,7 @@ func getConsensusObservation(
 	fRoleDON int,
 	destChain cciptypes.ChainSelector,
 	aos []plugincommon.AttributedObservation[Observation],
+	metricsReporter MetricsReporter,
 ) (consensusObservation, error) {
 	aggObs := aggregateObservations(aos)
 
@@ -519,9 +524,10 @@ func getConsensusObservation(
 			"OnRamp Max Seq Nums",
 			aggObs.OnRampMaxSeqNums,
 			fChain),
-		OffRampNextSeqNums: getOffRampNextSequenceNumbersConsensus(lggr, uint(fDestChain), aggObs.OffRampNextSeqNums),
-		RMNRemoteConfig:    consensus.GetConsensusMap(lggr, "RMNRemote cfg", rmnRemoteConfigs, twoFChainPlus1),
-		FChain:             fChains,
+		OffRampNextSeqNums: getOffRampNextSequenceNumbersConsensus(
+			lggr, uint(fDestChain), aggObs.OffRampNextSeqNums, metricsReporter),
+		RMNRemoteConfig: consensus.GetConsensusMap(lggr, "RMNRemote cfg", rmnRemoteConfigs, twoFChainPlus1),
+		FChain:          fChains,
 	}
 
 	return consensusObs, nil
@@ -536,6 +542,7 @@ func getOffRampNextSequenceNumbersConsensus(
 	lggr logger.Logger,
 	fDestChain uint,
 	observationsPerChain map[cciptypes.ChainSelector][]cciptypes.SeqNum,
+	metricsReporter MetricsReporter,
 ) map[cciptypes.ChainSelector]cciptypes.SeqNum {
 	lggr = logger.With(lggr, "fDestChain", fDestChain)
 
@@ -548,6 +555,7 @@ func getOffRampNextSequenceNumbersConsensus(
 				"numObservations", len(observedNextSeqNums),
 				"requiredObservations", 2*fDestChain+1,
 			)
+			metricsReporter.TrackOffRampConsensusInsufficient(sourceChain)
 			continue
 		}
 

--- a/commit/merkleroot/outcome.go
+++ b/commit/merkleroot/outcome.go
@@ -52,6 +52,17 @@ const (
 	InsufficientOffRampConsensus = "not enough observations for OffRampNextSeqNums consensus on chain"
 )
 
+// Violation-type labels used with MetricsReporter.TrackSeqNumInvariantViolation. Named here, rather
+// than left as inline literals, because these are effectively a stable label-value contract for
+// dashboards/runbooks/alerts (see docs/runbooks/uncommitted-message.md's metric reference table) with
+// no test asserting on the literal spelling -- a typo at a call site would silently create an
+// unmonitored label value instead of failing to compile.
+const (
+	seqNumViolationOnRampMaxZero          = "onramp_max_zero"
+	seqNumViolationOffRampAheadOfOnRamp   = "offramp_ahead_of_onramp"
+	seqNumViolationOffRampSeqNumRegressed = "offramp_seqnum_regression"
+)
+
 // Outcome depending on the current state, either:
 // - chooses the seq num ranges for the next round
 // - builds a report
@@ -164,12 +175,12 @@ func reportRangesOutcome(
 				lggr.Infow(OnRampMaxSeqNumZero,
 					logutil.FieldChain, chainSel,
 					"note", "not necessarily an issue, but if it persists without progress investigate why oracles observe 0")
-				metricsReporter.TrackSeqNumInvariantViolation(chainSel, "onramp_max_zero")
+				metricsReporter.TrackSeqNumInvariantViolation(chainSel, seqNumViolationOnRampMaxZero)
 			} else {
 				lggr.Errorw(ImpossibleSeqNumsOnOffRamp,
 					"detail", "offRamp latest executed sequence number is greater than onRamp latest executed sequence number",
 					logutil.FieldChain, chainSel, "onRampMaxSeqNum", onRampMaxSeqNum, "offRampNextSeqNum", offRampNextSeqNum)
-				metricsReporter.TrackSeqNumInvariantViolation(chainSel, "offramp_ahead_of_onramp")
+				metricsReporter.TrackSeqNumInvariantViolation(chainSel, seqNumViolationOffRampAheadOfOnRamp)
 			}
 		}
 
@@ -443,7 +454,8 @@ func checkForReportTransmission(
 					logutil.FieldSeqNum, previousSeqNumChain.SeqNum,
 					"currentSeqNum", currentSeqNum,
 				)
-				metricsReporter.TrackSeqNumInvariantViolation(previousSeqNumChain.ChainSel, "offramp_seqnum_regression")
+				metricsReporter.TrackSeqNumInvariantViolation(
+					previousSeqNumChain.ChainSel, seqNumViolationOffRampSeqNumRegressed)
 			}
 		}
 	}

--- a/commit/merkleroot/outcome_test.go
+++ b/commit/merkleroot/outcome_test.go
@@ -1464,7 +1464,7 @@ func Test_getOffRampNextSequenceNumbersConsensus(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			res := getOffRampNextSequenceNumbersConsensus(lggr, tc.fDestChain, tc.observationsPerChain)
+			res := getOffRampNextSequenceNumbersConsensus(lggr, tc.fDestChain, tc.observationsPerChain, NoopMetrics{})
 			require.Equal(t, tc.expRes, res)
 		})
 	}

--- a/commit/merkleroot/outcome_test.go
+++ b/commit/merkleroot/outcome_test.go
@@ -1228,7 +1228,8 @@ func Test_reportRangesOutcome(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			outcome := reportRangesOutcome(Query{}, lggr, tc.consensusObservation, tc.merkleTreeSizeLimit, destChain)
+			outcome := reportRangesOutcome(
+				Query{}, lggr, tc.consensusObservation, tc.merkleTreeSizeLimit, destChain, NoopMetrics{})
 			require.Equal(t, tc.expectedOutcome, outcome)
 		})
 	}
@@ -1392,6 +1393,7 @@ func TestCheckForReportTransmission(t *testing.T) {
 				tt.multipleReports,
 				tt.previousOutcome,
 				tt.consensusObservation,
+				NoopMetrics{},
 			)
 			require.Equal(t, tt.expectedOutcome, outcome)
 		})

--- a/commit/merkleroot/processor.go
+++ b/commit/merkleroot/processor.go
@@ -66,6 +66,7 @@ func NewProcessor(
 		chainSupport,
 		ccipReader,
 		msgHasher,
+		metricsReporter,
 	)
 	if !offchainCfg.MerkleRootAsyncObserverDisabled {
 		observer = newAsyncObserver(

--- a/commit/merkleroot/types.go
+++ b/commit/merkleroot/types.go
@@ -286,6 +286,23 @@ type MetricsReporter interface {
 	// TrackReportTransmissionAttempts records how many check-attempts were consumed by the time a report
 	// resolved (transmitted or gave up), so operators can see typical/creeping transmission latency.
 	TrackReportTransmissionAttempts(attempts uint, success bool)
+
+	// TrackRangeTruncated reports a source chain's selected sequence-number range being cut short by
+	// MaxMerkleTreeSize, i.e. the chain has more new messages than fit in a single report.
+	TrackRangeTruncated(sourceChain cciptypes.ChainSelector)
+	// TrackOffRampLaneStatus reports, for every round and every known offRamp lane status, whether a
+	// source chain is currently in that status. Reported unconditionally (active and inactive) for every
+	// status so the four buckets stay mutually exclusive and none of them can silently go stale.
+	TrackOffRampLaneStatus(sourceChain cciptypes.ChainSelector, status string, active bool)
+	// TrackSeqNumInvariantViolation reports a violation of the invariants the plugin relies on to make
+	// progress: offRamp ahead of onRamp, onRamp max seq num observed as 0, or offRamp's next seq num
+	// regressing between rounds. violationType is "offramp_ahead_of_onramp", "onramp_max_zero", or
+	// "offramp_seqnum_regression".
+	TrackSeqNumInvariantViolation(sourceChain cciptypes.ChainSelector, violationType string)
+	// TrackOffRampConsensusInsufficient reports a source chain being dropped from this round's outcome
+	// because fewer than 2*fDestChain+1 oracles agreed on its offRamp next sequence number. From outside,
+	// this looks identical to "no new messages on this lane".
+	TrackOffRampConsensusInsufficient(sourceChain cciptypes.ChainSelector)
 }
 
 type NoopMetrics struct{}
@@ -315,3 +332,11 @@ func (n NoopMetrics) TrackConsensusObservationFailed() {}
 func (n NoopMetrics) TrackReportTransmissionGaveUp(cciptypes.ChainSelector) {}
 
 func (n NoopMetrics) TrackReportTransmissionAttempts(uint, bool) {}
+
+func (n NoopMetrics) TrackRangeTruncated(cciptypes.ChainSelector) {}
+
+func (n NoopMetrics) TrackOffRampLaneStatus(cciptypes.ChainSelector, string, bool) {}
+
+func (n NoopMetrics) TrackSeqNumInvariantViolation(cciptypes.ChainSelector, string) {}
+
+func (n NoopMetrics) TrackOffRampConsensusInsufficient(cciptypes.ChainSelector) {}

--- a/commit/merkleroot/types.go
+++ b/commit/merkleroot/types.go
@@ -249,6 +249,43 @@ type MetricsReporter interface {
 	TrackRmnReport(latency float64, success bool)
 	TrackProcessorLatency(processor string, method string, latency time.Duration, err error)
 	TrackProcessorOutput(processor string, method plugincommon.MethodType, obs plugintypes.Trackable)
+
+	// TrackOnRampMaxSeqNum reports this oracle's own raw view of the latest onRamp sequence number for a
+	// source chain, every round it's read (selectingRangesForReport state) -- independent of whether a
+	// report ends up including that chain. This is the "is my reading of chain X up to date" signal.
+	TrackOnRampMaxSeqNum(sourceChain cciptypes.ChainSelector, seqNum cciptypes.SeqNum)
+	// TrackOffRampNextSeqNum reports this oracle's own raw view of the offRamp's next expected sequence
+	// number for a source chain, every round it's read.
+	TrackOffRampNextSeqNum(sourceChain cciptypes.ChainSelector, seqNum cciptypes.SeqNum)
+	// TrackPendingMessages reports the consensus backlog (onRampMaxSeqNum - offRampNextSeqNum + 1) per
+	// source chain, computed once per round from the DON's agreed values.
+	TrackPendingMessages(sourceChain cciptypes.ChainSelector, pending uint64)
+
+	// TrackRmnCurseActive reports whether a global or destination-wide RMN curse is currently blocking all
+	// reporting for this destination chain. curseType is "global" or "destination".
+	TrackRmnCurseActive(curseType string, active bool)
+	// TrackSourceChainCursed reports whether a specific source chain is currently cursed (and therefore
+	// excluded from offRamp reads this round).
+	TrackSourceChainCursed(sourceChain cciptypes.ChainSelector, cursed bool)
+
+	// TrackObservationError reports a per-source-chain failure while reading onRamp sequence numbers or
+	// computing a merkle root for a chain range. These failures are swallowed per-goroutine today and
+	// never reach the generic processor-error counter since the outer Observation() call still succeeds.
+	TrackObservationError(sourceChain cciptypes.ChainSelector, reason string)
+	// TrackFChainReadError reports a failure to read FChain from the home chain.
+	TrackFChainReadError()
+	// TrackConsensusObservationFailed reports a round where the DON failed to reach consensus on FChain
+	// for the destination chain, producing an empty outcome. This is destination-chain-wide, not
+	// lane-specific -- see docs/metrics/commit-metrics.md.
+	TrackConsensusObservationFailed()
+
+	// TrackReportTransmissionGaveUp reports a source chain being abandoned (moving back to
+	// selectingRangesForReport) after MaxReportTransmissionCheckAttempts were exhausted without the
+	// offRamp's next sequence number moving.
+	TrackReportTransmissionGaveUp(sourceChain cciptypes.ChainSelector)
+	// TrackReportTransmissionAttempts records how many check-attempts were consumed by the time a report
+	// resolved (transmitted or gave up), so operators can see typical/creeping transmission latency.
+	TrackReportTransmissionAttempts(attempts uint, success bool)
 }
 
 type NoopMetrics struct{}
@@ -258,3 +295,23 @@ func (n NoopMetrics) TrackRmnReport(float64, bool) {}
 func (n NoopMetrics) TrackProcessorLatency(string, string, time.Duration, error) {}
 
 func (n NoopMetrics) TrackProcessorOutput(string, plugincommon.MethodType, plugintypes.Trackable) {}
+
+func (n NoopMetrics) TrackOnRampMaxSeqNum(cciptypes.ChainSelector, cciptypes.SeqNum) {}
+
+func (n NoopMetrics) TrackOffRampNextSeqNum(cciptypes.ChainSelector, cciptypes.SeqNum) {}
+
+func (n NoopMetrics) TrackPendingMessages(cciptypes.ChainSelector, uint64) {}
+
+func (n NoopMetrics) TrackRmnCurseActive(string, bool) {}
+
+func (n NoopMetrics) TrackSourceChainCursed(cciptypes.ChainSelector, bool) {}
+
+func (n NoopMetrics) TrackObservationError(cciptypes.ChainSelector, string) {}
+
+func (n NoopMetrics) TrackFChainReadError() {}
+
+func (n NoopMetrics) TrackConsensusObservationFailed() {}
+
+func (n NoopMetrics) TrackReportTransmissionGaveUp(cciptypes.ChainSelector) {}
+
+func (n NoopMetrics) TrackReportTransmissionAttempts(uint, bool) {}

--- a/commit/metrics/prom.go
+++ b/commit/metrics/prom.go
@@ -139,6 +139,10 @@ type PromReporter struct {
 	bhConsensusObservationFailed metric.Int64Counter
 	bhReportTransmissionGaveUp   metric.Int64Counter
 	bhReportTransmissionAttempts metric.Int64Histogram
+	bhRangeTruncated             metric.Int64Counter
+	bhOffRampLaneStatus          metric.Int64Gauge
+	bhSeqNumInvariantViolation   metric.Int64Counter
+	bhOffRampConsensusInsuff     metric.Int64Counter
 }
 
 func NewPromReporter(
@@ -225,6 +229,22 @@ func NewPromReporter(
 	if err != nil {
 		return nil, fmt.Errorf("failed to register ccip_commit_report_transmission_attempts histogram: %w", err)
 	}
+	rangeTruncated, err := bhClient.Meter.Int64Counter("ccip_commit_range_truncated")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_commit_range_truncated counter: %w", err)
+	}
+	offRampLaneStatus, err := bhClient.Meter.Int64Gauge("ccip_commit_offramp_lane_status")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_commit_offramp_lane_status gauge: %w", err)
+	}
+	seqNumInvariantViolation, err := bhClient.Meter.Int64Counter("ccip_commit_seqnum_invariant_violation")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_commit_seqnum_invariant_violation counter: %w", err)
+	}
+	offRampConsensusInsuff, err := bhClient.Meter.Int64Counter("ccip_commit_offramp_consensus_insufficient")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_commit_offramp_consensus_insufficient counter: %w", err)
+	}
 
 	return &PromReporter{
 		lggr:        lggr,
@@ -264,6 +284,10 @@ func NewPromReporter(
 		bhConsensusObservationFailed: consensusObservationFailed,
 		bhReportTransmissionGaveUp:   reportTransmissionGaveUp,
 		bhReportTransmissionAttempts: reportTransmissionAttempts,
+		bhRangeTruncated:             rangeTruncated,
+		bhOffRampLaneStatus:          offRampLaneStatus,
+		bhSeqNumInvariantViolation:   seqNumInvariantViolation,
+		bhOffRampConsensusInsuff:     offRampConsensusInsuff,
 	}, nil
 }
 
@@ -550,4 +574,26 @@ func (p *PromReporter) TrackReportTransmissionAttempts(attempts uint, success bo
 		attribute.String("chainID", p.chainID),
 		attribute.Bool("success", success),
 	))
+}
+
+func (p *PromReporter) TrackRangeTruncated(sourceChain cciptypes.ChainSelector) {
+	p.bhRangeTruncated.Add(context.Background(), 1, metric.WithAttributes(p.sourceChainAttrs(sourceChain)...))
+}
+
+func (p *PromReporter) TrackOffRampLaneStatus(sourceChain cciptypes.ChainSelector, status string, active bool) {
+	var value int64
+	if active {
+		value = 1
+	}
+	attrs := append(p.sourceChainAttrs(sourceChain), attribute.String("status", status))
+	p.bhOffRampLaneStatus.Record(context.Background(), value, metric.WithAttributes(attrs...))
+}
+
+func (p *PromReporter) TrackSeqNumInvariantViolation(sourceChain cciptypes.ChainSelector, violationType string) {
+	attrs := append(p.sourceChainAttrs(sourceChain), attribute.String("type", violationType))
+	p.bhSeqNumInvariantViolation.Add(context.Background(), 1, metric.WithAttributes(attrs...))
+}
+
+func (p *PromReporter) TrackOffRampConsensusInsufficient(sourceChain cciptypes.ChainSelector) {
+	p.bhOffRampConsensusInsuff.Add(context.Background(), 1, metric.WithAttributes(p.sourceChainAttrs(sourceChain)...))
 }

--- a/commit/metrics/prom.go
+++ b/commit/metrics/prom.go
@@ -123,6 +123,22 @@ type PromReporter struct {
 
 	configDigestMismatch   *prometheus.GaugeVec
 	bhConfigDigestMismatch metric.Int64Gauge
+
+	// Beholder-only metrics (no prometheus equivalent): mainnet NOP nodes aren't scraped by our
+	// prometheus, only ingested via beholder, so anything meant to give us visibility into NOP-run
+	// nodes should be defined here rather than as a promauto metric.
+	bhPluginHeartbeat            metric.Int64Counter
+	bhReportValidationRejected   metric.Int64Counter
+	bhOnRampMaxSeqNum            metric.Int64Gauge
+	bhOffRampNextSeqNum          metric.Int64Gauge
+	bhPendingMessages            metric.Int64Gauge
+	bhRmnCurseActive             metric.Int64Gauge
+	bhSourceChainCursed          metric.Int64Gauge
+	bhMerkleRootObservationErrs  metric.Int64Counter
+	bhFChainReadErrors           metric.Int64Counter
+	bhConsensusObservationFailed metric.Int64Counter
+	bhReportTransmissionGaveUp   metric.Int64Counter
+	bhReportTransmissionAttempts metric.Int64Histogram
 }
 
 func NewPromReporter(
@@ -161,6 +177,55 @@ func NewPromReporter(
 		return nil, fmt.Errorf("failed to register ccip_commit_config_digest_mismatch gauge: %w", err)
 	}
 
+	pluginHeartbeat, err := bhClient.Meter.Int64Counter("ccip_commit_plugin_heartbeat")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_commit_plugin_heartbeat counter: %w", err)
+	}
+	reportValidationRejected, err := bhClient.Meter.Int64Counter("ccip_commit_report_validation_rejected")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_commit_report_validation_rejected counter: %w", err)
+	}
+	onRampMaxSeqNum, err := bhClient.Meter.Int64Gauge("ccip_commit_onramp_max_seq_num")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_commit_onramp_max_seq_num gauge: %w", err)
+	}
+	offRampNextSeqNum, err := bhClient.Meter.Int64Gauge("ccip_commit_offramp_next_seq_num")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_commit_offramp_next_seq_num gauge: %w", err)
+	}
+	pendingMessages, err := bhClient.Meter.Int64Gauge("ccip_commit_pending_messages")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_commit_pending_messages gauge: %w", err)
+	}
+	rmnCurseActive, err := bhClient.Meter.Int64Gauge("ccip_commit_rmn_curse_active")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_commit_rmn_curse_active gauge: %w", err)
+	}
+	sourceChainCursed, err := bhClient.Meter.Int64Gauge("ccip_commit_source_chain_cursed")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_commit_source_chain_cursed gauge: %w", err)
+	}
+	merkleRootObservationErrs, err := bhClient.Meter.Int64Counter("ccip_commit_merkleroot_observation_errors")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_commit_merkleroot_observation_errors counter: %w", err)
+	}
+	fChainReadErrors, err := bhClient.Meter.Int64Counter("ccip_commit_fchain_read_errors")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_commit_fchain_read_errors counter: %w", err)
+	}
+	consensusObservationFailed, err := bhClient.Meter.Int64Counter("ccip_commit_consensus_observation_failed")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_commit_consensus_observation_failed counter: %w", err)
+	}
+	reportTransmissionGaveUp, err := bhClient.Meter.Int64Counter("ccip_commit_report_transmission_gave_up")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_commit_report_transmission_gave_up counter: %w", err)
+	}
+	reportTransmissionAttempts, err := bhClient.Meter.Int64Histogram("ccip_commit_report_transmission_attempts")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_commit_report_transmission_attempts histogram: %w", err)
+	}
+
 	return &PromReporter{
 		lggr:        lggr,
 		bhClient:    bhClient,
@@ -186,6 +251,19 @@ func NewPromReporter(
 		bhCommitLatestRound:         commitLatestRoundID,
 		bhLooppProviderSupported:    looppProviderSupported,
 		bhConfigDigestMismatch:      configDigestMismatch,
+
+		bhPluginHeartbeat:            pluginHeartbeat,
+		bhReportValidationRejected:   reportValidationRejected,
+		bhOnRampMaxSeqNum:            onRampMaxSeqNum,
+		bhOffRampNextSeqNum:          offRampNextSeqNum,
+		bhPendingMessages:            pendingMessages,
+		bhRmnCurseActive:             rmnCurseActive,
+		bhSourceChainCursed:          sourceChainCursed,
+		bhMerkleRootObservationErrs:  merkleRootObservationErrs,
+		bhFChainReadErrors:           fChainReadErrors,
+		bhConsensusObservationFailed: consensusObservationFailed,
+		bhReportTransmissionGaveUp:   reportTransmissionGaveUp,
+		bhReportTransmissionAttempts: reportTransmissionAttempts,
 	}, nil
 }
 
@@ -363,5 +441,113 @@ func (p *PromReporter) TrackConfigDigestMismatch(mismatch bool) {
 	p.bhConfigDigestMismatch.Record(context.Background(), int64(value), metric.WithAttributes(
 		attribute.String("chain_family", p.chainFamily),
 		attribute.String("chain_id", p.chainID),
+	))
+}
+
+func (p *PromReporter) TrackPluginHeartbeat(phase string) {
+	p.bhPluginHeartbeat.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("chainFamily", p.chainFamily),
+		attribute.String("chainID", p.chainID),
+		attribute.String("phase", phase),
+	))
+}
+
+func (p *PromReporter) TrackReportValidationRejected(phase string, reason string) {
+	p.bhReportValidationRejected.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("chainFamily", p.chainFamily),
+		attribute.String("chainID", p.chainID),
+		attribute.String("phase", phase),
+		attribute.String("reason", reason),
+	))
+}
+
+// sourceChainAttrs resolves a source chain selector into the same family/ID/network-name attributes
+// used elsewhere in this reporter (see trackMaxSequenceNumber), so dashboards can join on network name
+// consistently across metrics.
+func (p *PromReporter) sourceChainAttrs(sourceChainSelector cciptypes.ChainSelector) []attribute.KeyValue {
+	sourceFamily, sourceChainID, ok := libs.GetChainInfoFromSelector(sourceChainSelector)
+	if !ok {
+		p.lggr.Errorw("failed to get chain ID from selector", "selector", sourceChainSelector)
+		return []attribute.KeyValue{
+			attribute.String("sourceChainSelector", strconv.FormatUint(uint64(sourceChainSelector), 10)),
+		}
+	}
+	sourceName, err := libs.GetNameFromIDAndFamily(sourceChainID, sourceFamily)
+	if err != nil {
+		p.lggr.Errorw("failed to get chain name from ID and family", "chainID",
+			sourceChainID, "family", sourceFamily, "err", err)
+	}
+	return []attribute.KeyValue{
+		attribute.String("sourceChainFamily", sourceFamily),
+		attribute.String("sourceChainID", sourceChainID),
+		attribute.String("source_network_name", sourceName),
+	}
+}
+
+func (p *PromReporter) TrackOnRampMaxSeqNum(sourceChain cciptypes.ChainSelector, seqNum cciptypes.SeqNum) {
+	p.bhOnRampMaxSeqNum.Record(context.Background(), int64(seqNum),
+		metric.WithAttributes(p.sourceChainAttrs(sourceChain)...))
+}
+
+func (p *PromReporter) TrackOffRampNextSeqNum(sourceChain cciptypes.ChainSelector, seqNum cciptypes.SeqNum) {
+	p.bhOffRampNextSeqNum.Record(context.Background(), int64(seqNum),
+		metric.WithAttributes(p.sourceChainAttrs(sourceChain)...))
+}
+
+func (p *PromReporter) TrackPendingMessages(sourceChain cciptypes.ChainSelector, pending uint64) {
+	p.bhPendingMessages.Record(context.Background(), int64(pending),
+		metric.WithAttributes(p.sourceChainAttrs(sourceChain)...))
+}
+
+func (p *PromReporter) TrackRmnCurseActive(curseType string, active bool) {
+	var value int64
+	if active {
+		value = 1
+	}
+	p.bhRmnCurseActive.Record(context.Background(), value, metric.WithAttributes(
+		attribute.String("chain_family", p.chainFamily),
+		attribute.String("chain_id", p.chainID),
+		attribute.String("curse_type", curseType),
+	))
+}
+
+func (p *PromReporter) TrackSourceChainCursed(sourceChain cciptypes.ChainSelector, cursed bool) {
+	var value int64
+	if cursed {
+		value = 1
+	}
+	p.bhSourceChainCursed.Record(context.Background(), value,
+		metric.WithAttributes(p.sourceChainAttrs(sourceChain)...))
+}
+
+func (p *PromReporter) TrackObservationError(sourceChain cciptypes.ChainSelector, reason string) {
+	attrs := append(p.sourceChainAttrs(sourceChain), attribute.String("reason", reason))
+	p.bhMerkleRootObservationErrs.Add(context.Background(), 1, metric.WithAttributes(attrs...))
+}
+
+func (p *PromReporter) TrackFChainReadError() {
+	p.bhFChainReadErrors.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("chainFamily", p.chainFamily),
+		attribute.String("chainID", p.chainID),
+	))
+}
+
+func (p *PromReporter) TrackConsensusObservationFailed() {
+	p.bhConsensusObservationFailed.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("chain_family", p.chainFamily),
+		attribute.String("chain_id", p.chainID),
+	))
+}
+
+func (p *PromReporter) TrackReportTransmissionGaveUp(sourceChain cciptypes.ChainSelector) {
+	p.bhReportTransmissionGaveUp.Add(context.Background(), 1,
+		metric.WithAttributes(p.sourceChainAttrs(sourceChain)...))
+}
+
+func (p *PromReporter) TrackReportTransmissionAttempts(attempts uint, success bool) {
+	p.bhReportTransmissionAttempts.Record(context.Background(), int64(attempts), metric.WithAttributes(
+		attribute.String("chainFamily", p.chainFamily),
+		attribute.String("chainID", p.chainID),
+		attribute.Bool("success", success),
 	))
 }

--- a/commit/metrics/prom.go
+++ b/commit/metrics/prom.go
@@ -145,6 +145,7 @@ type PromReporter struct {
 	bhOffRampConsensusInsuff     metric.Int64Counter
 }
 
+//nolint:gocyclo
 func NewPromReporter(
 	lggr logger.Logger, selector cciptypes.ChainSelector, bhClient beholder.Client) (*PromReporter, error,
 ) {

--- a/commit/metrics/reporter.go
+++ b/commit/metrics/reporter.go
@@ -3,6 +3,8 @@ package metrics
 import (
 	"time"
 
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+
 	"github.com/smartcontractkit/chainlink-ccip/commit/committypes"
 	"github.com/smartcontractkit/chainlink-ccip/commit/merkleroot"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
@@ -29,12 +31,40 @@ type Reporter interface {
 	TrackProcessorOutput(processor string, method plugincommon.MethodType, obs plugintypes.Trackable)
 
 	TrackConfigDigestMismatch(mismatch bool)
+
+	// TrackPluginHeartbeat is called unconditionally near the top of Observation()/Outcome(), before
+	// anything downstream can fail, so it keeps ticking even if the rest of the round is wedged. Absence
+	// of this metric (not a bad value) is the signal: it means the plugin isn't scheduling rounds at all.
+	TrackPluginHeartbeat(phase string)
+
+	// TrackReportValidationRejected is called for every rejection reason inside validateReport, from both
+	// ShouldAcceptAttestedReport (phase="should_accept") and ShouldTransmitAcceptedReport
+	// (phase="should_transmit"). This is what lets an on-call engineer tell "nobody ever tried to transmit
+	// because every oracle's local validation rejected it" apart from "a tx was submitted and reverted".
+	TrackReportValidationRejected(phase string, reason string)
+
+	// The methods below mirror merkleroot.MetricsReporter (see that type for docs on each). They're
+	// duplicated here rather than embedded, matching the existing convention for TrackRmnReport etc.,
+	// because Reporter is what's passed down to merkleroot.NewProcessor and Go requires the static
+	// interface type doing the passing to already declare every method the narrower interface needs.
+	TrackOnRampMaxSeqNum(sourceChain cciptypes.ChainSelector, seqNum cciptypes.SeqNum)
+	TrackOffRampNextSeqNum(sourceChain cciptypes.ChainSelector, seqNum cciptypes.SeqNum)
+	TrackPendingMessages(sourceChain cciptypes.ChainSelector, pending uint64)
+	TrackRmnCurseActive(curseType string, active bool)
+	TrackSourceChainCursed(sourceChain cciptypes.ChainSelector, cursed bool)
+	TrackObservationError(sourceChain cciptypes.ChainSelector, reason string)
+	TrackFChainReadError()
+	TrackConsensusObservationFailed()
+	TrackReportTransmissionGaveUp(sourceChain cciptypes.ChainSelector)
+	TrackReportTransmissionAttempts(attempts uint, success bool)
 }
 
 type CommitPluginReporter interface {
 	TrackObservation(obs committypes.Observation, round uint64)
 	TrackOutcome(outcome committypes.Outcome, round uint64)
 	TrackConfigDigestMismatch(mismatch bool)
+	TrackPluginHeartbeat(phase string)
+	TrackReportValidationRejected(phase string, reason string)
 }
 
 type Noop struct{}
@@ -52,6 +82,30 @@ func (n *Noop) TrackProcessorLatency(string, plugincommon.MethodType, time.Durat
 func (n *Noop) TrackProcessorOutput(string, plugincommon.MethodType, plugintypes.Trackable) {}
 
 func (n *Noop) TrackConfigDigestMismatch(bool) {}
+
+func (n *Noop) TrackPluginHeartbeat(string) {}
+
+func (n *Noop) TrackReportValidationRejected(string, string) {}
+
+func (n *Noop) TrackOnRampMaxSeqNum(cciptypes.ChainSelector, cciptypes.SeqNum) {}
+
+func (n *Noop) TrackOffRampNextSeqNum(cciptypes.ChainSelector, cciptypes.SeqNum) {}
+
+func (n *Noop) TrackPendingMessages(cciptypes.ChainSelector, uint64) {}
+
+func (n *Noop) TrackRmnCurseActive(string, bool) {}
+
+func (n *Noop) TrackSourceChainCursed(cciptypes.ChainSelector, bool) {}
+
+func (n *Noop) TrackObservationError(cciptypes.ChainSelector, string) {}
+
+func (n *Noop) TrackFChainReadError() {}
+
+func (n *Noop) TrackConsensusObservationFailed() {}
+
+func (n *Noop) TrackReportTransmissionGaveUp(cciptypes.ChainSelector) {}
+
+func (n *Noop) TrackReportTransmissionAttempts(uint, bool) {}
 
 var _ Reporter = &PromReporter{}
 var _ CommitPluginReporter = &PromReporter{}

--- a/commit/metrics/reporter.go
+++ b/commit/metrics/reporter.go
@@ -57,6 +57,10 @@ type Reporter interface {
 	TrackConsensusObservationFailed()
 	TrackReportTransmissionGaveUp(sourceChain cciptypes.ChainSelector)
 	TrackReportTransmissionAttempts(attempts uint, success bool)
+	TrackRangeTruncated(sourceChain cciptypes.ChainSelector)
+	TrackOffRampLaneStatus(sourceChain cciptypes.ChainSelector, status string, active bool)
+	TrackSeqNumInvariantViolation(sourceChain cciptypes.ChainSelector, violationType string)
+	TrackOffRampConsensusInsufficient(sourceChain cciptypes.ChainSelector)
 }
 
 type CommitPluginReporter interface {
@@ -106,6 +110,14 @@ func (n *Noop) TrackConsensusObservationFailed() {}
 func (n *Noop) TrackReportTransmissionGaveUp(cciptypes.ChainSelector) {}
 
 func (n *Noop) TrackReportTransmissionAttempts(uint, bool) {}
+
+func (n *Noop) TrackRangeTruncated(cciptypes.ChainSelector) {}
+
+func (n *Noop) TrackOffRampLaneStatus(cciptypes.ChainSelector, string, bool) {}
+
+func (n *Noop) TrackSeqNumInvariantViolation(cciptypes.ChainSelector, string) {}
+
+func (n *Noop) TrackOffRampConsensusInsufficient(cciptypes.ChainSelector) {}
 
 var _ Reporter = &PromReporter{}
 var _ CommitPluginReporter = &PromReporter{}

--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -254,6 +254,10 @@ func (p *Plugin) ObservationQuorum(
 func (p *Plugin) Observation(
 	ctx context.Context, outCtx ocr3types.OutcomeContext, q types.Query,
 ) (types.Observation, error) {
+	// Unconditional heartbeat: fires before anything below can fail, so its absence -- not a bad value --
+	// is the "is the plugin scheduling rounds at all" signal. See docs/metrics/commit-metrics.md.
+	p.metricsReporter.TrackPluginHeartbeat("observation")
+
 	if p.offchainCfg.DonBreakingChangesVersion < pluginconfig.DonBreakingChangesVersion1RoleDonSupport {
 		p.lggr.Info("running old observation")
 		return p.observationOld(ctx, outCtx, q)
@@ -434,6 +438,9 @@ func (p *Plugin) trackConfigDigestMismatch(ctx context.Context, lggr logger.Logg
 func (p *Plugin) Outcome(
 	ctx context.Context, outCtx ocr3types.OutcomeContext, q types.Query, aos []types.AttributedObservation,
 ) (ocr3types.Outcome, error) {
+	// Unconditional heartbeat: see the matching comment in Observation().
+	p.metricsReporter.TrackPluginHeartbeat("outcome")
+
 	if p.offchainCfg.DonBreakingChangesVersion < pluginconfig.DonBreakingChangesVersion1RoleDonSupport {
 		p.lggr.Info("running old outcome")
 		return p.outcomeOld(ctx, outCtx, q, aos)

--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -256,7 +256,7 @@ func (p *Plugin) Observation(
 ) (types.Observation, error) {
 	// Unconditional heartbeat: fires before anything below can fail, so its absence -- not a bad value --
 	// is the "is the plugin scheduling rounds at all" signal. See docs/metrics/commit-metrics.md.
-	p.metricsReporter.TrackPluginHeartbeat("observation")
+	p.metricsReporter.TrackPluginHeartbeat(plugincommon.ObservationMethod)
 
 	if p.offchainCfg.DonBreakingChangesVersion < pluginconfig.DonBreakingChangesVersion1RoleDonSupport {
 		p.lggr.Info("running old observation")
@@ -439,7 +439,7 @@ func (p *Plugin) Outcome(
 	ctx context.Context, outCtx ocr3types.OutcomeContext, q types.Query, aos []types.AttributedObservation,
 ) (ocr3types.Outcome, error) {
 	// Unconditional heartbeat: see the matching comment in Observation().
-	p.metricsReporter.TrackPluginHeartbeat("outcome")
+	p.metricsReporter.TrackPluginHeartbeat(plugincommon.OutcomeMethod)
 
 	if p.offchainCfg.DonBreakingChangesVersion < pluginconfig.DonBreakingChangesVersion1RoleDonSupport {
 		p.lggr.Info("running old outcome")

--- a/commit/report.go
+++ b/commit/report.go
@@ -128,6 +128,7 @@ func (p *Plugin) validateReport(
 	lggr logger.Logger,
 	seqNr uint64,
 	r ocr3types.ReportWithInfo[[]byte],
+	phase string,
 ) (cciptypes.CommitPluginReport, error) {
 	if r.Report == nil {
 		lggr.Warn("nil report")
@@ -136,12 +137,14 @@ func (p *Plugin) validateReport(
 
 	decodedReport, err := p.decodeReport(ctx, r.Report)
 	if err != nil {
+		p.metricsReporter.TrackReportValidationRejected(phase, "decode_report")
 		return cciptypes.CommitPluginReport{},
 			plugincommon.NewErrValidatingReport(fmt.Errorf("decode report: %w, report: %x", err, r.Report))
 	}
 
 	var reportInfo cciptypes.CommitReportInfo
 	if reportInfo, err = cciptypes.DecodeCommitReportInfo(r.Info); err != nil {
+		p.metricsReporter.TrackReportValidationRejected(phase, "decode_report_info")
 		return cciptypes.CommitPluginReport{},
 			plugincommon.NewErrValidatingReport(fmt.Errorf("decode report info: %w", err))
 	}
@@ -149,11 +152,13 @@ func (p *Plugin) validateReport(
 	for _, root := range decodedReport.BlessedMerkleRoots {
 		if root.MerkleRoot == (cciptypes.Bytes32{}) {
 			lggr.Warnw("empty blessed merkle root", "root", root)
+			p.metricsReporter.TrackReportValidationRejected(phase, "empty_root")
 			return cciptypes.CommitPluginReport{}, plugincommon.NewErrInvalidReport("empty blessed merkle root")
 
 		}
 		if root.SeqNumsRange.Start() > root.SeqNumsRange.End() {
 			lggr.Warnw("invalid seqNumsRange", "blessed root", root)
+			p.metricsReporter.TrackReportValidationRejected(phase, "invalid_seqnum_range")
 			return cciptypes.CommitPluginReport{}, plugincommon.NewErrInvalidReport("invalid seqNumsRange")
 		}
 	}
@@ -161,14 +166,18 @@ func (p *Plugin) validateReport(
 	for _, root := range decodedReport.UnblessedMerkleRoots {
 		if root.MerkleRoot == (cciptypes.Bytes32{}) {
 			lggr.Warnw("empty unblessed merkle root", "root", root)
+			p.metricsReporter.TrackReportValidationRejected(phase, "empty_root")
 			return cciptypes.CommitPluginReport{}, plugincommon.NewErrInvalidReport("empty unblessed merkle root")
 		}
 		if root.SeqNumsRange.Start() > root.SeqNumsRange.End() {
 			lggr.Warnw("invalid seqNumsRange", "unblessed root", root)
+			p.metricsReporter.TrackReportValidationRejected(phase, "invalid_seqnum_range")
 			return cciptypes.CommitPluginReport{}, plugincommon.NewErrInvalidReport("invalid seqNumsRange")
 		}
 	}
 
+	// RMN blessing/signing is effectively dead code now that RMNEnabled is hardcoded off (see NewPlugin),
+	// so duplicate/insufficient RMN signature rejections aren't instrumented -- they shouldn't occur.
 	seen := make(map[cciptypes.RMNECDSASignature]struct{})
 	for _, sig := range decodedReport.RMNSignatures {
 
@@ -189,15 +198,18 @@ func (p *Plugin) validateReport(
 
 	if isCursed, err := p.checkReportCursed(ctx, lggr, decodedReport); err != nil || isCursed {
 		if err != nil {
+			p.metricsReporter.TrackReportValidationRejected(phase, "cursed_check_error")
 			return cciptypes.CommitPluginReport{},
 				plugincommon.NewErrValidatingReport(fmt.Errorf("check report cursed: %w", err))
 		}
+		p.metricsReporter.TrackReportValidationRejected(phase, "cursed")
 		return cciptypes.CommitPluginReport{}, plugincommon.NewErrInvalidReport("report cursed")
 	}
 
 	// check if we support the dest, if not we can't do the checks needed.
 	supports, err := p.chainSupport.SupportsDestChain(p.oracleID)
 	if err != nil {
+		p.metricsReporter.TrackReportValidationRejected(phase, "dest_support_check_error")
 		return cciptypes.CommitPluginReport{},
 			plugincommon.NewErrValidatingReport(fmt.Errorf("supports dest chain: %w", err))
 	}
@@ -207,6 +219,7 @@ func (p *Plugin) validateReport(
 			"transmission schedule is wrong - check CCIPHome chainConfigs and ensure that the right oracles are " +
 			"assigned as readers of the destination chain, or if " +
 			"this oracle should support the destination chain but isn't!")
+		p.metricsReporter.TrackReportValidationRejected(phase, "dest_not_supported")
 		return cciptypes.CommitPluginReport{}, plugincommon.NewErrInvalidReport("dest chain not supported")
 	}
 
@@ -214,6 +227,7 @@ func (p *Plugin) validateReport(
 		ctx, p.ccipReader, consts.PluginTypeCommit, p.reportingCfg.ConfigDigest,
 	)
 	if err != nil {
+		p.metricsReporter.TrackReportValidationRejected(phase, "config_digest_check_error")
 		return cciptypes.CommitPluginReport{},
 			plugincommon.NewErrValidatingReport(fmt.Errorf("check config digest: %w", err))
 	}
@@ -223,11 +237,13 @@ func (p *Plugin) validateReport(
 			"myConfigDigest", p.reportingCfg.ConfigDigest,
 			"offRampConfigDigest", plugincommon.FormatConfigDigest(offRampDigest),
 		)
+		p.metricsReporter.TrackReportValidationRejected(phase, "config_digest_mismatch")
 		return cciptypes.CommitPluginReport{}, plugincommon.NewErrInvalidReport("config digest mismatch")
 	}
 
 	err = p.isStaleReport(ctx, seqNr, decodedReport)
 	if err != nil {
+		p.metricsReporter.TrackReportValidationRejected(phase, "stale")
 		return cciptypes.CommitPluginReport{}, plugincommon.NewErrStaleReport(fmt.Sprintf("%v", err))
 	}
 
@@ -239,6 +255,7 @@ func (p *Plugin) validateReport(
 	)
 	if err != nil {
 		lggr.Errorw("report not accepted due to root blessings validation error", "err", err)
+		p.metricsReporter.TrackReportValidationRejected(phase, "root_blessing_mismatch")
 		err = plugincommon.NewErrInvalidReport(fmt.Sprintf("root blessings validation: %v", err))
 		return cciptypes.CommitPluginReport{}, err
 	}
@@ -251,7 +268,7 @@ func (p *Plugin) ShouldAcceptAttestedReport(
 ) (bool, error) {
 	ctx, lggr := logutil.WithOCRInfo(ctx, p.lggr, seqNr, logutil.PhaseShouldAccept)
 
-	decodedReport, err := p.validateReport(ctx, lggr, seqNr, r)
+	decodedReport, err := p.validateReport(ctx, lggr, seqNr, r, "should_accept")
 	if errors.Is(err, plugincommon.ErrStaleReport) {
 		lggr.Infow("stale report, not accepting", "err", err)
 		return false, nil
@@ -389,7 +406,7 @@ func (p *Plugin) ShouldTransmitAcceptedReport(
 ) (bool, error) {
 	ctx, lggr := logutil.WithOCRInfo(ctx, p.lggr, seqNr, logutil.PhaseShouldTransmit)
 
-	decodedReport, err := p.validateReport(ctx, lggr, seqNr, r)
+	decodedReport, err := p.validateReport(ctx, lggr, seqNr, r, "should_transmit")
 	if errors.Is(err, plugincommon.ErrStaleReport) {
 		lggr.Infow("stale report, not accepting", "err", err)
 		return false, nil

--- a/commit/report.go
+++ b/commit/report.go
@@ -24,6 +24,29 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/pkg/logutil"
 )
 
+// Reasons passed to MetricsReporter.TrackReportValidationRejected from validateReport. Named
+// here, rather than left as inline literals, because these are effectively a stable label-value
+// contract for dashboards/runbooks/alerts (see docs/runbooks/uncommitted-message.md's metric
+// reference table) with no test asserting on the literal spelling -- a typo at a call site would
+// silently create an unmonitored label value instead of failing to compile.
+const (
+	rejectReasonDecodeReport         = "decode_report"
+	rejectReasonDecodeReportInfo     = "decode_report_info"
+	rejectReasonEmptyRoot            = "empty_root"
+	rejectReasonInvalidSeqNumRange   = "invalid_seqnum_range"
+	rejectReasonCursedCheckError     = "cursed_check_error"
+	rejectReasonCursed               = "cursed"
+	rejectReasonDestSupportCheckErr  = "dest_support_check_error"
+	rejectReasonDestNotSupported     = "dest_not_supported"
+	rejectReasonConfigDigestCheckErr = "config_digest_check_error"
+	rejectReasonConfigDigestMismatch = "config_digest_mismatch"
+	rejectReasonStale                = "stale"
+	rejectReasonRootBlessingMismatch = "root_blessing_mismatch"
+
+	validatePhaseShouldAccept   = "should_accept"
+	validatePhaseShouldTransmit = "should_transmit"
+)
+
 func encodeReports(
 	ctx context.Context,
 	lggr logger.Logger,
@@ -137,14 +160,14 @@ func (p *Plugin) validateReport(
 
 	decodedReport, err := p.decodeReport(ctx, r.Report)
 	if err != nil {
-		p.metricsReporter.TrackReportValidationRejected(phase, "decode_report")
+		p.metricsReporter.TrackReportValidationRejected(phase, rejectReasonDecodeReport)
 		return cciptypes.CommitPluginReport{},
 			plugincommon.NewErrValidatingReport(fmt.Errorf("decode report: %w, report: %x", err, r.Report))
 	}
 
 	var reportInfo cciptypes.CommitReportInfo
 	if reportInfo, err = cciptypes.DecodeCommitReportInfo(r.Info); err != nil {
-		p.metricsReporter.TrackReportValidationRejected(phase, "decode_report_info")
+		p.metricsReporter.TrackReportValidationRejected(phase, rejectReasonDecodeReportInfo)
 		return cciptypes.CommitPluginReport{},
 			plugincommon.NewErrValidatingReport(fmt.Errorf("decode report info: %w", err))
 	}
@@ -152,13 +175,13 @@ func (p *Plugin) validateReport(
 	for _, root := range decodedReport.BlessedMerkleRoots {
 		if root.MerkleRoot == (cciptypes.Bytes32{}) {
 			lggr.Warnw("empty blessed merkle root", "root", root)
-			p.metricsReporter.TrackReportValidationRejected(phase, "empty_root")
+			p.metricsReporter.TrackReportValidationRejected(phase, rejectReasonEmptyRoot)
 			return cciptypes.CommitPluginReport{}, plugincommon.NewErrInvalidReport("empty blessed merkle root")
 
 		}
 		if root.SeqNumsRange.Start() > root.SeqNumsRange.End() {
 			lggr.Warnw("invalid seqNumsRange", "blessed root", root)
-			p.metricsReporter.TrackReportValidationRejected(phase, "invalid_seqnum_range")
+			p.metricsReporter.TrackReportValidationRejected(phase, rejectReasonInvalidSeqNumRange)
 			return cciptypes.CommitPluginReport{}, plugincommon.NewErrInvalidReport("invalid seqNumsRange")
 		}
 	}
@@ -166,12 +189,12 @@ func (p *Plugin) validateReport(
 	for _, root := range decodedReport.UnblessedMerkleRoots {
 		if root.MerkleRoot == (cciptypes.Bytes32{}) {
 			lggr.Warnw("empty unblessed merkle root", "root", root)
-			p.metricsReporter.TrackReportValidationRejected(phase, "empty_root")
+			p.metricsReporter.TrackReportValidationRejected(phase, rejectReasonEmptyRoot)
 			return cciptypes.CommitPluginReport{}, plugincommon.NewErrInvalidReport("empty unblessed merkle root")
 		}
 		if root.SeqNumsRange.Start() > root.SeqNumsRange.End() {
 			lggr.Warnw("invalid seqNumsRange", "unblessed root", root)
-			p.metricsReporter.TrackReportValidationRejected(phase, "invalid_seqnum_range")
+			p.metricsReporter.TrackReportValidationRejected(phase, rejectReasonInvalidSeqNumRange)
 			return cciptypes.CommitPluginReport{}, plugincommon.NewErrInvalidReport("invalid seqNumsRange")
 		}
 	}
@@ -198,18 +221,18 @@ func (p *Plugin) validateReport(
 
 	if isCursed, err := p.checkReportCursed(ctx, lggr, decodedReport); err != nil || isCursed {
 		if err != nil {
-			p.metricsReporter.TrackReportValidationRejected(phase, "cursed_check_error")
+			p.metricsReporter.TrackReportValidationRejected(phase, rejectReasonCursedCheckError)
 			return cciptypes.CommitPluginReport{},
 				plugincommon.NewErrValidatingReport(fmt.Errorf("check report cursed: %w", err))
 		}
-		p.metricsReporter.TrackReportValidationRejected(phase, "cursed")
+		p.metricsReporter.TrackReportValidationRejected(phase, rejectReasonCursed)
 		return cciptypes.CommitPluginReport{}, plugincommon.NewErrInvalidReport("report cursed")
 	}
 
 	// check if we support the dest, if not we can't do the checks needed.
 	supports, err := p.chainSupport.SupportsDestChain(p.oracleID)
 	if err != nil {
-		p.metricsReporter.TrackReportValidationRejected(phase, "dest_support_check_error")
+		p.metricsReporter.TrackReportValidationRejected(phase, rejectReasonDestSupportCheckErr)
 		return cciptypes.CommitPluginReport{},
 			plugincommon.NewErrValidatingReport(fmt.Errorf("supports dest chain: %w", err))
 	}
@@ -219,7 +242,7 @@ func (p *Plugin) validateReport(
 			"transmission schedule is wrong - check CCIPHome chainConfigs and ensure that the right oracles are " +
 			"assigned as readers of the destination chain, or if " +
 			"this oracle should support the destination chain but isn't!")
-		p.metricsReporter.TrackReportValidationRejected(phase, "dest_not_supported")
+		p.metricsReporter.TrackReportValidationRejected(phase, rejectReasonDestNotSupported)
 		return cciptypes.CommitPluginReport{}, plugincommon.NewErrInvalidReport("dest chain not supported")
 	}
 
@@ -227,7 +250,7 @@ func (p *Plugin) validateReport(
 		ctx, p.ccipReader, consts.PluginTypeCommit, p.reportingCfg.ConfigDigest,
 	)
 	if err != nil {
-		p.metricsReporter.TrackReportValidationRejected(phase, "config_digest_check_error")
+		p.metricsReporter.TrackReportValidationRejected(phase, rejectReasonConfigDigestCheckErr)
 		return cciptypes.CommitPluginReport{},
 			plugincommon.NewErrValidatingReport(fmt.Errorf("check config digest: %w", err))
 	}
@@ -237,13 +260,13 @@ func (p *Plugin) validateReport(
 			"myConfigDigest", p.reportingCfg.ConfigDigest,
 			"offRampConfigDigest", plugincommon.FormatConfigDigest(offRampDigest),
 		)
-		p.metricsReporter.TrackReportValidationRejected(phase, "config_digest_mismatch")
+		p.metricsReporter.TrackReportValidationRejected(phase, rejectReasonConfigDigestMismatch)
 		return cciptypes.CommitPluginReport{}, plugincommon.NewErrInvalidReport("config digest mismatch")
 	}
 
 	err = p.isStaleReport(ctx, seqNr, decodedReport)
 	if err != nil {
-		p.metricsReporter.TrackReportValidationRejected(phase, "stale")
+		p.metricsReporter.TrackReportValidationRejected(phase, rejectReasonStale)
 		return cciptypes.CommitPluginReport{}, plugincommon.NewErrStaleReport(fmt.Sprintf("%v", err))
 	}
 
@@ -255,7 +278,7 @@ func (p *Plugin) validateReport(
 	)
 	if err != nil {
 		lggr.Errorw("report not accepted due to root blessings validation error", "err", err)
-		p.metricsReporter.TrackReportValidationRejected(phase, "root_blessing_mismatch")
+		p.metricsReporter.TrackReportValidationRejected(phase, rejectReasonRootBlessingMismatch)
 		err = plugincommon.NewErrInvalidReport(fmt.Sprintf("root blessings validation: %v", err))
 		return cciptypes.CommitPluginReport{}, err
 	}
@@ -268,7 +291,7 @@ func (p *Plugin) ShouldAcceptAttestedReport(
 ) (bool, error) {
 	ctx, lggr := logutil.WithOCRInfo(ctx, p.lggr, seqNr, logutil.PhaseShouldAccept)
 
-	decodedReport, err := p.validateReport(ctx, lggr, seqNr, r, "should_accept")
+	decodedReport, err := p.validateReport(ctx, lggr, seqNr, r, validatePhaseShouldAccept)
 	if errors.Is(err, plugincommon.ErrStaleReport) {
 		lggr.Infow("stale report, not accepting", "err", err)
 		return false, nil
@@ -406,7 +429,7 @@ func (p *Plugin) ShouldTransmitAcceptedReport(
 ) (bool, error) {
 	ctx, lggr := logutil.WithOCRInfo(ctx, p.lggr, seqNr, logutil.PhaseShouldTransmit)
 
-	decodedReport, err := p.validateReport(ctx, lggr, seqNr, r, "should_transmit")
+	decodedReport, err := p.validateReport(ctx, lggr, seqNr, r, validatePhaseShouldTransmit)
 	if errors.Is(err, plugincommon.ErrStaleReport) {
 		lggr.Infow("stale report, not accepting", "err", err)
 		return false, nil

--- a/commit/report.go
+++ b/commit/report.go
@@ -406,6 +406,12 @@ func (p *Plugin) ShouldTransmitAcceptedReport(
 ) (bool, error) {
 	ctx, lggr := logutil.WithOCRInfo(ctx, p.lggr, seqNr, logutil.PhaseShouldTransmit)
 
+	// TEMPORARY FAULT INJECTION FOR RUNBOOK TESTING -- REVERT BEFORE MERGE
+	lggr.Warnw("forced test failure: always rejecting should_transmit")
+	p.metricsReporter.TrackReportValidationRejected("should_transmit", "forced_test_failure")
+	return false, nil
+	// END TEMPORARY
+
 	decodedReport, err := p.validateReport(ctx, lggr, seqNr, r, "should_transmit")
 	if errors.Is(err, plugincommon.ErrStaleReport) {
 		lggr.Infow("stale report, not accepting", "err", err)

--- a/commit/report.go
+++ b/commit/report.go
@@ -406,12 +406,6 @@ func (p *Plugin) ShouldTransmitAcceptedReport(
 ) (bool, error) {
 	ctx, lggr := logutil.WithOCRInfo(ctx, p.lggr, seqNr, logutil.PhaseShouldTransmit)
 
-	// TEMPORARY FAULT INJECTION FOR RUNBOOK TESTING -- REVERT BEFORE MERGE
-	lggr.Warnw("forced test failure: always rejecting should_transmit")
-	p.metricsReporter.TrackReportValidationRejected("should_transmit", "forced_test_failure")
-	return false, nil
-	// END TEMPORARY
-
 	decodedReport, err := p.validateReport(ctx, lggr, seqNr, r, "should_transmit")
 	if errors.Is(err, plugincommon.ErrStaleReport) {
 		lggr.Infow("stale report, not accepting", "err", err)

--- a/devenv/cmd/ccip/ccip.go
+++ b/devenv/cmd/ccip/ccip.go
@@ -20,8 +20,9 @@ import (
 )
 
 const (
-	LocalWASPLoadDashboard = "http://localhost:3000/d/WASPLoadTests/wasp-load-test?orgId=1&from=now-5m&to=now&refresh=5s"
-	LocalCCIPDashboard     = "http://localhost:3000/d/f8a04cef-653f-46d3-86df-87c532300672/ccip-services?orgId=1&refresh=5s"
+	LocalWASPLoadDashboard  = "http://localhost:3000/d/WASPLoadTests/wasp-load-test?orgId=1&from=now-5m&to=now&refresh=5s"
+	LocalCCIPDashboard      = "http://localhost:3000/d/f8a04cef-653f-46d3-86df-87c532300672/ccip-services?orgId=1&refresh=5s"
+	LocalGrafanaVictoriaURL = "http://localhost:3000"
 )
 
 var rootCmd = &cobra.Command{
@@ -178,15 +179,27 @@ var obsUpCmd = &cobra.Command{
 	Aliases: []string{"u"},
 	Short:   "Spin up the observability stack",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		victoria, _ := cmd.Flags().GetBool("victoria")
 		full, _ := cmd.Flags().GetBool("full")
 		var err error
-		if full {
+		switch {
+		case victoria:
+			err = framework.ObservabilityVictoriaMetricsUp()
+		case full:
 			err = framework.ObservabilityUpFull()
-		} else {
+		default:
 			err = framework.ObservabilityUp()
 		}
 		if err != nil {
 			return fmt.Errorf("observability up failed: %w", err)
+		}
+		if victoria {
+			// Beholder-only metrics (see docs/metrics/commit-metrics.md) are only ever pushed
+			// via OTLP, and only this stack's otel-collector ingests + remote-writes them into
+			// VictoriaMetrics. Nodes must be pointed at it via [Telemetry] in env.toml's
+			// node_config_overrides for anything to show up.
+			ccipde.Plog.Info().Msgf("Grafana: %s", LocalGrafanaVictoriaURL)
+			return nil
 		}
 		ccipde.Plog.Info().Msgf("CCIP Dashboard: %s", LocalCCIPDashboard)
 		ccipde.Plog.Info().Msgf("CCIP Load Test Dashboard: %s", LocalWASPLoadDashboard)
@@ -199,6 +212,10 @@ var obsDownCmd = &cobra.Command{
 	Aliases: []string{"d"},
 	Short:   "Spin down the observability stack",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		victoria, _ := cmd.Flags().GetBool("victoria")
+		if victoria {
+			return framework.ObservabilityVictoriaDown()
+		}
 		return framework.ObservabilityDown()
 	},
 }
@@ -208,10 +225,23 @@ var obsRestartCmd = &cobra.Command{
 	Aliases: []string{"r"},
 	Short:   "Restart the observability stack (data wipe)",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		victoria, _ := cmd.Flags().GetBool("victoria")
+		full, _ := cmd.Flags().GetBool("full")
+
+		if victoria {
+			if err := framework.ObservabilityVictoriaDown(); err != nil {
+				return fmt.Errorf("observability down failed: %w", err)
+			}
+			if err := framework.ObservabilityVictoriaMetricsUp(); err != nil {
+				return fmt.Errorf("observability up failed: %w", err)
+			}
+			ccipde.Plog.Info().Msgf("Grafana: %s", LocalGrafanaVictoriaURL)
+			return nil
+		}
+
 		if err := framework.ObservabilityDown(); err != nil {
 			return fmt.Errorf("observability down failed: %w", err)
 		}
-		full, _ := cmd.Flags().GetBool("full")
 		var err error
 		if full {
 			err = framework.ObservabilityUpFull()
@@ -369,6 +399,10 @@ func init() {
 
 	// observability
 	obsCmd.PersistentFlags().BoolP("full", "f", false, "Enable full observability stack with additional components")
+	obsCmd.PersistentFlags().BoolP("victoria", "m", false,
+		"Use the VictoriaMetrics stack instead (otel-collector + VictoriaMetrics/Logs/Traces). "+
+			"Required for the ccip_commit_* Beholder-only metrics; mutually exclusive with --full, "+
+			"and cannot run alongside the default stack (port/container-name collisions).")
 	obsCmd.AddCommand(obsRestartCmd)
 	obsCmd.AddCommand(obsUpCmd)
 	obsCmd.AddCommand(obsDownCmd)

--- a/devenv/dashboards/commit-plugin.json
+++ b/devenv/dashboards/commit-plugin.json
@@ -1,0 +1,3127 @@
+{
+ "annotations": {
+  "list": [
+   {
+    "builtIn": 1,
+    "datasource": {
+     "type": "grafana",
+     "uid": "-- Grafana --"
+    },
+    "enable": true,
+    "hide": true,
+    "iconColor": "rgba(0, 211, 255, 1)",
+    "name": "Annotations & Alerts",
+    "type": "dashboard"
+   }
+  ]
+ },
+ "editable": true,
+ "fiscalYearStartMonth": 0,
+ "graphTooltip": 0,
+ "links": [],
+ "liveNow": false,
+ "panels": [
+  {
+   "collapsed": false,
+   "gridPos": {
+    "h": 1,
+    "w": 24,
+    "x": 0,
+    "y": 0
+   },
+   "id": 1001,
+   "panels": [],
+   "title": "HEALTH \u2014 Commit Plugin & Merkle Root Processor",
+   "type": "row"
+  },
+  {
+   "gridPos": {
+    "h": 3,
+    "w": 24,
+    "x": 0,
+    "y": 1
+   },
+   "id": 1002,
+   "options": {
+    "mode": "markdown",
+    "code": {
+     "language": "plaintext",
+     "showLineNumbers": false,
+     "showMiniMap": false
+    },
+    "content": "Liveness, throughput, cursing, consensus and report-transmission signals for the commit plugin and the merkle-root processor, filtered by the `$destChain` / `$sourceChain` template variables above. All metrics here are Beholder-ingested (see `commit/metrics/prom.go`) unless noted \u2014 set the `DS_PROMETHEUS` dashboard datasource variable to whichever Grafana datasource serves your Beholder pipeline before relying on this. Full metric rationale: `docs/metrics/commit-metrics.md`."
+   },
+   "title": "About this section",
+   "type": "text",
+   "transparent": true
+  },
+  {
+   "gridPos": {
+    "h": 2,
+    "w": 24,
+    "x": 0,
+    "y": 4
+   },
+   "id": 1003,
+   "options": {
+    "mode": "markdown",
+    "code": {
+     "language": "plaintext",
+     "showLineNumbers": false,
+     "showMiniMap": false
+    },
+    "content": "**Step 0 of any triage**: is the plugin alive at all? A flat heartbeat means every other gauge below may simply be stale, not bad."
+   },
+   "title": "Liveness",
+   "type": "text",
+   "transparent": true
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "Unconditional per-round liveness signal, incremented at the top of Observation(), before any decode/state check. 0 = plugin not running rounds.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "thresholds"
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "red",
+        "value": null
+       },
+       {
+        "color": "green",
+        "value": 0.001
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 4,
+    "w": 6,
+    "x": 0,
+    "y": 6
+   },
+   "id": 1004,
+   "options": {
+    "colorMode": "value",
+    "graphMode": "area",
+    "justifyMode": "auto",
+    "orientation": "auto",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ],
+     "fields": "",
+     "values": false
+    },
+    "textMode": "auto"
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "sum(rate(ccip_commit_plugin_heartbeat_total{chainID=~\"$destChain\", phase=\"observation\"}[5m]))",
+     "legendFormat": "__auto",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Heartbeat rate \u2014 observation()",
+   "type": "stat"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "Same signal for Outcome(). If observation is healthy but outcome is flat, OCR is failing to schedule/deliver to the outcome stage.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "thresholds"
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "red",
+        "value": null
+       },
+       {
+        "color": "green",
+        "value": 0.001
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 4,
+    "w": 6,
+    "x": 6,
+    "y": 6
+   },
+   "id": 1005,
+   "options": {
+    "colorMode": "value",
+    "graphMode": "area",
+    "justifyMode": "auto",
+    "orientation": "auto",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ],
+     "fields": "",
+     "values": false
+    },
+    "textMode": "auto"
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "sum(rate(ccip_commit_plugin_heartbeat_total{chainID=~\"$destChain\", phase=\"outcome\"}[5m]))",
+     "legendFormat": "__auto",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Heartbeat rate \u2014 outcome()",
+   "type": "stat"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "1 = this node's home-chain config digest differs from the offramp's. Root cause for a wide range of downstream rejections.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "thresholds"
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 1
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 4,
+    "w": 6,
+    "x": 12,
+    "y": 6
+   },
+   "id": 1006,
+   "options": {
+    "colorMode": "value",
+    "graphMode": "area",
+    "justifyMode": "auto",
+    "orientation": "auto",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ],
+     "fields": "",
+     "values": false
+    },
+    "textMode": "auto"
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "max(ccip_commit_config_digest_mismatch{chain_id=~\"$destChain\"})",
+     "legendFormat": "__auto",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Config digest mismatch",
+   "type": "stat"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "1 = supported, 0 = not supported, per chain family.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "thresholds"
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "red",
+        "value": null
+       },
+       {
+        "color": "green",
+        "value": 1
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 4,
+    "w": 6,
+    "x": 18,
+    "y": 6
+   },
+   "id": 1007,
+   "options": {
+    "colorMode": "value",
+    "graphMode": "area",
+    "justifyMode": "auto",
+    "orientation": "auto",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ],
+     "fields": "",
+     "values": false
+    },
+    "textMode": "auto"
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "min(ccip_commit_loopp_ccip_provider_supported{chain_family=~\".*\"})",
+     "legendFormat": "__auto",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "LOOPP CCIP provider supported",
+   "type": "stat"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "Generic TrackedProcessor instrumentation wrapping merkleroot/chainfee/tokenprice. Errors here only fire on a returned error, not on the swallowed per-goroutine failures below.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     },
+     "unit": "s"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 7,
+    "w": 24,
+    "x": 0,
+    "y": 10
+   },
+   "id": 1008,
+   "options": {
+    "legend": {
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    }
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "histogram_quantile(0.95, sum(rate(ccip_commit_processor_latency_bucket{chainID=~\"$destChain\"}[5m])) by (le, processor, method))",
+     "legendFormat": "{{processor}}/{{method}} p95",
+     "range": true,
+     "refId": "A"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "sum(rate(ccip_commit_processor_errors_total{chainID=~\"$destChain\"}[5m])) by (processor, method)",
+     "legendFormat": "{{processor}}/{{method}} errors/s",
+     "range": true,
+     "refId": "B"
+    }
+   ],
+   "title": "Processor latency (p95) & errors",
+   "type": "timeseries"
+  },
+  {
+   "gridPos": {
+    "h": 2,
+    "w": 24,
+    "x": 0,
+    "y": 17
+   },
+   "id": 1009,
+   "options": {
+    "mode": "markdown",
+    "code": {
+     "language": "plaintext",
+     "showLineNumbers": false,
+     "showMiniMap": false
+    },
+    "content": "Per-source-chain read progress. Filter with `$sourceChain` to focus on one lane."
+   },
+   "title": "Lane Throughput & Backlog",
+   "type": "text",
+   "transparent": true
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "If offramp_next > X, a root covering X already landed \u2014 commit plugin's job is done for that message (Runbook Step 1). If onramp_max < X, the onramp read itself is lagging (Runbook Step 2).",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 0,
+    "y": 19
+   },
+   "id": 1010,
+   "options": {
+    "legend": {
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    }
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "max by (source_network_name) (ccip_commit_onramp_max_seq_num{source_network_name=~\"$sourceChain\"})",
+     "legendFormat": "{{source_network_name}} onramp max",
+     "range": true,
+     "refId": "A"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "max by (source_network_name) (ccip_commit_offramp_next_seq_num{source_network_name=~\"$sourceChain\"})",
+     "legendFormat": "{{source_network_name}} offramp next",
+     "range": true,
+     "refId": "B"
+    }
+   ],
+   "title": "OnRamp max seq num vs OffRamp next seq num",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "onRampMaxSeqNum - offRampNextSeqNum per source chain. Quantifies \"how far behind\" instead of mentally diffing the two gauges above.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 12,
+    "y": 19
+   },
+   "id": 1011,
+   "options": {
+    "legend": {
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    }
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "max by (source_network_name) (ccip_commit_pending_messages{source_network_name=~\"$sourceChain\"})",
+     "legendFormat": "{{source_network_name}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Pending messages (backlog)",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "Chain-throughput ceiling being hit \u2014 previously Debugf-only.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 7,
+    "w": 8,
+    "x": 0,
+    "y": 27
+   },
+   "id": 1012,
+   "options": {
+    "legend": {
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    }
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "sum(rate(ccip_commit_range_truncated_total{source_network_name=~\"$sourceChain\"}[5m])) by (source_network_name)",
+     "legendFormat": "{{source_network_name}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Range truncated (MaxMerkleTreeSize hit)",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "offramp_ahead_of_onramp / onramp_max_zero / offramp_seqnum_regression \u2014 documented in-code as stall signals.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 7,
+    "w": 8,
+    "x": 8,
+    "y": 27
+   },
+   "id": 1013,
+   "options": {
+    "legend": {
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    }
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "sum(rate(ccip_commit_seqnum_invariant_violation_total{source_network_name=~\"$sourceChain\"}[5m])) by (source_network_name, type)",
+     "legendFormat": "{{source_network_name}} / {{type}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Seq-num invariant violations",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "DON couldn't agree on OffRampNextSeqNum for this chain \u2014 looks identical to \"no new messages\" from the outside without this.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 7,
+    "w": 8,
+    "x": 16,
+    "y": 27
+   },
+   "id": 1014,
+   "options": {
+    "legend": {
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    }
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "sum(rate(ccip_commit_offramp_consensus_insufficient_total{source_network_name=~\"$sourceChain\"}[5m])) by (source_network_name)",
+     "legendFormat": "{{source_network_name}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "OffRamp consensus insufficient",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "live / skipped_not_a_lane / skipped_disabled / rmn_misconfigured, reported every round for all four buckets so a transition can't leave a stale \"still active\" value. rmn_misconfigured flags real config drift.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 7,
+    "w": 24,
+    "x": 0,
+    "y": 34
+   },
+   "id": 1015,
+   "options": {
+    "legend": {
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    }
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "max by (source_network_name, status) (ccip_commit_offramp_lane_status{source_network_name=~\"$sourceChain\"})",
+     "legendFormat": "{{source_network_name}} / {{status}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "OffRamp lane status",
+   "type": "timeseries"
+  },
+  {
+   "gridPos": {
+    "h": 2,
+    "w": 24,
+    "x": 0,
+    "y": 41
+   },
+   "id": 1016,
+   "options": {
+    "mode": "markdown",
+    "code": {
+     "language": "plaintext",
+     "showLineNumbers": false,
+     "showMiniMap": false
+    },
+    "content": "RMN cursing and home-chain / DON-agreement health. These are destination-chain-wide, not lane-specific."
+   },
+   "title": "Cursing & Consensus",
+   "type": "text",
+   "transparent": true
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "1 = halts ALL reporting for the dest chain.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "thresholds"
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 1
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 5,
+    "w": 6,
+    "x": 0,
+    "y": 43
+   },
+   "id": 1017,
+   "options": {
+    "colorMode": "value",
+    "graphMode": "area",
+    "justifyMode": "auto",
+    "orientation": "auto",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ],
+     "fields": "",
+     "values": false
+    },
+    "textMode": "auto"
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "max(ccip_commit_rmn_curse_active{chain_id=~\"$destChain\", curse_type=\"global\"})",
+     "legendFormat": "__auto",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "RMN global curse active",
+   "type": "stat"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "thresholds"
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 1
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 5,
+    "w": 6,
+    "x": 6,
+    "y": 43
+   },
+   "id": 1018,
+   "options": {
+    "colorMode": "value",
+    "graphMode": "area",
+    "justifyMode": "auto",
+    "orientation": "auto",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ],
+     "fields": "",
+     "values": false
+    },
+    "textMode": "auto"
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "max(ccip_commit_rmn_curse_active{chain_id=~\"$destChain\", curse_type=\"destination\"})",
+     "legendFormat": "__auto",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "RMN destination curse active",
+   "type": "stat"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "1 = this specific lane is excluded (expected/hand-off), distinct from a wedged plugin.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 5,
+    "w": 12,
+    "x": 12,
+    "y": 43
+   },
+   "id": 1019,
+   "options": {
+    "legend": {
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    }
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "max by (source_network_name) (ccip_commit_source_chain_cursed{source_network_name=~\"$sourceChain\"})",
+     "legendFormat": "{{source_network_name}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Source chain cursed (per lane)",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "Consensus-observation-failed can ONLY happen when the DON fails to agree 2\u00b7fRoleDON+1 on a single FChain value for the dest chain \u2014 every other field degrades gracefully per-chain. If this fires, expect every source chain into this dest to stall simultaneously (see Guided Debug \u2192 Scenario 3).",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 0,
+    "y": 48
+   },
+   "id": 1020,
+   "options": {
+    "legend": {
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    }
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "sum(rate(ccip_commit_consensus_observation_failed_total{chain_id=~\"$destChain\"}[5m])) by (chain_id)",
+     "legendFormat": "{{chain_id}} consensus failed/s",
+     "range": true,
+     "refId": "A"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "sum(rate(ccip_commit_fchain_read_errors_total{chainID=~\"$destChain\"}[5m])) by (chainID)",
+     "legendFormat": "{{chainID}} fchain read errors/s",
+     "range": true,
+     "refId": "B"
+    }
+   ],
+   "title": "Consensus observation failed (dest-wide) & FChain read errors",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "Per-goroutine RPC/read failures (no_bindings/timeout/rpc_error/msg_count_mismatch/hash_error/address_lookup_error) that are swallowed and never trip the generic processor-error counter.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 12,
+    "y": 48
+   },
+   "id": 1021,
+   "options": {
+    "legend": {
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    }
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "sum(rate(ccip_commit_merkleroot_observation_errors_total{source_network_name=~\"$sourceChain\"}[5m])) by (source_network_name, reason)",
+     "legendFormat": "{{source_network_name}} / {{reason}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Merkleroot observation errors by reason",
+   "type": "timeseries"
+  },
+  {
+   "gridPos": {
+    "h": 2,
+    "w": 24,
+    "x": 0,
+    "y": 56
+   },
+   "id": 1022,
+   "options": {
+    "mode": "markdown",
+    "code": {
+     "language": "plaintext",
+     "showLineNumbers": false,
+     "showMiniMap": false
+    },
+    "content": "One of the most common on-call pages: a report is built but never lands."
+   },
+   "title": "Report Transmission",
+   "type": "text",
+   "transparent": true
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "validateReport rejections from ShouldAcceptAttestedReport / ShouldTransmitAcceptedReport. Non-zero here BEFORE report_transmission_gave_up means the report never made it on-chain at all.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 0,
+    "y": 58
+   },
+   "id": 1023,
+   "options": {
+    "legend": {
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    }
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "sum(rate(ccip_commit_report_validation_rejected_total{chainID=~\"$destChain\"}[5m])) by (phase, reason)",
+     "legendFormat": "{{phase}} / {{reason}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Report validation rejected, by phase & reason",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "Previously a Warnw with no counter. Pair with the validation-rejected panel to distinguish \"never transmitted\" from \"transmitted but stuck/reverted on-chain\".",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 12,
+    "y": 58
+   },
+   "id": 1024,
+   "options": {
+    "legend": {
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    }
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "sum(rate(ccip_commit_report_transmission_gave_up_total{source_network_name=~\"$sourceChain\"}[5m])) by (source_network_name)",
+     "legendFormat": "{{source_network_name}} gave up/s",
+     "range": true,
+     "refId": "A"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "histogram_quantile(0.95, sum(rate(ccip_commit_report_transmission_attempts_bucket{chainID=~\"$destChain\"}[5m])) by (le, success))",
+     "legendFormat": "attempts p95, success={{success}}",
+     "range": true,
+     "refId": "B"
+    }
+   ],
+   "title": "Report transmission gave up & attempts (p95)",
+   "type": "timeseries"
+  },
+  {
+   "collapsed": false,
+   "gridPos": {
+    "h": 1,
+    "w": 24,
+    "x": 0,
+    "y": 66
+   },
+   "id": 1025,
+   "panels": [],
+   "title": "GUIDED DEBUG \u2014 Incident Runbook (mirrors docs/metrics/commit-metrics.md)",
+   "type": "row"
+  },
+  {
+   "gridPos": {
+    "h": 3,
+    "w": 24,
+    "x": 0,
+    "y": 67
+   },
+   "id": 1026,
+   "options": {
+    "mode": "markdown",
+    "code": {
+     "language": "plaintext",
+     "showLineNumbers": false,
+     "showMiniMap": false
+    },
+    "content": "**Alert**: message `$MsgID`, onramp sequence number `$SeqNum`, chain `$sourceChain` (source) \u2192 chain `$destChain` (dest), reported in-flight for 15 minutes. Set the variables above, then walk the steps below top to bottom \u2014 each stops the moment you have an answer. This is a direct dashboard rendering of the \"War games\" walkthroughs in `docs/metrics/commit-metrics.md`; read that doc for the full rationale."
+   },
+   "title": "Starting point",
+   "type": "text",
+   "transparent": true
+  },
+  {
+   "gridPos": {
+    "h": 4,
+    "w": 24,
+    "x": 0,
+    "y": 70
+   },
+   "id": 1027,
+   "options": {
+    "mode": "markdown",
+    "code": {
+     "language": "plaintext",
+     "showLineNumbers": false,
+     "showMiniMap": false
+    },
+    "content": "Check **OffRamp next seq num** for source `$sourceChain` \u2192 dest `$destChain`.\n\n- `> $SeqNum` \u2192 a root covering it already landed on the offramp. Commit plugin's job is done; **hand off to exec on-call. Stop.**\n- `<= $SeqNum` \u2192 continue to Step 2."
+   },
+   "title": "Step 1 \u2014 Is this even a commit-plugin problem?",
+   "type": "text",
+   "transparent": true
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 6,
+    "w": 24,
+    "x": 0,
+    "y": 74
+   },
+   "id": 1028,
+   "options": {
+    "legend": {
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    }
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "max by (source_network_name) (ccip_commit_offramp_next_seq_num{source_network_name=~\"$sourceChain\"})",
+     "legendFormat": "{{source_network_name}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Step 1 metric \u2014 ccip_commit_offramp_next_seq_num",
+   "type": "timeseries"
+  },
+  {
+   "gridPos": {
+    "h": 4,
+    "w": 24,
+    "x": 0,
+    "y": 80
+   },
+   "id": 1029,
+   "options": {
+    "mode": "markdown",
+    "code": {
+     "language": "plaintext",
+     "showLineNumbers": false,
+     "showMiniMap": false
+    },
+    "content": "Check **OnRamp max seq num** for source `$sourceChain`.\n\n- `< $SeqNum` \u2192 onramp read is lagging. Check the errors-by-reason panel below (no_bindings / timeout / rpc_error). This is a source-chain read/infra issue, not commit logic. **Stop here and escalate to chain infra.**\n- `>= $SeqNum` \u2192 plugin has seen it; continue to Step 3."
+   },
+   "title": "Step 2 \u2014 Has the plugin observed it on-chain yet?",
+   "type": "text",
+   "transparent": true
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 6,
+    "w": 12,
+    "x": 0,
+    "y": 84
+   },
+   "id": 1030,
+   "options": {
+    "legend": {
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    }
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "max by (source_network_name) (ccip_commit_onramp_max_seq_num{source_network_name=~\"$sourceChain\"})",
+     "legendFormat": "{{source_network_name}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Step 2 metric \u2014 ccip_commit_onramp_max_seq_num",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 6,
+    "w": 12,
+    "x": 12,
+    "y": 84
+   },
+   "id": 1031,
+   "options": {
+    "legend": {
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    }
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "sum(rate(ccip_commit_merkleroot_observation_errors_total{source_network_name=~\"$sourceChain\"}[5m])) by (reason)",
+     "legendFormat": "{{reason}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Step 2 metric \u2014 merkleroot_observation_errors by reason",
+   "type": "timeseries"
+  },
+  {
+   "gridPos": {
+    "h": 4,
+    "w": 24,
+    "x": 0,
+    "y": 90
+   },
+   "id": 1032,
+   "options": {
+    "mode": "markdown",
+    "code": {
+     "language": "plaintext",
+     "showLineNumbers": false,
+     "showMiniMap": false
+    },
+    "content": "Check **rate(ccip_commit_consensus_observation_failed_total[5m])** for dest `$destChain`.\n\n- Incrementing \u2192 destination-chain-wide consensus failure. Jump to the **Scenario 3 deep dive** below.\n- Flat \u2192 continue to Step 4."
+   },
+   "title": "Step 3 \u2014 Is the round producing outcomes at all?",
+   "type": "text",
+   "transparent": true
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 6,
+    "w": 24,
+    "x": 0,
+    "y": 94
+   },
+   "id": 1033,
+   "options": {
+    "legend": {
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    }
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "sum(rate(ccip_commit_consensus_observation_failed_total{chain_id=~\"$destChain\"}[5m])) by (chain_id)",
+     "legendFormat": "{{chain_id}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Step 3 metric \u2014 ccip_commit_consensus_observation_failed_total",
+   "type": "timeseries"
+  },
+  {
+   "gridPos": {
+    "h": 4,
+    "w": 24,
+    "x": 0,
+    "y": 100
+   },
+   "id": 1034,
+   "options": {
+    "mode": "markdown",
+    "code": {
+     "language": "plaintext",
+     "showLineNumbers": false,
+     "showMiniMap": false
+    },
+    "content": "Check **RMN curse active** for dest `$destChain` and **source chain cursed** for `$sourceChain`.\n\n- Any `== 1` \u2192 found it; likely intentional/incident-flagged, hand off to whoever owns the curse. **Stop.**\n- All `0` \u2192 continue to Step 5."
+   },
+   "title": "Step 4 \u2014 Is chain A or B cursed?",
+   "type": "text",
+   "transparent": true
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "thresholds"
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 1
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 6,
+    "w": 8,
+    "x": 0,
+    "y": 104
+   },
+   "id": 1035,
+   "options": {
+    "colorMode": "value",
+    "graphMode": "area",
+    "justifyMode": "auto",
+    "orientation": "auto",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ],
+     "fields": "",
+     "values": false
+    },
+    "textMode": "auto"
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "max(ccip_commit_rmn_curse_active{chain_id=~\"$destChain\", curse_type=\"global\"})",
+     "legendFormat": "__auto",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Step 4 metric \u2014 RMN global curse",
+   "type": "stat"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "thresholds"
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 1
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 6,
+    "w": 8,
+    "x": 8,
+    "y": 104
+   },
+   "id": 1036,
+   "options": {
+    "colorMode": "value",
+    "graphMode": "area",
+    "justifyMode": "auto",
+    "orientation": "auto",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ],
+     "fields": "",
+     "values": false
+    },
+    "textMode": "auto"
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "max(ccip_commit_rmn_curse_active{chain_id=~\"$destChain\", curse_type=\"destination\"})",
+     "legendFormat": "__auto",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Step 4 metric \u2014 RMN destination curse",
+   "type": "stat"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "thresholds"
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 1
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 6,
+    "w": 8,
+    "x": 16,
+    "y": 104
+   },
+   "id": 1037,
+   "options": {
+    "colorMode": "value",
+    "graphMode": "area",
+    "justifyMode": "auto",
+    "orientation": "auto",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ],
+     "fields": "",
+     "values": false
+    },
+    "textMode": "auto"
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "max(ccip_commit_source_chain_cursed{source_network_name=~\"$sourceChain\"})",
+     "legendFormat": "__auto",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Step 4 metric \u2014 source chain cursed",
+   "type": "stat"
+  },
+  {
+   "gridPos": {
+    "h": 4,
+    "w": 24,
+    "x": 0,
+    "y": 110
+   },
+   "id": 1038,
+   "options": {
+    "mode": "markdown",
+    "code": {
+     "language": "plaintext",
+     "showLineNumbers": false,
+     "showMiniMap": false
+    },
+    "content": "Check **report_transmission_gave_up** and **report_transmission_attempts** for `$sourceChain` / `$destChain`.\n\n- Incrementing/maxed \u2192 jump to the **Scenario 2 deep dive** below.\n- Otherwise \u2192 likely just backlog size; check **pending_messages** and estimate ETA from round cadence."
+   },
+   "title": "Step 5 \u2014 Is a report being built but never landing?",
+   "type": "text",
+   "transparent": true
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 6,
+    "w": 24,
+    "x": 0,
+    "y": 114
+   },
+   "id": 1039,
+   "options": {
+    "legend": {
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    }
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "sum(rate(ccip_commit_report_transmission_gave_up_total{source_network_name=~\"$sourceChain\"}[5m])) by (source_network_name)",
+     "legendFormat": "{{source_network_name}} gave up/s",
+     "range": true,
+     "refId": "A"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "max by (source_network_name) (ccip_commit_pending_messages{source_network_name=~\"$sourceChain\"})",
+     "legendFormat": "{{source_network_name}} pending",
+     "range": true,
+     "refId": "B"
+    }
+   ],
+   "title": "Step 5 metric \u2014 gave up & pending backlog",
+   "type": "timeseries"
+  },
+  {
+   "gridPos": {
+    "h": 2,
+    "w": 24,
+    "x": 0,
+    "y": 120
+   },
+   "id": 1040,
+   "options": {
+    "mode": "markdown",
+    "code": {
+     "language": "plaintext",
+     "showLineNumbers": false,
+     "showMiniMap": false
+    },
+    "content": ""
+   },
+   "title": "\u26a0\ufe0f RMN-signature branches (signed-roots-dropped, chain quorum, Byzantine root disagreement) were dropped from this runbook: RMNEnabled is hardcoded off in production. Cursing (Step 4) is the one RMN-adjacent signal still live.",
+   "type": "text",
+   "transparent": true
+  },
+  {
+   "gridPos": {
+    "h": 6,
+    "w": 24,
+    "x": 0,
+    "y": 122
+   },
+   "id": 1041,
+   "options": {
+    "mode": "markdown",
+    "code": {
+     "language": "plaintext",
+     "showLineNumbers": false,
+     "showMiniMap": false
+    },
+    "content": "Three hypotheses, cheapest first:\n\n- **A \u2014 never transmitted (rejected pre-send).** Check the reason breakdown below for `phase=\"should_transmit\"`. `config_digest_mismatch` \u2192 cross-check the digest-mismatch panel above, config sync issue. `stale` \u2192 often benign, a different overlapping report already landed, re-check Step 1. `dest_not_supported` \u2192 transmission-schedule/config bug. `cursed` \u2192 converges with Step 4. All flat \u2192 move to B.\n- **B \u2014 transmitted, reverted/stuck on-chain.** *Outside commit-plugin metrics*: check chain B's TXM/tx-sender dashboards for the assigned transmitter (nonce gap, underpriced gas, wallet balance, revert reason).\n- **C \u2014 actually succeeded, read is lagging.** `offramp_next_seq_num` is sourced from this plugin's own chain-B reader; cross-check chain B's block explorer / chain-reader health directly before escalating further."
+   },
+   "title": "Deep dive: Scenario 2 \u2014 report transmission stuck (Step 5)",
+   "type": "text",
+   "transparent": true
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 7,
+    "w": 24,
+    "x": 0,
+    "y": 128
+   },
+   "id": 1042,
+   "options": {
+    "legend": {
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    }
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "sum(rate(ccip_commit_report_validation_rejected_total{chainID=~\"$destChain\", phase=\"should_transmit\"}[15m])) by (reason)",
+     "legendFormat": "{{reason}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Scenario 2 metric \u2014 report_validation_rejected{phase=\"should_transmit\"} by reason",
+   "type": "timeseries"
+  },
+  {
+   "gridPos": {
+    "h": 8,
+    "w": 24,
+    "x": 0,
+    "y": 135
+   },
+   "id": 1043,
+   "options": {
+    "mode": "markdown",
+    "code": {
+     "language": "plaintext",
+     "showLineNumbers": false,
+     "showMiniMap": false
+    },
+    "content": "Grounded in `getConsensusObservation` (`merkleroot/outcome.go`): the *only* way the whole round fails is the DON not reaching 2\u00b7fRoleDON+1 agreement on a single FChain value for the **destination chain** \u2014 every other field degrades gracefully per-chain.\n\n- **This is destination-chain-wide, not lane-specific.** Before going further, check whether *other* source chains into this dest are also stalled (their pending-messages also climbing, panel below). If only `$sourceChain` is affected, this branch is wrong \u2014 back to Step 4/5.\n- **H1 \u2014 too few oracles could read it.** `fchain_read_errors` spiking broadly across oracles \u2192 home-chain RPC/read outage.\n- **H2 \u2014 oracles disagree.** *(Needs the not-yet-implemented `consensus.go` split-vote metric \u2014 `ccip_commit_consensus_dropped{objectName=\"fChain\", reason=\"split\"}`, reviewed design only per the metrics doc.)* Corroborate with `config_digest_mismatch` flipping for a subset of oracles around the same time."
+   },
+   "title": "Deep dive: Scenario 3 \u2014 consensus never completes (Step 3)",
+   "type": "text",
+   "transparent": true
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "The second series is intentionally unfiltered by $sourceChain \u2014 you need every lane into this dest chain to rule this branch in/out.",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 24,
+    "x": 0,
+    "y": 143
+   },
+   "id": 1044,
+   "options": {
+    "legend": {
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    }
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "sum(rate(ccip_commit_fchain_read_errors_total{chainID=~\"$destChain\"}[5m])) by (chainID)",
+     "legendFormat": "{{chainID}} fchain read errors/s",
+     "range": true,
+     "refId": "A"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "max by (source_network_name) (ccip_commit_pending_messages{dest_network_name=~\".*\"})",
+     "legendFormat": "{{source_network_name}} pending (all lanes)",
+     "range": true,
+     "refId": "B"
+    }
+   ],
+   "title": "Scenario 3 metric \u2014 fchain_read_errors & pending_messages across ALL source chains into $destChain",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "${DS_PROMETHEUS}"
+   },
+   "description": "",
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "custom": {
+      "axisCenteredZero": false,
+      "axisColorMode": "text",
+      "axisLabel": "",
+      "axisPlacement": "auto",
+      "barAlignment": 0,
+      "drawStyle": "line",
+      "fillOpacity": 0,
+      "gradientMode": "none",
+      "hideFrom": {
+       "legend": false,
+       "tooltip": false,
+       "viz": false
+      },
+      "insertNulls": false,
+      "lineInterpolation": "linear",
+      "lineWidth": 1,
+      "pointSize": 5,
+      "scaleDistribution": {
+       "type": "linear"
+      },
+      "showPoints": "auto",
+      "spanNulls": false,
+      "stacking": {
+       "group": "A",
+       "mode": "none"
+      },
+      "thresholdsStyle": {
+       "mode": "off"
+      }
+     },
+     "mappings": [],
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "red",
+        "value": 80
+       }
+      ]
+     },
+     "unit": "short"
+    },
+    "overrides": []
+   },
+   "gridPos": {
+    "h": 6,
+    "w": 24,
+    "x": 0,
+    "y": 151
+   },
+   "id": 1045,
+   "options": {
+    "legend": {
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ],
+     "displayMode": "table",
+     "placement": "bottom",
+     "showLegend": true
+    },
+    "tooltip": {
+     "mode": "multi",
+     "sort": "desc"
+    }
+   },
+   "pluginVersion": "10.1.0",
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "${DS_PROMETHEUS}"
+     },
+     "editorMode": "code",
+     "expr": "ccip_commit_config_digest_mismatch{chain_id=~\"$destChain\"}",
+     "legendFormat": "{{chain_id}}",
+     "range": true,
+     "refId": "A"
+    }
+   ],
+   "title": "Scenario 3 metric \u2014 config_digest_mismatch (corroborating H2)",
+   "type": "timeseries"
+  }
+ ],
+ "refresh": "30s",
+ "schemaVersion": 38,
+ "style": "dark",
+ "tags": [
+  "ccip",
+  "commit-plugin",
+  "merkleroot"
+ ],
+ "templating": {
+  "list": [
+   {
+    "current": {
+     "text": "VictoriaMetrics",
+     "value": "victoriametrics"
+    },
+    "hide": 0,
+    "includeAll": false,
+    "label": "Datasource",
+    "multi": false,
+    "name": "DS_PROMETHEUS",
+    "options": [],
+    "query": "prometheus",
+    "refresh": 1,
+    "regex": "",
+    "skipUrlSync": false,
+    "type": "datasource"
+   },
+   {
+    "current": {
+     "selected": false,
+     "text": "All",
+     "value": "$__all"
+    },
+    "datasource": {
+     "type": "prometheus",
+     "uid": "${DS_PROMETHEUS}"
+    },
+    "definition": "label_values(ccip_commit_plugin_heartbeat_total, chainID)",
+    "hide": 0,
+    "includeAll": true,
+    "label": "Dest chain (chainID)",
+    "multi": true,
+    "name": "destChain",
+    "options": [],
+    "query": {
+     "query": "label_values(ccip_commit_plugin_heartbeat_total, chainID)",
+     "refId": "StandardVariableQuery"
+    },
+    "refresh": 2,
+    "regex": "",
+    "skipUrlSync": false,
+    "sort": 1,
+    "type": "query"
+   },
+   {
+    "current": {
+     "selected": false,
+     "text": "All",
+     "value": "$__all"
+    },
+    "datasource": {
+     "type": "prometheus",
+     "uid": "${DS_PROMETHEUS}"
+    },
+    "definition": "label_values(ccip_commit_pending_messages, source_network_name)",
+    "hide": 0,
+    "includeAll": true,
+    "label": "Source chain (network name)",
+    "multi": true,
+    "name": "sourceChain",
+    "options": [],
+    "query": {
+     "query": "label_values(ccip_commit_pending_messages, source_network_name)",
+     "refId": "StandardVariableQuery"
+    },
+    "refresh": 2,
+    "regex": "",
+    "skipUrlSync": false,
+    "sort": 1,
+    "type": "query"
+   },
+   {
+    "current": {
+     "selected": false,
+     "text": "",
+     "value": ""
+    },
+    "hide": 0,
+    "label": "Onramp seq num under investigation (X)",
+    "name": "SeqNum",
+    "options": [
+     {
+      "selected": true,
+      "text": "",
+      "value": ""
+     }
+    ],
+    "query": "",
+    "skipUrlSync": false,
+    "type": "textbox"
+   },
+   {
+    "current": {
+     "selected": false,
+     "text": "0x",
+     "value": "0x"
+    },
+    "hide": 0,
+    "label": "Message ID (hex)",
+    "name": "MsgID",
+    "options": [
+     {
+      "selected": true,
+      "text": "0x",
+      "value": "0x"
+     }
+    ],
+    "query": "0x",
+    "skipUrlSync": false,
+    "type": "textbox"
+   }
+  ]
+ },
+ "time": {
+  "from": "now-6h",
+  "to": "now"
+ },
+ "timepicker": {},
+ "timezone": "",
+ "title": "CCIP Commit Plugin",
+ "uid": "ccip-commit-plugin",
+ "version": 1,
+ "weekStart": ""
+}

--- a/devenv/env.toml
+++ b/devenv/env.toml
@@ -1,6 +1,21 @@
 cl_nodes_funding_eth = 50
 cl_nodes_funding_link = 50
 
+# Beholder-only commit-plugin metrics (see docs/metrics/commit-metrics.md) only ever leave the
+# node via this OTLP/gRPC push client -- there is no promauto counterpart to scrape. Requires
+# the VictoriaMetrics observability stack (`ccip obs up --victoria`; see devenv/README.md),
+# whose otel-collector listens on gRPC:4317 (chainlink core's Beholder client is gRPC-only,
+# see core/services/chainlink/config_telemetry.go OtelExporterGRPCEndpoint) and remote-writes
+# into VictoriaMetrics for the "victoriametrics" Grafana datasource.
+node_config_overrides = """
+[Telemetry]
+Enabled = true
+Endpoint = 'host.docker.internal:4317'
+InsecureConnection = true
+TraceSampleRatio = 1.0
+LogStreamingEnabled = true
+"""
+
 [cldf]
 
 [[blockchains]]

--- a/docs/metrics/commit-metrics.md
+++ b/docs/metrics/commit-metrics.md
@@ -6,11 +6,7 @@
       + [Shared: consensus aggregation](#shared-consensus-aggregation)
       + [Merkle root processor — High](#merkle-root-processor--high)
       + [Merkle root processor — Medium](#merkle-root-processor--medium)
-   * [War games: incident walkthroughs](#war-games-incident-walkthroughs)
-      + [Scenario 1 — full decision tree](#scenario-1--full-decision-tree)
-      + [Scenario 2 — deep dive: report transmission stuck (Step 5)](#scenario-2--deep-dive-report-transmission-stuck-step-5)
-      + [Scenario 3 — deep dive: consensus never completes (Step 3)](#scenario-3--deep-dive-consensus-never-completes-step-3)
-      + [Gaps this exercise surfaced (already folded into the findings above)](#gaps-this-exercise-surfaced-already-folded-into-the-findings-above)
+   * [Incident triage](#incident-triage)
    * [Full findings](#full-findings)
       + [Top-level plugin orchestration (`commit/plugin.go`, `commit/report.go`)](#top-level-plugin-orchestration-commitplugingo-commitreportgo)
       + [Shared: consensus aggregation (`internal/plugincommon/consensus/consensus.go`)](#shared-consensus-aggregation-internalplugincommonconsensusconsensusgo)
@@ -87,56 +83,21 @@ Every metric proposed in this doc, with a one/two-line "why" — the full ration
 
 ---
 
-## War games: incident walkthroughs
+## Incident triage
 
-Three scenarios worked through against the metric set above (some referencing not-yet-implemented items, noted inline) to validate the design before building it: does an on-call engineer actually get a straight-line diagnosis, or just more noise? Each starts from the same alert: **message `0xabc...def`, onramp sequence number `X`, chain A (source) → chain B (dest), reported in-flight for 15 minutes.**
+The metrics above were validated against simulated incidents before being built (does an
+on-call engineer actually get a straight-line diagnosis, or just more noise?), and that
+walkthrough has since been extracted, hardened, and kept current as its own pair of runbooks
+rather than living here as a point-in-time exercise:
 
-### Scenario 1 — full decision tree
+- [`docs/runbooks/uncommitted-message.md`](../runbooks/uncommitted-message.md) — triage for a
+  specific stuck message (the full decision tree and both deep dives that used to be here).
+- [`docs/runbooks/commit-plugin-health.md`](../runbooks/commit-plugin-health.md) — point-in-time
+  health check, no specific incident required.
 
-1. **Is this even a commit-plugin problem?** Check `ccip_commit_offramp_next_seq_num{source_network_name="chain-a", dest_network_name="chain-b"}`.
-   - `> X` → a root covering X already landed on the offramp. Commit plugin's job is done; hand off to exec on-call. Stop.
-   - `<= X` → continue.
-2. **Has the plugin observed X on-chain yet?** Check `ccip_commit_onramp_max_seq_num{sourceChain="chain-a"}`.
-   - `< X` → onramp read is lagging. Check `ccip_commit_merkleroot_observation_errors{sourceChain="chain-a"}` by reason (no_bindings/timeout/rpc_error). Source-chain read/infra issue, not commit logic.
-   - `>= X` → plugin has seen it; continue.
-3. **Is the round producing outcomes at all?** Check `rate(ccip_commit_consensus_observation_failed[5m])`.
-   - Incrementing → destination-chain-wide consensus failure — see Scenario 3 deep dive.
-   - Flat → continue.
-4. **Is chain A or B cursed?** Check `ccip_commit_rmn_curse_active{chain_id="chain-b", curse_type="global"|"destination"}` and `ccip_commit_source_chain_cursed{sourceChain="chain-a"}`.
-   - Any `== 1` → found it; likely intentional/incident-flagged, hand off to whoever owns the curse. Stop.
-   - All `0` → continue.
-5. **Is a report being built but never landing?** Check `ccip_commit_report_transmission_gave_up{sourceChain="chain-a"}` and `ccip_commit_report_transmission_attempts`.
-   - Incrementing/maxed → see Scenario 2 deep dive.
-   - Otherwise → likely just backlog size; check `ccip_commit_pending_messages{sourceChain="chain-a"}` and estimate ETA from round cadence.
-
-(RMN-signature-specific branches — signed-roots-dropped, chain quorum result, Byzantine root disagreement — were dropped from the implementation scope: RMN blessing/signing is effectively dead code now that `RMNEnabled` is hardcoded off. Cursing is the one RMN-adjacent signal still live in production, hence Step 4.)
-
-### Scenario 2 — deep dive: report transmission stuck (Step 5)
-
-Three hypotheses, in order of how cheap they are to check:
-
-- **A — never transmitted (rejected pre-send).** `sum by (reason) (rate(ccip_commit_report_validation_rejected{phase="should_transmit"}[15m]))`.
-  - `config_digest_mismatch` climbing → cross-check `ccip_commit_config_digest_mismatch`; config sync issue.
-  - `stale` climbing → often benign — a different, overlapping report already landed; re-check Step 1's gauge, it may have just moved.
-  - `dest_not_supported` → transmission-schedule/config bug.
-  - `cursed` → converges with Step 4.
-  - All flat → move to B.
-- **B — transmitted, reverted/stuck on-chain.** Outside commit-plugin metrics: check chain B's TXM/tx-sender dashboards for the assigned transmitter (nonce gap, underpriced gas, wallet balance, revert reason). A revert here for the same reasons as A but caught on-chain instead of locally usually means a race between the pre-check and the tx landing (config rollout, chain congestion).
-- **C — actually succeeded, read is lagging.** `ccip_commit_offramp_next_seq_num` is sourced from the plugin's own chain-B reader; if that's behind, "no change" can persist for a few rounds after a real success. Cross-check chain B's block explorer / chain-reader health directly before escalating further.
-
-### Scenario 3 — deep dive: consensus never completes (Step 3)
-
-Grounded in `getConsensusObservation` (`merkleroot/outcome.go:461-508`): the *only* way the whole round fails is the DON not reaching 2·fRoleDON+1 agreement on a single FChain value for the **destination chain** — every other field degrades per-chain gracefully. Two implications:
-
-- **This is destination-chain-wide, not lane-specific.** Before going further, check whether *other* source chains reporting into chain B are also stalled (their `ccip_commit_pending_messages` also climbing). If only chain A is affected, this branch is the wrong one — back to Scenario 1, Step 4/5.
-- **The counter alone can't tell you why.** Two sub-hypotheses, using the not-yet-implemented shared `consensus.go` fix:
-  - **H1 — too few oracles could read it.** `ccip_commit_fchain_read_errors` spiking broadly across oracles → home-chain RPC/read outage.
-  - **H2 — oracles disagree.** `ccip_commit_consensus_dropped{objectName="fChain", reason="split"}` firing while H1 stays flat → home-chain config (e.g. CCIPHome update, DON membership change) mid-rollout/desynced across the DON. Corroborate with `ccip_commit_config_digest_mismatch` flipping for a subset of oracles around the same time.
-
-### Gaps this exercise surfaced (already folded into the findings above)
-- No plugin-level heartbeat — added to "Top-level plugin orchestration."
-- No reason breakdown for report-acceptance/transmission-validation rejections — added to "Top-level plugin orchestration."
-- `GetConsensusMap`'s two-vs-three-outcome ambiguity — added to "Shared: consensus aggregation" (not yet implemented — reviewed design only).
+Both are written to be followed mechanically by a human or an AI agent (see
+[`docs/runbooks/README.md`](../runbooks/README.md)) and have been tested against a live devenv
+DON under two independently forced failure modes, not just read for plausibility.
 
 ---
 

--- a/docs/metrics/commit-metrics.md
+++ b/docs/metrics/commit-metrics.md
@@ -55,10 +55,11 @@ Every metric proposed in this doc, with a one/two-line "why" — the full ration
 
 | Metric | Status | Why |
 |---|---|---|
-| Truncation counter `{sourceChain}` (`MaxMerkleTreeSize`) | Proposed | Chain-throughput ceiling being hit is currently `Debugf`-only. |
-| Offramp lane misconfiguration gauge `{sourceChain,status}` | Proposed | `rmn-misconfigured` in particular now flags real config drift, since a lane still expecting RMN blessing while RMN is globally off is permanently broken. |
-| Onramp/offramp invariant-violation counter `{sourceChain,type}` | Proposed | These are already documented in-code as stall signals but were never counted. |
-| Insufficient-consensus-on-`OffRampNextSeqNums` counter `{sourceChain}` | Proposed | Looks identical to "no new messages" from the outside without it. |
+| `ccip_commit_range_truncated{sourceChain}` (`MaxMerkleTreeSize`) | ✅ Implemented | Chain-throughput ceiling being hit was previously `Debugf`-only. |
+| `ccip_commit_offramp_lane_status{sourceChain,status}` | ✅ Implemented | `rmn_misconfigured` in particular now flags real config drift, since a lane still expecting RMN blessing while RMN is globally off is permanently broken. |
+| `ccip_commit_seqnum_invariant_violation{sourceChain,type}` | ✅ Implemented | These are already documented in-code as stall signals but were never counted. |
+| `ccip_commit_offramp_consensus_insufficient{sourceChain}` | ✅ Implemented | Looks identical to "no new messages" from the outside without it. |
+
 ---
 
 ## War games: incident walkthroughs
@@ -175,10 +176,10 @@ Used by commit (`chainfee`, `merkleroot`, `plugin.go`, `report.go`), `execute/pl
 - **Report transmission gives up / retry cost.** `outcome.go` (`ReportTransmissionGaveUp`), `Outcome.ReportTransmissionCheckAttempts`. One of the most common on-call pages; today `Warnw` with no counter. → Counter + histogram of attempts.
 
 **Medium**
-- Truncation due to `MaxMerkleTreeSize` (chain throughput-bound). `outcome.go:174-178`, `Debugf`. → Counter `{sourceChain}`.
-- Offramp lane misconfiguration bucket (live / skipped-not-a-lane / skipped-disabled / rmn-misconfigured); `rmnMisconfigured` in particular indicates config drift. `observation.go:53-89,634-646`. → Gauge `{sourceChain, status}`.
-- OnRamp/OffRamp invariant violations (offramp-ahead-of-onramp, onramp-max-zero, offramp-seqnum-regression) — explicitly documented in-package as stall signals. `outcome.go:43-44,152-161,421-428`. → Counter `{sourceChain, type}`.
-- Insufficient consensus on `OffRampNextSeqNums` for a chain — chain silently stops progressing, looks identical to "no new messages" from outside. `outcome.go:515-531`. → Counter `{sourceChain}`.
+- Truncation due to `MaxMerkleTreeSize` (chain throughput-bound). `outcome.go:174-178`, `Debugf`. → **Implemented**: counter `ccip_commit_range_truncated{sourceChain}`.
+- Offramp lane misconfiguration bucket (live / skipped-not-a-lane / skipped-disabled / rmn-misconfigured); `rmnMisconfigured` in particular indicates config drift. `observation.go:53-89,634-646`. → **Implemented**: gauge `ccip_commit_offramp_lane_status{sourceChain, status="live"|"skipped_not_a_lane"|"skipped_disabled"|"rmn_misconfigured"}` (1/0), reported for all four statuses every round so a chain moving between buckets can't leave a stale "still active" value behind.
+- OnRamp/OffRamp invariant violations (offramp-ahead-of-onramp, onramp-max-zero, offramp-seqnum-regression) — explicitly documented in-package as stall signals. `outcome.go:43-44,152-161,421-428`. → **Implemented**: counter `ccip_commit_seqnum_invariant_violation{sourceChain, type="offramp_ahead_of_onramp"|"onramp_max_zero"|"offramp_seqnum_regression"}`.
+- Insufficient consensus on `OffRampNextSeqNums` for a chain — chain silently stops progressing, looks identical to "no new messages" from outside. `outcome.go:515-531`. → **Implemented**: counter `ccip_commit_offramp_consensus_insufficient{sourceChain}`.
 
 (RMN blessing/signing findings — signed-roots-dropped, per-root signed/unsigned filtering, chain quorum result, Byzantine root disagreement, RMN controller node-coverage/internal-errors, signature-verification conflation, `ErrSignaturesNotProvidedByLeader`, `ObserveRMNRemoteCfg` failures, peer/stream connectivity, controller re-init churn, and the standalone `ValidateRootBlessings` proposal (now covered by the implemented `root_blessing_mismatch` reason above) — were all dropped from this doc. All of these sit behind `if rmnEnabled` in `buildMerkleRootsOutcome` or are otherwise part of the RMN controller/signing path, which is effectively dead code now that `RMNEnabled` is hardcoded off and the controller is slated for removal; cursing, covered above, is the one RMN-adjacent signal still live in production.)
 

--- a/docs/metrics/commit-metrics.md
+++ b/docs/metrics/commit-metrics.md
@@ -1,0 +1,216 @@
+## Metrics coverage assessment — commit plugin
+
+I read through `commit/metrics`, `commit/merkleroot` (+ `rmn`), `commit/chainfee`, `commit/tokenprice`, and the top-level `commit/plugin.go` / `report.go` / `factory.go`. There's a real gap, and it's structural, not just a few missing gauges.
+
+**Ground rule for everything below: the presence of a log line — even a "stable identifier" some log-analysis tooling already keys on — is never a reason to exclude a metric.** Logs are exactly the noisy, low-signal, un-queryable thing motivating this work; a few items here are genuinely *only* visible at `Debugw`, which is worse than a "stable" log, not better. Nothing was cut from the list below because it was already logged.
+
+### What exists today (`commit/metrics/prom.go`)
+
+- Generic per-processor instrumentation via `TrackedProcessor` (wraps merkleroot/chainfee/tokenprice): latency histogram, error counter, and an **output-size counter** driven by each type's `Stats()` — but `Stats()` only returns `len(map)`-style item counts (e.g. `gasPrices: 3`), never the actual values.
+- `ccip_commit_max_sequence_number` gauge — but only fed from `MerkleRootChain.SeqNumsRange.End()` in `TrackObservation`/`TrackOutcome`, i.e. **only when a root is actually being built for a report**.
+- `ccip_commit_latest_round_id`, `ccip_commit_config_digest_mismatch`, `ccip_commit_loopp_ccip_provider_supported`.
+- RMN-specific: `TrackRmnReport` (build latency/success) and `TrackRmnRequest` (per-node request latency/error) — merkleroot and its `rmn` subpackage are the only parts of the plugin with a dedicated `MetricsReporter` sub-interface.
+- **`chainfee` and `tokenprice` have no dedicated metrics interface at all** — they only get the generic latency/error/size instrumentation above. Token prices, gas prices, and their staleness/deviation/failure states are otherwise 100% log-only.
+
+### Your example, confirmed
+
+`merkleroot.Observation` has `OnRampMaxSeqNums` and `OffRampNextSeqNums` fields (`commit/merkleroot/types.go:34-35`) populated **every round**, but no `Reporter` method ever reads them — the only sequence-number gauge (`ccip_commit_max_sequence_number`) comes from `MerkleRootChain.SeqNumsRange.End()`, which only exists once a root is already being built. So if the plugin is stuck reading a chain (RPC lag, stuck in `selectingRangesForReport`), there's no gauge showing it — the one gauge that looks related lags or is absent during exactly the failure mode you'd want visibility into.
+
+### Cross-cutting themes (repeat in every processor)
+
+Merkleroot, chainfee, and tokenprice each independently:
+1. Compute a **per-item value** (seq num / fee / price) that's never gauged — only counted.
+2. Compute **staleness** (age since last update) to decide on a heartbeat write, then discard the number and keep only the boolean.
+3. Swallow **fetch/RPC failures** into empty maps with an `Errorw` — these never increment `ccip_commit_processor_errors` because the processor's top-level `Observation()` still returns `nil` error.
+4. Drop entries during **consensus aggregation** silently — `internal/plugincommon/consensus/consensus.go:42,52` literally has `// TODO: metrics` next to the exact code path that discards a chain/token when too few nodes agree. This is shared infra, hit by every processor, and the team already flagged it (reviewed fix shape below).
+5. `internal/libs/asynclib/goroutines.go` (used by chainfee's async observer, similar pattern in tokenprice) has **zero logging or metrics** when an operation times out — it just drops the key from the results map and the caller's blind type-assertion silently degrades to an empty value. This is the most severe blind spot found: a hung RPC call produces no log line and no metric anywhere.
+6. **No plugin-level heartbeat/liveness signal.** Surfaced by war-gaming an incident end-to-end rather than by reading the code in isolation: if the whole round pipeline wedges or the process crashes, every metric in this doc simply stops updating instead of showing a bad value — and "gauge went flat" reads very differently in monitoring than "gauge shows a bad value," easy to miss unless dashboards specifically alert on staleness/absence rather than thresholds. There's no dedicated "is the plugin alive at all" signal today; see below.
+
+---
+
+## Full findings
+
+Severity is about production-triage value, independent of whether something is logged today.
+
+### Top-level plugin orchestration (`commit/plugin.go`, `commit/report.go`)
+
+These aren't owned by any single processor — they're the outer round loop and the report-acceptance path — but two gaps here turned out to matter as much as anything processor-specific once an actual incident was traced end-to-end.
+
+**High**
+- **No heartbeat / liveness signal.** `commit/plugin.go:434` (`Outcome()`). If the whole round pipeline wedges (deadlock, a panic-recovery masking a crash loop, OCR itself failing to schedule rounds), every metric in this doc simply stops updating instead of showing a bad value. A stale gauge and a valid-but-bad gauge look identical unless you specifically alert on absence/staleness — easy to forget when every other alert here is threshold-based. This should be step 0 of any triage tree, and today it isn't answerable from commit-plugin metrics at all. → Gauge/counter, e.g. `ccip_commit_last_successful_round_timestamp`, set unconditionally near the top of `Outcome()` (and ideally `Observation()` too) regardless of what happens downstream.
+- **Report-acceptance / transmission-validation rejections have zero metrics.** `commit/report.go:126-247` (`validateReport`, called from both `ShouldAcceptAttestedReport` and `ShouldTransmitAcceptedReport`) has eight distinct rejection paths — empty/invalid merkle root, duplicate RMN signature, insufficient RMN signatures, cursed report, dest chain unsupported, config digest mismatch, stale report, root-blessing mismatch — every one of them `Warnw`/`Errorw`/`Debugf` only. This sits directly upstream of merkleroot's own `ReportTransmissionGaveUp` counter: if every oracle's local `validateReport` call rejects a report before anyone ever calls transmit, "gave up" fires with **zero on-chain trace at all** (no tx ever submitted) — a completely different remediation path than "tx submitted but reverted" or "tx stuck in mempool." Without per-reason counts here, those scenarios are indistinguishable from `ccip_commit_report_transmission_gave_up_total` alone. → Counter `ccip_commit_report_validation_rejected_total{phase="should_accept"|"should_transmit", reason="empty_root|invalid_seqnum_range|duplicate_rmn_sig|insufficient_rmn_sigs|cursed|dest_not_supported|config_digest_mismatch|stale|root_blessing_mismatch"}`.
+
+### Shared: consensus aggregation (`internal/plugincommon/consensus/consensus.go`)
+
+Used by commit (`chainfee`, `merkleroot`, `merkleroot/rmn/controller.go`, `plugin.go`, `report.go`), `execute/plugin_functions.go`, **and** `internal/plugincommon/discovery/processor.go` — this is genuinely shared infra, not commit-specific, which shapes the recommended fix below. Reviewed design, not yet implemented.
+
+**High**
+- **`GetConsensusMap` collapses three distinguishable outcomes into one `Debugw`/`Warnw` line, both marked `// TODO: metrics`** (`consensus.go:34-56`). `NewMinObservation.GetValid()` (`min_observation.go:57-66`) buckets observations by identical value and returns every distinct value that independently cleared the threshold, which means there are three cases today, not two:
+  1. `minObs.Get(key)` returns `!exists` (`consensus.go:51-54`) — no threshold configured for this key at all. A caller-side data/config mismatch, not a DON-agreement problem — deserves its own reason so it doesn't get chased as an oracle-health issue.
+  2. `len(items) == 0` after `GetValid()` — no single value reached the threshold (too few oracles reporting, or votes scattered thin). The routine "insufficient agreement" case.
+  3. `len(items) > 1` — two or more *distinct* values each independently cleared the threshold. Given BFT-style thresholds this is the more alarming one: it implies something actively changing mid-round across the DON, or is worth treating as a potential integrity signal rather than routine flakiness.
+
+  Cases 2 and 3 want different on-call responses (see the merkleroot `ConsensusObservationFailed` writeup below for a worked example); case 1 wants a bug ticket, not a page.
+
+  **Recommended shape:** don't emit metrics from inside this package — it's shared with `execute`, and hardcoding a `ccip_commit_*`-prefixed metric here would either be wrong for execute or force a plugin-type branch into shared code. Instead, extend the return signature additively so each caller routes the reason through its own `MetricsReporter`:
+  ```go
+  type ConsensusDropReason int
+
+  const (
+      DropReasonNone ConsensusDropReason = iota
+      DropReasonThresholdNotDefined
+      DropReasonInsufficientAgreement // 0 values met threshold
+      DropReasonSplit                 // >1 values met threshold — treat as higher severity
+  )
+
+  func GetConsensusMap[K comparable, T any](
+      lggr logger.Logger,
+      objectName string,
+      itemsByKey map[K][]T,
+      minObs MultiThreshold[K],
+  ) (map[K]T, map[K]ConsensusDropReason)
+  ```
+  Callers that don't care about metrics can `_` the second return value — small blast radius, ~6 call sites total. Callers that do care loop the returned map and call their own reporter: `ccip_commit_consensus_dropped_total{objectName, key, reason}` for commit, an analogous `ccip_exec_...` metric for execute.
+
+  **Consistency note:** `GetConsensusMapAggregator` (`consensus.go:62-81`) and `GetOrderedConsensus` (`consensus.go:113-148`) have the same unmetriced pattern but structurally can't produce case 3 — the aggregator combines all values regardless of agreement, and ordered-consensus just needs a count, not matching values. `GetOrderedConsensus` does have its own distinct third case (`consensus.go:127-133`, "found a negative or 0 threshold" — a config-error class, currently silently skipped). If this file is being touched, apply the same additive `(result, reasons)` pattern to all three for one coherent `{objectName, key, reason}` metric family instead of fixing `GetConsensusMap` alone and leaving the other two as later follow-ups.
+
+### Merkle root processor (`commit/merkleroot`, `commit/merkleroot/rmn`)
+
+**High**
+- **Raw onramp max seq num / offramp next seq num per source chain, every round** (your example). `observation.go:287-288` (`ObserveLatestOnRampSeqNums`/`ObserveOffRampNextSeqNums`), logged at `Debugw` only. → Gauge `{sourceChain}`, both series, distinct from the existing `ccip_commit_max_sequence_number`.
+- **Pending-message backlog per chain** (`onRampMaxSeqNum - offRampNextSeqNum`). Computed inline at `outcome.go:152-179` then discarded. → Gauge `{sourceChain}`.
+- **RMN global/destination curse active** — halts all reporting for the dest chain; today `Warnw` every round while cursed. `observation.go:553-565`. → Gauge `{chain_id, curse_type}` (1/0).
+- **Per-source-chain curse** (lane silently excluded). `observation.go:562-582`, `Infow` only. → Gauge `{sourceChain}` (1/0).
+- **Per-chain onramp/merkle-root read failures**, swallowed per-goroutine (no-bindings / timeout / rpc-error / msg-count-mismatch / hash-error / address-lookup-error) — never reaches `ccip_commit_processor_errors` since the outer `Observation()` call still succeeds. `observation.go:656-777`. → Counter `{sourceChain, reason}`.
+- **`GetFChain` failure** — literally has `// TODO: metrics` in the source. `observation.go:862-871`. Degrades to empty FChain map, which then fails consensus and stalls the round. → Counter.
+- **Consensus-observation-failed round** (`ConsensusObservationFailed`, entire outcome empty) — `outcome.go:88-92`, gated entirely by `getConsensusObservation`'s upfront requirement that the DON reach 2·fRoleDON+1 agreement on a *single* FChain value for the **destination chain** (`outcome.go:471-480`); every other per-chain consensus computation (roots, onramp/offramp seq nums, RMN config) degrades gracefully per-chain and cannot trigger this path. Two consequences for the runbook: (1) this failure is inherently **destination-chain-wide, not lane-specific** — if it's firing, every source chain reporting into this dest chain should be stalling simultaneously, not just one lane, which is a fast way to rule this branch in or out; (2) the counter alone only tells you *that* consensus failed, not *why*. Pair it with the shared `consensus.go` fix above (`objectName="fChain", key=<destChain>`) to see the drop directly, and with the `GetFChain`-failure counter to distinguish "too few oracles could even read it" (home-chain RPC/read outage) from "oracles disagree" (home-chain config mid-rollout/desynced across the DON — corroborate with `ccip_commit_config_digest_mismatch` flipping around the same time). Already a "stable log identifier" the team log-mines — evidence a metric is overdue, not a reason to skip one. → Counter, `{chain_family, chain_id}` (destination chain, matching labels used elsewhere in this reporter).
+- **Report transmission gives up / retry cost.** `outcome.go` (`ReportTransmissionGaveUp`), `Outcome.ReportTransmissionCheckAttempts`. One of the most common on-call pages; today `Warnw` with no counter. → Counter + histogram of attempts.
+- **RMN-enabled roots dropped wholesale** (signed-roots-not-subset / parse error) — an entire round's RMN-protected chains get zero inclusion. `outcome.go:270-299`, `Errorw`. → Counter `{reason}`.
+- **RMN chain-level quorum result** (zero roots / insufficient votes / success) per source chain — `controller.go:557-603`, `Infow` only, easily lost in volume. → Counter `{sourceChain, result}`.
+- **Byzantine root disagreement** (`"more than one valid root for chain"` / `"no valid root for chain"`) — a security/integrity signal currently indistinguishable from a mundane timeout. `controller.go:848-876`. → Counter `{reason}`.
+
+**Medium**
+- Truncation due to `MaxMerkleTreeSize` (chain throughput-bound). `outcome.go:174-178`, `Debugf`. → Counter `{sourceChain}`.
+- Offramp lane misconfiguration bucket (live / skipped-not-a-lane / skipped-disabled / rmn-misconfigured); `rmnMisconfigured` in particular indicates config drift. `observation.go:53-89,634-646`. → Gauge `{sourceChain, status}`.
+- OnRamp/OffRamp invariant violations (offramp-ahead-of-onramp, onramp-max-zero, offramp-seqnum-regression) — explicitly documented in-package as stall signals. `outcome.go:43-44,152-161,421-428`. → Counter `{sourceChain, type}`.
+- Insufficient consensus on `OffRampNextSeqNums` for a chain — chain silently stops progressing, looks identical to "no new messages" from outside. `outcome.go:515-531`. → Counter `{sourceChain}`.
+- Per-root inclusion/exclusion reason (rmn-enabled-unsigned vs rmn-disabled-unexpectedly-signed) — answers "why didn't chain X's root make the report." `outcome.go:342-378`. → Counter `{sourceChain, reason}`.
+- `ValidateRootBlessings` mismatches at report-acceptance time (`commit/report.go:234` → `merkleroot/transmission_checks.go:28-52`) — distinct from the existing config-digest-mismatch gauge. → Counter `{reason}`.
+- RMN node-coverage shortfall per chain (dropped from signature request entirely). `controller.go:188-203`. → Counter/gauge `{sourceChain}`.
+- RMN internal-error classes currently unlabeled or folded into a generic `invalid_response` (dest==source config bug, sanity-check failure, node-info-not-found / stale registry). `controller.go:395-398,358-367,421-425,908-909,1010-1013`. → Counter `{reason}`.
+- Signature-verification failure conflated with generic "invalid response" (crypto mismatch vs. malformed-but-honest data are very different security signals), both in the RMN controller (`crypto.go:36-63`, `controller.go:1052-1089`) and on the plugin/query side (`observation.go:245-248`). → Split the existing label or add a dedicated counter.
+- `ErrSignaturesNotProvidedByLeader` recurrence — points to a leader-side RMN problem invisible to followers today. `observation.go:41-42,118-125`. → Counter.
+- RMN `ObserveRMNRemoteCfg` failures — blocks RMN controller init and outcome's RMN report building. `observation.go:846-856`, `Errorw`. → Counter.
+
+**Low**
+- RMN peer/stream connectivity state (active streams, peer-group connected) — currently only per-message `Infow` (log noise, no aggregate). `rmn/peerclient.go:57-183`. → Gauge.
+- RMN controller re-initialization churn (should be rare; frequent churn = config flapping or bug). `observation.go:143-185`. → Counter. Also worth a static `ccip_commit_rmn_enabled{chain_id}` gauge since RMN is now hardcoded off — useful for dashboard filtering / confirming the deprecation.
+
+### Chain fee processor (`commit/chainfee`)
+
+No dedicated `MetricsReporter` exists for this package at all (unlike merkleroot) — everything below is currently 100% log-only.
+
+**High**
+- **A single `GetChainConfig` failure for the dest chain aborts gas-price updates for *every* chain that round.** `outcome.go:259-263`, `Errorw`. The subagent that found this called it "likely the single highest-value item to alert on" — it's a total, silent loss of gas-price-update capability for a round. → Counter `ccip_commit_chainfee_update_aborted_total`, plus `{chain_id, scope=dest|source}` for the narrower per-source-chain config errors at `outcome.go:268-272,311-315`.
+- **Async op timeout → silently empty fee data**, no log, no metric anywhere (see cross-cutting #5). `observation.go:43-62` blindly type-asserts missing keys to zero value. → Counter `{operation}`.
+- **Per-chain USD gas fee (exec + DA) never gauged.** `outcome.go:65,103-108,129`, only `Infow`. → Gauge `{chain_id, component=exec|da}`.
+- **Fee staleness discarded after the boolean heartbeat decision.** `outcome.go:276,293-298` computes `consensusTimestamp.Sub(lastUpdate.Timestamp)` then keeps only a bool. → Gauge, seconds, `{chain_id}`.
+- **Whole-round "no consensus on any fee components."** `outcome.go:59-63`, `Warnw`. A whole-DON health signal — all chains' fee updates stall that round. → Counter `{chain_id}`.
+- **Consensus-map silently drops a chain** (fChain / FeeComponents / NativeTokenPrices / ChainFeeUpdates) when too few nodes agree — shared `consensus.go`, has `// TODO: metrics` in the source. See the "Shared: consensus aggregation" writeup above for the reviewed fix (adds a `reason`: threshold-not-defined vs. insufficient-agreement vs. split, not just a bare counter). → Counter `{objectName, chain_id, reason}` (shared fix benefits tokenprice too).
+
+**Medium**
+- Chains missing native token price, dropped from the update entirely (`missingNativeTokenPriceChains`). `outcome.go:66,81-85,126`, `Infow`. → Gauge/counter `{chain_id}`.
+- Same distinction at observation time, per-oracle (before consensus) — could isolate a single bad node's fee-quoter reader. `observation.go:65-86`. → Counter, watch cardinality.
+- Update-decision reason breakdown (no-previous / heartbeat / deviation / not-needed) — another "stable identifier" the log tooling already keys on; that's a reason to graduate it, not skip it. `outcome.go:21-38`. → Counter `{chain_id, reason}`.
+- Deviation magnitude discarded, boolean kept ("exceeded threshold" vs. "by how much"). `outcome.go:317-328`. → Gauge `{chain_id, component}`.
+- Async-cache staleness (async mode serves a ticker-refreshed cache with no tracked last-successful-sync time — a stuck background `sync()` looks healthy indefinitely). `observation_async.go:264-302`. → Gauge, last-success timestamp.
+- Reader-side error branches (`getSupportedSourceChains`, `SupportsDestChain`, `getEnabledSourceChains` failures) collapse into the same empty map as "legitimately zero chains configured." `observation_async.go:53-97`, `Errorw`. → Counter `{operation, chain_id}`.
+
+**Low**
+- Disabled/unsupported chain exclusion counts (config-drift detection across a large DON). `observation_async.go:59-129`, `Debugw`. → Gauge, supported/enabled chain counts.
+
+### Token price processor (`commit/tokenprice`)
+
+Also no dedicated `MetricsReporter`. Note `ValidateObservation` isn't even wrapped by the generic `TrackedProcessor` latency/error instrumentation — it's invisible by construction, not just under-instrumented.
+
+**High**
+- **`ValidateObservation` rejections have zero logs *and* zero metrics** — every failure path (non-positive price, unsupported chain, missing token info, bad timestamp) is a bare `fmt.Errorf` with no `lggr` call anywhere in `validate_observation.go:12-88`, and the wrapper isn't tracked. This is exactly the signal for detecting a misbehaving/misconfigured oracle in the DON. → Counter `{oracleID, reason}`.
+- **Price/FeeQuoter/FChain fetch failures degrade to empty maps that look identical to "legitimately nothing to report."** `observation.go:73-79,115-142,144-181`, `Errorw`, and `Observation()` still returns `nil` error so `ccip_commit_processor_errors` never fires. → Counter `{source=feed|feequoter|fchain}`.
+- **Per-token feed/fee-quoter USD price never gauged.** `outcome.go:107`, `types.go:31,59`. → Gauge `{token, destChain}`.
+- **Token price staleness discarded after the boolean heartbeat decision** — same pattern as chainfee. `outcome.go:127-129`. → Gauge, seconds, `{token}`.
+- **Consensus-not-reached per token/chain silently drops it from the map** (the closest thing to "outlier rejection" in this codebase) — shared `consensus.go`, also has `// TODO: metrics`. See the "Shared: consensus aggregation" writeup above for the reviewed fix (adds a `reason`: threshold-not-defined vs. insufficient-agreement vs. split, not just a bare counter). → Counter `{objectName, key, reason}`.
+
+**Medium**
+- Missing `TokenInfo` config count (feed has a token the offchain config doesn't know about) — `Warnw` per token per round, no aggregate. `outcome.go:120-125`. → Counter `{token}`.
+- Update-decision reason breakdown (no-previous / heartbeat / deviation / not-needed). `outcome.go:22-30`. → Counter `{token, reason}`.
+- Deviation magnitude discarded — `mathslib.Deviates` computes a ppb diff internally and returns only a bool. `internal/libs/mathslib/calc.go:25-39`. → Would need `Deviates` (or a wrapper) to also return the magnitude; Gauge `{token}`.
+- Async observer cache staleness (same risk as chainfee's async cache — stuck `sync()` serves old prices indefinitely, looks healthy). `observation.go:187-330`. → Gauge, last-success timestamp `{source}`.
+- Oracle feed/dest-chain support gaps — per-node capability info that explains *why* consensus on `fFeedChain` might fail. `observation.go:121-130,152-159`. → Gauge/counter `{oracleID, chainRole}`.
+
+**Low, but flagged as a miss in my first pass — don't let "it's Debug" read as "low priority"**
+- **Token-price reporting silently disabled by config** (`TokenPriceBatchWriteFrequency == 0`) is logged at `Debugw` — *less* visible in prod than a "stable" Info/Warn log, since Debug is typically off entirely. `processor.go:102-106`. This is exactly the pattern the existing `ccip_commit_loopp_ccip_provider_supported` boolean gauge was built for, and it's a cheap, precedented fix. → Gauge `{destChain}` (1/0).
+
+---
+
+## Suggested next step
+
+This is large enough to be its own workstream. I'd sequence it as:
+1. **Shared infra first** (benefits all three processors): fix `internal/plugincommon/consensus/consensus.go`'s `// TODO: metrics`, and add a timeout counter in `internal/libs/asynclib/goroutines.go`. Small, high-leverage, no processor-specific design needed.
+2. **Merkleroot high-severity list** — directly answers your stated pain point (onramp/offramp liveness, curse state, transmission give-up).
+3. **Chainfee + tokenprice high-severity list** — both need a dedicated `MetricsReporter` sub-interface first (mirroring `merkleroot.MetricsReporter`), then the per-value gauges/staleness/failure counters.
+4. Medium/low tiers as follow-up passes.
+
+Want me to turn this into an implementation plan (starting with #1), or file it as a ticket first?
+
+---
+
+## War games: incident walkthroughs
+
+Three scenarios worked through against the merkleroot-high-severity metric set above (some referencing not-yet-implemented items, noted inline) to validate the design before building it: does an on-call engineer actually get a straight-line diagnosis, or just more noise? Each starts from the same alert: **message `0xabc...def`, onramp sequence number `X`, chain A (source) → chain B (dest), reported in-flight for 15 minutes.**
+
+### Scenario 1 — full decision tree
+
+1. **Is this even a commit-plugin problem?** Check `ccip_commit_offramp_next_seq_num{source_network_name="chain-a", dest_network_name="chain-b"}`.
+   - `> X` → a root covering X already landed on the offramp. Commit plugin's job is done; hand off to exec on-call. Stop.
+   - `<= X` → continue.
+2. **Has the plugin observed X on-chain yet?** Check `ccip_commit_onramp_max_seq_num{source_network_name="chain-a"}`.
+   - `< X` → onramp read is lagging. Check `ccip_commit_merkleroot_observation_errors{sourceChain="chain-a"}` by reason (no_bindings/timeout/rpc_error). Source-chain read/infra issue, not commit logic.
+   - `>= X` → plugin has seen it; continue.
+3. **Is the round producing outcomes at all?** Check `rate(ccip_commit_consensus_observation_failed[5m])`.
+   - Incrementing → destination-chain-wide consensus failure — see Scenario 3 deep dive.
+   - Flat → continue.
+4. **Is chain A or B cursed?** Check `ccip_commit_rmn_curse_active{chain_id="chain-b", curse_type="global"|"destination"}` and `ccip_commit_source_chain_cursed{sourceChain="chain-a"}`.
+   - Any `== 1` → found it; likely intentional/incident-flagged, hand off to whoever owns the curse. Stop.
+   - All `0` → continue.
+5. **Is a report being built but never landing?** Check `ccip_commit_report_transmission_gave_up{sourceChain="chain-a"}` and `ccip_commit_report_transmission_attempts`.
+   - Incrementing/maxed → see Scenario 2 deep dive.
+   - Otherwise → likely just backlog size; check `ccip_commit_pending_messages{sourceChain="chain-a"}` and estimate ETA from round cadence.
+
+(RMN-signature-specific branches — signed-roots-dropped, chain quorum result, Byzantine root disagreement — were dropped from the implementation scope: RMN blessing/signing is effectively dead code now that `RMNEnabled` is hardcoded off. Cursing is the one RMN-adjacent signal still live in production, hence Step 4.)
+
+### Scenario 2 — deep dive: report transmission stuck (Step 5)
+
+Three hypotheses, in order of how cheap they are to check:
+
+- **A — never transmitted (rejected pre-send).** `sum by (reason) (rate(ccip_commit_report_validation_rejected{phase="should_transmit"}[15m]))`.
+  - `config_digest_mismatch` climbing → cross-check `ccip_commit_config_digest_mismatch`; config sync issue.
+  - `stale` climbing → often benign — a different, overlapping report already landed; re-check Step 1's gauge, it may have just moved.
+  - `dest_not_supported` → transmission-schedule/config bug.
+  - `cursed` → converges with Step 4.
+  - All flat → move to B.
+- **B — transmitted, reverted/stuck on-chain.** Outside commit-plugin metrics: check chain B's TXM/tx-sender dashboards for the assigned transmitter (nonce gap, underpriced gas, wallet balance, revert reason). A revert here for the same reasons as A but caught on-chain instead of locally usually means a race between the pre-check and the tx landing (config rollout, chain congestion).
+- **C — actually succeeded, read is lagging.** `ccip_commit_offramp_next_seq_num` is sourced from the plugin's own chain-B reader; if that's behind, "no change" can persist for a few rounds after a real success. Cross-check chain B's block explorer / chain-reader health directly before escalating further.
+
+### Scenario 3 — deep dive: consensus never completes (Step 3)
+
+Grounded in `getConsensusObservation` (`merkleroot/outcome.go:461-508`): the *only* way the whole round fails is the DON not reaching 2·fRoleDON+1 agreement on a single FChain value for the **destination chain** — every other field degrades per-chain gracefully. Two implications:
+
+- **This is destination-chain-wide, not lane-specific.** Before going further, check whether *other* source chains reporting into chain B are also stalled (their `ccip_commit_pending_messages` also climbing). If only chain A is affected, this branch is the wrong one — back to Scenario 1, Step 4/5.
+- **The counter alone can't tell you why.** Two sub-hypotheses, using the not-yet-implemented shared `consensus.go` fix:
+  - **H1 — too few oracles could read it.** `ccip_commit_fchain_read_errors` spiking broadly across oracles → home-chain RPC/read outage.
+  - **H2 — oracles disagree.** `ccip_commit_consensus_dropped{objectName="fChain", reason="split"}` firing while H1 stays flat → home-chain config (e.g. CCIPHome update, DON membership change) mid-rollout/desynced across the DON. Corroborate with `ccip_commit_config_digest_mismatch` flipping for a subset of oracles around the same time.
+
+### Gaps this exercise surfaced (already folded into the findings above)
+- No plugin-level heartbeat — added to "Top-level plugin orchestration."
+- No reason breakdown for report-acceptance/transmission-validation rejections — added to "Top-level plugin orchestration."
+- `GetConsensusMap`'s two-vs-three-outcome ambiguity — added to "Shared: consensus aggregation" (not yet implemented — reviewed design only).

--- a/docs/metrics/commit-metrics.md
+++ b/docs/metrics/commit-metrics.md
@@ -21,9 +21,102 @@ Merkleroot, chainfee, and tokenprice each independently:
 
 ---
 
+## Proposed metrics at a glance (merkle root processor)
+
+Every metric proposed in this doc, with a one/two-line "why" — the full rationale, exact file:line evidence, and severity ranking live in [Full findings](#full-findings) below. ✅ = implemented and merged; everything else is proposed/reviewed only.
+
+#### Top-level plugin orchestration
+
+| Metric | Status | Why |
+|---|---|---|
+| `ccip_commit_plugin_heartbeat{chainFamily,chainID,phase="observation"\|"outcome"}` | ✅ Implemented | Unconditional per-round liveness signal — the only way to tell "process wedged" apart from "valid but stale gauge" for every other metric in this doc. |
+| `ccip_commit_report_validation_rejected{phase="should_accept"\|"should_transmit",reason}` | ✅ Implemented | Distinguishes "report never submitted" (rejected locally) from "submitted but stuck/reverted on-chain" — different remediation paths entirely. |
+
+#### Shared: consensus aggregation
+
+| Metric | Status | Why |
+|---|---|---|
+| `ccip_commit_consensus_dropped{objectName,key,reason}` (needs an additive `GetConsensusMap` return value) | Reviewed design, not implemented | Splits "no threshold configured" (config bug) from "insufficient agreement" (routine) from "split vote" (integrity signal) — currently collapsed into one `TODO: metrics` log line. |
+
+#### Merkle root processor — High
+
+| Metric | Status | Why |
+|---|---|---|
+| `ccip_commit_onramp_max_seq_num{sourceChain}` / `ccip_commit_offramp_next_seq_num{sourceChain}` | ✅ Implemented | Direct per-lane chain-read liveness — the original motivating gap for this whole assessment. |
+| `ccip_commit_pending_messages{sourceChain}` | ✅ Implemented | Quantifies "how far behind" instead of forcing on-call to mentally subtract the two seq-num gauges. |
+| `ccip_commit_rmn_curse_active{chain_id,curse_type="global"\|"destination"}` | ✅ Implemented | Curse halts all reporting for the dest chain; needs to be page-visible, not a per-round `Warnw`. |
+| `ccip_commit_source_chain_cursed{sourceChain}` | ✅ Implemented | Distinguishes "this lane is cursed" (expected, hand off) from "plugin is wedged" (page). |
+| `ccip_commit_merkleroot_observation_errors{sourceChain,reason}` | ✅ Implemented | Surfaces per-goroutine RPC/read failures that are swallowed and never trip the generic processor-error counter. |
+| `ccip_commit_fchain_read_errors` | ✅ Implemented | Distinguishes "can't read home chain" from "DON disagrees" — the two root causes of a consensus-failed round. |
+| `ccip_commit_consensus_observation_failed{chain_family,chain_id}` | ✅ Implemented | Flags a destination-chain-wide stall immediately instead of looking like N independent lane stalls. |
+| `ccip_commit_report_transmission_gave_up{sourceChain}` + `ccip_commit_report_transmission_attempts` (histogram) | ✅ Implemented | One of the most common on-call pages today; previously only a `Warnw` with no counter. |
+
+#### Merkle root processor — Medium
+
+| Metric | Status | Why |
+|---|---|---|
+| Truncation counter `{sourceChain}` (`MaxMerkleTreeSize`) | Proposed | Chain-throughput ceiling being hit is currently `Debugf`-only. |
+| Offramp lane misconfiguration gauge `{sourceChain,status}` | Proposed | `rmn-misconfigured` in particular now flags real config drift, since a lane still expecting RMN blessing while RMN is globally off is permanently broken. |
+| Onramp/offramp invariant-violation counter `{sourceChain,type}` | Proposed | These are already documented in-code as stall signals but were never counted. |
+| Insufficient-consensus-on-`OffRampNextSeqNums` counter `{sourceChain}` | Proposed | Looks identical to "no new messages" from the outside without it. |
+---
+
+## War games: incident walkthroughs
+
+Three scenarios worked through against the metric set above (some referencing not-yet-implemented items, noted inline) to validate the design before building it: does an on-call engineer actually get a straight-line diagnosis, or just more noise? Each starts from the same alert: **message `0xabc...def`, onramp sequence number `X`, chain A (source) → chain B (dest), reported in-flight for 15 minutes.**
+
+### Scenario 1 — full decision tree
+
+1. **Is this even a commit-plugin problem?** Check `ccip_commit_offramp_next_seq_num{source_network_name="chain-a", dest_network_name="chain-b"}`.
+   - `> X` → a root covering X already landed on the offramp. Commit plugin's job is done; hand off to exec on-call. Stop.
+   - `<= X` → continue.
+2. **Has the plugin observed X on-chain yet?** Check `ccip_commit_onramp_max_seq_num{sourceChain="chain-a"}`.
+   - `< X` → onramp read is lagging. Check `ccip_commit_merkleroot_observation_errors{sourceChain="chain-a"}` by reason (no_bindings/timeout/rpc_error). Source-chain read/infra issue, not commit logic.
+   - `>= X` → plugin has seen it; continue.
+3. **Is the round producing outcomes at all?** Check `rate(ccip_commit_consensus_observation_failed[5m])`.
+   - Incrementing → destination-chain-wide consensus failure — see Scenario 3 deep dive.
+   - Flat → continue.
+4. **Is chain A or B cursed?** Check `ccip_commit_rmn_curse_active{chain_id="chain-b", curse_type="global"|"destination"}` and `ccip_commit_source_chain_cursed{sourceChain="chain-a"}`.
+   - Any `== 1` → found it; likely intentional/incident-flagged, hand off to whoever owns the curse. Stop.
+   - All `0` → continue.
+5. **Is a report being built but never landing?** Check `ccip_commit_report_transmission_gave_up{sourceChain="chain-a"}` and `ccip_commit_report_transmission_attempts`.
+   - Incrementing/maxed → see Scenario 2 deep dive.
+   - Otherwise → likely just backlog size; check `ccip_commit_pending_messages{sourceChain="chain-a"}` and estimate ETA from round cadence.
+
+(RMN-signature-specific branches — signed-roots-dropped, chain quorum result, Byzantine root disagreement — were dropped from the implementation scope: RMN blessing/signing is effectively dead code now that `RMNEnabled` is hardcoded off. Cursing is the one RMN-adjacent signal still live in production, hence Step 4.)
+
+### Scenario 2 — deep dive: report transmission stuck (Step 5)
+
+Three hypotheses, in order of how cheap they are to check:
+
+- **A — never transmitted (rejected pre-send).** `sum by (reason) (rate(ccip_commit_report_validation_rejected{phase="should_transmit"}[15m]))`.
+  - `config_digest_mismatch` climbing → cross-check `ccip_commit_config_digest_mismatch`; config sync issue.
+  - `stale` climbing → often benign — a different, overlapping report already landed; re-check Step 1's gauge, it may have just moved.
+  - `dest_not_supported` → transmission-schedule/config bug.
+  - `cursed` → converges with Step 4.
+  - All flat → move to B.
+- **B — transmitted, reverted/stuck on-chain.** Outside commit-plugin metrics: check chain B's TXM/tx-sender dashboards for the assigned transmitter (nonce gap, underpriced gas, wallet balance, revert reason). A revert here for the same reasons as A but caught on-chain instead of locally usually means a race between the pre-check and the tx landing (config rollout, chain congestion).
+- **C — actually succeeded, read is lagging.** `ccip_commit_offramp_next_seq_num` is sourced from the plugin's own chain-B reader; if that's behind, "no change" can persist for a few rounds after a real success. Cross-check chain B's block explorer / chain-reader health directly before escalating further.
+
+### Scenario 3 — deep dive: consensus never completes (Step 3)
+
+Grounded in `getConsensusObservation` (`merkleroot/outcome.go:461-508`): the *only* way the whole round fails is the DON not reaching 2·fRoleDON+1 agreement on a single FChain value for the **destination chain** — every other field degrades per-chain gracefully. Two implications:
+
+- **This is destination-chain-wide, not lane-specific.** Before going further, check whether *other* source chains reporting into chain B are also stalled (their `ccip_commit_pending_messages` also climbing). If only chain A is affected, this branch is the wrong one — back to Scenario 1, Step 4/5.
+- **The counter alone can't tell you why.** Two sub-hypotheses, using the not-yet-implemented shared `consensus.go` fix:
+  - **H1 — too few oracles could read it.** `ccip_commit_fchain_read_errors` spiking broadly across oracles → home-chain RPC/read outage.
+  - **H2 — oracles disagree.** `ccip_commit_consensus_dropped{objectName="fChain", reason="split"}` firing while H1 stays flat → home-chain config (e.g. CCIPHome update, DON membership change) mid-rollout/desynced across the DON. Corroborate with `ccip_commit_config_digest_mismatch` flipping for a subset of oracles around the same time.
+
+### Gaps this exercise surfaced (already folded into the findings above)
+- No plugin-level heartbeat — added to "Top-level plugin orchestration."
+- No reason breakdown for report-acceptance/transmission-validation rejections — added to "Top-level plugin orchestration."
+- `GetConsensusMap`'s two-vs-three-outcome ambiguity — added to "Shared: consensus aggregation" (not yet implemented — reviewed design only).
+
+---
+
 ## Full findings
 
-Severity is about production-triage value, independent of whether something is logged today.
+Severity is about production-triage value, independent of whether something is logged today. This section is the deep dive backing the brief table above: full rationale, file:line evidence, and severity ranking for each metric.
 
 ### Top-level plugin orchestration (`commit/plugin.go`, `commit/report.go`)
 
@@ -89,6 +182,54 @@ Used by commit (`chainfee`, `merkleroot`, `plugin.go`, `report.go`), `execute/pl
 
 (RMN blessing/signing findings — signed-roots-dropped, per-root signed/unsigned filtering, chain quorum result, Byzantine root disagreement, RMN controller node-coverage/internal-errors, signature-verification conflation, `ErrSignaturesNotProvidedByLeader`, `ObserveRMNRemoteCfg` failures, peer/stream connectivity, controller re-init churn, and the standalone `ValidateRootBlessings` proposal (now covered by the implemented `root_blessing_mismatch` reason above) — were all dropped from this doc. All of these sit behind `if rmnEnabled` in `buildMerkleRootsOutcome` or are otherwise part of the RMN controller/signing path, which is effectively dead code now that `RMNEnabled` is hardcoded off and the controller is slated for removal; cursing, covered above, is the one RMN-adjacent signal still live in production.)
 
+---
+
+## (Other Processors) Proposed metrics at a glance
+
+#### Chain fee processor — High
+
+| Metric | Status | Why |
+|---|---|---|
+| `ccip_commit_chainfee_update_aborted_total{chain_id,scope="dest"\|"source"}` | Proposed | A single dest-chain `GetChainConfig` failure silently aborts gas-price updates for *every* chain that round — flagged as likely the single highest-value item to alert on. |
+| Async-op-timeout counter `{operation}` | Proposed | A hung RPC call today produces zero log and zero metric anywhere. |
+| Per-chain USD gas fee gauge `{chain_id,component="exec"\|"da"}` | Proposed | The actual fee value is only ever logged (`Infow`), never gauged. |
+| Fee staleness gauge (seconds) `{chain_id}` | Proposed | Staleness is computed then discarded down to a bare heartbeat boolean. |
+| Whole-round no-consensus-on-any-fee-component counter `{chain_id}` | Proposed | A DON-wide health signal that stalls every chain's fee update that round; currently `Warnw` only. |
+| Consensus-map dropped-chain counter `{objectName,chain_id,reason}` | Proposed | Same shared-infra fix as above; benefits tokenprice too. |
+
+#### Chain fee processor — Medium / Low
+
+| Metric | Status | Why |
+|---|---|---|
+| Missing-native-token-price gauge/counter `{chain_id}` | Proposed | Chains silently dropped from the fee update entirely. |
+| Per-oracle missing-price counter (pre-consensus) `{chain_id}` | Proposed | Could isolate a single bad node's fee-quoter reader before it's masked by consensus. |
+| Update-decision reason-breakdown counter `{chain_id,reason}` | Proposed | Another "stable log identifier" already log-mined — reason to graduate it, not skip it. |
+| Deviation-magnitude gauge `{chain_id,component}` | Proposed | Only a boolean ("exceeded threshold") survives today; the magnitude is discarded. |
+| Async-cache last-success-timestamp gauge | Proposed | A stuck background `sync()` currently looks healthy indefinitely. |
+| Reader-error-branch counter `{operation,chain_id}` | Proposed | Real errors collapse into the same empty map as "legitimately zero chains configured." |
+| Disabled/unsupported chain-count gauge | Proposed (Low) | Config-drift detection across a large DON. |
+
+#### Token price processor — High
+
+| Metric | Status | Why |
+|---|---|---|
+| `ValidateObservation` rejection counter `{oracleID,reason}` | Proposed | Zero logs *and* zero metrics today for the exact signal that detects a misbehaving/misconfigured oracle. |
+| Fetch-failure counter `{source="feed"\|"feequoter"\|"fchain"}` | Proposed | Failures degrade to empty maps indistinguishable from "legitimately nothing to report." |
+| Per-token USD price gauge `{token,destChain}` | Proposed | Feed/fee-quoter price is never gauged, only logged. |
+| Token price staleness gauge (seconds) `{token}` | Proposed | Same discard-the-number-keep-the-bool pattern as chainfee. |
+| Consensus-dropped counter `{objectName,key,reason}` | Proposed | Shared fix with chainfee/merkleroot above — the closest thing to "outlier rejection" in this codebase, currently silent. |
+
+#### Token price processor — Medium / Low
+
+| Metric | Status | Why |
+|---|---|---|
+| Missing-`TokenInfo` counter `{token}` | Proposed | Logged per-token per-round (`Warnw`) with no aggregate view. |
+| Update-decision reason-breakdown counter `{token,reason}` | Proposed | Same "graduate, don't skip" logic as chainfee's version. |
+| Deviation-magnitude gauge `{token}` | Proposed | `mathslib.Deviates` computes a ppb diff internally and returns only a bool. |
+| Async cache staleness gauge `{source}` | Proposed | Same stuck-`sync()`-looks-healthy risk as chainfee. |
+| Oracle feed/dest-chain support gauge `{oracleID,chainRole}` | Proposed | Per-node capability info that explains *why* consensus on `fFeedChain` might fail. |
+| Token-price-reporting-disabled gauge `{destChain}` (1/0) | Proposed (Low, but don't deprioritize) | Currently `Debugw`-only — *less* visible than a "stable" Info/Warn log, since Debug is typically off entirely in prod. |
+
 ### Chain fee processor (`commit/chainfee`)
 
 No dedicated `MetricsReporter` exists for this package at all (unlike merkleroot) — everything below is currently 100% log-only.
@@ -132,56 +273,3 @@ Also no dedicated `MetricsReporter`. Note `ValidateObservation` isn't even wrapp
 
 **Low, but flagged as a miss in my first pass — don't let "it's Debug" read as "low priority"**
 - **Token-price reporting silently disabled by config** (`TokenPriceBatchWriteFrequency == 0`) is logged at `Debugw` — *less* visible in prod than a "stable" Info/Warn log, since Debug is typically off entirely. `processor.go:102-106`. This is exactly the pattern the existing `ccip_commit_loopp_ccip_provider_supported` boolean gauge was built for, and it's a cheap, precedented fix. → Gauge `{destChain}` (1/0).
-
----
-
-## War games: incident walkthroughs
-
-Three scenarios worked through against the merkleroot-high-severity metric set above (some referencing not-yet-implemented items, noted inline) to validate the design before building it: does an on-call engineer actually get a straight-line diagnosis, or just more noise? Each starts from the same alert: **message `0xabc...def`, onramp sequence number `X`, chain A (source) → chain B (dest), reported in-flight for 15 minutes.**
-
-### Scenario 1 — full decision tree
-
-1. **Is this even a commit-plugin problem?** Check `ccip_commit_offramp_next_seq_num{source_network_name="chain-a", dest_network_name="chain-b"}`.
-   - `> X` → a root covering X already landed on the offramp. Commit plugin's job is done; hand off to exec on-call. Stop.
-   - `<= X` → continue.
-2. **Has the plugin observed X on-chain yet?** Check `ccip_commit_onramp_max_seq_num{source_network_name="chain-a"}`.
-   - `< X` → onramp read is lagging. Check `ccip_commit_merkleroot_observation_errors{sourceChain="chain-a"}` by reason (no_bindings/timeout/rpc_error). Source-chain read/infra issue, not commit logic.
-   - `>= X` → plugin has seen it; continue.
-3. **Is the round producing outcomes at all?** Check `rate(ccip_commit_consensus_observation_failed[5m])`.
-   - Incrementing → destination-chain-wide consensus failure — see Scenario 3 deep dive.
-   - Flat → continue.
-4. **Is chain A or B cursed?** Check `ccip_commit_rmn_curse_active{chain_id="chain-b", curse_type="global"|"destination"}` and `ccip_commit_source_chain_cursed{sourceChain="chain-a"}`.
-   - Any `== 1` → found it; likely intentional/incident-flagged, hand off to whoever owns the curse. Stop.
-   - All `0` → continue.
-5. **Is a report being built but never landing?** Check `ccip_commit_report_transmission_gave_up{sourceChain="chain-a"}` and `ccip_commit_report_transmission_attempts`.
-   - Incrementing/maxed → see Scenario 2 deep dive.
-   - Otherwise → likely just backlog size; check `ccip_commit_pending_messages{sourceChain="chain-a"}` and estimate ETA from round cadence.
-
-(RMN-signature-specific branches — signed-roots-dropped, chain quorum result, Byzantine root disagreement — were dropped from the implementation scope: RMN blessing/signing is effectively dead code now that `RMNEnabled` is hardcoded off. Cursing is the one RMN-adjacent signal still live in production, hence Step 4.)
-
-### Scenario 2 — deep dive: report transmission stuck (Step 5)
-
-Three hypotheses, in order of how cheap they are to check:
-
-- **A — never transmitted (rejected pre-send).** `sum by (reason) (rate(ccip_commit_report_validation_rejected{phase="should_transmit"}[15m]))`.
-  - `config_digest_mismatch` climbing → cross-check `ccip_commit_config_digest_mismatch`; config sync issue.
-  - `stale` climbing → often benign — a different, overlapping report already landed; re-check Step 1's gauge, it may have just moved.
-  - `dest_not_supported` → transmission-schedule/config bug.
-  - `cursed` → converges with Step 4.
-  - All flat → move to B.
-- **B — transmitted, reverted/stuck on-chain.** Outside commit-plugin metrics: check chain B's TXM/tx-sender dashboards for the assigned transmitter (nonce gap, underpriced gas, wallet balance, revert reason). A revert here for the same reasons as A but caught on-chain instead of locally usually means a race between the pre-check and the tx landing (config rollout, chain congestion).
-- **C — actually succeeded, read is lagging.** `ccip_commit_offramp_next_seq_num` is sourced from the plugin's own chain-B reader; if that's behind, "no change" can persist for a few rounds after a real success. Cross-check chain B's block explorer / chain-reader health directly before escalating further.
-
-### Scenario 3 — deep dive: consensus never completes (Step 3)
-
-Grounded in `getConsensusObservation` (`merkleroot/outcome.go:461-508`): the *only* way the whole round fails is the DON not reaching 2·fRoleDON+1 agreement on a single FChain value for the **destination chain** — every other field degrades per-chain gracefully. Two implications:
-
-- **This is destination-chain-wide, not lane-specific.** Before going further, check whether *other* source chains reporting into chain B are also stalled (their `ccip_commit_pending_messages` also climbing). If only chain A is affected, this branch is the wrong one — back to Scenario 1, Step 4/5.
-- **The counter alone can't tell you why.** Two sub-hypotheses, using the not-yet-implemented shared `consensus.go` fix:
-  - **H1 — too few oracles could read it.** `ccip_commit_fchain_read_errors` spiking broadly across oracles → home-chain RPC/read outage.
-  - **H2 — oracles disagree.** `ccip_commit_consensus_dropped{objectName="fChain", reason="split"}` firing while H1 stays flat → home-chain config (e.g. CCIPHome update, DON membership change) mid-rollout/desynced across the DON. Corroborate with `ccip_commit_config_digest_mismatch` flipping for a subset of oracles around the same time.
-
-### Gaps this exercise surfaced (already folded into the findings above)
-- No plugin-level heartbeat — added to "Top-level plugin orchestration."
-- No reason breakdown for report-acceptance/transmission-validation rejections — added to "Top-level plugin orchestration."
-- `GetConsensusMap`'s two-vs-three-outcome ambiguity — added to "Shared: consensus aggregation" (not yet implemented — reviewed design only).

--- a/docs/metrics/commit-metrics.md
+++ b/docs/metrics/commit-metrics.md
@@ -1,7 +1,5 @@
 ## Metrics coverage assessment — commit plugin
 
-I read through `commit/metrics`, `commit/merkleroot` (+ `rmn`), `commit/chainfee`, `commit/tokenprice`, and the top-level `commit/plugin.go` / `report.go` / `factory.go`. There's a real gap, and it's structural, not just a few missing gauges.
-
 **Ground rule for everything below: the presence of a log line — even a "stable identifier" some log-analysis tooling already keys on — is never a reason to exclude a metric.** Logs are exactly the noisy, low-signal, un-queryable thing motivating this work; a few items here are genuinely *only* visible at `Debugw`, which is worse than a "stable" log, not better. Nothing was cut from the list below because it was already logged.
 
 ### What exists today (`commit/metrics/prom.go`)
@@ -9,12 +7,7 @@ I read through `commit/metrics`, `commit/merkleroot` (+ `rmn`), `commit/chainfee
 - Generic per-processor instrumentation via `TrackedProcessor` (wraps merkleroot/chainfee/tokenprice): latency histogram, error counter, and an **output-size counter** driven by each type's `Stats()` — but `Stats()` only returns `len(map)`-style item counts (e.g. `gasPrices: 3`), never the actual values.
 - `ccip_commit_max_sequence_number` gauge — but only fed from `MerkleRootChain.SeqNumsRange.End()` in `TrackObservation`/`TrackOutcome`, i.e. **only when a root is actually being built for a report**.
 - `ccip_commit_latest_round_id`, `ccip_commit_config_digest_mismatch`, `ccip_commit_loopp_ccip_provider_supported`.
-- RMN-specific: `TrackRmnReport` (build latency/success) and `TrackRmnRequest` (per-node request latency/error) — merkleroot and its `rmn` subpackage are the only parts of the plugin with a dedicated `MetricsReporter` sub-interface.
 - **`chainfee` and `tokenprice` have no dedicated metrics interface at all** — they only get the generic latency/error/size instrumentation above. Token prices, gas prices, and their staleness/deviation/failure states are otherwise 100% log-only.
-
-### Your example, confirmed
-
-`merkleroot.Observation` has `OnRampMaxSeqNums` and `OffRampNextSeqNums` fields (`commit/merkleroot/types.go:34-35`) populated **every round**, but no `Reporter` method ever reads them — the only sequence-number gauge (`ccip_commit_max_sequence_number`) comes from `MerkleRootChain.SeqNumsRange.End()`, which only exists once a root is already being built. So if the plugin is stuck reading a chain (RPC lag, stuck in `selectingRangesForReport`), there's no gauge showing it — the one gauge that looks related lags or is absent during exactly the failure mode you'd want visibility into.
 
 ### Cross-cutting themes (repeat in every processor)
 
@@ -37,12 +30,14 @@ Severity is about production-triage value, independent of whether something is l
 These aren't owned by any single processor — they're the outer round loop and the report-acceptance path — but two gaps here turned out to matter as much as anything processor-specific once an actual incident was traced end-to-end.
 
 **High**
-- **No heartbeat / liveness signal.** `commit/plugin.go:434` (`Outcome()`). If the whole round pipeline wedges (deadlock, a panic-recovery masking a crash loop, OCR itself failing to schedule rounds), every metric in this doc simply stops updating instead of showing a bad value. A stale gauge and a valid-but-bad gauge look identical unless you specifically alert on absence/staleness — easy to forget when every other alert here is threshold-based. This should be step 0 of any triage tree, and today it isn't answerable from commit-plugin metrics at all. → Gauge/counter, e.g. `ccip_commit_last_successful_round_timestamp`, set unconditionally near the top of `Outcome()` (and ideally `Observation()` too) regardless of what happens downstream.
-- **Report-acceptance / transmission-validation rejections have zero metrics.** `commit/report.go:126-247` (`validateReport`, called from both `ShouldAcceptAttestedReport` and `ShouldTransmitAcceptedReport`) has eight distinct rejection paths — empty/invalid merkle root, duplicate RMN signature, insufficient RMN signatures, cursed report, dest chain unsupported, config digest mismatch, stale report, root-blessing mismatch — every one of them `Warnw`/`Errorw`/`Debugf` only. This sits directly upstream of merkleroot's own `ReportTransmissionGaveUp` counter: if every oracle's local `validateReport` call rejects a report before anyone ever calls transmit, "gave up" fires with **zero on-chain trace at all** (no tx ever submitted) — a completely different remediation path than "tx submitted but reverted" or "tx stuck in mempool." Without per-reason counts here, those scenarios are indistinguishable from `ccip_commit_report_transmission_gave_up_total` alone. → Counter `ccip_commit_report_validation_rejected_total{phase="should_accept"|"should_transmit", reason="empty_root|invalid_seqnum_range|duplicate_rmn_sig|insufficient_rmn_sigs|cursed|dest_not_supported|config_digest_mismatch|stale|root_blessing_mismatch"}`.
+- **No heartbeat / liveness signal.** `commit/plugin.go:434` (`Outcome()`). If the whole round pipeline wedges (deadlock, a panic-recovery masking a crash loop, OCR itself failing to schedule rounds), every metric in this doc simply stops updating instead of showing a bad value. A stale gauge and a valid-but-bad gauge look identical unless you specifically alert on absence/staleness — easy to forget when every other alert here is threshold-based. This should be step 0 of any triage tree, and today it isn't answerable from commit-plugin metrics at all. → **Implemented**: counter `ccip_commit_plugin_heartbeat{chainFamily, chainID, phase="observation"|"outcome"}`, incremented unconditionally at the very top of `Observation()`/`Outcome()`, before any decode, state check, or early return.
+
+  **Why this isn't already covered by the pre-existing `ccip_commit_latest_round_id` gauge**, since at a glance both look like "something updates roughly once per round": `ccip_commit_latest_round_id` is set by `trackLatestRoundID`, called from inside `TrackObservation`/`TrackOutcome` — but only while looping over `obs.MerkleRootObs.MerkleRoots` / `outcome.MerkleRootOutcome.RootsToReport`. Per `merkleroot.getObservation` (`merkleroot/observation.go:281-331`), that field is only populated in the `buildingReport` state; it's empty in `selectingRangesForReport` and `waitingForReportTransmission`, i.e. for most of the state machine's time. It's also labeled per **source chain**, not per plugin instance. So it only moves during the fraction of rounds where the processor happens to be actively building a report with at least one root in it — a perfectly healthy processor sitting in `selectingRangesForReport` because a lane has no new messages will let this gauge go stale for entirely benign reasons. You can't tell "no traffic on this lane" apart from "plugin is wedged" by watching it alone. `ccip_commit_plugin_heartbeat` is unconditional and per-instance precisely to remove that ambiguity: the two are complementary, not overlapping — `latest_round_id` tells you about a specific chain's last-reported root, `plugin_heartbeat` tells you the process is alive at all, and you need the second to safely interpret staleness in the first (or in any other gauge in this doc).
+- **Report-acceptance / transmission-validation rejections have zero metrics.** `commit/report.go:126-247` (`validateReport`, called from both `ShouldAcceptAttestedReport` and `ShouldTransmitAcceptedReport`) has several distinct rejection paths — decode failures, empty/invalid merkle root, cursed report, dest chain unsupported, config digest mismatch, stale report, root-blessing mismatch — every one of them `Warnw`/`Errorw`/`Debugf` only. (The RMN-signature rejection paths in the same function — duplicate/insufficient RMN signatures — aren't instrumented: RMN blessing/signing is effectively dead code now that `RMNEnabled` is hardcoded off, so they shouldn't occur.) This sits directly upstream of merkleroot's own `ReportTransmissionGaveUp` counter: if every oracle's local `validateReport` call rejects a report before anyone ever calls transmit, "gave up" fires with **zero on-chain trace at all** (no tx ever submitted) — a completely different remediation path than "tx submitted but reverted" or "tx stuck in mempool." Without per-reason counts here, those scenarios are indistinguishable from `ccip_commit_report_transmission_gave_up_total` alone. → **Implemented**: counter `ccip_commit_report_validation_rejected{phase="should_accept"|"should_transmit", reason="decode_report|decode_report_info|empty_root|invalid_seqnum_range|cursed_check_error|cursed|dest_support_check_error|dest_not_supported|config_digest_check_error|config_digest_mismatch|stale|root_blessing_mismatch"}`.
 
 ### Shared: consensus aggregation (`internal/plugincommon/consensus/consensus.go`)
 
-Used by commit (`chainfee`, `merkleroot`, `merkleroot/rmn/controller.go`, `plugin.go`, `report.go`), `execute/plugin_functions.go`, **and** `internal/plugincommon/discovery/processor.go` — this is genuinely shared infra, not commit-specific, which shapes the recommended fix below. Reviewed design, not yet implemented.
+Used by commit (`chainfee`, `merkleroot`, `plugin.go`, `report.go`), `execute/plugin_functions.go`, **and** `internal/plugincommon/discovery/processor.go` — this is genuinely shared infra, not commit-specific, which shapes the recommended fix below. Reviewed design, not yet implemented.
 
 **High**
 - **`GetConsensusMap` collapses three distinguishable outcomes into one `Debugw`/`Warnw` line, both marked `// TODO: metrics`** (`consensus.go:34-56`). `NewMinObservation.GetValid()` (`min_observation.go:57-66`) buckets observations by identical value and returns every distinct value that independently cleared the threshold, which means there are three cases today, not two:
@@ -74,7 +69,7 @@ Used by commit (`chainfee`, `merkleroot`, `merkleroot/rmn/controller.go`, `plugi
 
   **Consistency note:** `GetConsensusMapAggregator` (`consensus.go:62-81`) and `GetOrderedConsensus` (`consensus.go:113-148`) have the same unmetriced pattern but structurally can't produce case 3 — the aggregator combines all values regardless of agreement, and ordered-consensus just needs a count, not matching values. `GetOrderedConsensus` does have its own distinct third case (`consensus.go:127-133`, "found a negative or 0 threshold" — a config-error class, currently silently skipped). If this file is being touched, apply the same additive `(result, reasons)` pattern to all three for one coherent `{objectName, key, reason}` metric family instead of fixing `GetConsensusMap` alone and leaving the other two as later follow-ups.
 
-### Merkle root processor (`commit/merkleroot`, `commit/merkleroot/rmn`)
+### Merkle root processor (`commit/merkleroot`)
 
 **High**
 - **Raw onramp max seq num / offramp next seq num per source chain, every round** (your example). `observation.go:287-288` (`ObserveLatestOnRampSeqNums`/`ObserveOffRampNextSeqNums`), logged at `Debugw` only. → Gauge `{sourceChain}`, both series, distinct from the existing `ccip_commit_max_sequence_number`.
@@ -85,26 +80,14 @@ Used by commit (`chainfee`, `merkleroot`, `merkleroot/rmn/controller.go`, `plugi
 - **`GetFChain` failure** — literally has `// TODO: metrics` in the source. `observation.go:862-871`. Degrades to empty FChain map, which then fails consensus and stalls the round. → Counter.
 - **Consensus-observation-failed round** (`ConsensusObservationFailed`, entire outcome empty) — `outcome.go:88-92`, gated entirely by `getConsensusObservation`'s upfront requirement that the DON reach 2·fRoleDON+1 agreement on a *single* FChain value for the **destination chain** (`outcome.go:471-480`); every other per-chain consensus computation (roots, onramp/offramp seq nums, RMN config) degrades gracefully per-chain and cannot trigger this path. Two consequences for the runbook: (1) this failure is inherently **destination-chain-wide, not lane-specific** — if it's firing, every source chain reporting into this dest chain should be stalling simultaneously, not just one lane, which is a fast way to rule this branch in or out; (2) the counter alone only tells you *that* consensus failed, not *why*. Pair it with the shared `consensus.go` fix above (`objectName="fChain", key=<destChain>`) to see the drop directly, and with the `GetFChain`-failure counter to distinguish "too few oracles could even read it" (home-chain RPC/read outage) from "oracles disagree" (home-chain config mid-rollout/desynced across the DON — corroborate with `ccip_commit_config_digest_mismatch` flipping around the same time). Already a "stable log identifier" the team log-mines — evidence a metric is overdue, not a reason to skip one. → Counter, `{chain_family, chain_id}` (destination chain, matching labels used elsewhere in this reporter).
 - **Report transmission gives up / retry cost.** `outcome.go` (`ReportTransmissionGaveUp`), `Outcome.ReportTransmissionCheckAttempts`. One of the most common on-call pages; today `Warnw` with no counter. → Counter + histogram of attempts.
-- **RMN-enabled roots dropped wholesale** (signed-roots-not-subset / parse error) — an entire round's RMN-protected chains get zero inclusion. `outcome.go:270-299`, `Errorw`. → Counter `{reason}`.
-- **RMN chain-level quorum result** (zero roots / insufficient votes / success) per source chain — `controller.go:557-603`, `Infow` only, easily lost in volume. → Counter `{sourceChain, result}`.
-- **Byzantine root disagreement** (`"more than one valid root for chain"` / `"no valid root for chain"`) — a security/integrity signal currently indistinguishable from a mundane timeout. `controller.go:848-876`. → Counter `{reason}`.
 
 **Medium**
 - Truncation due to `MaxMerkleTreeSize` (chain throughput-bound). `outcome.go:174-178`, `Debugf`. → Counter `{sourceChain}`.
 - Offramp lane misconfiguration bucket (live / skipped-not-a-lane / skipped-disabled / rmn-misconfigured); `rmnMisconfigured` in particular indicates config drift. `observation.go:53-89,634-646`. → Gauge `{sourceChain, status}`.
 - OnRamp/OffRamp invariant violations (offramp-ahead-of-onramp, onramp-max-zero, offramp-seqnum-regression) — explicitly documented in-package as stall signals. `outcome.go:43-44,152-161,421-428`. → Counter `{sourceChain, type}`.
 - Insufficient consensus on `OffRampNextSeqNums` for a chain — chain silently stops progressing, looks identical to "no new messages" from outside. `outcome.go:515-531`. → Counter `{sourceChain}`.
-- Per-root inclusion/exclusion reason (rmn-enabled-unsigned vs rmn-disabled-unexpectedly-signed) — answers "why didn't chain X's root make the report." `outcome.go:342-378`. → Counter `{sourceChain, reason}`.
-- `ValidateRootBlessings` mismatches at report-acceptance time (`commit/report.go:234` → `merkleroot/transmission_checks.go:28-52`) — distinct from the existing config-digest-mismatch gauge. → Counter `{reason}`.
-- RMN node-coverage shortfall per chain (dropped from signature request entirely). `controller.go:188-203`. → Counter/gauge `{sourceChain}`.
-- RMN internal-error classes currently unlabeled or folded into a generic `invalid_response` (dest==source config bug, sanity-check failure, node-info-not-found / stale registry). `controller.go:395-398,358-367,421-425,908-909,1010-1013`. → Counter `{reason}`.
-- Signature-verification failure conflated with generic "invalid response" (crypto mismatch vs. malformed-but-honest data are very different security signals), both in the RMN controller (`crypto.go:36-63`, `controller.go:1052-1089`) and on the plugin/query side (`observation.go:245-248`). → Split the existing label or add a dedicated counter.
-- `ErrSignaturesNotProvidedByLeader` recurrence — points to a leader-side RMN problem invisible to followers today. `observation.go:41-42,118-125`. → Counter.
-- RMN `ObserveRMNRemoteCfg` failures — blocks RMN controller init and outcome's RMN report building. `observation.go:846-856`, `Errorw`. → Counter.
 
-**Low**
-- RMN peer/stream connectivity state (active streams, peer-group connected) — currently only per-message `Infow` (log noise, no aggregate). `rmn/peerclient.go:57-183`. → Gauge.
-- RMN controller re-initialization churn (should be rare; frequent churn = config flapping or bug). `observation.go:143-185`. → Counter. Also worth a static `ccip_commit_rmn_enabled{chain_id}` gauge since RMN is now hardcoded off — useful for dashboard filtering / confirming the deprecation.
+(RMN blessing/signing findings — signed-roots-dropped, per-root signed/unsigned filtering, chain quorum result, Byzantine root disagreement, RMN controller node-coverage/internal-errors, signature-verification conflation, `ErrSignaturesNotProvidedByLeader`, `ObserveRMNRemoteCfg` failures, peer/stream connectivity, controller re-init churn, and the standalone `ValidateRootBlessings` proposal (now covered by the implemented `root_blessing_mismatch` reason above) — were all dropped from this doc. All of these sit behind `if rmnEnabled` in `buildMerkleRootsOutcome` or are otherwise part of the RMN controller/signing path, which is effectively dead code now that `RMNEnabled` is hardcoded off and the controller is slated for removal; cursing, covered above, is the one RMN-adjacent signal still live in production.)
 
 ### Chain fee processor (`commit/chainfee`)
 
@@ -149,18 +132,6 @@ Also no dedicated `MetricsReporter`. Note `ValidateObservation` isn't even wrapp
 
 **Low, but flagged as a miss in my first pass — don't let "it's Debug" read as "low priority"**
 - **Token-price reporting silently disabled by config** (`TokenPriceBatchWriteFrequency == 0`) is logged at `Debugw` — *less* visible in prod than a "stable" Info/Warn log, since Debug is typically off entirely. `processor.go:102-106`. This is exactly the pattern the existing `ccip_commit_loopp_ccip_provider_supported` boolean gauge was built for, and it's a cheap, precedented fix. → Gauge `{destChain}` (1/0).
-
----
-
-## Suggested next step
-
-This is large enough to be its own workstream. I'd sequence it as:
-1. **Shared infra first** (benefits all three processors): fix `internal/plugincommon/consensus/consensus.go`'s `// TODO: metrics`, and add a timeout counter in `internal/libs/asynclib/goroutines.go`. Small, high-leverage, no processor-specific design needed.
-2. **Merkleroot high-severity list** — directly answers your stated pain point (onramp/offramp liveness, curse state, transmission give-up).
-3. **Chainfee + tokenprice high-severity list** — both need a dedicated `MetricsReporter` sub-interface first (mirroring `merkleroot.MetricsReporter`), then the per-value gauges/staleness/failure counters.
-4. Medium/low tiers as follow-up passes.
-
-Want me to turn this into an implementation plan (starting with #1), or file it as a ticket first?
 
 ---
 

--- a/docs/metrics/commit-metrics.md
+++ b/docs/metrics/commit-metrics.md
@@ -1,15 +1,40 @@
-## Metrics coverage assessment — commit plugin
+- [Metrics coverage assessment — commit plugin](#metrics-coverage-assessment--commit-plugin)
+   * [What exists today (`commit/metrics/prom.go`)](#what-exists-today-commitmetricspromgo)
+   * [Cross-cutting themes (repeat in every processor)](#cross-cutting-themes-repeat-in-every-processor)
+   * [Proposed metrics at a glance (merkle root processor)](#proposed-metrics-at-a-glance-merkle-root-processor)
+      + [Top-level plugin orchestration](#top-level-plugin-orchestration)
+      + [Shared: consensus aggregation](#shared-consensus-aggregation)
+      + [Merkle root processor — High](#merkle-root-processor--high)
+      + [Merkle root processor — Medium](#merkle-root-processor--medium)
+   * [War games: incident walkthroughs](#war-games-incident-walkthroughs)
+      + [Scenario 1 — full decision tree](#scenario-1--full-decision-tree)
+      + [Scenario 2 — deep dive: report transmission stuck (Step 5)](#scenario-2--deep-dive-report-transmission-stuck-step-5)
+      + [Scenario 3 — deep dive: consensus never completes (Step 3)](#scenario-3--deep-dive-consensus-never-completes-step-3)
+      + [Gaps this exercise surfaced (already folded into the findings above)](#gaps-this-exercise-surfaced-already-folded-into-the-findings-above)
+   * [Full findings](#full-findings)
+      + [Top-level plugin orchestration (`commit/plugin.go`, `commit/report.go`)](#top-level-plugin-orchestration-commitplugingo-commitreportgo)
+      + [Shared: consensus aggregation (`internal/plugincommon/consensus/consensus.go`)](#shared-consensus-aggregation-internalplugincommonconsensusconsensusgo)
+      + [Merkle root processor (`commit/merkleroot`)](#merkle-root-processor-commitmerkleroot)
+   * [(Other Processors) Proposed metrics at a glance](#other-processors-proposed-metrics-at-a-glance)
+         - [Chain fee processor — High](#chain-fee-processor--high)
+         - [Chain fee processor — Medium / Low](#chain-fee-processor--medium--low)
+         - [Token price processor — High](#token-price-processor--high)
+         - [Token price processor — Medium / Low](#token-price-processor--medium--low)
+      + [Chain fee processor (`commit/chainfee`)](#chain-fee-processor-commitchainfee)
+      + [Token price processor (`commit/tokenprice`)](#token-price-processor-committokenprice)
+
+# Metrics coverage assessment — commit plugin
 
 **Ground rule for everything below: the presence of a log line — even a "stable identifier" some log-analysis tooling already keys on — is never a reason to exclude a metric.** Logs are exactly the noisy, low-signal, un-queryable thing motivating this work; a few items here are genuinely *only* visible at `Debugw`, which is worse than a "stable" log, not better. Nothing was cut from the list below because it was already logged.
 
-### What exists today (`commit/metrics/prom.go`)
+## What exists today (`commit/metrics/prom.go`)
 
 - Generic per-processor instrumentation via `TrackedProcessor` (wraps merkleroot/chainfee/tokenprice): latency histogram, error counter, and an **output-size counter** driven by each type's `Stats()` — but `Stats()` only returns `len(map)`-style item counts (e.g. `gasPrices: 3`), never the actual values.
 - `ccip_commit_max_sequence_number` gauge — but only fed from `MerkleRootChain.SeqNumsRange.End()` in `TrackObservation`/`TrackOutcome`, i.e. **only when a root is actually being built for a report**.
 - `ccip_commit_latest_round_id`, `ccip_commit_config_digest_mismatch`, `ccip_commit_loopp_ccip_provider_supported`.
 - **`chainfee` and `tokenprice` have no dedicated metrics interface at all** — they only get the generic latency/error/size instrumentation above. Token prices, gas prices, and their staleness/deviation/failure states are otherwise 100% log-only.
 
-### Cross-cutting themes (repeat in every processor)
+## Cross-cutting themes (repeat in every processor)
 
 Merkleroot, chainfee, and tokenprice each independently:
 1. Compute a **per-item value** (seq num / fee / price) that's never gauged — only counted.
@@ -25,20 +50,20 @@ Merkleroot, chainfee, and tokenprice each independently:
 
 Every metric proposed in this doc, with a one/two-line "why" — the full rationale, exact file:line evidence, and severity ranking live in [Full findings](#full-findings) below. ✅ = implemented and merged; everything else is proposed/reviewed only.
 
-#### Top-level plugin orchestration
+### Top-level plugin orchestration
 
 | Metric | Status | Why |
 |---|---|---|
 | `ccip_commit_plugin_heartbeat{chainFamily,chainID,phase="observation"\|"outcome"}` | ✅ Implemented | Unconditional per-round liveness signal — the only way to tell "process wedged" apart from "valid but stale gauge" for every other metric in this doc. |
 | `ccip_commit_report_validation_rejected{phase="should_accept"\|"should_transmit",reason}` | ✅ Implemented | Distinguishes "report never submitted" (rejected locally) from "submitted but stuck/reverted on-chain" — different remediation paths entirely. |
 
-#### Shared: consensus aggregation
+### Shared: consensus aggregation
 
 | Metric | Status | Why |
 |---|---|---|
 | `ccip_commit_consensus_dropped{objectName,key,reason}` (needs an additive `GetConsensusMap` return value) | Reviewed design, not implemented | Splits "no threshold configured" (config bug) from "insufficient agreement" (routine) from "split vote" (integrity signal) — currently collapsed into one `TODO: metrics` log line. |
 
-#### Merkle root processor — High
+### Merkle root processor — High
 
 | Metric | Status | Why |
 |---|---|---|
@@ -51,7 +76,7 @@ Every metric proposed in this doc, with a one/two-line "why" — the full ration
 | `ccip_commit_consensus_observation_failed{chain_family,chain_id}` | ✅ Implemented | Flags a destination-chain-wide stall immediately instead of looking like N independent lane stalls. |
 | `ccip_commit_report_transmission_gave_up{sourceChain}` + `ccip_commit_report_transmission_attempts` (histogram) | ✅ Implemented | One of the most common on-call pages today; previously only a `Warnw` with no counter. |
 
-#### Merkle root processor — Medium
+### Merkle root processor — Medium
 
 | Metric | Status | Why |
 |---|---|---|

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,103 @@
+# Runbooks
+
+Operational docs for triaging and health-checking CCIP plugins, written to be followed
+mechanically by a human **or** an AI agent — not read once and internalized. Each doc pairs a
+structured, machine-checkable spec (a fenced YAML block: a decision graph or a checklist) with
+prose explaining the *why*, sharing the same step/check IDs so the two can't silently drift
+apart.
+
+| doc | use when |
+|---|---|
+| [`uncommitted-message.md`](uncommitted-message.md) | reactive — you have a specific stuck message (source chain, dest chain, onramp seq num) and need to find where it's stuck |
+| [`commit-plugin-health.md`](commit-plugin-health.md) | proactive — no specific incident; is this commit plugin instance healthy right now |
+
+Both currently cover the **commit plugin / merkle root processor** only, built from the metric
+coverage work in [`docs/metrics/commit-metrics.md`](../metrics/commit-metrics.md) and rendered
+visually in [`devenv/dashboards/commit-plugin.json`](../../devenv/dashboards/commit-plugin.json)
+(that dashboard's Health section mirrors `commit-plugin-health.md`; its Guided Debug section
+mirrors `uncommitted-message.md`).
+
+## As a human
+
+1. Read the frontmatter first (`trigger`, `inputs`, `related`) — it tells you whether this is the
+   right doc before you read anything else.
+2. Skip the YAML block unless you want the exact query for a step; the prose under
+   `## Steps`/`## Groups` explains the reasoning in the same order.
+3. You need a Prometheus-compatible query endpoint with these metrics in it. Locally, that's the
+   VictoriaMetrics stack started by `ccip obs up --victoria` (see `devenv/README.md`) — query it
+   via Grafana Explore (`http://localhost:3000`, datasource `VictoriaMetrics`) or directly at
+   `http://localhost:8428/api/v1/query`. Outside devenv, use whatever datasource your
+   environment's Beholder pipeline actually feeds — see each doc's note on counter `_total`
+   suffixing, which depends on that pipeline, not on the runbook.
+4. `uncommitted-message.md`'s Guided Debug panels and `commit-plugin-health.md`'s Health panels
+   in `devenv/dashboards/commit-plugin.json` run the same queries pre-wired with dashboard
+   variables — often faster than copy-pasting PromQL by hand.
+5. Every terminal outcome in these docs is `STOP` or `REPORT:<owner>` — never an instruction to
+   page or act. If a doc leads you to a `REPORT`, that's a handoff for you to make, not something
+   the doc did for you.
+
+## Invoking an AI agent with a runbook
+
+Point the agent at the file and the query endpoint, give it the specific inputs, and ask for the
+doc's own output contract — don't ask it to "check if things look okay," the doc already defines
+what "okay" means and how to report it.
+
+**Template:**
+
+```
+Read <path to runbook> fully, then execute it against <query endpoint, e.g.
+http://localhost:8428/api/v1/query for local devenv VictoriaMetrics>.
+
+Inputs:
+- destChain = "<value>"
+- sourceChain = "<value>"       # uncommitted-message.md only
+- seqNum = <value>              # uncommitted-message.md only
+- msgID = "<value>"             # uncommitted-message.md only
+- sourceChains = "<regex>"      # commit-plugin-health.md only, default ".*"
+
+Follow the decision graph / checklist exactly as written, substituting the inputs above into
+each query. Produce the doc's defined output as your final answer, fully filled in with real
+query results -- not a description of what you'd do.
+
+Do not page, escalate, or take any remediation action. Every terminal outcome in this doc is
+`STOP` or `REPORT:<owner>` -- your job ends at reporting the finding and the suggested owner.
+```
+
+Two things worth being explicit about when you invoke one of these, because they're easy to get
+wrong even for an agent reading the doc carefully:
+
+- **The empty-result rule matters more than it looks like it should.** Both docs distinguish "no
+  data because the pipeline is broken" from "no data because this counter has never fired" —
+  getting this backwards silently turns a healthy system's report into a false alarm (or the
+  reverse). If you're spot-checking an agent's output, this is the first thing to verify against
+  the raw query results.
+- **Label keys are not uniform across metrics** (`chainID` vs `chain_id`, see each doc's cheat
+  sheet). An agent that "normalizes" these to one spelling will get silent empty results, not an
+  error.
+
+### Re-testing a runbook after editing it
+
+If you change a decision graph, checklist, or severity rule, re-run it through an agent against
+a real datasource before trusting the edit — a doc that reads correctly is not the same as a doc
+that resolves correctly, and the fastest way either doc in this directory reached its current
+state was by having an agent literally execute it and report back where it guessed. Ask the
+agent to also report friction: places it had to guess, or where a real query result didn't match
+what the doc told it to expect. That feedback is usually more valuable than the health/triage
+result itself while a doc is still being iterated on.
+
+## Adding a new runbook
+
+Keep new docs consistent with the two here:
+
+- Frontmatter: `name`, `description`, `trigger`, `severity`, `owner`, typed `inputs`, `related`,
+  `status`.
+- A `## For agents` section defining the outcome vocabulary you're using and any non-obvious
+  interpretation rules (empty results, label inconsistencies, anything an agent would otherwise
+  have to guess).
+- A fenced YAML block that's the actual control structure (decision graph for
+  reactive/triage docs, checklist for proactive/health docs) — prose explains it, doesn't replace
+  it.
+- A defined output contract, so "did the agent get the right answer" is checkable against a
+  schema instead of read as prose.
+- `STOP` / `CONTINUE:<id>` / `REPORT:<owner>` as the only outcomes. No outcome that implies the
+  agent itself pages, escalates, or takes a remediation action.

--- a/docs/runbooks/commit-plugin-health.md
+++ b/docs/runbooks/commit-plugin-health.md
@@ -7,6 +7,7 @@ owner: ccip-commit-oncall
 inputs:
   destChain: {type: string, description: "chainID/chain_id label value of the node's destination chain"}
   sourceChains: {type: string, description: "source_network_name regex filter; defaults to all lanes into destChain", default: ".*"}
+  fRoleDON: {type: integer, required: false, description: "optional. If known, expected live oracle count for destChain's DON is 3*fRoleDON+1 and the consensus threshold is 2*fRoleDON+1. Omit if uncertain (e.g. local devenvs with a possible bootstrap-node offset) -- live_oracle_count reports the raw count either way, it just can't grade it against a threshold without this."}
 related:
   - docs/runbooks/uncommitted-message.md   # incident triage for one specific stuck message
   - docs/metrics/commit-metrics.md         # design rationale + full metric-by-metric findings
@@ -18,6 +19,7 @@ status: living
    * [For agents](#for-agents)
       + [Label key cheat sheet](#label-key-cheat-sheet)
       + [Empty result sets: the rule that actually matters](#empty-result-sets-the-rule-that-actually-matters)
+      + [rate() detection lag: found by live testing, not designed in](#rate-detection-lag-found-by-live-testing-not-designed-in)
    * [Checklist](#checklist)
    * [Groups](#groups)
       + [Liveness](#liveness)
@@ -48,9 +50,14 @@ label key from each check's own query; don't assume one spelling applies file-wi
 
 | label key | checks that use it |
 |---|---|
-| `chainID` | `heartbeat_observation`, `heartbeat_outcome`, `processor_errors`, `processor_latency_p95`, `fchain_read_errors`, `report_validation_rejected`, `report_transmission_attempts_p95` |
+| `chainID` | `heartbeat_observation`, `heartbeat_outcome`, `processor_errors`, `processor_latency_p95`, `live_oracle_count`, `fchain_read_errors`, `report_validation_rejected`, `report_transmission_attempts_p95` |
 | `chain_id` | `config_digest_mismatch`, `rmn_curse_active`, `consensus_observation_failed` |
 | `source_network_name` | every check under `lane_throughput`, plus `source_chain_cursed`, `report_transmission_gave_up` |
+
+`csa_public_key` is a different kind of label — it's not used to filter by chain, it's a
+per-node identity present on *every* commit metric series (confirmed against a live devenv, not
+just inferred). `live_oracle_count` is the only check that groups by it; nothing else in this
+checklist needs to.
 
 ### Empty result sets: the rule that actually matters
 
@@ -81,6 +88,23 @@ For metric types, label sets, and the `_total`/`_bucket` suffix caveat, see
 
 Produce the [output contract](#output-contract) at the end — don't just narrate findings inline.
 
+### `rate()` detection lag: found by live testing, not designed in
+
+This was found by actually forcing a failure and running this checklist against it, not by
+reading the doc carefully — worth internalizing before you edit any check's window size.
+`rate(metric[Nm])` extrapolates across its *whole* window using the oldest and newest samples it
+finds inside it. That means a `crit_if: result == 0` check (or a headcount built on
+`rate(...) > 0`) does not go bad the instant the underlying process dies — it stays looking
+healthy for up to `N` more minutes, because there were still real samples earlier in the window.
+Confirmed empirically: with a `[5m]` window, `live_oracle_count` kept reporting the pre-outage
+oracle count for several minutes after 3 of 5 oracles were actually stopped; only a `[1m]` window
+(or, better, a `timestamp()`-based staleness check — what `live_oracle_count` now uses) reflected
+the real state promptly. Every liveness check in this checklist uses a short window (`[1m]`) or a
+direct staleness check specifically because of this. If you widen one, you're trading detection
+speed for smoothing against transient blips — that's a real tradeoff, not a free cleanup, and any
+resulting delay should be [re-tested against a forced failure](README.md#re-testing-a-runbook-after-editing-it),
+not assumed correct because the query still reads sensibly.
+
 ## Checklist
 
 ```yaml
@@ -89,18 +113,18 @@ checks:
   - id: heartbeat_observation
     group: liveness
     always_emitted: true
-    query: 'sum(rate(ccip_commit_plugin_heartbeat_total{chainID=~"$destChain", phase="observation"}[5m]))'
+    query: 'sum(rate(ccip_commit_plugin_heartbeat_total{chainID=~"$destChain", phase="observation"}[1m]))'
     severity: {crit_if: "result == 0", ok_if: "result > 0"}
     owner: ccip-commit-oncall
-    note: "unconditional per-round liveness signal for Observation(); 0 or empty means every other check below may simply be stale, not bad"
+    note: "unconditional per-round liveness signal for Observation(); 0 or empty means every other check below may simply be stale, not bad. Window is deliberately 1m, not 5m -- rate() extrapolates across its whole window, so a plugin that died N minutes ago still reads as alive for up to [window] more minutes; confirmed empirically (see live_oracle_count's note) that a 5m window delays detecting a real outage by up to 5 minutes. Don't widen this window without re-checking that tradeoff"
 
   - id: heartbeat_outcome
     group: liveness
     always_emitted: true
-    query: 'sum(rate(ccip_commit_plugin_heartbeat_total{chainID=~"$destChain", phase="outcome"}[5m]))'
+    query: 'sum(rate(ccip_commit_plugin_heartbeat_total{chainID=~"$destChain", phase="outcome"}[1m]))'
     severity: {crit_if: "result == 0", ok_if: "result > 0"}
     owner: ccip-commit-oncall
-    note: "same signal for Outcome(); flat while observation is healthy means OCR is failing to schedule/deliver to the outcome stage"
+    note: "same signal for Outcome(); flat while observation is healthy means OCR is failing to schedule/deliver to the outcome stage. Same 1m-window rationale as heartbeat_observation"
 
   - id: config_digest_mismatch
     group: liveness
@@ -192,6 +216,14 @@ checks:
     owner: ccip-commit-oncall
     note: "the only way a whole round fails: DON can't reach 2*fRoleDON+1 agreement on FChain for the dest chain. Destination-chain-wide by construction, not lane-specific"
 
+  - id: live_oracle_count
+    group: cursing_consensus
+    always_emitted: true
+    query: 'count(count by (csa_public_key) (timestamp(ccip_commit_plugin_heartbeat_total{chainID=~"$destChain", phase="observation"}) > time() - 60))'
+    severity: {crit_if: "$fRoleDON known and result < 2*$fRoleDON+1", warn_if: "$fRoleDON known and 2*$fRoleDON+1 <= result < 3*$fRoleDON+1", ok_if: "$fRoleDON known and result >= 3*$fRoleDON+1", info: "$fRoleDON not supplied -- report the raw count, no verdict"}
+    owner: ccip-commit-oncall
+    note: "csa_public_key uniquely identifies each node in every commit metric series (confirmed empirically against a live devenv, not just inferred from source). This deliberately uses timestamp()-vs-time(), not rate()>0: confirmed by live testing that rate([5m])>0 stays true for up to 5 minutes after a node actually stops, because rate() extrapolates across its whole window using the oldest and newest samples it finds -- a node that died 3 minutes ago still reports a positive rate at the 5m window size, making the headcount silently wrong for the first several minutes of a real outage. timestamp() answers 'did this series get a sample in the last 60s' directly, with no extrapolation lag. This is the ONLY check in this file that can detect 'not enough oracles are even running' -- fchain_read_errors below only reports a *surviving* oracle's own read failures, it has no visibility into oracles that never started. If this comes back CRIT, it likely explains consensus_observation_failed on its own; don't let fchain_read_errors being flat push you toward blaming a split vote instead (see the aggregation rule)"
+
   - id: fchain_read_errors
     group: cursing_consensus
     always_emitted: false
@@ -252,7 +284,11 @@ already-known state (see `uncommitted-message.md` step4), and a health check tha
 expected state trains people to ignore it. `consensus_observation_failed` is unambiguous `CRIT`
 when it fires — by construction it can only mean the DON-wide FChain agreement failed for this
 destination chain, which cannot happen for benign reasons — but it's `always_emitted: false`, so
-absence is the expected/healthy state, not a gap in coverage.
+absence is the expected/healthy state, not a gap in coverage. If it does fire, check
+`live_oracle_count` before `fchain_read_errors`: an oracle that never started can't emit
+`fchain_read_errors` at all (only a *surviving* oracle's own read failures are counted there), so
+a low oracle count is a root cause `fchain_read_errors` is structurally unable to surface on its
+own.
 
 ### Report transmission
 
@@ -263,11 +299,19 @@ a fully empty result is `OK`, not `UNKNOWN`.
 ## Aggregation rule
 
 Overall status is the worst individual status, `CRIT` > `WARN` > `UNKNOWN` > `INFO`/`OK`, with
-one explicit combination rule: **`fchain_read_errors` (`WARN`) firing at the same time as
-`consensus_observation_failed` (`CRIT`) doesn't change the overall verdict (already `CRIT`) but
-should be called out together in `concerns` as one finding, not two** — they're the same
-incident (H1 in `uncommitted-message.md`'s Scenario 3), and reporting them separately reads as
-two problems instead of one with corroborating evidence.
+two explicit combination rules:
+
+- **`fchain_read_errors` (`WARN`) firing at the same time as `consensus_observation_failed`
+  (`CRIT`) doesn't change the overall verdict (already `CRIT`) but should be called out together
+  in `concerns` as one finding, not two** — they're the same incident (H1 in
+  `uncommitted-message.md`'s Scenario 3), and reporting them separately reads as two problems
+  instead of one with corroborating evidence.
+- **`live_oracle_count` resolving `CRIT` (or `WARN`) takes priority over whatever
+  `fchain_read_errors` says, when both are present in the same `concerns` entry.** A low oracle
+  count fully explains `consensus_observation_failed` on its own; `fchain_read_errors` being flat
+  in that situation is expected (dead oracles can't emit it), not evidence that points elsewhere.
+  Don't report "H1 ruled out, likely a split vote" if `live_oracle_count` already found the real
+  cause — that conclusion would be actively wrong, not just unconfirmed.
 
 `UNKNOWN` is never silently dropped to `OK` — but per the [empty-result rule](#empty-result-sets-the-rule-that-actually-matters),
 most checks should legitimately resolve `UNKNOWN` only when an `always_emitted: true` check comes

--- a/docs/runbooks/commit-plugin-health.md
+++ b/docs/runbooks/commit-plugin-health.md
@@ -1,0 +1,312 @@
+---
+name: commit-plugin-health
+description: Point-in-time health check for a commit plugin instance and its merkle root processor. No incident or specific message required.
+trigger: "ad hoc / scheduled health check, or as step0 before docs/runbooks/uncommitted-message.md"
+severity: informational
+owner: ccip-commit-oncall
+inputs:
+  destChain: {type: string, description: "chainID/chain_id label value of the node's destination chain"}
+  sourceChains: {type: string, description: "source_network_name regex filter; defaults to all lanes into destChain", default: ".*"}
+related:
+  - docs/runbooks/uncommitted-message.md   # incident triage for one specific stuck message
+  - docs/metrics/commit-metrics.md         # design rationale + full metric-by-metric findings
+  - devenv/dashboards/commit-plugin.json   # Grafana rendering of this runbook (Health section)
+status: living
+---
+
+- [Runbook: commit plugin health](#runbook-commit-plugin-health)
+   * [For agents](#for-agents)
+      + [Label key cheat sheet](#label-key-cheat-sheet)
+      + [Empty result sets: the rule that actually matters](#empty-result-sets-the-rule-that-actually-matters)
+   * [Checklist](#checklist)
+   * [Groups](#groups)
+      + [Liveness](#liveness)
+      + [Lane throughput & backlog](#lane-throughput--backlog)
+      + [Cursing & consensus](#cursing--consensus)
+      + [Report transmission](#report-transmission)
+   * [Aggregation rule](#aggregation-rule)
+   * [Output contract](#output-contract)
+
+# Runbook: commit plugin health
+
+Unlike [`uncommitted-message.md`](uncommitted-message.md), this isn't triggered by a specific
+stuck message — it's "is this commit plugin instance (and its merkle root processor) healthy
+right now." Run it periodically, on demand, or as the first thing you do before diving into a
+specific-message incident (its `step0` is a subset of this runbook's `heartbeat_observation` /
+`heartbeat_outcome` checks).
+
+## For agents
+
+Every check below is independent — run all of them, don't stop early. Each has a fixed
+severity mapping, not a branch.
+
+### Label key cheat sheet
+
+The destination chain is filtered by **two different label names depending on the metric** —
+this is a real inconsistency in `commit/metrics/prom.go`, not a typo to normalize away. Copy the
+label key from each check's own query; don't assume one spelling applies file-wide:
+
+| label key | checks that use it |
+|---|---|
+| `chainID` | `heartbeat_observation`, `heartbeat_outcome`, `processor_errors`, `processor_latency_p95`, `fchain_read_errors`, `report_validation_rejected`, `report_transmission_attempts_p95` |
+| `chain_id` | `config_digest_mismatch`, `rmn_curse_active`, `consensus_observation_failed` |
+| `source_network_name` | every check under `lane_throughput`, plus `source_chain_cursed`, `report_transmission_gave_up` |
+
+### Empty result sets: the rule that actually matters
+
+An empty Prometheus/PromQL result (zero series returned) is **not** the same as "all series are
+0" — `ok_if: "all series == 0"` is vacuously true over an empty set, and resolving it that way
+silently turns "we have no idea" into "confirmed fine." Getting this wrong is the single easiest
+way to make this checklist wrong in practice, so the rule is:
+
+1. Every check below is tagged `always_emitted: true` or `always_emitted: false`.
+2. **`always_emitted: true`** means the underlying code records this metric unconditionally,
+   every round, regardless of outcome (heartbeats, gauges reported every round, the latency
+   histogram). An empty result here means the telemetry pipeline itself isn't delivering data for
+   this series — status is `UNKNOWN`, full stop, regardless of what the check's own
+   `ok_if`/`warn_if`/`crit_if` says.
+3. **`always_emitted: false`** means the underlying metric is an event counter that Prometheus/
+   OTel only creates a time series for *after* it increments at least once — these are almost
+   always the error/failure counters. **An empty result here is the expected, healthy state**
+   (the event has never happened) — treat it as `value == 0` and evaluate `ok_if`/`warn_if`/
+   `crit_if` against that value normally, do not report `UNKNOWN`.
+4. The one exception: if step 3 would resolve a check to `OK`-via-empty, but any
+   `always_emitted: true` check in the same run is itself `UNKNOWN` (pipeline may be broken),
+   don't trust the distinction — treat the `always_emitted: false` check as `UNKNOWN` too, and
+   say so in `concerns`. You cannot tell "never happened" apart from "telemetry is broken" once
+   you've already lost confidence in the pipeline.
+
+For metric types, label sets, and the `_total`/`_bucket` suffix caveat, see
+[`uncommitted-message.md#metric-reference`](uncommitted-message.md#metric-reference).
+
+Produce the [output contract](#output-contract) at the end — don't just narrate findings inline.
+
+## Checklist
+
+```yaml
+checks:
+  # --- liveness ---
+  - id: heartbeat_observation
+    group: liveness
+    always_emitted: true
+    query: 'sum(rate(ccip_commit_plugin_heartbeat_total{chainID=~"$destChain", phase="observation"}[5m]))'
+    severity: {crit_if: "result == 0", ok_if: "result > 0"}
+    owner: ccip-commit-oncall
+    note: "unconditional per-round liveness signal for Observation(); 0 or empty means every other check below may simply be stale, not bad"
+
+  - id: heartbeat_outcome
+    group: liveness
+    always_emitted: true
+    query: 'sum(rate(ccip_commit_plugin_heartbeat_total{chainID=~"$destChain", phase="outcome"}[5m]))'
+    severity: {crit_if: "result == 0", ok_if: "result > 0"}
+    owner: ccip-commit-oncall
+    note: "same signal for Outcome(); flat while observation is healthy means OCR is failing to schedule/deliver to the outcome stage"
+
+  - id: config_digest_mismatch
+    group: liveness
+    always_emitted: true
+    query: 'max(ccip_commit_config_digest_mismatch{chain_id=~"$destChain"})'
+    severity: {crit_if: "result == 1", ok_if: "result == 0"}
+    owner: ccip-commit-oncall
+    note: "home-chain config digest differs from the offramp's; root cause for a wide range of downstream rejections"
+
+  - id: processor_errors
+    group: liveness
+    always_emitted: false
+    query: 'sum(rate(ccip_commit_processor_errors_total{chainID=~"$destChain"}[15m])) by (processor, method)'
+    severity: {warn_if: "any series > 0", ok_if: "all series == 0 (including empty result)"}
+    owner: ccip-commit-oncall
+    note: "generic TrackedProcessor error counter; empty means zero errors, not unknown. Does not include swallowed per-goroutine failures (see merkleroot_observation_errors in uncommitted-message.md)"
+
+  - id: processor_latency_p95
+    group: liveness
+    always_emitted: true
+    query: 'histogram_quantile(0.95, sum(rate(ccip_commit_processor_latency_bucket{chainID=~"$destChain"}[15m])) by (le, processor, method))'
+    severity: {info: true}
+    owner: ccip-commit-oncall
+    note: "report raw value only, this is a single point-in-time sample with nothing to trend against -- do not infer a trend from one run. If a value lands exactly on a bucket boundary (e.g. pinned at the histogram's max bucket), report that fact explicitly as it likely means real latency exceeds the highest defined bucket; still do not elevate this to WARN/CRIT, there is no defined SLO"
+
+  # --- lane throughput & backlog (per source chain) ---
+  - id: pending_messages
+    group: lane_throughput
+    always_emitted: true
+    query: 'max by (source_network_name) (ccip_commit_pending_messages{source_network_name=~"$sourceChains"})'
+    severity: {info: true}
+    owner: ccip-commit-oncall
+    note: "onRampMaxSeqNum - offRampNextSeqNum; no universal healthy value, watch for sustained growth not a single sample. Empty result here (no lanes matched) is UNKNOWN, not zero backlog -- this metric is always emitted per active lane"
+
+  - id: range_truncated
+    group: lane_throughput
+    always_emitted: false
+    query: 'sum(rate(ccip_commit_range_truncated_total{source_network_name=~"$sourceChains"}[15m])) by (source_network_name)'
+    severity: {warn_if: "any series > 0", ok_if: "all series == 0 (including empty result)"}
+    owner: ccip-commit-oncall
+    note: "chain-throughput ceiling (MaxMerkleTreeSize) being hit"
+
+  - id: seqnum_invariant_violation
+    group: lane_throughput
+    always_emitted: false
+    query: 'sum(rate(ccip_commit_seqnum_invariant_violation_total{source_network_name=~"$sourceChains"}[15m])) by (source_network_name, type)'
+    severity: {crit_if: "any series > 0", ok_if: "all series == 0 (including empty result)"}
+    owner: ccip-commit-oncall
+    note: "offramp_ahead_of_onramp / onramp_max_zero / offramp_seqnum_regression -- documented in-code as stall signals, not routine noise"
+
+  - id: offramp_consensus_insufficient
+    group: lane_throughput
+    always_emitted: false
+    query: 'sum(rate(ccip_commit_offramp_consensus_insufficient_total{source_network_name=~"$sourceChains"}[15m])) by (source_network_name)'
+    severity: {warn_if: "any series > 0", ok_if: "all series == 0 (including empty result)"}
+    owner: ccip-commit-oncall
+    note: "DON couldn't agree on OffRampNextSeqNum for this chain; looks identical to \"no new messages\" without this"
+
+  - id: offramp_lane_status
+    group: lane_throughput
+    always_emitted: true
+    query: 'max by (source_network_name, status) (ccip_commit_offramp_lane_status{source_network_name=~"$sourceChains"})'
+    severity: {crit_if: 'status="rmn_misconfigured" and result == 1', info_if: 'status=~"skipped_.*" and result == 1', ok_if: 'status="live" and result == 1'}
+    owner: ccip-commit-oncall
+    note: "rmn_misconfigured flags real config drift (a lane still expecting RMN blessing while RMN is globally off); skipped_* are expected states, not unhealthy. Reported for all four statuses every round by design, so empty result is UNKNOWN, not \"no active lanes\""
+
+  # --- cursing & consensus ---
+  - id: rmn_curse_active
+    group: cursing_consensus
+    always_emitted: true
+    query: 'max(ccip_commit_rmn_curse_active{chain_id=~"$destChain", curse_type=~"global|destination"}) by (curse_type)'
+    severity: {warn_if: "any series == 1", ok_if: "all series == 0"}
+    owner: curse-owner
+    note: "halts ALL reporting for the dest chain while active; often intentional/incident-flagged (see uncommitted-message.md step4) -- WARN not CRIT because an active curse is frequently expected, not a plugin bug"
+
+  - id: source_chain_cursed
+    group: cursing_consensus
+    always_emitted: true
+    query: 'max by (source_network_name) (ccip_commit_source_chain_cursed{source_network_name=~"$sourceChains"})'
+    severity: {warn_if: "any series == 1", ok_if: "all series == 0"}
+    owner: curse-owner
+    note: "per-lane curse; same intentional-vs-bug ambiguity as rmn_curse_active"
+
+  - id: consensus_observation_failed
+    group: cursing_consensus
+    always_emitted: false
+    query: 'sum(rate(ccip_commit_consensus_observation_failed_total{chain_id=~"$destChain"}[5m]))'
+    severity: {crit_if: "result > 0", ok_if: "result == 0 (including empty result)"}
+    owner: ccip-commit-oncall
+    note: "the only way a whole round fails: DON can't reach 2*fRoleDON+1 agreement on FChain for the dest chain. Destination-chain-wide by construction, not lane-specific"
+
+  - id: fchain_read_errors
+    group: cursing_consensus
+    always_emitted: false
+    query: 'sum(rate(ccip_commit_fchain_read_errors_total{chainID=~"$destChain"}[5m]))'
+    severity: {warn_if: "result > 0", ok_if: "result == 0 (including empty result)"}
+    owner: home-chain-infra-oncall
+    note: "if this AND consensus_observation_failed are both firing, treat the combination as one CRIT finding, not two (see aggregation rule) -- likely H1, home-chain RPC/read outage"
+
+  # --- report transmission ---
+  - id: report_validation_rejected
+    group: report_transmission
+    always_emitted: false
+    query: 'sum(rate(ccip_commit_report_validation_rejected_total{chainID=~"$destChain"}[15m])) by (phase, reason)'
+    severity: {warn_if: 'any series with reason!="stale" > 0', info_if: 'only reason="stale" > 0', ok_if: "empty result, or all series == 0"}
+    owner: ccip-commit-oncall
+    note: "reason=\"stale\" is usually benign (an overlapping report already landed); other reasons are worth a look"
+
+  - id: report_transmission_gave_up
+    group: report_transmission
+    always_emitted: false
+    query: 'sum(rate(ccip_commit_report_transmission_gave_up_total{source_network_name=~"$sourceChains"}[15m])) by (source_network_name)'
+    severity: {crit_if: "any series > 0", ok_if: "all series == 0 (including empty result)"}
+    owner: ccip-commit-oncall
+    note: "one of the most common on-call pages historically; previously a Warnw with no counter at all. If CRIT, uncommitted-message.md Scenario 2 may name a different owner (chain-b-txm-oncall) once root-caused -- this check alone doesn't know which"
+
+  - id: report_transmission_attempts_p95
+    group: report_transmission
+    always_emitted: false
+    query: 'histogram_quantile(0.95, sum(rate(ccip_commit_report_transmission_attempts_bucket{chainID=~"$destChain"}[15m])) by (le, success))'
+    severity: {info: true}
+    owner: ccip-commit-oncall
+    note: "recorded once per transmission-check attempt; empty result means zero transmission cycles in the window, which is itself informational (report as INFO with value \"no data\"), not UNKNOWN. Rising attempts alongside report_transmission_gave_up firing is the actionable combination, not this alone"
+```
+
+## Groups
+
+### Liveness
+
+`heartbeat_observation` / `heartbeat_outcome` first — if either is `CRIT` or `UNKNOWN`, every
+other check's `OK` in this run is suspect (a wedged plugin can leave gauges parked at their
+last-good value, and an `always_emitted: false` check resolving empty-to-OK assumes the pipeline
+itself is trustworthy). `config_digest_mismatch` and `processor_errors` are the other two checks
+here with an unambiguous bad state; `processor_latency_p95` is context, not a verdict.
+
+### Lane throughput & backlog
+
+Run per source chain (`$sourceChains` regex, default all lanes into `$destChain`).
+`seqnum_invariant_violation` is the one `CRIT` here — it's explicitly documented in-code as a
+stall signal, not routine noise. `offramp_lane_status="rmn_misconfigured"` is the other `CRIT`:
+config drift, not a transient condition. Both `pending_messages` and `offramp_lane_status` are
+`always_emitted: true` — don't let an empty result for either read as "no lanes, nothing to
+worry about."
+
+### Cursing & consensus
+
+Cursing is `WARN` not `CRIT` deliberately: an active curse is frequently an intentional,
+already-known state (see `uncommitted-message.md` step4), and a health check that pages on
+expected state trains people to ignore it. `consensus_observation_failed` is unambiguous `CRIT`
+when it fires — by construction it can only mean the DON-wide FChain agreement failed for this
+destination chain, which cannot happen for benign reasons — but it's `always_emitted: false`, so
+absence is the expected/healthy state, not a gap in coverage.
+
+### Report transmission
+
+`report_transmission_gave_up` is `CRIT`. `report_validation_rejected` is split by reason:
+`stale` alone is `INFO`, anything else present is `WARN`, and — being `always_emitted: false` —
+a fully empty result is `OK`, not `UNKNOWN`.
+
+## Aggregation rule
+
+Overall status is the worst individual status, `CRIT` > `WARN` > `UNKNOWN` > `INFO`/`OK`, with
+one explicit combination rule: **`fchain_read_errors` (`WARN`) firing at the same time as
+`consensus_observation_failed` (`CRIT`) doesn't change the overall verdict (already `CRIT`) but
+should be called out together in `concerns` as one finding, not two** — they're the same
+incident (H1 in `uncommitted-message.md`'s Scenario 3), and reporting them separately reads as
+two problems instead of one with corroborating evidence.
+
+`UNKNOWN` is never silently dropped to `OK` — but per the [empty-result rule](#empty-result-sets-the-rule-that-actually-matters),
+most checks should legitimately resolve `UNKNOWN` only when an `always_emitted: true` check comes
+back empty, which in a genuinely healthy, actively-running system should be rare. If you're
+seeing `UNKNOWN` on an `always_emitted: false` check, re-check that you applied the
+empty-means-zero rule for that check before reporting it as a pipeline problem.
+
+## Output contract
+
+```yaml
+health_report:
+  destChain: string
+  sourceChains: string        # the regex actually used
+  timestamp: string           # ISO8601, when checks were run
+  overall: OK | WARN | CRIT | UNKNOWN
+  checks:
+    - id: string               # matches an id in the Checklist above
+      status: OK | WARN | CRIT | UNKNOWN | INFO
+      value: string            # scalar checks: the raw number. Multi-series (`by (...)`) checks,
+                                # regardless of how many grouping labels the query has: for each
+                                # series, join ALL of its grouping labels into one
+                                # "label1=v1,label2=v2" key, then ":", then the numeric result;
+                                # separate series with "; ". E.g. a `by (source_network_name,
+                                # status)` result becomes
+                                # "source_network_name=chain-a,status=live:1; source_network_name=chain-a,status=rmn_misconfigured:0; ...".
+                                # This is the canonical non-paraphrased form, not free-form
+                                # summarization -- do not drop labels or collapse series to save space.
+      note: string             # optional, only if it adds something the checklist note doesn't
+  concerns:                    # every non-OK/non-INFO finding, worst first, plus any UNKNOWN.
+                                # Use an empty list (`concerns: []`) when there are none -- never
+                                # omit the key.
+    - checks: [string]         # one or more related check ids (see the fchain/consensus combination rule)
+      severity: WARN | CRIT | UNKNOWN
+      summary: string
+      owner: string             # copy from the matching check's `owner` field in the Checklist.
+                                 # If a concern spans checks with different owners, list the
+                                 # primary one first and name the others in `summary`.
+```
+
+Do not page, escalate, or act on any `concerns` entry — this contract's job is to hand a human
+(or the next runbook) a report, the same non-negotiable boundary as `uncommitted-message.md`'s
+`REPORT:<owner>`.

--- a/docs/runbooks/uncommitted-message.md
+++ b/docs/runbooks/uncommitted-message.md
@@ -141,10 +141,19 @@ steps:
     query: 'sum(rate(ccip_commit_report_validation_rejected_total{chainID=~"$destChain", phase="should_transmit"}[15m])) by (reason)'
     condition: "any reason count > 0"
     if_true:
-      config_digest_mismatch: {action: "REPORT:ccip-commit-oncall", reason: "config sync issue; cross-check ccip_commit_config_digest_mismatch"}
-      stale:                  {action: "STOP", reason: "often benign — a different overlapping report already landed; re-check step1, the gauge may have just moved"}
-      dest_not_supported:     {action: "REPORT:ccip-commit-oncall", reason: "transmission-schedule/config bug"}
-      cursed:                 {action: "CONTINUE:step4", reason: "converges with step4"}
+      config_digest_mismatch:  {action: "REPORT:ccip-commit-oncall", reason: "config sync issue; cross-check ccip_commit_config_digest_mismatch"}
+      config_digest_check_error: {action: "REPORT:chain-infra-oncall", reason: "error *reading* the offramp's config digest (RPC/read failure), distinct from an actual mismatch -- chain-B read/infra issue, not a config sync issue"}
+      stale:                   {action: "STOP", reason: "often benign — a different overlapping report already landed; re-check step1, the gauge may have just moved"}
+      dest_not_supported:      {action: "REPORT:ccip-commit-oncall", reason: "transmission-schedule/config bug"}
+      dest_support_check_error: {action: "REPORT:chain-infra-oncall", reason: "error *checking* dest-chain support (RPC/read failure), distinct from a real config gap"}
+      cursed:                  {action: "CONTINUE:step4", reason: "converges with step4"}
+      cursed_check_error:      {action: "REPORT:chain-infra-oncall", reason: "error *checking* the curse state (RPC/read failure), not an actual curse -- don't conflate with step4's cursed=1 case"}
+      empty_root:              {action: "REPORT:ccip-commit-oncall", reason: "report-builder produced an empty merkle root; likely a bug upstream in the merkleroot processor, not an infra issue"}
+      invalid_seqnum_range:    {action: "REPORT:ccip-commit-oncall", reason: "report-builder produced start>end seqnums; likely a bug upstream in the merkleroot processor"}
+      decode_report:           {action: "REPORT:ccip-commit-oncall", reason: "report codec failure; check for a report-codec/chainlink-common version skew across the DON"}
+      decode_report_info:      {action: "REPORT:ccip-commit-oncall", reason: "same as decode_report but for the report-info envelope"}
+      root_blessing_mismatch:  {action: "REPORT:ccip-commit-oncall", reason: "root blessing validation failed; check on-chain blessing state for the roots in this report. RMN signing itself is dead code (RMNEnabled hardcoded off) but this specific check still runs"}
+      default:                 {action: "REPORT:ccip-commit-oncall", reason: "reason string not in this list -- do NOT go source-diving to interpret it as one of the reasons above by guessing. Report the exact reason string, the rate, and say explicitly this runbook doesn't have a mapping for it yet. (This is exactly how a hardcoded test-only fault injection with reason=\"forced_test_failure\" surfaces if a stale binary is still deployed -- treat an unmapped reason as equally likely to be a real new rejection path OR leftover test/debug code, and say you can't tell which from metrics alone.)"}
     if_false: {action: "CONTINUE:scenario2b", reason: "never rejected locally — check on-chain / read-lag hypotheses"}
     automatable: true
 
@@ -277,10 +286,27 @@ sum(rate(ccip_commit_report_validation_rejected_total{chainID=~"$destChain", pha
 ```
 - `config_digest_mismatch` climbing → cross-check `ccip_commit_config_digest_mismatch`; config
   sync issue.
+- `config_digest_check_error` → an RPC/read error *checking* the digest, not an actual mismatch —
+  chain-B infra issue, don't conflate with the reason above.
 - `stale` climbing → often benign — a different, overlapping report already landed; re-check
   step1, it may have just moved.
 - `dest_not_supported` → transmission-schedule/config bug.
+- `dest_support_check_error` → RPC/read error checking dest support, not a real config gap.
 - `cursed` → converges with step4.
+- `cursed_check_error` → RPC/read error checking curse state, not an actual curse — don't
+  conflate with step4's `cursed=1`.
+- `empty_root` / `invalid_seqnum_range` → the report-builder produced an invalid report; likely a
+  bug upstream in the merkleroot processor, not an infra issue.
+- `decode_report` / `decode_report_info` → report/report-info codec failure; check for a
+  report-codec or `chainlink-common` version skew across the DON.
+- `root_blessing_mismatch` → on-chain root blessing validation failed for this report. RMN
+  signing itself is dead code (`RMNEnabled` hardcoded off) but this specific check still runs.
+- **Any other reason string** → do not guess which of the above it's "close enough to." Report
+  the exact string and rate and say plainly this runbook has no mapping for it — confirmed by
+  live testing that an unmapped reason (`forced_test_failure`, deliberately not a real production
+  value) forces exactly this situation. An unmapped reason is equally likely to be a genuinely
+  new rejection path in the code or leftover test/debug instrumentation in a stale binary; metrics
+  alone can't tell you which, and the doc shouldn't pretend otherwise.
 - All flat → move to B.
 
 **B — transmitted, reverted/stuck on-chain.** *(`automatable: false` — outside commit-plugin

--- a/docs/runbooks/uncommitted-message.md
+++ b/docs/runbooks/uncommitted-message.md
@@ -9,6 +9,7 @@ inputs:
   destChain: {type: string, description: "chainID/chain_id label value of the destination chain, e.g. chain-b"}
   seqNum: {type: integer, description: "onramp sequence number of the message under investigation (X)"}
   msgID: {type: string, description: "message ID, hex, for cross-referencing logs/explorers"}
+  fRoleDON: {type: integer, required: false, description: "optional. If known, expected live oracle count for destChain's DON is 3*fRoleDON+1 and the consensus threshold is 2*fRoleDON+1. Omit if uncertain (e.g. local devenvs with a possible bootstrap-node offset) -- scenario3's H0 check reports the raw live oracle count either way, it just can't grade it against a threshold without this."}
 related:
   - docs/metrics/commit-metrics.md        # design rationale + full metric-by-metric findings
   - devenv/dashboards/commit-plugin.json  # Grafana rendering of this runbook (Guided Debug section)
@@ -85,11 +86,12 @@ against your actual datasource's metric browser before trusting the rest; don't 
 steps:
   - id: step0
     check: plugin_heartbeat
-    query: 'sum(rate(ccip_commit_plugin_heartbeat_total{chainID=~"$destChain"}[5m]))'
+    query: 'sum(rate(ccip_commit_plugin_heartbeat_total{chainID=~"$destChain"}[1m]))'
     condition: "result == 0"
-    if_true:  {action: "REPORT:ccip-commit-oncall", reason: "plugin process is not running rounds at all; every other metric below may simply be stale, not bad"}
+    if_true:  {action: "REPORT:ccip-commit-oncall", reason: "plugin process is not running rounds at all; every other metric below may simply be stale, not bad. Always run followup_query before reporting -- a bare 'not running' is a real but unsatisfyingly blunt finding on its own (confirmed by live testing: an agent that stopped here reported a correct but generic conclusion, then went and ran this exact followup_query anyway 'out of curiosity' because the plain heartbeat result didn't feel actionable)", followup_query: 'count(count by (csa_public_key) (timestamp(ccip_commit_plugin_heartbeat_total{chainID=~"$destChain", phase="observation"}) > time() - 60))', followup_meaning: "live oracle headcount -- this is a DON-level signal, same trust tier as heartbeat itself, safe to check here even though lane-specific metrics below are not (yet) trustworthy. A low count turns 'plugin not running' into 'N of the DON's oracles are actually alive', which is what an on-call needs next regardless of whether it's below consensus threshold -- grade it against $fRoleDON per scenario3b's rule if known, otherwise report the raw number"}
     if_false: {action: "CONTINUE:step1"}
     automatable: true
+    note: "window is deliberately 1m, not 5m -- confirmed by live testing (see scenario3b's note) that rate() extrapolates across its whole window, so a plugin that died N minutes ago still reads as alive for up to [window] more minutes. Don't widen this without re-testing against a forced failure."
 
   - id: step1
     check: offramp_next_seq_num
@@ -167,11 +169,23 @@ steps:
     automatable: true
 
   - id: scenario3b
+    check: h0_live_oracle_count
+    query: 'count(count by (csa_public_key) (timestamp(ccip_commit_plugin_heartbeat_total{chainID=~"$destChain", phase="observation"}) > time() - 60))'
+    condition: "compare result against 2*fRoleDON+1 (consensus threshold) and 3*fRoleDON+1 (full DON), if fRoleDON was supplied as an input"
+    if_true:
+      below_threshold:   {action: "REPORT:ccip-commit-oncall", reason: "H0 — result < 2*fRoleDON+1: too few oracles are even running to reach consensus, full stop. This is the answer; don't proceed to H1/H2, they're checks for a *different* failure mode (an oracle that's running but can't read its home chain, or oracles that disagree) and will likely read as flat/inconclusive here even though they're not the cause."}
+      degraded_but_over_threshold: {action: "CONTINUE:scenario3c", reason: "some oracles down but still >= 2*fRoleDON+1; consensus should theoretically still be possible, so if it's failing anyway H1/H2 are still the right next check"}
+      full_don:          {action: "CONTINUE:scenario3c", reason: "oracle count isn't the explanation; proceed to H1/H2"}
+    if_false: {action: "CONTINUE:scenario3c", reason: "fRoleDON wasn't supplied — report the raw count as context (see note) and proceed to H1/H2 regardless; a human/agent should sanity-check the count against what they know the DON size to be before trusting H1/H2's conclusion"}
+    automatable: true
+    note: "csa_public_key uniquely identifies each node in every commit metric series (confirmed empirically, not just in the source) -- this is a direct headcount, not a proxy. Deliberately uses timestamp()-vs-time(), not rate()>0: confirmed by live testing that rate([5m])>0 stays true for up to 5 minutes after a node actually stops (rate() extrapolates across its whole window using the oldest/newest samples it finds), which silently under-counts a fresh outage. timestamp() answers 'did this series get a sample in the last 60s' directly, no extrapolation lag. Distinguishes 'not enough oracles are online' (a category H1/H2 cannot detect at all, since fchain_read_errors only reports a *surviving* oracle's own read failures and has no way to see oracles that never started) from the H1/H2 failure modes below. This is exactly the gap docs/metrics/commit-metrics.md's unimplemented ccip_commit_consensus_dropped{reason=\"insufficient_agreement\"} would otherwise close at the source instead of needing to be inferred from heartbeat cardinality."
+
+  - id: scenario3c
     check: h1_vs_h2
     query: 'sum(rate(ccip_commit_fchain_read_errors_total{chainID=~"$destChain"}[5m]))'
     condition: "result spiking broadly across oracles"
     if_true:  {action: "REPORT:home-chain-infra-oncall", reason: "H1 — too few oracles could read FChain; home-chain RPC/read outage"}
-    if_false: {action: "REPORT:ccip-commit-oncall", reason: "H2 — oracles likely disagree (split vote). Needs ccip_commit_consensus_dropped{reason=\"split\"}, NOT IMPLEMENTED as of this writing — see Known gaps. Corroborate with ccip_commit_config_digest_mismatch flipping for a subset of oracles around the same time.", followup_query: 'ccip_commit_config_digest_mismatch{chain_id=~"$destChain"}'}
+    if_false: {action: "REPORT:ccip-commit-oncall", reason: "H2 — oracles likely disagree (split vote). Needs ccip_commit_consensus_dropped{reason=\"split\"}, NOT IMPLEMENTED as of this writing — see Known gaps. Corroborate with ccip_commit_config_digest_mismatch flipping for a subset of oracles around the same time. If scenario3b (H0) wasn't able to rule out insufficient participation (fRoleDON unknown), treat this H2 conclusion as low-confidence, not a firm diagnosis.", followup_query: 'ccip_commit_config_digest_mismatch{chain_id=~"$destChain"}'}
     automatable: true
 ```
 
@@ -184,9 +198,17 @@ reports "no signal" identically whether the plugin is healthy-and-idle or wedged
 that out before reading anything else as a bad value.
 
 ```promql
-sum(rate(ccip_commit_plugin_heartbeat_total{chainID=~"$destChain"}[5m]))
+sum(rate(ccip_commit_plugin_heartbeat_total{chainID=~"$destChain"}[1m]))
 ```
-`0` → nothing else here is trustworthy; report and stop. `> 0` → continue.
+`0` → before reporting, also run the oracle headcount (same query as scenario3b's H0 —
+it's a DON-level signal, safe to check even though lane-specific metrics aren't trustworthy yet):
+```promql
+count(count by (csa_public_key) (timestamp(ccip_commit_plugin_heartbeat_total{chainID=~"$destChain", phase="observation"}) > time() - 60))
+```
+Report both numbers together. "Plugin not running rounds" on its own is a real but blunt
+finding — confirmed by live testing that it's unsatisfying enough that whoever's investigating
+will go run this exact query anyway; do it here instead of making them rediscover it. `> 0` →
+continue to step1.
 
 ### step1 — is this even a commit-plugin problem?
 
@@ -282,12 +304,30 @@ fails is the DON not reaching 2·fRoleDON+1 agreement on a single FChain value f
   max by (source_network_name) (ccip_commit_pending_messages{dest_network_name=~".*"})
   ```
   If only `$sourceChain` is affected, this branch is wrong — back to step4/step5.
+- **H0 — not enough oracles are even running.** *(Check this before H1/H2 — it's a distinct
+  failure mode neither of them can detect, not a variant of either.)* `fchain_read_errors` below
+  only reports a *surviving* oracle's own read failures; it has no way to see an oracle that
+  never started at all. Count oracles that got an Observation-phase heartbeat sample in the last
+  60s — `csa_public_key` uniquely identifies each node in every commit metric series. Uses
+  `timestamp()`, not `rate()>0`: `rate()` extrapolates across its whole window, so it stays
+  `> 0` for up to that window's length after a node actually dies — confirmed by live testing,
+  this genuinely produced a stale headcount at `[5m]` that only corrected itself once enough
+  time had passed:
+  ```promql
+  count(count by (csa_public_key) (timestamp(ccip_commit_plugin_heartbeat_total{chainID=~"$destChain", phase="observation"}) > time() - 60))
+  ```
+  If `$fRoleDON` is known: `< 2*$fRoleDON+1` → this **is** the answer, stop here — don't let a
+  flat H1 push you toward H2 below, H1/H2 are checks for a different failure mode and will likely
+  look inconclusive here even though they're not the cause. `>= 2*$fRoleDON+1` → oracle count
+  isn't the explanation, continue. If `$fRoleDON` is unknown, report the raw count as context and
+  continue regardless — but treat whatever H1/H2 concludes below as lower-confidence, since you
+  haven't ruled this out.
 - **H1 — too few oracles could read it.**
   ```promql
   sum(rate(ccip_commit_fchain_read_errors_total{chainID=~"$destChain"}[5m]))
   ```
   Spiking broadly across oracles → home-chain RPC/read outage.
-- **H2 — oracles disagree (split vote).** *(Needs `ccip_commit_consensus_dropped{objectName="fChain", reason="split"}` — **not implemented**, reviewed design only, see [Known gaps](#known-gaps).)*
+- **H2 — oracles disagree (split vote).** *(Needs `ccip_commit_consensus_dropped{objectName="fChain", reason="split"}` — **not implemented**, reviewed design only, see [Known gaps](#known-gaps). This is genuine disagreement among oracles that DID submit a value — not the same as H0's "too few submitted at all.")*
   Corroborate with:
   ```promql
   ccip_commit_config_digest_mismatch{chain_id=~"$destChain"}

--- a/docs/runbooks/uncommitted-message.md
+++ b/docs/runbooks/uncommitted-message.md
@@ -1,0 +1,339 @@
+---
+name: uncommitted-message
+description: Triage a message that has not landed on the destination offramp within the expected time window.
+trigger: "message reported in-flight for > 15m: onramp seq num observed, no corresponding offramp commit"
+severity: page
+owner: ccip-commit-oncall
+inputs:
+  sourceChain: {type: string, description: "source_network_name label value, e.g. chain-a"}
+  destChain: {type: string, description: "chainID/chain_id label value of the destination chain, e.g. chain-b"}
+  seqNum: {type: integer, description: "onramp sequence number of the message under investigation (X)"}
+  msgID: {type: string, description: "message ID, hex, for cross-referencing logs/explorers"}
+related:
+  - docs/metrics/commit-metrics.md        # design rationale + full metric-by-metric findings
+  - devenv/dashboards/commit-plugin.json  # Grafana rendering of this runbook (Guided Debug section)
+status: living
+---
+
+- [Runbook: uncommitted message](#runbook-uncommitted-message)
+   * [For agents](#for-agents)
+      + [A note on counter naming](#a-note-on-counter-naming)
+   * [Decision graph](#decision-graph)
+   * [Steps](#steps)
+      + [step0 — is the plugin alive at all?](#step0-is-the-plugin-alive-at-all)
+      + [step1 — is this even a commit-plugin problem?](#step1-is-this-even-a-commit-plugin-problem)
+      + [step2 — has the plugin observed it on-chain yet?](#step2-has-the-plugin-observed-it-on-chain-yet)
+      + [step3 — is the round producing outcomes at all?](#step3-is-the-round-producing-outcomes-at-all)
+      + [step4 — is chain A or B cursed?](#step4-is-chain-a-or-b-cursed)
+      + [step5 — is a report being built but never landing?](#step5-is-a-report-being-built-but-never-landing)
+   * [Deep dives](#deep-dives)
+      + [Scenario 2 — report transmission stuck (step5)](#scenario-2-report-transmission-stuck-step5)
+      + [Scenario 3 — consensus never completes (step3)](#scenario-3-consensus-never-completes-step3)
+   * [Metric reference](#metric-reference)
+   * [Known gaps](#known-gaps)
+
+# Runbook: uncommitted message
+
+A message's onramp sequence number has been observed but no report covering it has landed on
+the destination offramp within the expected window. This runbook walks source → destination
+metrics to find where the pipeline is stuck.
+
+## For agents
+
+This doc is meant to be walked mechanically, not just read. Two things make that possible:
+
+1. **[Decision graph](#decision-graph)** below is the authoritative control flow. Each step has
+   a `query` (fill in `$sourceChain`/`$destChain`/`$seqNum` from the Inputs above) and a
+   `condition`. Evaluate the query against your Prometheus-compatible datasource, evaluate the
+   condition, and follow the matching outcome. The prose in [Steps](#steps) explains *why* each
+   step exists — read it if you need rationale, skip it if you don't.
+2. **Outcome vocabulary** is fixed and every step uses only these three:
+   - `STOP` — investigation is resolved from commit-plugin metrics alone. Nothing further to check.
+   - `CONTINUE:<step_id>` — proceed to the named step.
+   - `REPORT:<owner>` — a plausible root cause was found, but it names a system, decision, or
+     action outside this runbook's scope (another team, an on-chain tx, a config change). **Do
+     not page, escalate, or act on `REPORT` yourself** — surface the finding, the evidence
+     (the query + result that produced it), and the suggested `<owner>` to the human, and stop.
+
+   Every check in this runbook is a read-only PromQL query (`automatable: true`). A few steps in
+   the deep dives point at systems this runbook has no query for (chain explorers, TXM
+   dashboards) — those are marked `automatable: false`; treat them the same as `REPORT`: name
+   what a human should look at, don't try to fetch it yourself unless you have another tool for
+   it.
+
+If a query's metric doesn't exist on your datasource (e.g. `ccip_commit_consensus_dropped`,
+see [Known gaps](#known-gaps)), treat the result as unknown, not as `0`/flat — say so explicitly
+rather than silently treating "no such metric" as "no signal."
+
+### A note on counter naming
+
+Every metric below is named as it's registered in `commit/metrics/prom.go`. Whether you need to
+append `_total` depends on how metrics reach your datasource, **not** on the runbook — see the
+[metric reference table](#metric-reference) for the per-metric OTel type. Beholder-only metrics
+(anything not also `promauto`-registered) only ever leave the node as OTel instruments; if your
+pipeline converts those to Prometheus via an OTel collector's `prometheusremotewrite` exporter
+(e.g. this repo's `devenv` VictoriaMetrics stack, see `devenv/env.toml` /
+`docs/metrics/commit-metrics.md`), every `Counter` gets a `_total` suffix and every `Histogram`
+becomes `_bucket`/`_sum`/`_count` — `Gauge`s are untouched. If instead you're scraping a
+`promauto`-registered metric directly (only the handful of pre-existing metrics that have both a
+`promauto` and a Beholder registration — see the table), no suffix is added. Check one query
+against your actual datasource's metric browser before trusting the rest; don't assume.
+
+## Decision graph
+
+```yaml
+steps:
+  - id: step0
+    check: plugin_heartbeat
+    query: 'sum(rate(ccip_commit_plugin_heartbeat_total{chainID=~"$destChain"}[5m]))'
+    condition: "result == 0"
+    if_true:  {action: "REPORT:ccip-commit-oncall", reason: "plugin process is not running rounds at all; every other metric below may simply be stale, not bad"}
+    if_false: {action: "CONTINUE:step1"}
+    automatable: true
+
+  - id: step1
+    check: offramp_next_seq_num
+    query: 'max by (source_network_name) (ccip_commit_offramp_next_seq_num{source_network_name=~"$sourceChain"})'
+    condition: "result > $seqNum"
+    if_true:  {action: "STOP", reason: "a root covering X already landed on the offramp; commit plugin's job is done, hand off to exec on-call for delivery status"}
+    if_false: {action: "CONTINUE:step2"}
+    automatable: true
+
+  - id: step2
+    check: onramp_max_seq_num
+    query: 'max by (source_network_name) (ccip_commit_onramp_max_seq_num{source_network_name=~"$sourceChain"})'
+    condition: "result < $seqNum"
+    if_true:  {action: "REPORT:chain-infra-oncall", reason: "onramp read is lagging; check ccip_commit_merkleroot_observation_errors_total by reason (no_bindings/timeout/rpc_error) for the source-chain read/infra issue", followup_query: 'sum(rate(ccip_commit_merkleroot_observation_errors_total{source_network_name=~"$sourceChain"}[5m])) by (reason)'}
+    if_false: {action: "CONTINUE:step3"}
+    automatable: true
+
+  - id: step3
+    check: consensus_observation_failed
+    query: 'sum(rate(ccip_commit_consensus_observation_failed_total{chain_id=~"$destChain"}[5m]))'
+    condition: "result > 0"
+    if_true:  {action: "CONTINUE:scenario3", reason: "destination-chain-wide consensus failure — see deep dive"}
+    if_false: {action: "CONTINUE:step4"}
+    automatable: true
+
+  - id: step4
+    check: cursing
+    queries:
+      - 'max(ccip_commit_rmn_curse_active{chain_id=~"$destChain", curse_type="global"})'
+      - 'max(ccip_commit_rmn_curse_active{chain_id=~"$destChain", curse_type="destination"})'
+      - 'max(ccip_commit_source_chain_cursed{source_network_name=~"$sourceChain"})'
+    condition: "any result == 1"
+    if_true:  {action: "REPORT:curse-owner", reason: "chain A or B is cursed; likely intentional/incident-flagged, hand off to whoever owns the curse"}
+    if_false: {action: "CONTINUE:step5"}
+    automatable: true
+
+  - id: step5
+    check: report_transmission
+    query: 'sum(rate(ccip_commit_report_transmission_gave_up_total{source_network_name=~"$sourceChain"}[5m]))'
+    condition: "result > 0"
+    if_true:  {action: "CONTINUE:scenario2", reason: "report is being built but never landing — see deep dive"}
+    if_false: {action: "REPORT:ccip-commit-oncall", reason: "no failure signal found; likely just backlog size — report ccip_commit_pending_messages and an ETA estimate from round cadence", followup_query: 'max by (source_network_name) (ccip_commit_pending_messages{source_network_name=~"$sourceChain"})'}
+    automatable: true
+
+  - id: scenario2
+    check: report_validation_rejected
+    query: 'sum(rate(ccip_commit_report_validation_rejected_total{chainID=~"$destChain", phase="should_transmit"}[15m])) by (reason)'
+    condition: "any reason count > 0"
+    if_true:
+      config_digest_mismatch: {action: "REPORT:ccip-commit-oncall", reason: "config sync issue; cross-check ccip_commit_config_digest_mismatch"}
+      stale:                  {action: "STOP", reason: "often benign — a different overlapping report already landed; re-check step1, the gauge may have just moved"}
+      dest_not_supported:     {action: "REPORT:ccip-commit-oncall", reason: "transmission-schedule/config bug"}
+      cursed:                 {action: "CONTINUE:step4", reason: "converges with step4"}
+    if_false: {action: "CONTINUE:scenario2b", reason: "never rejected locally — check on-chain / read-lag hypotheses"}
+    automatable: true
+
+  - id: scenario2b
+    check: transmitted_but_stuck_or_read_lag
+    hypotheses:
+      - name: "reverted/stuck on-chain"
+        action: "REPORT:chain-b-txm-oncall"
+        reason: "outside commit-plugin metrics — check chain B's TXM/tx-sender dashboard for the assigned transmitter (nonce gap, underpriced gas, wallet balance, revert reason)"
+        automatable: false
+      - name: "actually succeeded, read is lagging"
+        action: "REPORT:ccip-commit-oncall"
+        reason: "ccip_commit_offramp_next_seq_num is sourced from this plugin's own chain-B reader; cross-check chain B's block explorer / chain-reader health directly before escalating further"
+        automatable: false
+
+  - id: scenario3
+    check: destination_wide_vs_lane_specific
+    query: 'max by (source_network_name) (ccip_commit_pending_messages{dest_network_name=~".*"})'
+    condition: "only $sourceChain's series is climbing, others into the same destChain are flat"
+    if_true:  {action: "CONTINUE:step4", reason: "this branch is wrong if only one lane is affected — back to step4/step5"}
+    if_false: {action: "CONTINUE:scenario3b", reason: "confirmed destination-chain-wide"}
+    automatable: true
+
+  - id: scenario3b
+    check: h1_vs_h2
+    query: 'sum(rate(ccip_commit_fchain_read_errors_total{chainID=~"$destChain"}[5m]))'
+    condition: "result spiking broadly across oracles"
+    if_true:  {action: "REPORT:home-chain-infra-oncall", reason: "H1 — too few oracles could read FChain; home-chain RPC/read outage"}
+    if_false: {action: "REPORT:ccip-commit-oncall", reason: "H2 — oracles likely disagree (split vote). Needs ccip_commit_consensus_dropped{reason=\"split\"}, NOT IMPLEMENTED as of this writing — see Known gaps. Corroborate with ccip_commit_config_digest_mismatch flipping for a subset of oracles around the same time.", followup_query: 'ccip_commit_config_digest_mismatch{chain_id=~"$destChain"}'}
+    automatable: true
+```
+
+## Steps
+
+### step0 — is the plugin alive at all?
+
+Not in the original design doc's walkthrough, but should be checked first: every metric below
+reports "no signal" identically whether the plugin is healthy-and-idle or wedged/crashed. Rule
+that out before reading anything else as a bad value.
+
+```promql
+sum(rate(ccip_commit_plugin_heartbeat_total{chainID=~"$destChain"}[5m]))
+```
+`0` → nothing else here is trustworthy; report and stop. `> 0` → continue.
+
+### step1 — is this even a commit-plugin problem?
+
+```promql
+max by (source_network_name) (ccip_commit_offramp_next_seq_num{source_network_name=~"$sourceChain"})
+```
+`> $seqNum` → a root covering it already landed on the offramp. Commit plugin's job is done;
+hand off to exec on-call. `<= $seqNum` → continue.
+
+### step2 — has the plugin observed it on-chain yet?
+
+```promql
+max by (source_network_name) (ccip_commit_onramp_max_seq_num{source_network_name=~"$sourceChain"})
+```
+`< $seqNum` → onramp read is lagging. Check the reason breakdown:
+```promql
+sum(rate(ccip_commit_merkleroot_observation_errors_total{source_network_name=~"$sourceChain"}[5m])) by (reason)
+```
+(`no_bindings` / `timeout` / `rpc_error` / `msg_count_mismatch` / `hash_error` /
+`address_lookup_error`). This is a source-chain read/infra issue, not commit logic — report and
+stop. `>= $seqNum` → plugin has seen it; continue.
+
+### step3 — is the round producing outcomes at all?
+
+```promql
+sum(rate(ccip_commit_consensus_observation_failed_total{chain_id=~"$destChain"}[5m]))
+```
+Incrementing → destination-chain-wide consensus failure, jump to [Scenario 3](#scenario-3--consensus-never-completes-step3).
+Flat → continue.
+
+### step4 — is chain A or B cursed?
+
+```promql
+max(ccip_commit_rmn_curse_active{chain_id=~"$destChain", curse_type="global"})
+max(ccip_commit_rmn_curse_active{chain_id=~"$destChain", curse_type="destination"})
+max(ccip_commit_source_chain_cursed{source_network_name=~"$sourceChain"})
+```
+Any `== 1` → found it; likely intentional/incident-flagged, report to whoever owns the curse and
+stop. All `0` → continue.
+
+> RMN-signature branches (signed-roots-dropped, chain quorum, Byzantine root disagreement) are
+> intentionally absent from this runbook: `RMNEnabled` is hardcoded off in production, so those
+> paths are dead code. Cursing (this step) is the one RMN-adjacent signal still live.
+
+### step5 — is a report being built but never landing?
+
+```promql
+sum(rate(ccip_commit_report_transmission_gave_up_total{source_network_name=~"$sourceChain"}[5m]))
+```
+Incrementing/maxed → jump to [Scenario 2](#scenario-2--report-transmission-stuck-step5).
+Otherwise → likely just backlog size:
+```promql
+max by (source_network_name) (ccip_commit_pending_messages{source_network_name=~"$sourceChain"})
+```
+Report the backlog size and an ETA estimate from round cadence, and stop.
+
+## Deep dives
+
+### Scenario 2 — report transmission stuck (step5)
+
+Three hypotheses, cheapest first.
+
+**A — never transmitted (rejected pre-send).**
+```promql
+sum(rate(ccip_commit_report_validation_rejected_total{chainID=~"$destChain", phase="should_transmit"}[15m])) by (reason)
+```
+- `config_digest_mismatch` climbing → cross-check `ccip_commit_config_digest_mismatch`; config
+  sync issue.
+- `stale` climbing → often benign — a different, overlapping report already landed; re-check
+  step1, it may have just moved.
+- `dest_not_supported` → transmission-schedule/config bug.
+- `cursed` → converges with step4.
+- All flat → move to B.
+
+**B — transmitted, reverted/stuck on-chain.** *(`automatable: false` — outside commit-plugin
+metrics.)* Check chain B's TXM/tx-sender dashboards for the assigned transmitter (nonce gap,
+underpriced gas, wallet balance, revert reason).
+
+**C — actually succeeded, read is lagging.** *(`automatable: false`.)*
+`ccip_commit_offramp_next_seq_num` is sourced from this plugin's own chain-B reader; if that's
+behind, "no change" can persist for a few rounds after a real success. Cross-check chain B's
+block explorer / chain-reader health directly before escalating further.
+
+### Scenario 3 — consensus never completes (step3)
+
+Grounded in `getConsensusObservation` (`merkleroot/outcome.go`): the *only* way the whole round
+fails is the DON not reaching 2·fRoleDON+1 agreement on a single FChain value for the
+**destination chain** — every other field degrades gracefully per-chain.
+
+- **This is destination-chain-wide, not lane-specific.** Before going further, check whether
+  *other* source chains reporting into this dest chain are also stalled:
+  ```promql
+  max by (source_network_name) (ccip_commit_pending_messages{dest_network_name=~".*"})
+  ```
+  If only `$sourceChain` is affected, this branch is wrong — back to step4/step5.
+- **H1 — too few oracles could read it.**
+  ```promql
+  sum(rate(ccip_commit_fchain_read_errors_total{chainID=~"$destChain"}[5m]))
+  ```
+  Spiking broadly across oracles → home-chain RPC/read outage.
+- **H2 — oracles disagree (split vote).** *(Needs `ccip_commit_consensus_dropped{objectName="fChain", reason="split"}` — **not implemented**, reviewed design only, see [Known gaps](#known-gaps).)*
+  Corroborate with:
+  ```promql
+  ccip_commit_config_digest_mismatch{chain_id=~"$destChain"}
+  ```
+  flipping for a subset of oracles around the same time.
+
+## Metric reference
+
+`otel_type` is what governs whether a `_total`/`_bucket` suffix gets added by an OTel→Prometheus
+pipeline — see [the naming note above](#a-note-on-counter-naming). `dual` means the metric is
+*also* directly `promauto`-registered (scrapeable without going through Beholder/OTel at all);
+everything else is Beholder-only.
+
+| metric | otel_type | key labels | registration |
+|---|---|---|---|
+| `ccip_commit_plugin_heartbeat` | Counter | `chainFamily,chainID,phase` | beholder-only |
+| `ccip_commit_report_validation_rejected` | Counter | `chainFamily,chainID,phase,reason` | beholder-only |
+| `ccip_commit_onramp_max_seq_num` | Gauge | `sourceChainFamily,sourceChainID,source_network_name` | beholder-only |
+| `ccip_commit_offramp_next_seq_num` | Gauge | `sourceChainFamily,sourceChainID,source_network_name` | beholder-only |
+| `ccip_commit_pending_messages` | Gauge | `sourceChainFamily,sourceChainID,source_network_name` | beholder-only |
+| `ccip_commit_rmn_curse_active` | Gauge | `chain_family,chain_id,curse_type` | beholder-only |
+| `ccip_commit_source_chain_cursed` | Gauge | `sourceChainFamily,sourceChainID,source_network_name` | beholder-only |
+| `ccip_commit_merkleroot_observation_errors` | Counter | `...,reason` | beholder-only |
+| `ccip_commit_fchain_read_errors` | Counter | `chainFamily,chainID` | beholder-only |
+| `ccip_commit_consensus_observation_failed` | Counter | `chain_family,chain_id` | beholder-only |
+| `ccip_commit_report_transmission_gave_up` | Counter | `sourceChainFamily,sourceChainID,source_network_name` | beholder-only |
+| `ccip_commit_report_transmission_attempts` | Histogram | `chainFamily,chainID,success` | beholder-only |
+| `ccip_commit_range_truncated` | Counter | `...,source_network_name` | beholder-only |
+| `ccip_commit_offramp_lane_status` | Gauge | `...,status` | beholder-only |
+| `ccip_commit_seqnum_invariant_violation` | Counter | `...,type` | beholder-only |
+| `ccip_commit_offramp_consensus_insufficient` | Counter | `...,source_network_name` | beholder-only |
+| `ccip_commit_config_digest_mismatch` | Gauge | `chain_family,chain_id` | dual |
+| `ccip_commit_max_sequence_number` | Gauge | `chainFamily,chainID,sourceChainFamily,sourceChain,method,source_network_name,dest_network_name` | dual |
+| `ccip_commit_latest_round_id` | Gauge | `source_network_name,dest_network_name,contract_address,plugin` | dual |
+| `ccip_commit_processor_errors` | Counter | `chainFamily,chainID,processor,method` | dual |
+| `ccip_commit_processor_latency` | Histogram | `chainFamily,chainID,processor,method` | dual |
+| `ccip_commit_loopp_ccip_provider_supported` | Gauge | `chain_family` | dual |
+| `ccip_commit_consensus_dropped` | — | `objectName,key,reason` | **not implemented** (reviewed design only) |
+
+Note the label-casing inconsistency in the source (`chainFamily`/`chainID` vs.
+`chain_family`/`chain_id`) — copy the exact casing from this table per metric, it's not
+uniform across the file.
+
+## Known gaps
+
+- `ccip_commit_consensus_dropped` (Scenario 3, H1/H2 split) is **not implemented** — reviewed
+  design only. Any query against it will return no data; that's expected, not a signal.
+- This runbook assumes `RMNEnabled` is hardcoded off (current production state). If that
+  changes, the RMN-signature branches dropped from step4 need to be reinstated.


### PR DESCRIPTION
For reviewers: it is recommended to read https://github.com/smartcontractkit/chainlink-ccip/blob/mk/CCIP-13011/docs/metrics/commit-metrics.md first. It contains the proposed metrics being added + reasoning as to why. All the code changes are based on this document.

Feel free to skip the dashboard.json changes (they are for the local grafana that is spun up when spinning up devenv).

In addition, we produced agent-runnable (and human-followable) runbooks for determining whether:

* The commit plugin and the merkle root processor is _healthy_ (docs/runbooks/commit-plugin-health.md)
* The commit plugin is misbehaving (and _where_ in the pipeline it is misbehaving) (docs/runbooks/uncommitted-message.md)

There is also a new grafana dashboard that has a Health and Step-by-Step runbook section to help a human debug. These mirror the agent/human runbooks.

We also added a `--victoria` flag to spin up the victoria metrics stack - that's where all the beholder metrics end up.

**Note**: this is intended as a starting point or a building block for more sophisticated runbooks in the future, that use other tools, i.e. `ccip-cli` or plain RPC calls to RPC nodes, if applicable (for e.g. revert reasons). 

## Testing

The runbooks were tested using real AI agents (via Claude Code subagents) against the devenv environment, with a full CCIP DON running these new metrics, sending messages via the smoke test (`go test -count=1 -run "TestE2ESmoke" ./tests/e2e`) throughout.

Testing was iterative, not a single pass: an agent would execute a runbook against a live, deliberately-broken environment, and friction or incorrect conclusions in its output were treated as bugs in the runbook, fixed, then re-verified with another agent run against the same failure. This found and fixed several real defects that reading the docs alone didn't surface — e.g. an empty-result-set check that resolved to a false "healthy" verdict, a `rate()` window that hid a real outage for several minutes, and a decision step that reported a correct-but-unhelpfully-generic finding when a much more specific one was one query away.

Two independent failure modes were forced, exercising different, largely non-overlapping parts of both runbooks:
- **DON outage**: stopped 3 of 6 node containers to simulate a real "DON is down" incident — exercised the health runbook's liveness/oracle-count checks and the debug runbook's `step0` heartbeat gate.
- **Report-transmission failure**: temporarily patched `ShouldTransmitAcceptedReport` (`commit/report.go`, reverted before merge — see commit history) to always reject, simulating a stuck/misbehaving transmission path — exercised `step5`→`scenario2`'s rejection-reason branching, including a reason the runbook didn't originally have a mapping for (fixed with a fallback arm).

To reproduce, do the following:

```
# go get this branch's sha in your local chainlink directory first
cd devenv
# Build the ccip cli
just cli
# Start victoria metrics
ccip obs up --victoria 
# Start the don, build the chainlink image
ccip up env.toml,env-anvil.toml,env-cl-rebuild.toml
# Visit localhost:3000 for grafana, go to Dashboards/local/CCIP Commit Plugin
# Send some messages 
go test -count=1 -run "TestE2ESmoke" ./tests/e2e
```