### PR TITLE
feat: replace deposit ceremony with plain transfer for MigrateLockReleaseLiquidity changeset

### DIFF
--- a/chains/evm/deployment/v1_0_0/operations/erc20/erc20.go
+++ b/chains/evm/deployment/v1_0_0/operations/erc20/erc20.go
@@ -96,6 +96,28 @@ var GetDecimals = contract.NewRead(contract.ReadParams[struct{}, uint8, *erc20.E
 	},
 })
 
+// TransferProposalOnly is identical to Transfer but forces the operation into a proposal
+// rather than executing directly. Use when the transfer must be called by a timelock
+// as part of an atomic MCMS batch (e.g., withdraw → transfer liquidity flows).
+var TransferProposalOnly = contract.NewWrite(contract.WriteParams[TransferArgs, *erc20.ERC20]{
+	Name:            "erc20:transfer-proposal-only",
+	Version:         utils.Version_1_0_0,
+	Description:     "Transfer ERC20 tokens to a specified address (proposal-only, never executed directly)",
+	ContractType:    ContractType,
+	ContractABI:     erc20.ERC20ABI,
+	NewContract:     erc20.NewERC20,
+	IsAllowedCaller: contract.NoCallersAllowed[*erc20.ERC20, TransferArgs],
+	Validate: func(args TransferArgs) error {
+		if args.Amount == nil || args.Amount.Cmp(big.NewInt(0)) <= 0 {
+			return errors.New("amount must be greater than 0")
+		}
+		return nil
+	},
+	CallContract: func(token *erc20.ERC20, opts *bind.TransactOpts, args TransferArgs) (*types.Transaction, error) {
+		return token.Transfer(opts, args.Receiver, args.Amount)
+	},
+})
+
 var Approve = contract.NewWrite(contract.WriteParams[ApproveArgs, *erc20.ERC20]{
 	Name:            "erc20:approve",
 	Version:         utils.Version_1_0_0,

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/migrate_lock_release_pool_liquidity.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/migrate_lock_release_pool_liquidity.go
@@ -164,7 +164,7 @@ func migrateUnsiloedPool(
 		return sequences.OnChainOutput{}, err
 	}
 
-	transferReport, err := cldf_ops.ExecuteOperation(b, erc20_ops.Transfer, evmChain, evm_contract.FunctionInput[erc20_ops.TransferArgs]{
+	transferReport, err := cldf_ops.ExecuteOperation(b, erc20_ops.TransferProposalOnly, evmChain, evm_contract.FunctionInput[erc20_ops.TransferArgs]{
 		ChainSelector: chainSel,
 		Address:       tokenAddr,
 		Args: erc20_ops.TransferArgs{
@@ -378,7 +378,7 @@ func migrateSiloedPool(
 		}
 		ops = append(ops, withdrawReport.Output)
 
-		siloTransferReport, err := cldf_ops.ExecuteOperation(b, erc20_ops.Transfer, evmChain, evm_contract.FunctionInput[erc20_ops.TransferArgs]{
+		siloTransferReport, err := cldf_ops.ExecuteOperation(b, erc20_ops.TransferProposalOnly, evmChain, evm_contract.FunctionInput[erc20_ops.TransferArgs]{
 			ChainSelector: chainSel,
 			Address:       tokenAddr,
 			Args: erc20_ops.TransferArgs{
@@ -424,7 +424,7 @@ func migrateSiloedPool(
 		}
 		ops = append(ops, withdrawUnsiloedReport.Output)
 
-		unsiloedTransferReport, err := cldf_ops.ExecuteOperation(b, erc20_ops.Transfer, evmChain, evm_contract.FunctionInput[erc20_ops.TransferArgs]{
+		unsiloedTransferReport, err := cldf_ops.ExecuteOperation(b, erc20_ops.TransferProposalOnly, evmChain, evm_contract.FunctionInput[erc20_ops.TransferArgs]{
 			ChainSelector: chainSel,
 			Address:       tokenAddr,
 			Args: erc20_ops.TransferArgs{

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/migrate_lock_release_pool_liquidity.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/migrate_lock_release_pool_liquidity.go
@@ -18,7 +18,6 @@ import (
 	tar_ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/operations/token_admin_registry"
 	lrtp_ops_v161 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_1/operations/lock_release_token_pool"
 	siloed_ops_v161 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_1/operations/siloed_lock_release_token_pool"
-	lockbox_ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/erc20_lock_box"
 	lrtp_ops_v170 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/lock_release_token_pool"
 	siloed_lrtp_ops_v170 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/siloed_lock_release_token_pool"
 	token_pool_ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/token_pool"
@@ -165,15 +164,28 @@ func migrateUnsiloedPool(
 		return sequences.OnChainOutput{}, err
 	}
 
-	ops, err = appendAuthApproveDeposit(b, evmChain, chainSel, lockboxAddr, tokenAddr, timelockAddr, amount, 0, ops)
+	transferReport, err := cldf_ops.ExecuteOperation(b, erc20_ops.Transfer, evmChain, evm_contract.FunctionInput[erc20_ops.TransferArgs]{
+		ChainSelector: chainSel,
+		Address:       tokenAddr,
+		Args: erc20_ops.TransferArgs{
+			Receiver: lockboxAddr,
+			Amount:   amount,
+		},
+	})
 	if err != nil {
-		return sequences.OnChainOutput{}, err
+		return sequences.OnChainOutput{}, fmt.Errorf("failed to transfer tokens to lockbox %s: %w", lockboxAddr, err)
 	}
+	ops = append(ops, transferReport.Output)
 
-	ops, err = appendCleanup(b, evmChain, chainSel, lockboxAddr, oldPoolAddr, timelockAddr, originalRebalancer, ops)
+	restoreRebalancerReport, err := cldf_ops.ExecuteOperation(b, lrtp_ops_v161.SetRebalancer, evmChain, evm_contract.FunctionInput[common.Address]{
+		ChainSelector: chainSel,
+		Address:       oldPoolAddr,
+		Args:          originalRebalancer,
+	})
 	if err != nil {
-		return sequences.OnChainOutput{}, err
+		return sequences.OnChainOutput{}, fmt.Errorf("failed to restore rebalancer on old pool %s: %w", oldPoolAddr, err)
 	}
+	ops = append(ops, restoreRebalancerReport.Output)
 
 	if input.SetPoolConfig != nil {
 		ops, err = appendSetPool(b, evmChain, chainSel, input.SetPoolConfig, newPoolAddr, ops)
@@ -325,7 +337,6 @@ func migrateSiloedPool(
 	}
 
 	var firstLockbox common.Address
-	usedLockboxes := make(map[common.Address]bool)
 	for _, info := range siloInfos {
 		if !info.isSiloed {
 			continue
@@ -367,11 +378,18 @@ func migrateSiloedPool(
 		}
 		ops = append(ops, withdrawReport.Output)
 
-		ops, err = appendAuthApproveDeposit(b, evmChain, chainSel, lockbox, tokenAddr, timelockAddr, siloAmount, info.chainSelector, ops)
+		siloTransferReport, err := cldf_ops.ExecuteOperation(b, erc20_ops.Transfer, evmChain, evm_contract.FunctionInput[erc20_ops.TransferArgs]{
+			ChainSelector: chainSel,
+			Address:       tokenAddr,
+			Args: erc20_ops.TransferArgs{
+				Receiver: lockbox,
+				Amount:   siloAmount,
+			},
+		})
 		if err != nil {
-			return sequences.OnChainOutput{}, fmt.Errorf("failed to build deposit ops for chain %d: %w", info.chainSelector, err)
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to transfer siloed liquidity to lockbox for chain %d: %w", info.chainSelector, err)
 		}
-		usedLockboxes[lockbox] = true
+		ops = append(ops, siloTransferReport.Output)
 	}
 
 	unsiloedReport, err := cldf_ops.ExecuteOperation(b, siloed_ops_v161.GetUnsiloedLiquidity, evmChain, evm_contract.FunctionInput[struct{}]{
@@ -406,11 +424,18 @@ func migrateSiloedPool(
 		}
 		ops = append(ops, withdrawUnsiloedReport.Output)
 
-		ops, err = appendAuthApproveDeposit(b, evmChain, chainSel, depositLockbox, tokenAddr, timelockAddr, unsiloedAmount, 0, ops)
+		unsiloedTransferReport, err := cldf_ops.ExecuteOperation(b, erc20_ops.Transfer, evmChain, evm_contract.FunctionInput[erc20_ops.TransferArgs]{
+			ChainSelector: chainSel,
+			Address:       tokenAddr,
+			Args: erc20_ops.TransferArgs{
+				Receiver: depositLockbox,
+				Amount:   unsiloedAmount,
+			},
+		})
 		if err != nil {
-			return sequences.OnChainOutput{}, fmt.Errorf("failed to build deposit ops for unsiloed liquidity: %w", err)
+			return sequences.OnChainOutput{}, fmt.Errorf("failed to transfer unsiloed liquidity to lockbox: %w", err)
 		}
-		usedLockboxes[depositLockbox] = true
+		ops = append(ops, unsiloedTransferReport.Output)
 	}
 
 	for _, info := range siloInfos {
@@ -439,21 +464,6 @@ func migrateSiloedPool(
 		return sequences.OnChainOutput{}, fmt.Errorf("failed to restore unsiloed rebalancer: %w", err)
 	}
 	ops = append(ops, restoreUnsiloedReport.Output)
-
-	for lb := range usedLockboxes {
-		removeAuthReport, err := cldf_ops.ExecuteOperation(b, lockbox_ops.ApplyAuthorizedCallerUpdatesProposalOnly, evmChain, evm_contract.FunctionInput[lockbox_ops.AuthorizedCallerArgs]{
-			ChainSelector: chainSel,
-			Address:       lb,
-			Args: lockbox_ops.AuthorizedCallerArgs{
-				AddedCallers:   []common.Address{},
-				RemovedCallers: []common.Address{timelockAddr},
-			},
-		})
-		if err != nil {
-			return sequences.OnChainOutput{}, fmt.Errorf("failed to remove timelock from lockbox %s authorized callers: %w", lb, err)
-		}
-		ops = append(ops, removeAuthReport.Output)
-	}
 
 	if input.SetPoolConfig != nil {
 		ops, err = appendSetPool(b, evmChain, chainSel, input.SetPoolConfig, newPoolAddr, ops)
@@ -499,91 +509,6 @@ func appendSetRebalancerAndWithdraw(
 		return nil, fmt.Errorf("failed to withdraw liquidity from old pool %s: %w", oldPoolAddr, err)
 	}
 	ops = append(ops, withdrawReport.Output)
-
-	return ops, nil
-}
-
-func appendAuthApproveDeposit(
-	b cldf_ops.Bundle,
-	evmChain evm.Chain,
-	chainSel uint64,
-	lockboxAddr, tokenAddr, timelockAddr common.Address,
-	amount *big.Int,
-	remoteChainSelector uint64,
-	ops []evm_contract.WriteOutput,
-) ([]evm_contract.WriteOutput, error) {
-	addAuthReport, err := cldf_ops.ExecuteOperation(b, lockbox_ops.ApplyAuthorizedCallerUpdatesProposalOnly, evmChain, evm_contract.FunctionInput[lockbox_ops.AuthorizedCallerArgs]{
-		ChainSelector: chainSel,
-		Address:       lockboxAddr,
-		Args: lockbox_ops.AuthorizedCallerArgs{
-			AddedCallers:   []common.Address{timelockAddr},
-			RemovedCallers: []common.Address{},
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to add timelock as authorized caller on lockbox %s: %w", lockboxAddr, err)
-	}
-	ops = append(ops, addAuthReport.Output)
-
-	approveReport, err := cldf_ops.ExecuteOperation(b, erc20_ops.ApproveProposalOnly, evmChain, evm_contract.FunctionInput[erc20_ops.ApproveArgs]{
-		ChainSelector: chainSel,
-		Address:       tokenAddr,
-		Args: erc20_ops.ApproveArgs{
-			Spender: lockboxAddr,
-			Value:   amount,
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to approve lockbox %s to spend tokens: %w", lockboxAddr, err)
-	}
-	ops = append(ops, approveReport.Output)
-
-	depositReport, err := cldf_ops.ExecuteOperation(b, lockbox_ops.Deposit, evmChain, evm_contract.FunctionInput[lockbox_ops.DepositArgs]{
-		ChainSelector: chainSel,
-		Address:       lockboxAddr,
-		Args: lockbox_ops.DepositArgs{
-			Token:               tokenAddr,
-			RemoteChainSelector: remoteChainSelector,
-			Amount:              amount,
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to deposit into lockbox %s: %w", lockboxAddr, err)
-	}
-	ops = append(ops, depositReport.Output)
-
-	return ops, nil
-}
-
-func appendCleanup(
-	b cldf_ops.Bundle,
-	evmChain evm.Chain,
-	chainSel uint64,
-	lockboxAddr, oldPoolAddr, timelockAddr, originalRebalancer common.Address,
-	ops []evm_contract.WriteOutput,
-) ([]evm_contract.WriteOutput, error) {
-	removeAuthReport, err := cldf_ops.ExecuteOperation(b, lockbox_ops.ApplyAuthorizedCallerUpdatesProposalOnly, evmChain, evm_contract.FunctionInput[lockbox_ops.AuthorizedCallerArgs]{
-		ChainSelector: chainSel,
-		Address:       lockboxAddr,
-		Args: lockbox_ops.AuthorizedCallerArgs{
-			AddedCallers:   []common.Address{},
-			RemovedCallers: []common.Address{timelockAddr},
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to remove timelock as authorized caller on lockbox %s: %w", lockboxAddr, err)
-	}
-	ops = append(ops, removeAuthReport.Output)
-
-	restoreRebalancerReport, err := cldf_ops.ExecuteOperation(b, lrtp_ops_v161.SetRebalancer, evmChain, evm_contract.FunctionInput[common.Address]{
-		ChainSelector: chainSel,
-		Address:       oldPoolAddr,
-		Args:          originalRebalancer,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to restore rebalancer on old pool %s: %w", oldPoolAddr, err)
-	}
-	ops = append(ops, restoreRebalancerReport.Output)
 
 	return ops, nil
 }

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/migrate_lock_release_pool_liquidity_test.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/migrate_lock_release_pool_liquidity_test.go
@@ -434,7 +434,7 @@ func TestMigrateLockReleasePoolLiquidity_UnsiloedPartialBasisPoints(t *testing.T
 	require.Equal(t, common.Address{}, rebalancerReport.Output,
 		"Rebalancer should be restored to original value (zero address)")
 
-	// Verify timelock was removed from lockbox authorized callers
+	// Verify timelock was never added to lockbox authorized callers
 	authCallersReport, err := operations.ExecuteOperation(
 		testsetup.BundleWithFreshReporter(s.env.OperationsBundle),
 		erc20_lock_box.GetAllAuthorizedCallers,
@@ -446,7 +446,7 @@ func TestMigrateLockReleasePoolLiquidity_UnsiloedPartialBasisPoints(t *testing.T
 	)
 	require.NoError(t, err)
 	require.NotContains(t, authCallersReport.Output, s.deployer,
-		"Timelock should be removed from lockbox authorized callers after migration")
+		"Timelock should not be in lockbox authorized callers (transfer-only flow)")
 }
 
 func TestMigrateLockReleasePoolLiquidity_UnsiloedFullBasisPoints(t *testing.T) {
@@ -960,7 +960,7 @@ func TestMigrateLockReleasePoolLiquidity_WithSetPoolConfig(t *testing.T) {
 	require.Equal(t, 0, totalLiquidity.Cmp(lockboxBal.Output), "Lockbox should hold all liquidity")
 }
 
-func TestMigrateLockReleasePoolLiquidity_AuthorizedCallerCleanup(t *testing.T) {
+func TestMigrateLockReleasePoolLiquidity_DoesNotTamperWithAuthorizedCallers(t *testing.T) {
 	chainSel := uint64(5009297550715157269)
 	totalLiquidity := big.NewInt(5000)
 	s := setupMigrationTest(t, chainSel, totalLiquidity)
@@ -987,7 +987,7 @@ func TestMigrateLockReleasePoolLiquidity_AuthorizedCallerCleanup(t *testing.T) {
 	require.Contains(t, preCallersReport.Output, preExistingCaller,
 		"Pre-existing caller should be present before migration")
 
-	// Run migration
+	// Run migration (transfer-based, never touches authorized callers)
 	basisPoints := uint16(10000)
 	executeMigrationSequence(t,
 		testsetup.BundleWithFreshReporter(s.env.OperationsBundle),
@@ -1007,11 +1007,11 @@ func TestMigrateLockReleasePoolLiquidity_AuthorizedCallerCleanup(t *testing.T) {
 		evm_contract.FunctionInput[struct{}]{ChainSelector: chainSel, Address: s.lockBoxAddr})
 	require.NoError(t, err)
 	require.Contains(t, postCallersReport.Output, preExistingCaller,
-		"Pre-existing authorized caller should be preserved after migration")
+		"Pre-existing authorized caller should be preserved after migration (transfer does not touch authorized callers)")
 
-	// Verify timelock (deployer) was removed from authorized callers
+	// Verify timelock was never added to authorized callers
 	require.NotContains(t, postCallersReport.Output, s.deployer,
-		"Timelock should be removed from lockbox authorized callers after migration")
+		"Timelock should not be in lockbox authorized callers (transfer-only flow)")
 }
 
 func TestMigrateLockReleasePoolLiquidity_MultiplePartialMigrations(t *testing.T) {

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/migrate_lock_release_pool_liquidity_test.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/migrate_lock_release_pool_liquidity_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/erc20_lock_box"
 	new_lrtp "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/lock_release_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences"
+	seqtypes "github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences/tokens"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/testsetup"
 	latest_siloed "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v2_0_0/siloed_lock_release_token_pool"
@@ -326,7 +327,7 @@ func executeMigrationSequence(
 	bundle operations.Bundle,
 	blockChains chain.BlockChains,
 	input tokens_core.MigrateLockReleasePoolLiquidityInput,
-) {
+) seqtypes.OnChainOutput {
 	t.Helper()
 
 	report, err := operations.ExecuteSequence(
@@ -367,6 +368,8 @@ func executeMigrationSequence(
 			require.NoError(t, err)
 		}
 	}
+
+	return report.Output
 }
 
 func TestMigrateLockReleasePoolLiquidity_UnsiloedPartialBasisPoints(t *testing.T) {
@@ -989,7 +992,7 @@ func TestMigrateLockReleasePoolLiquidity_DoesNotTamperWithAuthorizedCallers(t *t
 
 	// Run migration (transfer-based, never touches authorized callers)
 	basisPoints := uint16(10000)
-	executeMigrationSequence(t,
+	output := executeMigrationSequence(t,
 		testsetup.BundleWithFreshReporter(s.env.OperationsBundle),
 		s.env.BlockChains,
 		tokens_core.MigrateLockReleasePoolLiquidityInput{
@@ -1000,6 +1003,19 @@ func TestMigrateLockReleasePoolLiquidity_DoesNotTamperWithAuthorizedCallers(t *t
 			BasisPoints:     &basisPoints,
 		},
 	)
+
+	// Verify no applyAuthorizedCallerUpdates calls appear in any batch transaction
+	parsedABI, err := abi.JSON(strings.NewReader(erc20_lock_box.ERC20LockBoxABI))
+	require.NoError(t, err)
+	authSelector := parsedABI.Methods["applyAuthorizedCallerUpdates"].ID
+	for _, batch := range output.BatchOps {
+		for _, tx := range batch.Transactions {
+			if len(tx.Data) >= 4 {
+				require.NotEqual(t, authSelector[:], tx.Data[:4],
+					"migration batch should not contain applyAuthorizedCallerUpdates calls")
+			}
+		}
+	}
 
 	// Verify pre-existing caller is still present after migration
 	postCallersReport, err := operations.ExecuteOperation(


### PR DESCRIPTION
# MigrateLockReleaseLiquidity: Replace deposit ceremony with plain transfer

## What this does

The standalone `MigrateLockReleasePoolLiquidity` changeset (drain path for legacy lock-release pools) previously funded the v2.0 ERC20LockBox via a 3-step ceremony: **add timelock as authorized caller → approve lockbox → call deposit()**. This required the lockbox to be owned by the timelock (an extra pre-step) and injected 2N unnecessary transactions into the MCMS proposal (add-auth + remove-auth per lockbox).

This PR replaces that ceremony with a plain `erc20.transfer(timelock, lockbox, amount)`.

## Why this works

The ERC20LockBox contract tracks liquidity by raw `balanceOf(address(this))` — not internal accounting. The `withdraw()` function (used by the pool at runtime) reads the raw balance. Tokens that arrive via `transfer()` are indistinguishable from those that arrive via `deposit()`. The only thing lost is the `Deposit` event — not a functional concern for a one-time migration tool.

The pool's runtime `_lockOrBurn` path is unaffected: the pool remains an authorized caller and retains its unlimited approval from the constructor. The migration tooling and the pool contract are orthogonal.

## Scope

- **`erc20.TransferProposalOnly`**: added a new `NoCallersAllowed` variant of the ERC20 transfer operation (mirroring the existing `ApproveProposalOnly` pattern). The framework's `NewWrite` executes `AllCallersAllowed` operations immediately with the deployer's key. Since the deployer never holds the tokens (they arrive via an MCMS-batched withdrawal), the transfer would fire before the proposal executes and fail. `TransferProposalOnly` forces the transfer into the MCMS batch alongside the withdrawal, preserving ordering and sender identity.
- **Unsiloed path** (`migrateUnsiloedPool`): replaced the `appendAuthApproveDeposit` + `appendCleanup` pair with a single inline `TransferProposalOnly` operation plus an inline rebalancer restore (which was previously buried in `appendCleanup`). The rebalancer restore remains — it's still needed to reverse the temporary rebalancer handover.
- **Siloed path** (`migrateSiloedPool`): same swap in both the siloed-liquidity loop and the unsiloed-liquidity branch. Removed the `usedLockboxes` tracking map and the post-migration loop that removed the timelock from each lockbox's authorized callers — the timelock is never added, so there's nothing to clean up.
- **Deleted**: `appendAuthApproveDeposit`, `appendCleanup`, `appendTransfer` (the last never made it past the inlining step). The helper was removed because it wrapped a single `ExecuteOperation` call — the indirection wasn't worth it.
- **Import cleanup**: `lockbox_ops` removed from imports (zero remaining references).

## Not changed

- `SetPoolConfig` — untouched, still optional, still orthogonal to the drain flow.
- No Solidity contracts changed. `ERC20LockBox.deposit()` still exists and works for the pool's runtime path. The change is entirely in Go tooling.
- No backwards incompatibility. The migration batch still produces the same end state: old pool drained to its rebalancer, lockbox funded, old pool's rebalancer restored.
