### PR TITLE
Add SuiExtraArgsV1

### DIFF
--- a/chains/solana/contracts/programs/fee-quoter/src/extra_args.rs
+++ b/chains/solana/contracts/programs/fee-quoter/src/extra_args.rs
@@ -18,6 +18,9 @@ pub const GENERIC_EXTRA_ARGS_V2_TAG: u32 = 0x181dcf10;
 /// bytes4(keccak256("CCIP SVMExtraArgsV1"));
 pub const SVM_EXTRA_ARGS_V1_TAG: u32 = 0x1f3b3aba;
 
+// Extra args tag for chains that use the Sui VM.
+pub const SUI_EXTRA_ARGS_V1_TAG: u32 = 0x21ea4ca9;
+
 /// The maximum number of accounts that can be passed in SVMExtraArgs.
 pub const SVM_EXTRA_ARGS_MAX_ACCOUNTS: usize = 64;
 
@@ -61,10 +64,30 @@ impl SVMExtraArgsV1 {
         buffer.append(&mut data);
         buffer
     }
+
     pub fn default_config(cfg: &DestChainConfig) -> SVMExtraArgsV1 {
         SVMExtraArgsV1 {
             compute_units: cfg.default_tx_gas_limit,
             ..Default::default()
         }
+    }
+}
+
+// Extra Args of message when SVM -> SUI
+#[derive(Clone, AnchorSerialize, AnchorDeserialize, Default)]
+pub struct SuiExtraArgsV1 {
+    pub gas_limit: u128,                    // message gas limit
+    pub allow_out_of_order_execution: bool, // user configurable OOO execution that must match with the DestChainConfig.EnforceOutOfOrderExecution
+    pub token_receiver: [u8; 32],           // cannot be 0-address if tokens are sent in message
+    pub receiver_object_ids: Vec<[u8; 32]>, // list of object ids for messaging on remote SUI chain
+}
+
+impl SuiExtraArgsV1 {
+    pub fn serialize_with_tag(&self) -> Vec<u8> {
+        let mut buffer = SUI_EXTRA_ARGS_V1_TAG.to_be_bytes().to_vec();
+        let mut data = self.try_to_vec().unwrap();
+
+        buffer.append(&mut data);
+        buffer
     }
 }

--- a/chains/solana/contracts/programs/fee-quoter/src/instructions/v1/messages.rs
+++ b/chains/solana/contracts/programs/fee-quoter/src/instructions/v1/messages.rs
@@ -1,8 +1,8 @@
 use anchor_lang::prelude::*;
 
 use ccip_common::v1::{
-    validate_aptos_address, validate_evm_address, validate_sui_address, validate_svm_address,
-    validate_tvm_address,
+    validate_aptos_address, validate_evm_address, validate_svm_address, validate_tvm_address,
+    SUI_PRECOMPILE_SPACE,
 };
 use ccip_common::{
     CommonCcipError, CHAIN_FAMILY_SELECTOR_APTOS, CHAIN_FAMILY_SELECTOR_EVM,
@@ -35,10 +35,36 @@ pub const SUI_TOKEN_TRANSFER_DATA_OVERHEAD: usize = (4 + 32) // source_pool, 4 b
     + 4 // extra_data length, the contents are calculated separately
     + 32; // amount
 
+/// The expected static payload size of a token transfer when Borsh encoded and submitted to SVM.
+/// TokenPool extra data and offchain data sizes are dynamic, and should be accounted for separately.
+pub const SVM_TOKEN_TRANSFER_DATA_OVERHEAD: usize = (4 + 32) // source_pool
+    + 32 // token_address
+    + 4 // gas_amount
+    + 4 // extra_data overhead
+    + 32 // amount
+    + 32 // size of the token lookup table account
+    + 32 // token-related accounts in the lookup table, over-estimated to 32, typically between 11 - 13
+    + 32 // token account belonging to the token receiver, e.g ATA, not included in the token lookup table
+    + 32 // per-chain token pool config, not included in the token lookup table
+    + 32 // per-chain token billing config, not always included in the token lookup table
+    + 32; // OffRamp pool signer PDA, not included in the token lookup table
+
+/// Number of overhead accounts needed for message execution on SVM.
+/// These are message.receiver and the OffRamp Signer PDA specific to the receiver.
+pub const SVM_MESSAGING_ACCOUNTS_OVERHEAD: usize = 2;
+
+/// The size of each SVM account address in bytes.
+pub const SVM_ACCOUNT_BYTE_SIZE: usize = 32;
+
 pub struct MessageInfo {
     pub number_of_tokens: usize,
     pub contains_receiver: bool,
     pub data_len: usize,
+}
+
+pub struct ValidatedMessage {
+    pub processed_extra_args: ProcessedExtraArgs,
+    pub extra_args_data_len: u32,
 }
 
 pub fn validate_svm2any(
@@ -46,7 +72,7 @@ pub fn validate_svm2any(
     dest_chain: &DestChain,
     token_config: &BillingTokenConfig,
     dest_bytes_overhead: &u32,
-) -> Result<ProcessedExtraArgs> {
+) -> Result<ValidatedMessage> {
     require!(
         dest_chain.config.is_enabled,
         FeeQuoterError::DestinationChainDisabled
@@ -66,7 +92,7 @@ pub fn validate_svm2any(
         FeeQuoterError::UnsupportedNumberOfTokens
     );
 
-    let processed_extra_args = process_extra_args(
+    let validated_message = process_extra_args_with_data_len(
         &dest_chain.config,
         &msg.extra_args,
         &MessageInfo {
@@ -79,23 +105,25 @@ pub fn validate_svm2any(
 
     require_gte!(
         dest_chain.config.max_per_msg_gas_limit as u128,
-        processed_extra_args.gas_limit,
+        validated_message.processed_extra_args.gas_limit,
         FeeQuoterError::MessageGasLimitTooHigh,
     );
 
     require!(
         !dest_chain.config.enforce_out_of_order
-            || processed_extra_args.allow_out_of_order_execution,
+            || validated_message
+                .processed_extra_args
+                .allow_out_of_order_execution,
         FeeQuoterError::ExtraArgOutOfOrderExecutionMustBeTrue,
     );
 
     validate_dest_family_address(
         msg,
         dest_chain.config.chain_family_selector,
-        &processed_extra_args,
+        &validated_message.processed_extra_args,
     )?;
 
-    Ok(processed_extra_args)
+    Ok(validated_message)
 }
 
 fn validate_dest_family_address(
@@ -107,7 +135,9 @@ fn validate_dest_family_address(
     match selector {
         CHAIN_FAMILY_SELECTOR_APTOS => validate_aptos_address(&msg.receiver),
         CHAIN_FAMILY_SELECTOR_EVM => validate_evm_address(&msg.receiver),
-        CHAIN_FAMILY_SELECTOR_SUI => validate_sui_address(&msg.receiver),
+        CHAIN_FAMILY_SELECTOR_SUI => {
+            validate_sui_address(&msg.receiver, msg_extra_args.gas_limit > 0)
+        }
         CHAIN_FAMILY_SELECTOR_SVM => {
             validate_svm_address(&msg.receiver, msg_extra_args.gas_limit > 0)
         }
@@ -116,14 +146,14 @@ fn validate_dest_family_address(
     }
 }
 
-// process_extra_args returns serialized extraArgs, gas_limit, allow_out_of_order_execution
+// process_extra_args_with_data_len returns serialized extraArgs, gas_limit, allow_out_of_order_execution
 // it calls the chain-specific extra args validation logic
-pub fn process_extra_args(
+fn process_extra_args_with_data_len(
     dest_config: &DestChainConfig,
     extra_args: &[u8],
     message_info: &MessageInfo,
     dest_bytes_overhead: &u32,
-) -> Result<ProcessedExtraArgs> {
+) -> Result<ValidatedMessage> {
     match u32::from_be_bytes(dest_config.chain_family_selector) {
         CHAIN_FAMILY_SELECTOR_SVM => {
             // Extra args are mandatory for a SVM destination, so the tag must exist.
@@ -134,19 +164,15 @@ pub fn process_extra_args(
             );
             let tag: [u8; 4] = extra_args[..4].try_into().unwrap();
             let mut data = &extra_args[4..];
-            Ok(parse_and_validate_svm_extra_args(
+            parse_and_validate_svm_extra_args(
                 dest_config,
                 tag,
                 &mut data,
-                message_info.number_of_tokens != 0,
-            )?)
+                message_info,
+                dest_bytes_overhead,
+            )
         }
         CHAIN_FAMILY_SELECTOR_SUI => {
-            require!(
-                !extra_args.is_empty(),
-                FeeQuoterError::InvalidInputsMissingExtraArgs
-            );
-
             require_gte!(
                 extra_args.len(),
                 4,
@@ -165,11 +191,14 @@ pub fn process_extra_args(
             )
         }
         _ => {
-            // Extra args are optional for non-SVM destinations. In case there
+            // Extra args are optional for other chain family destinations. In case there
             // are extra args, they must be prefixed by a four byte tag
             // -> bytes4(keccak256("CCIP EVMExtraArgsV2"));
             let Some(tag) = extra_args.get(..4) else {
-                return Ok(ProcessedExtraArgs::defaults(dest_config));
+                return Ok(ValidatedMessage {
+                    processed_extra_args: ProcessedExtraArgs::defaults(dest_config),
+                    extra_args_data_len: 0,
+                });
             };
 
             let mut data = &extra_args[4..];
@@ -181,18 +210,21 @@ pub fn process_extra_args(
 fn parse_and_validate_generic_extra_args(
     tag: [u8; 4],
     data: &mut &[u8],
-) -> Result<ProcessedExtraArgs> {
+) -> Result<ValidatedMessage> {
     match u32::from_be_bytes(tag) {
         GENERIC_EXTRA_ARGS_V2_TAG => {
             if data.is_empty() {
                 Err(FeeQuoterError::InvalidInputsMissingDataAfterExtraArgs.into())
             } else {
                 let args = GenericExtraArgsV2::deserialize(data)?;
-                Ok(ProcessedExtraArgs {
-                    bytes: args.serialize_with_tag(),
-                    gas_limit: args.gas_limit,
-                    allow_out_of_order_execution: args.allow_out_of_order_execution,
-                    token_receiver: None,
+                Ok(ValidatedMessage {
+                    processed_extra_args: ProcessedExtraArgs {
+                        bytes: args.serialize_with_tag(),
+                        gas_limit: args.gas_limit,
+                        allow_out_of_order_execution: args.allow_out_of_order_execution,
+                        token_receiver: None,
+                    },
+                    extra_args_data_len: 0,
                 })
             }
         }
@@ -204,8 +236,9 @@ fn parse_and_validate_svm_extra_args(
     cfg: &DestChainConfig,
     tag: [u8; 4],
     data: &mut &[u8],
-    message_contains_tokens: bool,
-) -> Result<ProcessedExtraArgs> {
+    message_info: &MessageInfo,
+    dest_bytes_overhead: &u32,
+) -> Result<ValidatedMessage> {
     match u32::from_be_bytes(tag) {
         SVM_EXTRA_ARGS_V1_TAG => {
             let args = if data.is_empty() {
@@ -227,16 +260,45 @@ fn parse_and_validate_svm_extra_args(
             // token_receiver != 0 when tokens are present
             // token_receiver == 0 when tokens are not present
             let receiver_is_zero_address = args.token_receiver == [0; 32];
+            let message_contains_tokens = message_info.number_of_tokens != 0;
             require!(
                 message_contains_tokens != receiver_is_zero_address,
                 FeeQuoterError::InvalidTokenReceiver
             );
 
-            Ok(ProcessedExtraArgs {
-                bytes: args.serialize_with_tag(),
-                gas_limit: args.compute_units as u128,
-                allow_out_of_order_execution: args.allow_out_of_order_execution,
-                token_receiver: message_contains_tokens.then_some(args.token_receiver.to_vec()),
+            let accounts_len = args.accounts.len();
+            let mut svm_expanded_data_len = message_info.data_len;
+            let mut extra_args_data_len = 0;
+
+            if !message_info.contains_receiver {
+                require_eq!(accounts_len, 0, FeeQuoterError::InvalidExtraArgsAccounts);
+            } else {
+                extra_args_data_len =
+                    (accounts_len + SVM_MESSAGING_ACCOUNTS_OVERHEAD) * SVM_ACCOUNT_BYTE_SIZE;
+                svm_expanded_data_len += extra_args_data_len;
+            }
+
+            let token_transfer_data_overhead =
+                message_info.number_of_tokens * SVM_TOKEN_TRANSFER_DATA_OVERHEAD;
+            extra_args_data_len += token_transfer_data_overhead;
+            svm_expanded_data_len += token_transfer_data_overhead;
+
+            svm_expanded_data_len += *dest_bytes_overhead as usize;
+
+            require_gte!(
+                cfg.max_data_bytes as usize,
+                svm_expanded_data_len,
+                FeeQuoterError::MessageTooLarge,
+            );
+
+            Ok(ValidatedMessage {
+                processed_extra_args: ProcessedExtraArgs {
+                    bytes: args.serialize_with_tag(),
+                    gas_limit: args.compute_units as u128,
+                    allow_out_of_order_execution: args.allow_out_of_order_execution,
+                    token_receiver: message_contains_tokens.then_some(args.token_receiver.to_vec()),
+                },
+                extra_args_data_len: extra_args_data_len as u32,
             })
         }
         _ => Err(FeeQuoterError::InvalidExtraArgsTag.into()),
@@ -249,12 +311,13 @@ fn parse_and_validate_sui_extra_args(
     data: &mut &[u8],
     message_info: &MessageInfo,
     dest_bytes_overhead: &u32,
-) -> Result<ProcessedExtraArgs> {
+) -> Result<ValidatedMessage> {
     match u32::from_be_bytes(tag) {
         SUI_EXTRA_ARGS_V1_TAG => {
             let args = SuiExtraArgsV1::deserialize(data)?;
 
             let mut sui_expanded_data_len = message_info.data_len;
+            let mut extra_args_data_len = 0;
 
             // token_receiver != 0 when tokens are present
             let receiver_is_present = args.token_receiver != [0; 32];
@@ -273,9 +336,9 @@ fn parse_and_validate_sui_extra_args(
                     FeeQuoterError::InvalidSuiReceiverObjectIds,
                 );
             } else {
-                let extra_data_len = (receiver_object_ids_len + SUI_MESSAGING_ACCOUNTS_OVERHEAD)
+                extra_args_data_len = (receiver_object_ids_len + SUI_MESSAGING_ACCOUNTS_OVERHEAD)
                     * SUI_ACCOUNT_BYTE_SIZE;
-                sui_expanded_data_len += extra_data_len;
+                sui_expanded_data_len += extra_args_data_len;
             }
 
             require_gte!(
@@ -286,6 +349,7 @@ fn parse_and_validate_sui_extra_args(
 
             let token_transfer_data_overhead =
                 message_info.number_of_tokens * SUI_TOKEN_TRANSFER_DATA_OVERHEAD;
+            extra_args_data_len += token_transfer_data_overhead;
             sui_expanded_data_len += token_transfer_data_overhead;
 
             // The token destBytesOverhead can be very different per token so we have to take it into account as well.
@@ -297,15 +361,36 @@ fn parse_and_validate_sui_extra_args(
                 FeeQuoterError::MessageTooLarge,
             );
 
-            Ok(ProcessedExtraArgs {
-                bytes: args.serialize_with_tag(),
-                gas_limit: args.gas_limit,
-                allow_out_of_order_execution: args.allow_out_of_order_execution,
-                token_receiver: message_contains_tokens.then_some(args.token_receiver.to_vec()),
+            Ok(ValidatedMessage {
+                processed_extra_args: ProcessedExtraArgs {
+                    bytes: args.serialize_with_tag(),
+                    gas_limit: args.gas_limit,
+                    allow_out_of_order_execution: args.allow_out_of_order_execution,
+                    token_receiver: message_contains_tokens.then_some(args.token_receiver.to_vec()),
+                },
+                extra_args_data_len: extra_args_data_len as u32,
             })
         }
         _ => Err(FeeQuoterError::InvalidExtraArgsTag.into()),
     }
+}
+
+fn validate_sui_address(
+    address: &[u8],
+    address_must_be_outside_precompile_space: bool,
+) -> Result<()> {
+    require_eq!(address.len(), 32, CommonCcipError::InvalidSuiAddress);
+
+    let addr_32: &[u8; 32] = address
+        .try_into()
+        .expect("slice length is guaranteed to be 32");
+
+    require!(
+        !address_must_be_outside_precompile_space || addr_32 >= &SUI_PRECOMPILE_SPACE,
+        CommonCcipError::InvalidSuiAddress
+    );
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -317,13 +402,40 @@ pub mod tests {
     use anchor_spl::token::spl_token::native_mint;
     use ethnum::U256;
 
+    fn process_extra_args(
+        dest_config: &DestChainConfig,
+        extra_args: &[u8],
+        message_info: &MessageInfo,
+        dest_bytes_overhead: &u32,
+    ) -> Result<ProcessedExtraArgs> {
+        Ok(process_extra_args_with_data_len(
+            dest_config,
+            extra_args,
+            message_info,
+            dest_bytes_overhead,
+        )?
+        .processed_extra_args)
+    }
+
+    fn validation_err<T>(result: Result<T>) -> anchor_lang::error::Error {
+        match result {
+            Ok(_) => panic!("expected validation to fail"),
+            Err(err) => err,
+        }
+    }
+
     #[test]
     fn message_not_validated_for_disabled_destination_chain() {
         let mut chain = sample_dest_chain();
         chain.config.is_enabled = false;
 
         assert_eq!(
-            validate_svm2any(&sample_message(), &chain, &sample_billing_config(), &0).unwrap_err(),
+            validation_err(validate_svm2any(
+                &sample_message(),
+                &chain,
+                &sample_billing_config(),
+                &0
+            )),
             FeeQuoterError::DestinationChainDisabled.into()
         );
     }
@@ -334,8 +446,12 @@ pub mod tests {
         billing_config.enabled = false;
 
         assert_eq!(
-            validate_svm2any(&sample_message(), &sample_dest_chain(), &billing_config, &0)
-                .unwrap_err(),
+            validation_err(validate_svm2any(
+                &sample_message(),
+                &sample_dest_chain(),
+                &billing_config,
+                &0
+            )),
             FeeQuoterError::FeeTokenDisabled.into()
         );
     }
@@ -346,8 +462,12 @@ pub mod tests {
         let mut message = sample_message();
         message.data = vec![0; dest_chain.config.max_data_bytes as usize + 1];
         assert_eq!(
-            validate_svm2any(&message, &sample_dest_chain(), &sample_billing_config(), &0)
-                .unwrap_err(),
+            validation_err(validate_svm2any(
+                &message,
+                &sample_dest_chain(),
+                &sample_billing_config(),
+                &0
+            )),
             FeeQuoterError::MessageTooLarge.into()
         );
     }
@@ -370,8 +490,12 @@ pub mod tests {
         for address in invalid_addresses {
             message.receiver = address;
             assert_eq!(
-                validate_svm2any(&message, &sample_dest_chain(), &sample_billing_config(), &0)
-                    .unwrap_err(),
+                validation_err(validate_svm2any(
+                    &message,
+                    &sample_dest_chain(),
+                    &sample_billing_config(),
+                    &0
+                )),
                 CommonCcipError::InvalidEVMAddress.into()
             );
         }
@@ -389,8 +513,12 @@ pub mod tests {
             dest_chain.config.max_number_of_tokens_per_msg as usize + 1
         ];
         assert_eq!(
-            validate_svm2any(&message, &sample_dest_chain(), &sample_billing_config(), &0)
-                .unwrap_err(),
+            validation_err(validate_svm2any(
+                &message,
+                &sample_dest_chain(),
+                &sample_billing_config(),
+                &0
+            )),
             FeeQuoterError::UnsupportedNumberOfTokens.into()
         );
     }
@@ -404,8 +532,12 @@ pub mod tests {
         }
         .serialize_with_tag();
         assert_eq!(
-            validate_svm2any(&message, &sample_dest_chain(), &sample_billing_config(), &0)
-                .unwrap_err(),
+            validation_err(validate_svm2any(
+                &message,
+                &sample_dest_chain(),
+                &sample_billing_config(),
+                &0
+            )),
             FeeQuoterError::MessageGasLimitTooHigh.into()
         );
     }
@@ -455,13 +587,12 @@ pub mod tests {
 
         // not allowed cases
         assert_eq!(
-            validate_svm2any(
+            validation_err(validate_svm2any(
                 &message_not_ooo,
                 &dest_chain_enforce,
                 &sample_billing_config(),
                 &0
-            )
-            .unwrap_err(),
+            )),
             FeeQuoterError::ExtraArgOutOfOrderExecutionMustBeTrue.into()
         );
     }
@@ -670,7 +801,7 @@ pub mod tests {
             &args.serialize_with_tag(),
             &MessageInfo {
                 number_of_tokens: 1,
-                contains_receiver: false,
+                contains_receiver: true,
                 data_len: 0,
             },
             &0,
@@ -695,6 +826,111 @@ pub mod tests {
             )
             .unwrap_err(),
             FeeQuoterError::InvalidExtraArgsTag.into()
+        );
+    }
+
+    #[test]
+    fn svm_extra_args_data_len_matches_destination_payload_overhead() {
+        let mut svm_dest_chain = sample_dest_chain();
+        svm_dest_chain.config.chain_family_selector = CHAIN_FAMILY_SELECTOR_SVM.to_be_bytes();
+
+        let token_receiver = [1; 32];
+        let args = SVMExtraArgsV1 {
+            compute_units: 100,
+            allow_out_of_order_execution: true,
+            token_receiver,
+            accounts: vec![[1; 32], [2; 32]],
+            ..Default::default()
+        };
+
+        let validated_message = process_extra_args_with_data_len(
+            &svm_dest_chain.config,
+            &args.serialize_with_tag(),
+            &MessageInfo {
+                number_of_tokens: 1,
+                contains_receiver: true,
+                data_len: 0,
+            },
+            &100,
+        )
+        .unwrap();
+
+        assert_eq!(
+            validated_message.extra_args_data_len as usize,
+            (args.accounts.len() + SVM_MESSAGING_ACCOUNTS_OVERHEAD) * SVM_ACCOUNT_BYTE_SIZE
+                + SVM_TOKEN_TRANSFER_DATA_OVERHEAD
+        );
+    }
+
+    #[test]
+    fn svm_expanded_payload_counts_towards_max_data_bytes() {
+        let mut svm_dest_chain = sample_dest_chain();
+        svm_dest_chain.config.chain_family_selector = CHAIN_FAMILY_SELECTOR_SVM.to_be_bytes();
+
+        let args = SVMExtraArgsV1 {
+            token_receiver: [1; 32],
+            accounts: vec![[1; 32], [2; 32]],
+            ..Default::default()
+        };
+
+        let dest_bytes_overhead = 100_u32;
+        let account_overhead =
+            (args.accounts.len() + SVM_MESSAGING_ACCOUNTS_OVERHEAD) * SVM_ACCOUNT_BYTE_SIZE;
+        let token_overhead = SVM_TOKEN_TRANSFER_DATA_OVERHEAD + dest_bytes_overhead as usize;
+        let total_overhead = account_overhead + token_overhead;
+        let data_len = svm_dest_chain.config.max_data_bytes as usize - total_overhead;
+
+        process_extra_args(
+            &svm_dest_chain.config,
+            &args.serialize_with_tag(),
+            &MessageInfo {
+                number_of_tokens: 1,
+                contains_receiver: true,
+                data_len,
+            },
+            &dest_bytes_overhead,
+        )
+        .unwrap();
+
+        assert_eq!(
+            process_extra_args(
+                &svm_dest_chain.config,
+                &args.serialize_with_tag(),
+                &MessageInfo {
+                    number_of_tokens: 1,
+                    contains_receiver: true,
+                    data_len: data_len + 1,
+                },
+                &dest_bytes_overhead,
+            )
+            .unwrap_err(),
+            FeeQuoterError::MessageTooLarge.into()
+        );
+    }
+
+    #[test]
+    fn svm_accounts_require_message_receiver() {
+        let mut svm_dest_chain = sample_dest_chain();
+        svm_dest_chain.config.chain_family_selector = CHAIN_FAMILY_SELECTOR_SVM.to_be_bytes();
+
+        let args = SVMExtraArgsV1 {
+            accounts: vec![[1; 32]],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            process_extra_args(
+                &svm_dest_chain.config,
+                &args.serialize_with_tag(),
+                &MessageInfo {
+                    number_of_tokens: 0,
+                    contains_receiver: false,
+                    data_len: 0,
+                },
+                &0,
+            )
+            .unwrap_err(),
+            FeeQuoterError::InvalidExtraArgsAccounts.into()
         );
     }
 
@@ -1085,6 +1321,82 @@ pub mod tests {
             )
             .unwrap_err(),
             FeeQuoterError::MessageTooLarge.into()
+        );
+    }
+
+    #[test]
+    fn sui_extra_args_data_len_matches_destination_payload_overhead() {
+        let mut sui_dest_chain = sample_dest_chain();
+        sui_dest_chain.config.chain_family_selector = CHAIN_FAMILY_SELECTOR_SUI.to_be_bytes();
+
+        let args = SuiExtraArgsV1 {
+            token_receiver: [1; 32],
+            receiver_object_ids: vec![[1; 32], [2; 32]],
+            ..Default::default()
+        };
+
+        let validated_message = process_extra_args_with_data_len(
+            &sui_dest_chain.config,
+            &args.serialize_with_tag(),
+            &MessageInfo {
+                number_of_tokens: 1,
+                contains_receiver: true,
+                data_len: 0,
+            },
+            &100,
+        )
+        .unwrap();
+
+        assert_eq!(
+            validated_message.extra_args_data_len as usize,
+            (args.receiver_object_ids.len() + SUI_MESSAGING_ACCOUNTS_OVERHEAD)
+                * SUI_ACCOUNT_BYTE_SIZE
+                + SUI_TOKEN_TRANSFER_DATA_OVERHEAD
+        );
+    }
+
+    #[test]
+    fn sui_zero_receiver_is_allowed_when_gas_limit_is_zero() {
+        let mut sui_dest_chain = sample_dest_chain();
+        sui_dest_chain.config.chain_family_selector = CHAIN_FAMILY_SELECTOR_SUI.to_be_bytes();
+
+        let mut msg = sample_message();
+        msg.receiver = vec![0; 32];
+        msg.token_amounts = vec![SVMTokenAmount {
+            token: Pubkey::new_unique(),
+            amount: 1,
+        }];
+        msg.extra_args = SuiExtraArgsV1 {
+            gas_limit: 0,
+            token_receiver: [1; 32],
+            ..Default::default()
+        }
+        .serialize_with_tag();
+
+        validate_svm2any(&msg, &sui_dest_chain, &sample_billing_config(), &0).unwrap();
+    }
+
+    #[test]
+    fn sui_zero_receiver_is_rejected_when_gas_limit_is_nonzero() {
+        let mut sui_dest_chain = sample_dest_chain();
+        sui_dest_chain.config.chain_family_selector = CHAIN_FAMILY_SELECTOR_SUI.to_be_bytes();
+
+        let mut msg = sample_message();
+        msg.receiver = vec![0; 32];
+        msg.extra_args = SuiExtraArgsV1 {
+            gas_limit: 1,
+            ..Default::default()
+        }
+        .serialize_with_tag();
+
+        assert_eq!(
+            validation_err(validate_svm2any(
+                &msg,
+                &sui_dest_chain,
+                &sample_billing_config(),
+                &0
+            )),
+            CommonCcipError::InvalidSuiAddress.into()
         );
     }
 }

--- a/chains/solana/contracts/programs/fee-quoter/src/instructions/v1/messages.rs
+++ b/chains/solana/contracts/programs/fee-quoter/src/instructions/v1/messages.rs
@@ -250,8 +250,10 @@ fn parse_and_validate_svm_extra_args(
                     args.accounts.len(),
                     FeeQuoterError::InvalidExtraArgsAccounts
                 );
+                let has_writable_bits_beyond_accounts = (args.accounts.len()..u64::BITS as usize)
+                    .any(|bit| args.account_is_writable_bitmap & (1u64 << bit) != 0);
                 require!(
-                    args.account_is_writable_bitmap >> args.accounts.len() == 0,
+                    !has_writable_bits_beyond_accounts,
                     FeeQuoterError::InvalidExtraArgsWritabilityBitmap
                 );
                 args
@@ -863,6 +865,14 @@ pub mod tests {
     }
 
     #[test]
+    fn svm_token_transfer_data_overhead_matches_static_payload_size() {
+        assert_eq!(
+            SVM_TOKEN_TRANSFER_DATA_OVERHEAD,
+            (4 + 32) + 32 + 4 + 4 + 32 + (6 * SVM_ACCOUNT_BYTE_SIZE)
+        );
+    }
+
+    #[test]
     fn svm_expanded_payload_counts_towards_max_data_bytes() {
         let mut svm_dest_chain = sample_dest_chain();
         svm_dest_chain.config.chain_family_selector = CHAIN_FAMILY_SELECTOR_SVM.to_be_bytes();
@@ -905,6 +915,57 @@ pub mod tests {
             )
             .unwrap_err(),
             FeeQuoterError::MessageTooLarge.into()
+        );
+    }
+
+    #[test]
+    fn svm_writable_bitmap_allows_all_bits_for_max_accounts() {
+        let mut svm_dest_chain = sample_dest_chain();
+        svm_dest_chain.config.chain_family_selector = CHAIN_FAMILY_SELECTOR_SVM.to_be_bytes();
+
+        let args = SVMExtraArgsV1 {
+            accounts: vec![[1; 32]; SVM_EXTRA_ARGS_MAX_ACCOUNTS],
+            account_is_writable_bitmap: u64::MAX,
+            ..Default::default()
+        };
+
+        process_extra_args(
+            &svm_dest_chain.config,
+            &args.serialize_with_tag(),
+            &MessageInfo {
+                number_of_tokens: 0,
+                contains_receiver: true,
+                data_len: 0,
+            },
+            &0,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn svm_writable_bitmap_rejects_bits_beyond_accounts() {
+        let mut svm_dest_chain = sample_dest_chain();
+        svm_dest_chain.config.chain_family_selector = CHAIN_FAMILY_SELECTOR_SVM.to_be_bytes();
+
+        let args = SVMExtraArgsV1 {
+            accounts: vec![[1; 32]; SVM_EXTRA_ARGS_MAX_ACCOUNTS - 1],
+            account_is_writable_bitmap: u64::MAX,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            process_extra_args(
+                &svm_dest_chain.config,
+                &args.serialize_with_tag(),
+                &MessageInfo {
+                    number_of_tokens: 0,
+                    contains_receiver: true,
+                    data_len: 0,
+                },
+                &0,
+            )
+            .unwrap_err(),
+            FeeQuoterError::InvalidExtraArgsWritabilityBitmap.into()
         );
     }
 

--- a/chains/solana/contracts/programs/fee-quoter/src/instructions/v1/messages.rs
+++ b/chains/solana/contracts/programs/fee-quoter/src/instructions/v1/messages.rs
@@ -10,17 +10,42 @@ use ccip_common::{
 };
 
 use crate::extra_args::{
-    GenericExtraArgsV2, SVMExtraArgsV1, GENERIC_EXTRA_ARGS_V2_TAG, SVM_EXTRA_ARGS_MAX_ACCOUNTS,
-    SVM_EXTRA_ARGS_V1_TAG,
+    GenericExtraArgsV2, SVMExtraArgsV1, SuiExtraArgsV1, GENERIC_EXTRA_ARGS_V2_TAG,
+    SUI_EXTRA_ARGS_V1_TAG, SVM_EXTRA_ARGS_MAX_ACCOUNTS, SVM_EXTRA_ARGS_V1_TAG,
 };
 use crate::messages::{ProcessedExtraArgs, SVM2AnyMessage};
 use crate::state::{BillingTokenConfig, DestChain, DestChainConfig};
 use crate::FeeQuoterError;
 
+/// The maximum number of receiver object ids that can be passed in SuiExtraArgs.
+pub const SUI_EXTRA_ARGS_MAX_RECEIVER_OBJECT_IDS: usize = 64;
+
+/// Number of overhead accounts needed for message execution on SUI.
+/// This is the message.receiver.
+pub const SUI_MESSAGING_ACCOUNTS_OVERHEAD: usize = 1;
+
+/// The size of each SUI account address in bytes.
+pub const SUI_ACCOUNT_BYTE_SIZE: usize = 32;
+
+/// The expected static payload size of a token transfer when BCS encoded and submitted to SUI.
+/// TokenPool extra data and offchain data sizes are dynamic, and should be accounted for separately.
+pub const SUI_TOKEN_TRANSFER_DATA_OVERHEAD: usize = (4 + 32) // source_pool, 4 bytes for length, 32 bytes for address
+    + 32 // dest_token_address
+    + 4 // dest_gas_amount
+    + 4 // extra_data length, the contents are calculated separately
+    + 32; // amount
+
+pub struct MessageInfo {
+    pub number_of_tokens: usize,
+    pub contains_receiver: bool,
+    pub data_len: usize,
+}
+
 pub fn validate_svm2any(
     msg: &SVM2AnyMessage,
     dest_chain: &DestChain,
     token_config: &BillingTokenConfig,
+    dest_bytes_overhead: &u32,
 ) -> Result<ProcessedExtraArgs> {
     require!(
         dest_chain.config.is_enabled,
@@ -44,7 +69,12 @@ pub fn validate_svm2any(
     let processed_extra_args = process_extra_args(
         &dest_chain.config,
         &msg.extra_args,
-        !msg.token_amounts.is_empty(),
+        &MessageInfo {
+            number_of_tokens: msg.token_amounts.len(),
+            contains_receiver: msg.receiver != [0; 32],
+            data_len: msg.data.len(),
+        },
+        dest_bytes_overhead,
     )?;
 
     require_gte!(
@@ -91,7 +121,8 @@ fn validate_dest_family_address(
 pub fn process_extra_args(
     dest_config: &DestChainConfig,
     extra_args: &[u8],
-    message_contains_tokens: bool,
+    message_info: &MessageInfo,
+    dest_bytes_overhead: &u32,
 ) -> Result<ProcessedExtraArgs> {
     match u32::from_be_bytes(dest_config.chain_family_selector) {
         CHAIN_FAMILY_SELECTOR_SVM => {
@@ -107,8 +138,31 @@ pub fn process_extra_args(
                 dest_config,
                 tag,
                 &mut data,
-                message_contains_tokens,
+                message_info.number_of_tokens != 0,
             )?)
+        }
+        CHAIN_FAMILY_SELECTOR_SUI => {
+            require!(
+                !extra_args.is_empty(),
+                FeeQuoterError::InvalidInputsMissingExtraArgs
+            );
+
+            require_gte!(
+                extra_args.len(),
+                4,
+                FeeQuoterError::InvalidInputsMissingExtraArgs
+            );
+
+            let tag: [u8; 4] = extra_args[..4].try_into().unwrap();
+
+            let mut data = &extra_args[4..];
+            parse_and_validate_sui_extra_args(
+                dest_config,
+                tag,
+                &mut data,
+                message_info,
+                dest_bytes_overhead,
+            )
         }
         _ => {
             // Extra args are optional for non-SVM destinations. In case there
@@ -189,6 +243,71 @@ fn parse_and_validate_svm_extra_args(
     }
 }
 
+fn parse_and_validate_sui_extra_args(
+    cfg: &DestChainConfig,
+    tag: [u8; 4],
+    data: &mut &[u8],
+    message_info: &MessageInfo,
+    dest_bytes_overhead: &u32,
+) -> Result<ProcessedExtraArgs> {
+    match u32::from_be_bytes(tag) {
+        SUI_EXTRA_ARGS_V1_TAG => {
+            let args = SuiExtraArgsV1::deserialize(data)?;
+
+            let mut sui_expanded_data_len = message_info.data_len;
+
+            // token_receiver != 0 when tokens are present
+            let receiver_is_present = args.token_receiver != [0; 32];
+            let message_contains_tokens = message_info.number_of_tokens > 0;
+            require!(
+                !message_contains_tokens || receiver_is_present,
+                FeeQuoterError::InvalidTokenReceiver
+            );
+
+            let receiver_object_ids_len = args.receiver_object_ids.len();
+
+            if !message_info.contains_receiver {
+                require_eq!(
+                    receiver_object_ids_len,
+                    0,
+                    FeeQuoterError::InvalidSuiReceiverObjectIds,
+                );
+            } else {
+                let extra_data_len = (receiver_object_ids_len + SUI_MESSAGING_ACCOUNTS_OVERHEAD)
+                    * SUI_ACCOUNT_BYTE_SIZE;
+                sui_expanded_data_len += extra_data_len;
+            }
+
+            require_gte!(
+                SUI_EXTRA_ARGS_MAX_RECEIVER_OBJECT_IDS,
+                args.receiver_object_ids.len(),
+                FeeQuoterError::InvalidSuiReceiverObjectIds,
+            );
+
+            let token_transfer_data_overhead =
+                message_info.number_of_tokens * SUI_TOKEN_TRANSFER_DATA_OVERHEAD;
+            sui_expanded_data_len += token_transfer_data_overhead;
+
+            // The token destBytesOverhead can be very different per token so we have to take it into account as well.
+            sui_expanded_data_len += *dest_bytes_overhead as usize;
+
+            require_gte!(
+                cfg.max_data_bytes as usize,
+                sui_expanded_data_len,
+                FeeQuoterError::MessageTooLarge,
+            );
+
+            Ok(ProcessedExtraArgs {
+                bytes: args.serialize_with_tag(),
+                gas_limit: args.gas_limit,
+                allow_out_of_order_execution: args.allow_out_of_order_execution,
+                token_receiver: message_contains_tokens.then_some(args.token_receiver.to_vec()),
+            })
+        }
+        _ => Err(FeeQuoterError::InvalidExtraArgsTag.into()),
+    }
+}
+
 #[cfg(test)]
 pub mod tests {
     use super::*;
@@ -204,7 +323,7 @@ pub mod tests {
         chain.config.is_enabled = false;
 
         assert_eq!(
-            validate_svm2any(&sample_message(), &chain, &sample_billing_config()).unwrap_err(),
+            validate_svm2any(&sample_message(), &chain, &sample_billing_config(), &0).unwrap_err(),
             FeeQuoterError::DestinationChainDisabled.into()
         );
     }
@@ -215,7 +334,8 @@ pub mod tests {
         billing_config.enabled = false;
 
         assert_eq!(
-            validate_svm2any(&sample_message(), &sample_dest_chain(), &billing_config).unwrap_err(),
+            validate_svm2any(&sample_message(), &sample_dest_chain(), &billing_config, &0)
+                .unwrap_err(),
             FeeQuoterError::FeeTokenDisabled.into()
         );
     }
@@ -226,7 +346,8 @@ pub mod tests {
         let mut message = sample_message();
         message.data = vec![0; dest_chain.config.max_data_bytes as usize + 1];
         assert_eq!(
-            validate_svm2any(&message, &sample_dest_chain(), &sample_billing_config()).unwrap_err(),
+            validate_svm2any(&message, &sample_dest_chain(), &sample_billing_config(), &0)
+                .unwrap_err(),
             FeeQuoterError::MessageTooLarge.into()
         );
     }
@@ -249,7 +370,7 @@ pub mod tests {
         for address in invalid_addresses {
             message.receiver = address;
             assert_eq!(
-                validate_svm2any(&message, &sample_dest_chain(), &sample_billing_config())
+                validate_svm2any(&message, &sample_dest_chain(), &sample_billing_config(), &0)
                     .unwrap_err(),
                 CommonCcipError::InvalidEVMAddress.into()
             );
@@ -268,7 +389,8 @@ pub mod tests {
             dest_chain.config.max_number_of_tokens_per_msg as usize + 1
         ];
         assert_eq!(
-            validate_svm2any(&message, &sample_dest_chain(), &sample_billing_config()).unwrap_err(),
+            validate_svm2any(&message, &sample_dest_chain(), &sample_billing_config(), &0)
+                .unwrap_err(),
             FeeQuoterError::UnsupportedNumberOfTokens.into()
         );
     }
@@ -282,7 +404,8 @@ pub mod tests {
         }
         .serialize_with_tag();
         assert_eq!(
-            validate_svm2any(&message, &sample_dest_chain(), &sample_billing_config()).unwrap_err(),
+            validate_svm2any(&message, &sample_dest_chain(), &sample_billing_config(), &0)
+                .unwrap_err(),
             FeeQuoterError::MessageGasLimitTooHigh.into()
         );
     }
@@ -308,17 +431,25 @@ pub mod tests {
         .serialize_with_tag();
 
         // allowed cases
-        validate_svm2any(&message_ooo, &dest_chain_enforce, &sample_billing_config()).unwrap();
+        validate_svm2any(
+            &message_ooo,
+            &dest_chain_enforce,
+            &sample_billing_config(),
+            &0,
+        )
+        .unwrap();
         validate_svm2any(
             &message_ooo,
             &dest_chain_not_enforce,
             &sample_billing_config(),
+            &0,
         )
         .unwrap();
         validate_svm2any(
             &message_not_ooo,
             &dest_chain_not_enforce,
             &sample_billing_config(),
+            &0,
         )
         .unwrap();
 
@@ -327,7 +458,8 @@ pub mod tests {
             validate_svm2any(
                 &message_not_ooo,
                 &dest_chain_enforce,
-                &sample_billing_config()
+                &sample_billing_config(),
+                &0
             )
             .unwrap_err(),
             FeeQuoterError::ExtraArgOutOfOrderExecutionMustBeTrue.into()
@@ -381,12 +513,32 @@ pub mod tests {
 
         // tag but no data fails
         assert_eq!(
-            process_extra_args(&dest_chain.config, &generic_tag_bytes, false).unwrap_err(),
+            process_extra_args(
+                &dest_chain.config,
+                &generic_tag_bytes,
+                &MessageInfo {
+                    number_of_tokens: 0,
+                    contains_receiver: false,
+                    data_len: 0
+                },
+                &0,
+            )
+            .unwrap_err(),
             FeeQuoterError::InvalidInputsMissingDataAfterExtraArgs.into()
         );
 
         // default case: (no data or tag)
-        let extra_args = process_extra_args(&dest_chain.config, &[], false).unwrap();
+        let extra_args = process_extra_args(
+            &dest_chain.config,
+            &[],
+            &MessageInfo {
+                number_of_tokens: 0,
+                contains_receiver: false,
+                data_len: 0,
+            },
+            &0,
+        )
+        .unwrap();
         assert_eq!(
             extra_args.bytes[..4],
             GENERIC_EXTRA_ARGS_V2_TAG.to_be_bytes()
@@ -406,7 +558,12 @@ pub mod tests {
                 allow_out_of_order_execution: true,
             }
             .serialize_with_tag(),
-            false,
+            &MessageInfo {
+                number_of_tokens: 0,
+                contains_receiver: false,
+                data_len: 0,
+            },
+            &0,
         )
         .unwrap();
         assert_eq!(
@@ -419,7 +576,17 @@ pub mod tests {
 
         // fail to match an unrelated family's tag
         assert_eq!(
-            process_extra_args(&dest_chain.config, other_family_tag, false).unwrap_err(),
+            process_extra_args(
+                &dest_chain.config,
+                other_family_tag,
+                &MessageInfo {
+                    number_of_tokens: 0,
+                    contains_receiver: false,
+                    data_len: 0,
+                },
+                &0,
+            )
+            .unwrap_err(),
             FeeQuoterError::InvalidExtraArgsTag.into()
         );
     }
@@ -428,7 +595,17 @@ pub mod tests {
         let svm_tag_bytes = SVM_EXTRA_ARGS_V1_TAG.to_be_bytes().to_vec();
 
         // default case requires the SVM tag bytes
-        let extra_args = process_extra_args(&svm_dest_chain.config, &svm_tag_bytes, false).unwrap();
+        let extra_args = process_extra_args(
+            &svm_dest_chain.config,
+            &svm_tag_bytes,
+            &MessageInfo {
+                number_of_tokens: 0,
+                contains_receiver: false,
+                data_len: 0,
+            },
+            &0,
+        )
+        .unwrap();
         assert_eq!(extra_args.bytes[..4], SVM_EXTRA_ARGS_V1_TAG.to_be_bytes());
         assert_eq!(
             extra_args.gas_limit,
@@ -440,13 +617,33 @@ pub mod tests {
 
         // empty tag (no data) fails
         assert_eq!(
-            process_extra_args(&svm_dest_chain.config, &[], false).unwrap_err(),
+            process_extra_args(
+                &svm_dest_chain.config,
+                &[],
+                &MessageInfo {
+                    number_of_tokens: 0,
+                    contains_receiver: false,
+                    data_len: 0,
+                },
+                &0,
+            )
+            .unwrap_err(),
             FeeQuoterError::InvalidInputsMissingExtraArgs.into()
         );
 
         // contains tokens but no receiver address
         assert_eq!(
-            process_extra_args(&svm_dest_chain.config, &svm_tag_bytes, true).unwrap_err(),
+            process_extra_args(
+                &svm_dest_chain.config,
+                &svm_tag_bytes,
+                &MessageInfo {
+                    number_of_tokens: 1,
+                    contains_receiver: false,
+                    data_len: 0,
+                },
+                &0,
+            )
+            .unwrap_err(),
             FeeQuoterError::InvalidTokenReceiver.into(),
         );
 
@@ -468,8 +665,17 @@ pub mod tests {
                     .to_bytes(),
             ],
         };
-        let extra_args =
-            process_extra_args(&svm_dest_chain.config, &args.serialize_with_tag(), true).unwrap();
+        let extra_args = process_extra_args(
+            &svm_dest_chain.config,
+            &args.serialize_with_tag(),
+            &MessageInfo {
+                number_of_tokens: 1,
+                contains_receiver: false,
+                data_len: 0,
+            },
+            &0,
+        )
+        .unwrap();
         assert_eq!(extra_args.bytes, args.serialize_with_tag());
         assert_eq!(extra_args.gas_limit, 100);
         assert_eq!(extra_args.token_receiver, Some(token_receiver.to_vec()));
@@ -477,7 +683,17 @@ pub mod tests {
 
         // fail to match generic tag
         assert_eq!(
-            process_extra_args(&svm_dest_chain.config, generic_tag_bytes, false).unwrap_err(),
+            process_extra_args(
+                &svm_dest_chain.config,
+                generic_tag_bytes,
+                &MessageInfo {
+                    number_of_tokens: 0,
+                    contains_receiver: false,
+                    data_len: 0,
+                },
+                &0,
+            )
+            .unwrap_err(),
             FeeQuoterError::InvalidExtraArgsTag.into()
         );
     }
@@ -558,5 +774,317 @@ pub mod tests {
                 chain_family_selector: CHAIN_FAMILY_SELECTOR_EVM.to_be_bytes(),
             },
         }
+    }
+
+    /// SUI Tests
+
+    #[test]
+    fn process_extra_args_matches_family_sui() {
+        let mut sui_dest_chain = sample_dest_chain();
+        sui_dest_chain.config.chain_family_selector = CHAIN_FAMILY_SELECTOR_SUI.to_be_bytes();
+
+        // Empty extra args are invalid.
+        assert_eq!(
+            process_extra_args(
+                &sui_dest_chain.config,
+                &[],
+                &MessageInfo {
+                    number_of_tokens: 0,
+                    contains_receiver: false,
+                    data_len: 0,
+                },
+                &0,
+            )
+            .unwrap_err(),
+            FeeQuoterError::InvalidInputsMissingExtraArgs.into()
+        );
+
+        // Wrong tag fails.
+        let generic_tag = GENERIC_EXTRA_ARGS_V2_TAG.to_be_bytes();
+
+        assert_eq!(
+            process_extra_args(
+                &sui_dest_chain.config,
+                &generic_tag,
+                &MessageInfo {
+                    number_of_tokens: 0,
+                    contains_receiver: false,
+                    data_len: 0,
+                },
+                &0,
+            )
+            .unwrap_err(),
+            FeeQuoterError::InvalidExtraArgsTag.into()
+        );
+    }
+
+    #[test]
+    fn sui_tokens_require_token_receiver() {
+        let mut sui_dest_chain = sample_dest_chain();
+        sui_dest_chain.config.chain_family_selector = CHAIN_FAMILY_SELECTOR_SUI.to_be_bytes();
+
+        let args = SuiExtraArgsV1 {
+            token_receiver: [0; 32],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            process_extra_args(
+                &sui_dest_chain.config,
+                &args.serialize_with_tag(),
+                &MessageInfo {
+                    number_of_tokens: 1,
+                    contains_receiver: false,
+                    data_len: 0,
+                },
+                &0,
+            )
+            .unwrap_err(),
+            FeeQuoterError::InvalidTokenReceiver.into()
+        );
+    }
+
+    #[test]
+    fn sui_token_receiver_is_allowed_without_tokens() {
+        let mut sui_dest_chain = sample_dest_chain();
+        sui_dest_chain.config.chain_family_selector = CHAIN_FAMILY_SELECTOR_SUI.to_be_bytes();
+
+        let args = SuiExtraArgsV1 {
+            token_receiver: [1; 32],
+            ..Default::default()
+        };
+
+        let extra_args = process_extra_args(
+            &sui_dest_chain.config,
+            &args.serialize_with_tag(),
+            &MessageInfo {
+                number_of_tokens: 0,
+                contains_receiver: false,
+                data_len: 0,
+            },
+            &0,
+        )
+        .unwrap();
+
+        assert_eq!(extra_args.bytes, args.serialize_with_tag());
+        assert_eq!(extra_args.token_receiver, None);
+    }
+
+    #[test]
+    fn sui_receiver_object_ids_require_message_receiver() {
+        let mut sui_dest_chain = sample_dest_chain();
+        sui_dest_chain.config.chain_family_selector = CHAIN_FAMILY_SELECTOR_SUI.to_be_bytes();
+
+        let args = SuiExtraArgsV1 {
+            receiver_object_ids: vec![[1; 32]],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            process_extra_args(
+                &sui_dest_chain.config,
+                &args.serialize_with_tag(),
+                &MessageInfo {
+                    number_of_tokens: 0,
+                    contains_receiver: false,
+                    data_len: 0,
+                },
+                &0,
+            )
+            .unwrap_err(),
+            FeeQuoterError::InvalidSuiReceiverObjectIds.into()
+        );
+    }
+
+    #[test]
+    fn sui_max_receiver_object_ids_is_allowed() {
+        let mut sui_dest_chain = sample_dest_chain();
+        sui_dest_chain.config.chain_family_selector = CHAIN_FAMILY_SELECTOR_SUI.to_be_bytes();
+
+        let args = SuiExtraArgsV1 {
+            receiver_object_ids: vec![[1; 32]; SUI_EXTRA_ARGS_MAX_RECEIVER_OBJECT_IDS],
+            ..Default::default()
+        };
+
+        process_extra_args(
+            &sui_dest_chain.config,
+            &args.serialize_with_tag(),
+            &MessageInfo {
+                number_of_tokens: 0,
+                contains_receiver: true,
+                data_len: 0,
+            },
+            &0,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn sui_too_many_receiver_object_ids_fails() {
+        let mut sui_dest_chain = sample_dest_chain();
+        sui_dest_chain.config.chain_family_selector = CHAIN_FAMILY_SELECTOR_SUI.to_be_bytes();
+
+        let args = SuiExtraArgsV1 {
+            receiver_object_ids: vec![[1; 32]; SUI_EXTRA_ARGS_MAX_RECEIVER_OBJECT_IDS + 1],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            process_extra_args(
+                &sui_dest_chain.config,
+                &args.serialize_with_tag(),
+                &MessageInfo {
+                    number_of_tokens: 0,
+                    contains_receiver: true,
+                    data_len: 0,
+                },
+                &0,
+            )
+            .unwrap_err(),
+            FeeQuoterError::InvalidSuiReceiverObjectIds.into()
+        );
+    }
+
+    #[test]
+    fn sui_receiver_accounts_count_towards_max_data_bytes() {
+        let mut sui_dest_chain = sample_dest_chain();
+        sui_dest_chain.config.chain_family_selector = CHAIN_FAMILY_SELECTOR_SUI.to_be_bytes();
+
+        let args = SuiExtraArgsV1 {
+            receiver_object_ids: vec![[1; 32], [2; 32]],
+            ..Default::default()
+        };
+
+        let receiver_overhead = (args.receiver_object_ids.len() + SUI_MESSAGING_ACCOUNTS_OVERHEAD)
+            * SUI_ACCOUNT_BYTE_SIZE;
+
+        let data_len = sui_dest_chain.config.max_data_bytes as usize - receiver_overhead;
+
+        // Exactly max_data_bytes is allowed.
+        process_extra_args(
+            &sui_dest_chain.config,
+            &args.serialize_with_tag(),
+            &MessageInfo {
+                number_of_tokens: 0,
+                contains_receiver: true,
+                data_len,
+            },
+            &0,
+        )
+        .unwrap();
+
+        // One additional byte exceeds max_data_bytes.
+        assert_eq!(
+            process_extra_args(
+                &sui_dest_chain.config,
+                &args.serialize_with_tag(),
+                &MessageInfo {
+                    number_of_tokens: 0,
+                    contains_receiver: true,
+                    data_len: data_len + 1,
+                },
+                &0,
+            )
+            .unwrap_err(),
+            FeeQuoterError::MessageTooLarge.into()
+        );
+    }
+
+    #[test]
+    fn sui_token_transfer_overhead_counts_towards_max_data_bytes() {
+        let mut sui_dest_chain = sample_dest_chain();
+        sui_dest_chain.config.chain_family_selector = CHAIN_FAMILY_SELECTOR_SUI.to_be_bytes();
+
+        let args = SuiExtraArgsV1 {
+            token_receiver: [1; 32],
+            ..Default::default()
+        };
+
+        let dest_bytes_overhead = 100_u32;
+
+        let total_token_overhead = SUI_TOKEN_TRANSFER_DATA_OVERHEAD + dest_bytes_overhead as usize;
+
+        let data_len = sui_dest_chain.config.max_data_bytes as usize - total_token_overhead;
+
+        // Exactly max_data_bytes is allowed.
+        process_extra_args(
+            &sui_dest_chain.config,
+            &args.serialize_with_tag(),
+            &MessageInfo {
+                number_of_tokens: 1,
+                contains_receiver: false,
+                data_len,
+            },
+            &dest_bytes_overhead,
+        )
+        .unwrap();
+
+        // One additional byte exceeds max_data_bytes.
+        assert_eq!(
+            process_extra_args(
+                &sui_dest_chain.config,
+                &args.serialize_with_tag(),
+                &MessageInfo {
+                    number_of_tokens: 1,
+                    contains_receiver: false,
+                    data_len: data_len + 1,
+                },
+                &dest_bytes_overhead,
+            )
+            .unwrap_err(),
+            FeeQuoterError::MessageTooLarge.into()
+        );
+    }
+
+    #[test]
+    fn sui_combined_overheads_count_towards_max_data_bytes() {
+        let mut sui_dest_chain = sample_dest_chain();
+        sui_dest_chain.config.chain_family_selector = CHAIN_FAMILY_SELECTOR_SUI.to_be_bytes();
+
+        let args = SuiExtraArgsV1 {
+            token_receiver: [1; 32],
+            receiver_object_ids: vec![[1; 32], [2; 32]],
+            ..Default::default()
+        };
+
+        let dest_bytes_overhead = 100_u32;
+
+        let receiver_overhead = (args.receiver_object_ids.len() + SUI_MESSAGING_ACCOUNTS_OVERHEAD)
+            * SUI_ACCOUNT_BYTE_SIZE;
+
+        let token_overhead = SUI_TOKEN_TRANSFER_DATA_OVERHEAD + dest_bytes_overhead as usize;
+
+        let total_overhead = receiver_overhead + token_overhead;
+
+        let data_len = sui_dest_chain.config.max_data_bytes as usize - total_overhead;
+
+        // All overheads combined result in exactly max_data_bytes.
+        process_extra_args(
+            &sui_dest_chain.config,
+            &args.serialize_with_tag(),
+            &MessageInfo {
+                number_of_tokens: 1,
+                contains_receiver: true,
+                data_len,
+            },
+            &dest_bytes_overhead,
+        )
+        .unwrap();
+
+        // One additional byte exceeds max_data_bytes.
+        assert_eq!(
+            process_extra_args(
+                &sui_dest_chain.config,
+                &args.serialize_with_tag(),
+                &MessageInfo {
+                    number_of_tokens: 1,
+                    contains_receiver: true,
+                    data_len: data_len + 1,
+                },
+                &dest_bytes_overhead,
+            )
+            .unwrap_err(),
+            FeeQuoterError::MessageTooLarge.into()
+        );
     }
 }

--- a/chains/solana/contracts/programs/fee-quoter/src/instructions/v1/public.rs
+++ b/chains/solana/contracts/programs/fee-quoter/src/instructions/v1/public.rs
@@ -16,23 +16,6 @@ use super::super::interfaces::Public;
 use super::messages::validate_svm2any;
 use super::price_math::{get_validated_token_price, Exponential, Usd18Decimals};
 
-/// SVM2EVMRampMessage struct has 10 fields, including 3 variable unnested arrays (data, sender and tokenAmounts).
-/// Each variable array takes 1 more slot to store its length.
-/// When abi encoded, excluding array contents,
-/// SVM2AnyMessage takes up a fixed number of 13 slots, 32 bytes each.
-/// We assume sender always takes 1 slot.
-/// For structs that contain arrays, 1 more slot is added to the front, reaching a total of 15.
-/// The fixed bytes does not cover struct data (this is represented by SVM_2_EVM_MESSAGE_FIXED_BYTES_PER_TOKEN)
-pub const SVM_2_EVM_MESSAGE_FIXED_BYTES: U256 = U256::new(32 * 15);
-
-/// Each token transfer adds 1 RampTokenAmount
-/// RampTokenAmount has 5 fields, 2 of which are bytes type, 1 Address, 1 uint256 and 1 uint32.
-/// Each bytes type takes 1 slot for length, 1 slot for data and 1 slot for the offset.
-/// address
-/// uint256 amount takes 1 slot.
-/// uint32 destGasAmount takes 1 slot.
-pub const SVM_2_EVM_MESSAGE_FIXED_BYTES_PER_TOKEN: U256 = U256::new(32 * ((2 * 3) + 3));
-
 pub const CCIP_LOCK_OR_BURN_V1_RET_BYTES: u32 = 32;
 
 pub struct Impl;
@@ -185,28 +168,24 @@ fn fee_for_msg(
         additional_token_configs_for_dest_chain.len() == message.token_amounts.len(),
         FeeQuoterError::InvalidInputsMissingTokenConfig
     );
-    let dest_bytes_overhead = additional_token_configs_for_dest_chain
-        .iter()
-        .map(|config| match config {
-            Some(config)
-                if config.token_transfer_config.is_enabled
-                    && config.token_transfer_config.dest_bytes_overhead > 0 =>
-            {
-                config.token_transfer_config.dest_bytes_overhead
-            }
-            _ => CCIP_LOCK_OR_BURN_V1_RET_BYTES,
-        })
-        .sum::<u32>();
+    let token_transfer_bytes_overhead_for_validation =
+        get_token_transfer_bytes_overhead(additional_token_configs_for_dest_chain);
 
-    let validated_message =
-        validate_svm2any(message, dest_chain, fee_token_config, &dest_bytes_overhead)?;
-    let extra_args_data_len = validated_message.extra_args_data_len;
+    let validated_message = validate_svm2any(
+        message,
+        dest_chain,
+        fee_token_config,
+        &token_transfer_bytes_overhead_for_validation,
+    )?;
+    // extra_args_data_length is 0 for EVM/Aptos/TVM. For SUI/SVM it captures the additional bytes from
+    // accounts and per-token constant overhead that the destination chain must process.
+    let extra_args_data_length = validated_message.extra_args_data_len;
     let processed_extra_args = validated_message.processed_extra_args;
 
     let fee_token_price = get_validated_token_price(fee_token_config)?;
     let PackedPrice {
         execution_gas_price,
-        data_availability_gas_price,
+        ..
     } = get_validated_gas_price(dest_chain)?;
 
     let network_fee = network_fee(
@@ -215,49 +194,31 @@ fn fee_for_msg(
         additional_token_configs,
         additional_token_configs_for_dest_chain,
     )?;
+    let premium_fee = network_fee.premium;
+    let token_transfer_gas = network_fee.transfer_gas;
+    let token_transfer_bytes_overhead = network_fee.transfer_bytes_overhead;
 
     let gas_limit = U256::new(processed_extra_args.gas_limit);
 
-    // Calculate calldata gas cost while accounting for EIP-7623 variable calldata gas pricing
-    // This logic works for EVMs post Pectra upgrade, while being backwards compatible with pre-Pectra EVMs.
-    // This calculation is not exact, the goal is to not lose money on large payloads.
-    // The fixed OCR report calldata overhead gas is accounted for in `dest_gas_overhead`.
-    // It is not included in the calculation below for simplicity.
-    let calldata_length = U256::new(message.data.len() as u128)
-        + U256::new(extra_args_data_len as u128)
-        + network_fee.transfer_bytes_overhead;
-    let mut calldata_gas =
-        calldata_length * U256::new(dest_chain.config.dest_gas_per_payload_byte_base as u128);
-    let calldata_threshold =
-        U256::new(dest_chain.config.dest_gas_per_payload_byte_threshold as u128);
-    if calldata_length > calldata_threshold {
-        let base_calldata_gas = U256::new(dest_chain.config.dest_gas_per_payload_byte_base as u128)
-            * calldata_threshold;
-        let extra_bytes = calldata_length - calldata_threshold;
-        let extra_calldata_gas =
-            extra_bytes * U256::new(dest_chain.config.dest_gas_per_payload_byte_high as u128);
-        calldata_gas = base_calldata_gas + extra_calldata_gas;
-    }
-    let execution_gas = gas_limit
-        + U256::new(dest_chain.config.dest_gas_overhead as u128)
-        + calldata_gas
-        + network_fee.transfer_gas;
+    // Match EVM 1.6 legacy fee calculation: payload bytes are charged at the base per-byte gas rate.
+    let dest_call_data_length = U256::new(message.data.len() as u128)
+        + U256::new(extra_args_data_length as u128)
+        + token_transfer_bytes_overhead;
+    let dest_call_data_cost =
+        dest_call_data_length * U256::new(dest_chain.config.dest_gas_per_payload_byte_base as u128);
 
-    let execution_cost = execution_gas_price
-        * execution_gas
-        * U256::new(dest_chain.config.gas_multiplier_wei_per_eth as u128);
+    // We add the destination chain CCIP overhead, the token transfer gas, the calldata cost and the msg
+    // gas limit to get the total gas the tx costs to execute on the destination chain.
+    let total_dest_chain_gas = U256::new(dest_chain.config.dest_gas_overhead as u128)
+        + token_transfer_gas
+        + dest_call_data_cost
+        + gas_limit;
 
-    let data_availability_cost: Usd18Decimals = data_availability_cost(
-        data_availability_gas_price,
-        message,
-        network_fee.transfer_bytes_overhead,
-        dest_chain,
-    );
+    let execution_cost = execution_gas_price * total_dest_chain_gas * 1u32.e(18);
 
     let premium_multiplier = U256::new(fee_token_config.premium_multiplier_wei_per_eth.into());
     // At this step, every fee component has been raised to 36 decimals
-    let fee_token_value =
-        (network_fee.premium * premium_multiplier) + execution_cost + data_availability_cost;
+    let fee_token_value = (premium_fee * premium_multiplier) + execution_cost;
 
     // Fee token value is in 36 decimals
     // Fee token price is in 18 decimals USD for 1e18 smallest token denominations.
@@ -275,33 +236,23 @@ fn fee_for_msg(
     ))
 }
 
-fn data_availability_cost(
-    data_availability_gas_price: Usd18Decimals,
-    message: &SVM2AnyMessage,
-    token_transfer_bytes_overhead: U256,
-    dest_chain: &DestChain,
-) -> Usd18Decimals {
-    // Sums up byte lengths of fixed message fields and dynamic message fields.
-    // Fixed message fields do account for the offset and length slot of the dynamic fields.
-    let data_availability_length_bytes = SVM_2_EVM_MESSAGE_FIXED_BYTES
-        + U256::new(message.data.len() as u128)
-        + (U256::new(message.token_amounts.len() as u128)
-            * SVM_2_EVM_MESSAGE_FIXED_BYTES_PER_TOKEN)
-        + token_transfer_bytes_overhead;
-
-    // dest_data_availability_overhead_gas is a separate config value for flexibility to be updated
-    // independently of message cost. Its value is determined by CCIP lane implementation, e.g.
-    // the overhead data posted for OCR.
-    let data_availability_gas = data_availability_length_bytes
-        * U256::new(dest_chain.config.dest_gas_per_data_availability_byte as u128)
-        + U256::new(dest_chain.config.dest_data_availability_overhead_gas as u128);
-
-    // data_availability_gas_price is in 18 decimals, dest_data_availability_multiplier_bps is in 4 decimals
-    // We pad 14 decimals to bring the result to 36 decimals, in line with token bps and execution fee.
-    data_availability_gas_price
-        * data_availability_gas
-        * U256::new(dest_chain.config.dest_data_availability_multiplier_bps as u128)
-        * 1u32.e(14)
+fn get_token_transfer_bytes_overhead(
+    additional_token_configs_for_dest_chain: &[Option<PerChainPerTokenConfig>],
+) -> u32 {
+    let dest_bytes_overhead = additional_token_configs_for_dest_chain
+        .iter()
+        .map(|config| match config {
+            Some(config)
+                // In SVM the config can exist with any value, but if the feature is disabled we don't want to count the overhead.
+                if config.token_transfer_config.is_enabled
+                    && config.token_transfer_config.dest_bytes_overhead > 0 =>
+            {
+                config.token_transfer_config.dest_bytes_overhead
+            }
+            _ => CCIP_LOCK_OR_BURN_V1_RET_BYTES,
+        })
+        .sum::<u32>();
+    dest_bytes_overhead
 }
 
 #[derive(Clone, Default, Debug)]
@@ -375,7 +326,7 @@ fn token_network_fees(
         Usd18Decimals::from_usd_cents(config_for_dest_chain.token_transfer_config.min_fee_usdcents);
     let max_fee =
         Usd18Decimals::from_usd_cents(config_for_dest_chain.token_transfer_config.max_fee_usdcents);
-    let (premium, token_transfer_gas, token_transfer_bytes_overhead) = (
+    let (premium_fee, token_transfer_gas, token_transfer_bytes_overhead) = (
         bps_fee.clamp(min_fee, max_fee),
         U256::new(
             config_for_dest_chain
@@ -391,22 +342,22 @@ fn token_network_fees(
         ),
     );
     Ok(NetworkFee {
-        premium,
+        premium: premium_fee,
         transfer_gas: token_transfer_gas,
         transfer_bytes_overhead: token_transfer_bytes_overhead,
     })
 }
 
 fn default_token_network_fees(dest_chain: &DestChain) -> NetworkFee {
-    let (premium, global_gas, global_overhead) = (
+    let (premium_fee, token_transfer_gas, token_transfer_bytes_overhead) = (
         Usd18Decimals::from_usd_cents(dest_chain.config.default_token_fee_usdcents.into()),
         U256::new(dest_chain.config.default_token_dest_gas_overhead.into()),
         U256::new(CCIP_LOCK_OR_BURN_V1_RET_BYTES.into()),
     );
     NetworkFee {
-        premium,
-        transfer_gas: global_gas,
-        transfer_bytes_overhead: global_overhead,
+        premium: premium_fee,
+        transfer_gas: token_transfer_gas,
+        transfer_bytes_overhead: token_transfer_bytes_overhead,
     }
 }
 
@@ -517,6 +468,37 @@ mod tests {
         }
     }
 
+    fn expected_evm_legacy_fee_amount(
+        message: &SVM2AnyMessage,
+        dest_chain: &DestChain,
+        fee_token_config: &BillingTokenConfig,
+        premium_fee: Usd18Decimals,
+        token_transfer_gas: U256,
+        token_transfer_bytes_overhead: U256,
+        extra_args_data_length: u32,
+        gas_limit: u128,
+    ) -> u64 {
+        let fee_token_price = get_validated_token_price(fee_token_config).unwrap();
+        let PackedPrice {
+            execution_gas_price,
+            ..
+        } = get_validated_gas_price(dest_chain).unwrap();
+
+        let dest_call_data_cost = (U256::new(message.data.len() as u128)
+            + U256::new(extra_args_data_length as u128)
+            + token_transfer_bytes_overhead)
+            * U256::new(dest_chain.config.dest_gas_per_payload_byte_base as u128);
+        let total_dest_chain_gas = U256::new(dest_chain.config.dest_gas_overhead as u128)
+            + token_transfer_gas
+            + dest_call_data_cost
+            + U256::new(gas_limit);
+        let premium_multiplier = U256::new(fee_token_config.premium_multiplier_wei_per_eth.into());
+        let fee_token_value = (premium_fee * premium_multiplier)
+            + execution_gas_price * total_dest_chain_gas * 1u32.e(18);
+
+        (fee_token_value.0 / fee_token_price.0).try_into().unwrap()
+    }
+
     #[test]
     // NOTE: This test is unique in that the return value of `fee_for_msg` has been
     // directly validated against a `getFee` query in the Ethereum mainnet -> Avalanche Fuji
@@ -538,9 +520,203 @@ mod tests {
             .0,
             SVMTokenAmount {
                 token: native_mint::ID,
-                amount: 48282184443231661
+                amount: 45957271569960255
             }
         );
+    }
+
+    #[test]
+    fn get_validated_fee_equivalent_empty_message_is_non_zero() {
+        set_syscall_stubs(Box::new(TestStubs));
+
+        let fee = fee_for_msg(
+            &sample_message(),
+            &sample_dest_chain(),
+            &sample_billing_config(),
+            &[],
+            &[],
+        )
+        .unwrap()
+        .0;
+
+        assert!(fee.amount > 0);
+    }
+
+    #[test]
+    fn get_validated_fee_equivalent_high_gas_message_is_non_zero() {
+        set_syscall_stubs(Box::new(TestStubs));
+
+        let chain = sample_dest_chain();
+        let mut message = sample_message();
+        message.data = vec![0; chain.config.max_data_bytes as usize];
+        message.extra_args = crate::extra_args::GenericExtraArgsV2 {
+            gas_limit: chain.config.max_per_msg_gas_limit as u128,
+            allow_out_of_order_execution: true,
+        }
+        .serialize_with_tag();
+
+        let fee = fee_for_msg(&message, &chain, &sample_billing_config(), &[], &[])
+            .unwrap()
+            .0;
+
+        assert!(fee.amount > 0);
+    }
+
+    #[test]
+    fn get_validated_fee_equivalent_message_with_token_is_non_zero() {
+        set_syscall_stubs(Box::new(TestStubs));
+
+        let (token_config, per_chain_per_token_config) = sample_additional_token();
+        let mut message = sample_message();
+        message.token_amounts = vec![SVMTokenAmount {
+            token: per_chain_per_token_config.mint,
+            amount: 10_000,
+        }];
+
+        let fee = fee_for_msg(
+            &message,
+            &sample_dest_chain(),
+            &sample_billing_config(),
+            &[Some(token_config)],
+            &[Some(per_chain_per_token_config)],
+        )
+        .unwrap()
+        .0;
+
+        assert!(fee.amount > 0);
+    }
+
+    #[test]
+    fn get_validated_fee_equivalent_message_with_data_and_token_is_non_zero() {
+        set_syscall_stubs(Box::new(TestStubs));
+
+        let (token_config, per_chain_per_token_config) = sample_additional_token();
+        let mut message = sample_message();
+        message.data =
+            b"random bits and bytes that should be factored into the cost of the message".to_vec();
+        message.token_amounts = vec![SVMTokenAmount {
+            token: per_chain_per_token_config.mint,
+            amount: 10_000,
+        }];
+        message.extra_args = crate::extra_args::GenericExtraArgsV2 {
+            gas_limit: 1_000_000,
+            allow_out_of_order_execution: true,
+        }
+        .serialize_with_tag();
+
+        let fee = fee_for_msg(
+            &message,
+            &sample_dest_chain(),
+            &sample_billing_config(),
+            &[Some(token_config)],
+            &[Some(per_chain_per_token_config)],
+        )
+        .unwrap()
+        .0;
+
+        assert!(fee.amount > 0);
+    }
+
+    #[test]
+    fn fee_matches_evm_legacy_formula_for_message_only() {
+        set_syscall_stubs(Box::new(TestStubs));
+
+        let mut chain = sample_dest_chain();
+        chain.config.dest_gas_per_payload_byte_threshold = 1;
+        chain.config.dest_gas_per_payload_byte_high = 1_000_000;
+        chain.config.gas_multiplier_wei_per_eth = 2_000_000_000_000_000_000;
+
+        let mut message = sample_message();
+        message.data = vec![0; 4_000];
+        message.extra_args = crate::extra_args::GenericExtraArgsV2 {
+            gas_limit: 500_000,
+            allow_out_of_order_execution: true,
+        }
+        .serialize_with_tag();
+
+        let fee_token_config = sample_billing_config();
+        let fee = fee_for_msg(&message, &chain, &fee_token_config, &[], &[])
+            .unwrap()
+            .0;
+        let expected = expected_evm_legacy_fee_amount(
+            &message,
+            &chain,
+            &fee_token_config,
+            Usd18Decimals::from_usd_cents(chain.config.network_fee_usdcents),
+            U256::ZERO,
+            U256::ZERO,
+            0,
+            500_000,
+        );
+
+        assert_eq!(fee.amount, expected);
+    }
+
+    #[test]
+    fn fee_matches_evm_legacy_formula_for_svm_token_transfer() {
+        set_syscall_stubs(Box::new(TestStubs));
+
+        let mut chain = sample_dest_chain();
+        chain.config.chain_family_selector = CHAIN_FAMILY_SELECTOR_SVM.to_be_bytes();
+        chain.config.dest_gas_per_payload_byte_threshold = 1;
+        chain.config.dest_gas_per_payload_byte_high = 1_000_000;
+        chain.config.gas_multiplier_wei_per_eth = 2_000_000_000_000_000_000;
+
+        let (token_config, per_chain_per_token_config) = sample_additional_token();
+        let mut message = sample_message();
+        message.data = vec![0; 100];
+        message.token_amounts = vec![SVMTokenAmount {
+            token: per_chain_per_token_config.mint,
+            amount: 1,
+        }];
+        message.extra_args = SVMExtraArgsV1 {
+            compute_units: 500_000,
+            allow_out_of_order_execution: true,
+            token_receiver: [1; 32],
+            accounts: vec![[2; 32], [3; 32]],
+            ..Default::default()
+        }
+        .serialize_with_tag();
+
+        let fee_token_config = sample_billing_config();
+        let fee = fee_for_msg(
+            &message,
+            &chain,
+            &fee_token_config,
+            &[Some(token_config)],
+            &[Some(per_chain_per_token_config.clone())],
+        )
+        .unwrap()
+        .0;
+        let extra_args_data_length = ((2 + 2) * 32
+            + crate::instructions::v1::messages::SVM_TOKEN_TRANSFER_DATA_OVERHEAD)
+            as u32;
+        let expected = expected_evm_legacy_fee_amount(
+            &message,
+            &chain,
+            &fee_token_config,
+            Usd18Decimals::from_usd_cents(
+                per_chain_per_token_config
+                    .token_transfer_config
+                    .min_fee_usdcents,
+            ),
+            U256::new(
+                per_chain_per_token_config
+                    .token_transfer_config
+                    .dest_gas_overhead
+                    .into(),
+            ),
+            U256::new(
+                per_chain_per_token_config
+                    .token_transfer_config
+                    .dest_bytes_overhead
+                    .into(),
+            ),
+            extra_args_data_length,
+            500_000,
+        );
+
+        assert_eq!(fee.amount, expected);
     }
 
     #[test]
@@ -561,7 +737,7 @@ mod tests {
             SVMTokenAmount {
                 token: native_mint::ID,
                 // Increases proportionally to the network fee component of the sum
-                amount: 298071755652939846
+                amount: 295746842779668440
             }
         );
     }
@@ -621,7 +797,7 @@ mod tests {
             .0,
             SVMTokenAmount {
                 token: native_mint::ID,
-                amount: 52911699750913573,
+                amount: 50165921849671085,
             }
         );
     }
@@ -661,7 +837,7 @@ mod tests {
             SVMTokenAmount {
                 token: native_mint::ID,
                 // Increases proportionally to the min_fee
-                amount: 398634738352169990
+                amount: 395425242628876279
             }
         );
     }
@@ -704,7 +880,7 @@ mod tests {
             .0,
             SVMTokenAmount {
                 token: native_mint::ID,
-                amount: 36654452956230811
+                amount: 33444957232937101
             }
         );
 
@@ -726,7 +902,7 @@ mod tests {
             SVMTokenAmount {
                 token: native_mint::ID,
                 // Slight increase in price
-                amount: 38004452956230811
+                amount: 34794957232937101
             }
         );
     }
@@ -767,7 +943,7 @@ mod tests {
             .0,
             SVMTokenAmount {
                 token: native_mint::ID,
-                amount: 35758615812975735
+                amount: 32549120089682025
             }
         );
 
@@ -788,7 +964,7 @@ mod tests {
             .0,
             SVMTokenAmount {
                 token: native_mint::ID,
-                amount: 35758615812975735
+                amount: 32549120089682025
             }
         );
     }
@@ -826,7 +1002,7 @@ mod tests {
             SVMTokenAmount {
                 token: native_mint::ID,
                 // Increases proportionally to the number of tokens
-                amount: 155328258355951652
+                amount: 149465014082591029
             }
         );
     }

--- a/chains/solana/contracts/programs/fee-quoter/src/instructions/v1/public.rs
+++ b/chains/solana/contracts/programs/fee-quoter/src/instructions/v1/public.rs
@@ -198,8 +198,10 @@ fn fee_for_msg(
         })
         .sum::<u32>();
 
-    let processed_extra_args =
+    let validated_message =
         validate_svm2any(message, dest_chain, fee_token_config, &dest_bytes_overhead)?;
+    let extra_args_data_len = validated_message.extra_args_data_len;
+    let processed_extra_args = validated_message.processed_extra_args;
 
     let fee_token_price = get_validated_token_price(fee_token_config)?;
     let PackedPrice {
@@ -221,8 +223,9 @@ fn fee_for_msg(
     // This calculation is not exact, the goal is to not lose money on large payloads.
     // The fixed OCR report calldata overhead gas is accounted for in `dest_gas_overhead`.
     // It is not included in the calculation below for simplicity.
-    let calldata_length =
-        U256::new(message.data.len() as u128) + network_fee.transfer_bytes_overhead;
+    let calldata_length = U256::new(message.data.len() as u128)
+        + U256::new(extra_args_data_len as u128)
+        + network_fee.transfer_bytes_overhead;
     let mut calldata_gas =
         calldata_length * U256::new(dest_chain.config.dest_gas_per_payload_byte_base as u128);
     let calldata_threshold =
@@ -489,7 +492,9 @@ mod tests {
     };
 
     use super::super::messages::tests::{sample_billing_config, sample_dest_chain, sample_message};
+    use crate::extra_args::{SVMExtraArgsV1, SuiExtraArgsV1};
     use crate::TokenTransferFeeConfig;
+    use ccip_common::{CHAIN_FAMILY_SELECTOR_SUI, CHAIN_FAMILY_SELECTOR_SVM};
 
     use super::*;
 
@@ -824,6 +829,83 @@ mod tests {
                 amount: 155328258355951652
             }
         );
+    }
+
+    #[test]
+    fn sui_receiver_object_ids_are_reflected_in_fee_retrieval() {
+        set_syscall_stubs(Box::new(TestStubs));
+
+        let mut chain = sample_dest_chain();
+        chain.config.chain_family_selector = CHAIN_FAMILY_SELECTOR_SUI.to_be_bytes();
+
+        let mut message = sample_message();
+        message.extra_args = SuiExtraArgsV1 {
+            gas_limit: 0,
+            allow_out_of_order_execution: true,
+            receiver_object_ids: vec![],
+            ..Default::default()
+        }
+        .serialize_with_tag();
+
+        let fee_without_receiver_object_ids =
+            fee_for_msg(&message, &chain, &sample_billing_config(), &[], &[])
+                .unwrap()
+                .0
+                .amount;
+
+        message.extra_args = SuiExtraArgsV1 {
+            gas_limit: 0,
+            allow_out_of_order_execution: true,
+            receiver_object_ids: vec![[1; 32], [2; 32]],
+            ..Default::default()
+        }
+        .serialize_with_tag();
+
+        let fee_with_receiver_object_ids =
+            fee_for_msg(&message, &chain, &sample_billing_config(), &[], &[])
+                .unwrap()
+                .0
+                .amount;
+
+        assert!(fee_with_receiver_object_ids > fee_without_receiver_object_ids);
+    }
+
+    #[test]
+    fn svm_accounts_are_reflected_in_fee_retrieval() {
+        set_syscall_stubs(Box::new(TestStubs));
+
+        let mut chain = sample_dest_chain();
+        chain.config.chain_family_selector = CHAIN_FAMILY_SELECTOR_SVM.to_be_bytes();
+
+        let mut message = sample_message();
+        message.extra_args = SVMExtraArgsV1 {
+            compute_units: 0,
+            allow_out_of_order_execution: true,
+            accounts: vec![],
+            ..Default::default()
+        }
+        .serialize_with_tag();
+
+        let fee_without_accounts =
+            fee_for_msg(&message, &chain, &sample_billing_config(), &[], &[])
+                .unwrap()
+                .0
+                .amount;
+
+        message.extra_args = SVMExtraArgsV1 {
+            compute_units: 0,
+            allow_out_of_order_execution: true,
+            accounts: vec![[1; 32], [2; 32]],
+            ..Default::default()
+        }
+        .serialize_with_tag();
+
+        let fee_with_accounts = fee_for_msg(&message, &chain, &sample_billing_config(), &[], &[])
+            .unwrap()
+            .0
+            .amount;
+
+        assert!(fee_with_accounts > fee_without_accounts);
     }
 
     pub fn sample_additional_token() -> (BillingTokenConfig, PerChainPerTokenConfig) {

--- a/chains/solana/contracts/programs/fee-quoter/src/instructions/v1/public.rs
+++ b/chains/solana/contracts/programs/fee-quoter/src/instructions/v1/public.rs
@@ -185,7 +185,21 @@ fn fee_for_msg(
         additional_token_configs_for_dest_chain.len() == message.token_amounts.len(),
         FeeQuoterError::InvalidInputsMissingTokenConfig
     );
-    let processed_extra_args = validate_svm2any(message, dest_chain, fee_token_config)?;
+    let dest_bytes_overhead = additional_token_configs_for_dest_chain
+        .iter()
+        .map(|config| match config {
+            Some(config)
+                if config.token_transfer_config.is_enabled
+                    && config.token_transfer_config.dest_bytes_overhead > 0 =>
+            {
+                config.token_transfer_config.dest_bytes_overhead
+            }
+            _ => CCIP_LOCK_OR_BURN_V1_RET_BYTES,
+        })
+        .sum::<u32>();
+
+    let processed_extra_args =
+        validate_svm2any(message, dest_chain, fee_token_config, &dest_bytes_overhead)?;
 
     let fee_token_price = get_validated_token_price(fee_token_config)?;
     let PackedPrice {

--- a/chains/solana/contracts/programs/fee-quoter/src/lib.rs
+++ b/chains/solana/contracts/programs/fee-quoter/src/lib.rs
@@ -447,4 +447,6 @@ pub enum FeeQuoterError {
     DefaultOwnerProposal,
     #[msg("Invalid Sui receiver object ids")]
     InvalidSuiReceiverObjectIds,
+    #[msg("Token transfer fee config must be enabled")]
+    TokenTransferConfigMustBeEnabled,
 }

--- a/chains/solana/contracts/programs/fee-quoter/src/lib.rs
+++ b/chains/solana/contracts/programs/fee-quoter/src/lib.rs
@@ -445,4 +445,6 @@ pub enum FeeQuoterError {
     InvalidCodeVersion,
     #[msg("Proposed owner is the default pubkey")]
     DefaultOwnerProposal,
+    #[msg("Invalid Sui receiver object ids")]
+    InvalidSuiReceiverObjectIds,
 }

--- a/chains/solana/contracts/target/idl/fee_quoter.json
+++ b/chains/solana/contracts/target/idl/fee_quoter.json
@@ -955,6 +955,42 @@
       }
     },
     {
+      "name": "SuiExtraArgsV1",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "gasLimit",
+            "type": "u128"
+          },
+          {
+            "name": "allowOutOfOrderExecution",
+            "type": "bool"
+          },
+          {
+            "name": "tokenReceiver",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "receiverObjectIds",
+            "type": {
+              "vec": {
+                "array": [
+                  "u8",
+                  32
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "SVM2AnyMessage",
       "type": {
         "kind": "struct",
@@ -1741,6 +1777,11 @@
       "code": 8037,
       "name": "DefaultOwnerProposal",
       "msg": "Proposed owner is the default pubkey"
+    },
+    {
+      "code": 8038,
+      "name": "InvalidSuiReceiverObjectIds",
+      "msg": "Invalid Sui receiver object ids"
     }
   ]
 }

--- a/chains/solana/contracts/target/idl/fee_quoter.json
+++ b/chains/solana/contracts/target/idl/fee_quoter.json
@@ -1782,6 +1782,11 @@
       "code": 8038,
       "name": "InvalidSuiReceiverObjectIds",
       "msg": "Invalid Sui receiver object ids"
+    },
+    {
+      "code": 8039,
+      "name": "TokenTransferConfigMustBeEnabled",
+      "msg": "Token transfer fee config must be enabled"
     }
   ]
 }

--- a/chains/solana/contracts/target/types/fee_quoter.ts
+++ b/chains/solana/contracts/target/types/fee_quoter.ts
@@ -1782,6 +1782,11 @@ export type FeeQuoter = {
       "code": 8038,
       "name": "InvalidSuiReceiverObjectIds",
       "msg": "Invalid Sui receiver object ids"
+    },
+    {
+      "code": 8039,
+      "name": "TokenTransferConfigMustBeEnabled",
+      "msg": "Token transfer fee config must be enabled"
     }
   ]
 };
@@ -3570,6 +3575,11 @@ export const IDL: FeeQuoter = {
       "code": 8038,
       "name": "InvalidSuiReceiverObjectIds",
       "msg": "Invalid Sui receiver object ids"
+    },
+    {
+      "code": 8039,
+      "name": "TokenTransferConfigMustBeEnabled",
+      "msg": "Token transfer fee config must be enabled"
     }
   ]
 };

--- a/chains/solana/contracts/target/types/fee_quoter.ts
+++ b/chains/solana/contracts/target/types/fee_quoter.ts
@@ -955,6 +955,42 @@ export type FeeQuoter = {
       }
     },
     {
+      "name": "SuiExtraArgsV1",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "gasLimit",
+            "type": "u128"
+          },
+          {
+            "name": "allowOutOfOrderExecution",
+            "type": "bool"
+          },
+          {
+            "name": "tokenReceiver",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "receiverObjectIds",
+            "type": {
+              "vec": {
+                "array": [
+                  "u8",
+                  32
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "SVM2AnyMessage",
       "type": {
         "kind": "struct",
@@ -1741,6 +1777,11 @@ export type FeeQuoter = {
       "code": 8037,
       "name": "DefaultOwnerProposal",
       "msg": "Proposed owner is the default pubkey"
+    },
+    {
+      "code": 8038,
+      "name": "InvalidSuiReceiverObjectIds",
+      "msg": "Invalid Sui receiver object ids"
     }
   ]
 };
@@ -2702,6 +2743,42 @@ export const IDL: FeeQuoter = {
       }
     },
     {
+      "name": "SuiExtraArgsV1",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "gasLimit",
+            "type": "u128"
+          },
+          {
+            "name": "allowOutOfOrderExecution",
+            "type": "bool"
+          },
+          {
+            "name": "tokenReceiver",
+            "type": {
+              "array": [
+                "u8",
+                32
+              ]
+            }
+          },
+          {
+            "name": "receiverObjectIds",
+            "type": {
+              "vec": {
+                "array": [
+                  "u8",
+                  32
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "SVM2AnyMessage",
       "type": {
         "kind": "struct",
@@ -3488,6 +3565,11 @@ export const IDL: FeeQuoter = {
       "code": 8037,
       "name": "DefaultOwnerProposal",
       "msg": "Proposed owner is the default pubkey"
+    },
+    {
+      "code": 8038,
+      "name": "InvalidSuiReceiverObjectIds",
+      "msg": "Invalid Sui receiver object ids"
     }
   ]
 };

--- a/chains/solana/contracts/tests/ccip/ccip_router_test.go
+++ b/chains/solana/contracts/tests/ccip/ccip_router_test.go
@@ -1496,7 +1496,7 @@ func TestCCIPRouter(t *testing.T) {
 						ChainFamilySelector:     [4]uint8(config.SvmChainFamilySelector),
 						EnforceOutOfOrder:       true,
 						MaxNumberOfTokensPerMsg: 10,
-						MaxDataBytes:            100,
+						MaxDataBytes:            500,
 					},
 					config.FqConfigPDA,
 					config.FqSvmDestChainPDA,

--- a/chains/solana/gobindings/latest/fee_quoter/types.go
+++ b/chains/solana/gobindings/latest/fee_quoter/types.go
@@ -172,6 +172,61 @@ func (obj *SVMExtraArgsV1) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err
 	return nil
 }
 
+type SuiExtraArgsV1 struct {
+	GasLimit                 ag_binary.Uint128
+	AllowOutOfOrderExecution bool
+	TokenReceiver            [32]uint8
+	ReceiverObjectIds        [][32]uint8
+}
+
+func (obj SuiExtraArgsV1) MarshalWithEncoder(encoder *ag_binary.Encoder) (err error) {
+	// Serialize `GasLimit` param:
+	err = encoder.Encode(obj.GasLimit)
+	if err != nil {
+		return err
+	}
+	// Serialize `AllowOutOfOrderExecution` param:
+	err = encoder.Encode(obj.AllowOutOfOrderExecution)
+	if err != nil {
+		return err
+	}
+	// Serialize `TokenReceiver` param:
+	err = encoder.Encode(obj.TokenReceiver)
+	if err != nil {
+		return err
+	}
+	// Serialize `ReceiverObjectIds` param:
+	err = encoder.Encode(obj.ReceiverObjectIds)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (obj *SuiExtraArgsV1) UnmarshalWithDecoder(decoder *ag_binary.Decoder) (err error) {
+	// Deserialize `GasLimit`:
+	err = decoder.Decode(&obj.GasLimit)
+	if err != nil {
+		return err
+	}
+	// Deserialize `AllowOutOfOrderExecution`:
+	err = decoder.Decode(&obj.AllowOutOfOrderExecution)
+	if err != nil {
+		return err
+	}
+	// Deserialize `TokenReceiver`:
+	err = decoder.Decode(&obj.TokenReceiver)
+	if err != nil {
+		return err
+	}
+	// Deserialize `ReceiverObjectIds`:
+	err = decoder.Decode(&obj.ReceiverObjectIds)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 type SVM2AnyMessage struct {
 	Receiver     []byte
 	Data         []byte


### PR DESCRIPTION
Adds Sui extra args support to the Solana FeeQuoter and updates SVM/Sui payload size accounting.

This PR introduces Sui-specific extra args parsing and validation, including token receiver and receiver object IDs, and accounts for destination-side overhead when validating `max_data_bytes`. It also updates the SVM extra args path so token transfer overhead and destination byte overhead are included in expanded payload size checks. This matches one on one the behaviour for EVM.

Tests were updated to reflect the larger expanded payload size for SVM token transfers.