### PR TITLE
Add EVM adapters for onramp upgrader

### DIFF
--- a/chains/evm/deployment/operations_gen_config.yaml
+++ b/chains/evm/deployment/operations_gen_config.yaml
@@ -308,6 +308,8 @@ contracts:
         access: public
       - name: getStaticConfig
         access: public
+      - name: getAllDestChainConfigs
+        access: public
 
   - contract_name: OffRamp
     version: "2.0.0"

--- a/chains/evm/deployment/v2_0_0/adapters/init.go
+++ b/chains/evm/deployment/v2_0_0/adapters/init.go
@@ -37,6 +37,7 @@ import (
 	feequoterops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/fee_quoter"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/mock_receiver"
 	cctpverifierops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_1_0/operations/cctp_verifier"
+
 	// Blank import so the RMN 2.1.0 fastcurse adapter registers itself for consumers that only
 	// import this package.
 	usdctokenpoolproxyops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/usdc_token_pool_proxy"
@@ -84,6 +85,8 @@ func init() {
 	ccvadapters.GetDeployChainContractsRegistry().Register(chainsel.FamilyEVM, &EVMDeployChainContractsAdapter{})
 	ccvadapters.GetDeployChainContractsRegistry().RegisterConfigImporter(chainsel.FamilyEVM, semver.MustParse("1.6.0"), &adapters1_6.ConfigImportAdapter{})
 	ccvadapters.GetDeployChainContractsRegistry().RegisterLaneVersionResolver(chainsel.FamilyEVM, &adapters1_2.LaneVersionResolver{})
+
+	ccvadapters.GetOnRampUpgraderRegistry().Register(chainsel.FamilyEVM, &EVMOnRampUpgrader{})
 
 	tokens.GetTokenAdapterRegistry().RegisterTokenAdapter(chainsel.FamilyEVM, v, NewTokenAdapter())
 	feeAggReg := fees.GetFeeAggregatorRegistry()

--- a/chains/evm/deployment/v2_0_0/adapters/offramp_set_source_onramps.go
+++ b/chains/evm/deployment/v2_0_0/adapters/offramp_set_source_onramps.go
@@ -29,7 +29,7 @@ func (a *ChainFamilyAdapter) GetOffRampSourceOnRamps(
 	e cldf.Environment,
 	localChainSelector uint64,
 	sourceChainSelector uint64,
-) ([]string, error) {
+) ([][]byte, error) {
 	chain, ok := e.BlockChains.EVMChains()[localChainSelector]
 	if !ok {
 		return nil, fmt.Errorf("EVM chain %d not found in environment", localChainSelector)
@@ -51,9 +51,9 @@ func (a *ChainFamilyAdapter) GetOffRampSourceOnRamps(
 			sourceChainSelector, offRampAddr, err)
 	}
 
-	onRamps := make([]string, 0, len(report.Output.OnRamps))
+	onRamps := make([][]byte, 0, len(report.Output.OnRamps))
 	for _, onRamp := range report.Output.OnRamps {
-		onRamps = append(onRamps, hexutil.Encode(onRamp))
+		onRamps = append(onRamps, onRamp)
 	}
 	return onRamps, nil
 }

--- a/chains/evm/deployment/v2_0_0/adapters/offramp_set_source_onramps.go
+++ b/chains/evm/deployment/v2_0_0/adapters/offramp_set_source_onramps.go
@@ -19,7 +19,44 @@ import (
 	ccvadapters "github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/adapters"
 )
 
-var _ ccvadapters.OffRampSourceOnRampSetter = (*ChainFamilyAdapter)(nil)
+var (
+	_ ccvadapters.OffRampSourceOnRampSetter = (*ChainFamilyAdapter)(nil)
+	_ ccvadapters.OffRampSourceOnRampReader = (*ChainFamilyAdapter)(nil)
+)
+
+// GetOffRampSourceOnRamps implements [ccvadapters.OffRampSourceOnRampReader].
+func (a *ChainFamilyAdapter) GetOffRampSourceOnRamps(
+	e cldf.Environment,
+	localChainSelector uint64,
+	sourceChainSelector uint64,
+) ([]string, error) {
+	chain, ok := e.BlockChains.EVMChains()[localChainSelector]
+	if !ok {
+		return nil, fmt.Errorf("EVM chain %d not found in environment", localChainSelector)
+	}
+
+	offRampBytes, err := a.GetOffRampAddress(e.DataStore, localChainSelector)
+	if err != nil {
+		return nil, fmt.Errorf("resolve OffRamp on chain %d: %w", localChainSelector, err)
+	}
+	offRampAddr := common.BytesToAddress(offRampBytes)
+
+	report, err := cldf_ops.ExecuteOperation(e.OperationsBundle, offramp.GetSourceChainConfig, chain, contract.FunctionInput[uint64]{
+		ChainSelector: chain.Selector,
+		Address:       offRampAddr,
+		Args:          sourceChainSelector,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get source chain config for %d on OffRamp %s: %w",
+			sourceChainSelector, offRampAddr, err)
+	}
+
+	onRamps := make([]string, 0, len(report.Output.OnRamps))
+	for _, onRamp := range report.Output.OnRamps {
+		onRamps = append(onRamps, hexutil.Encode(onRamp))
+	}
+	return onRamps, nil
+}
 
 // SetOffRampSourceOnRamps updates the OffRamp source-chain onramp whitelist on an EVM chain.
 func (a *ChainFamilyAdapter) SetOffRampSourceOnRamps(

--- a/chains/evm/deployment/v2_0_0/adapters/upgrade_onramp.go
+++ b/chains/evm/deployment/v2_0_0/adapters/upgrade_onramp.go
@@ -16,6 +16,7 @@ import (
 	evmds "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/datastore"
 	rmnproxyops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/rmn_proxy"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/operations/router"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/offramp"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/onramp"
 	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	ccvadapters "github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/adapters"
@@ -70,6 +71,64 @@ func (a *EVMOnRampUpgrader) VerifyOnrampRequireUpgrade(e cldf.Environment, chain
 			"OnRamp %s already uses RMNProxy %s as RmnRemote; nothing to upgrade", oldAddr.Hex(), rmnProxyAddr.Hex())
 	}
 	return nil
+}
+
+// EnsureOffRampOnTestRouter implements [ccvadapters.OnRampUpgrader].
+func (a *EVMOnRampUpgrader) EnsureOffRampOnTestRouter(e cldf.Environment, destChainSelector uint64, sourceChainSelector uint64) ([]mcms_types.BatchOperation, error) {
+	chain, ok := e.BlockChains.EVMChains()[destChainSelector]
+	if !ok {
+		return nil, fmt.Errorf("no EVM chain found for selector %d", destChainSelector)
+	}
+
+	testRouterAddr, err := resolveTestRouter(e.DataStore, destChainSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	offRampAddr, err := datastore_utils.FindAndFormatCanonicalRef(e.DataStore, datastore.AddressRef{
+		Type:    datastore.ContractType(offramp.ContractType),
+		Version: offramp.Version,
+	}, destChainSelector, evmds.ToEVMAddress)
+	if err != nil {
+		return nil, fmt.Errorf("resolve OffRamp on chain %d: %w", destChainSelector, err)
+	}
+
+	currentReport, err := cldf_ops.ExecuteOperation(e.OperationsBundle, router.GetOffRamps, chain, contract.FunctionInput[any]{
+		ChainSelector: destChainSelector,
+		Address:       testRouterAddr,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get OffRamps from TestRouter on chain %d: %w", destChainSelector, err)
+	}
+
+	for _, current := range currentReport.Output {
+		if current.SourceChainSelector == sourceChainSelector && current.OffRamp == offRampAddr {
+			return nil, nil
+		}
+	}
+
+	report, err := cldf_ops.ExecuteOperation(e.OperationsBundle, router.ApplyRampUpdates, chain, contract.FunctionInput[router.ApplyRampsUpdatesArgs]{
+		ChainSelector: destChainSelector,
+		Address:       testRouterAddr,
+		Args: router.ApplyRampsUpdatesArgs{
+			OffRampAdds: []router.OffRamp{{
+				SourceChainSelector: sourceChainSelector,
+				OffRamp:             offRampAddr,
+			}},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("add OffRamp to TestRouter on chain %d: %w", destChainSelector, err)
+	}
+
+	batchOp, err := contract.NewBatchOperationFromWrites([]contract.WriteOutput{report.Output})
+	if err != nil {
+		return nil, fmt.Errorf("build batch op: %w", err)
+	}
+	if len(batchOp.Transactions) > 0 {
+		return []mcms_types.BatchOperation{batchOp}, nil
+	}
+	return nil, nil
 }
 
 // ExistingOnRampUpgrade implements [ccvadapters.OnRampUpgrader].

--- a/chains/evm/deployment/v2_0_0/adapters/upgrade_onramp.go
+++ b/chains/evm/deployment/v2_0_0/adapters/upgrade_onramp.go
@@ -27,10 +27,6 @@ const (
 	upgradeQualifier = "redeploy"
 )
 
-// testVerifierResolverQualifier is the fixed CREATE2 salt for the resolver wrapping the test
-// verifier. It must match the qualifier used by the DeployTestVerifierChain sequence.
-const testVerifierResolverQualifier = "redeploy-test-verifier-resolver"
-
 var _ ccvadapters.OnRampUpgrader = (*EVMOnRampUpgrader)(nil)
 
 type oldOnRampConfig struct {
@@ -55,8 +51,10 @@ func (a *EVMOnRampUpgrader) VerifyOnrampRequireUpgrade(e cldf.Environment, chain
 	}
 	oldAddr := common.HexToAddress(oldRef.Address)
 
-	legacyRef := oldRef
-	legacyRef.Qualifier = legacyQualifier
+	existingLegacy, err := a.LegacyOnRampRef(e, chainSelector)
+	if err == nil && existingLegacy.Address != "" {
+		oldAddr = common.HexToAddress(existingLegacy.Address)
+	}
 
 	cfg, err := a.readOldOnRampConfigs(e.OperationsBundle, chain, chainSelector, oldAddr)
 	if err != nil {

--- a/chains/evm/deployment/v2_0_0/adapters/upgrade_onramp.go
+++ b/chains/evm/deployment/v2_0_0/adapters/upgrade_onramp.go
@@ -1,0 +1,664 @@
+package adapters
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/ethereum/go-ethereum/common"
+	"k8s.io/utils/ptr"
+
+	cldf_evm "github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	mcms_types "github.com/smartcontractkit/mcms/types"
+
+	evmds "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/datastore"
+	rmnproxyops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/rmn_proxy"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/operations/router"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/onramp"
+	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
+	ccvadapters "github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/adapters"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
+)
+
+const (
+	legacyQualifier  = "legacy"
+	upgradeQualifier = "redeploy"
+)
+
+// testVerifierResolverQualifier is the fixed CREATE2 salt for the resolver wrapping the test
+// verifier. It must match the qualifier used by the DeployTestVerifierChain sequence.
+const testVerifierResolverQualifier = "redeploy-test-verifier-resolver"
+
+var _ ccvadapters.OnRampUpgrader = (*EVMOnRampUpgrader)(nil)
+
+type oldOnRampConfig struct {
+	StaticConfig        onramp.StaticConfig
+	DynamicConfig       onramp.DynamicConfig
+	DestChainConfigs    []uint64
+	DestChainConfigArgs []onramp.DestChainConfigArgs
+}
+
+// EVMOnRampUpgrader upgrades an EVM OnRamp
+type EVMOnRampUpgrader struct{}
+
+func (a *EVMOnRampUpgrader) VerifyOnrampRequireUpgrade(e cldf.Environment, chainSelector uint64) error {
+	chain, ok := e.BlockChains.EVMChains()[chainSelector]
+	if !ok {
+		return fmt.Errorf("no EVM chain found for selector %d", chainSelector)
+	}
+
+	oldRef, err := a.findOldOnRamp(e.DataStore, chainSelector)
+	if err != nil {
+		return err
+	}
+	oldAddr := common.HexToAddress(oldRef.Address)
+
+	legacyRef := oldRef
+	legacyRef.Qualifier = legacyQualifier
+
+	cfg, err := a.readOldOnRampConfigs(e.OperationsBundle, chain, chainSelector, oldAddr)
+	if err != nil {
+		return err
+	}
+	// Resolve every address the upgrade needs before mutating any state.
+	rmnProxyAddr, err := resolveRMNProxy(e.DataStore, chainSelector)
+	if err != nil {
+		return err
+	}
+	if cfg.StaticConfig.RmnRemote == rmnProxyAddr {
+		return fmt.Errorf(
+			"OnRamp %s already uses RMNProxy %s as RmnRemote; nothing to upgrade", oldAddr.Hex(), rmnProxyAddr.Hex())
+	}
+	return nil
+}
+
+// DeployNewOnRamp implements [ccvadapters.OnRampUpgrader].
+func (a *EVMOnRampUpgrader) DeployNewOnRamp(e cldf.Environment, chainSelector uint64) (ccvadapters.OnRampUpgradeResult, error) {
+	chain, ok := e.BlockChains.EVMChains()[chainSelector]
+	if !ok {
+		return ccvadapters.OnRampUpgradeResult{}, fmt.Errorf("no EVM chain found for selector %d", chainSelector)
+	}
+
+	oldRef, err := a.findOldOnRamp(e.DataStore, chainSelector)
+	if err != nil {
+		return ccvadapters.OnRampUpgradeResult{}, err
+	}
+	oldAddr := common.HexToAddress(oldRef.Address)
+
+	legacyRef := oldRef
+	legacyRef.Qualifier = legacyQualifier
+
+	existingLegacy, err := a.LegacyOnRampRef(e, chainSelector)
+	if err == nil && existingLegacy.Address != "" {
+		legacyRef = existingLegacy
+	}
+
+	cfg, err := a.readOldOnRampConfigs(e.OperationsBundle, chain, chainSelector, oldAddr)
+	if err != nil {
+		return ccvadapters.OnRampUpgradeResult{}, err
+	}
+	rmnProxyAddr, err := resolveRMNProxy(e.DataStore, chainSelector)
+	if err != nil {
+		return ccvadapters.OnRampUpgradeResult{}, err
+	}
+
+	newRef, err := a.deployNewOnRamp(e, chain, chainSelector, cfg, rmnProxyAddr)
+	if err != nil {
+		return ccvadapters.OnRampUpgradeResult{}, err
+	}
+	newAddr := common.HexToAddress(newRef.Address)
+
+	// Copy each dest chain config verbatim, including its current Router (already populated
+	// in cfg.DestChainConfigArgs by readAllDestChainConfigs). Neither router is repointed at
+	// the new OnRamp here — that only happens once the verifier jobs observe both OnRamps
+	// (Phase 1.5), so this write can never affect live traffic.
+	applyReport, err := cldf_ops.ExecuteOperation(e.OperationsBundle, onramp.ApplyDestChainConfigUpdates, chain, contract.FunctionInput[[]onramp.DestChainConfigArgs]{
+		ChainSelector: chainSelector,
+		Address:       newAddr,
+		Args:          cfg.DestChainConfigArgs,
+	})
+	if err != nil {
+		return ccvadapters.OnRampUpgradeResult{}, fmt.Errorf("apply dest chain configs to new OnRamp: %w", err)
+	}
+	writes := []contract.WriteOutput{applyReport.Output}
+
+	dynWrite, err := a.applyDynamicConfig(e.OperationsBundle, chain, chainSelector, newAddr, cfg.DynamicConfig)
+	if err != nil {
+		return ccvadapters.OnRampUpgradeResult{}, err
+	}
+	if dynWrite.ChainSelector != 0 {
+		writes = append(writes, dynWrite)
+	}
+
+	batchOp, err := contract.NewBatchOperationFromWrites(writes)
+	if err != nil {
+		return ccvadapters.OnRampUpgradeResult{}, fmt.Errorf("build batch op from writes: %w", err)
+	}
+
+	return ccvadapters.OnRampUpgradeResult{
+		NewOnRampRef:    newRef,
+		LegacyOnRampRef: legacyRef,
+		BatchOps:        []mcms_types.BatchOperation{batchOp},
+	}, nil
+}
+
+// DestChainSelectors implements [ccvadapters.OnRampUpgrader].
+func (a *EVMOnRampUpgrader) DestChainSelectors(e cldf.Environment, chainSelector uint64) ([]uint64, error) {
+	chain, ok := e.BlockChains.EVMChains()[chainSelector]
+	if !ok {
+		return nil, fmt.Errorf("no EVM chain found for selector %d", chainSelector)
+	}
+
+	newRef, err := canonicalOnRampRef(e.DataStore, chainSelector)
+	if err != nil {
+		return nil, fmt.Errorf("find new OnRamp: %w", err)
+	}
+
+	selectors, _, err := readAllDestChainConfigs(e.OperationsBundle, chain, chainSelector, common.HexToAddress(newRef.Address))
+	if err != nil {
+		return nil, err
+	}
+	return selectors, nil
+}
+
+// ClassifyDestChains implements [ccvadapters.OnRampUpgrader].
+func (a *EVMOnRampUpgrader) ClassifyDestChains(e cldf.Environment, chainSelector uint64) (ccvadapters.LaneClass, error) {
+	chain, ok := e.BlockChains.EVMChains()[chainSelector]
+	if !ok {
+		return ccvadapters.LaneClass{}, fmt.Errorf("no EVM chain found for selector %d", chainSelector)
+	}
+
+	// Classify off the legacy-qualified ref once it exists (Phase 1 has run): its dest
+	// configs are frozen at their original per-dest routers and never change again, unlike
+	// the canonical ref, which Phase 1 flips to the new OnRamp and whose dest configs get
+	// rewritten by later phases (e.g. Phase 2 repoints ProdRouter dests to the TestRouter).
+	// Reading canonical here would misclassify a ProdRouter dest as TestRouter dest once
+	// Phase 2 has staged it. Before Phase 1 runs, no legacy ref exists yet, so canonical
+	// (still the original onramp) is the only option and is correct at that point.
+	classifyRef, err := a.LegacyOnRampRef(e, chainSelector)
+	if err != nil {
+		classifyRef, err = a.findOldOnRamp(e.DataStore, chainSelector)
+		if err != nil {
+			return ccvadapters.LaneClass{}, err
+		}
+	}
+	classifyAddr := common.HexToAddress(classifyRef.Address)
+
+	prodRouterAddr, err := resolveProdRouter(e.DataStore, chainSelector)
+	if err != nil {
+		return ccvadapters.LaneClass{}, err
+	}
+	testRouterAddr, err := resolveTestRouter(e.DataStore, chainSelector)
+	if err != nil {
+		return ccvadapters.LaneClass{}, err
+	}
+
+	selectors, args, err := readAllDestChainConfigs(e.OperationsBundle, chain, chainSelector, classifyAddr)
+	if err != nil {
+		return ccvadapters.LaneClass{}, err
+	}
+
+	var class ccvadapters.LaneClass
+	for i, destSel := range selectors {
+		switch args[i].Router {
+		case prodRouterAddr:
+			class.ProdRouterDests = append(class.ProdRouterDests, destSel)
+		case testRouterAddr:
+			class.TestRouterDests = append(class.TestRouterDests, destSel)
+		default:
+			return ccvadapters.LaneClass{}, fmt.Errorf(
+				"dest chain %d is routed through neither the prod Router (%s) nor the TestRouter (%s): %s",
+				destSel, prodRouterAddr.Hex(), testRouterAddr.Hex(), args[i].Router.Hex())
+		}
+	}
+	return class, nil
+}
+
+// LegacyOnRampRef implements [ccvadapters.OnRampUpgrader].
+func (a *EVMOnRampUpgrader) LegacyOnRampRef(e cldf.Environment, chainSelector uint64) (datastore.AddressRef, error) {
+	ref, err := datastore_utils.FindAndFormatRef(e.DataStore, datastore.AddressRef{
+		Type:      datastore.ContractType(onramp.ContractType),
+		Version:   onramp.Version,
+		Qualifier: legacyQualifier,
+	}, chainSelector, toAddressRef)
+	if err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("find legacy OnRamp on chain %d: %w", chainSelector, err)
+	}
+	return ref, nil
+}
+
+// VerifyPromotedToProdRouter implements [ccvadapters.OnRampUpgrader].
+func (a *EVMOnRampUpgrader) VerifyPromotedToProdRouter(e cldf.Environment, chainSelector uint64, destSelectors []uint64) error {
+	newRef, err := canonicalOnRampRef(e.DataStore, chainSelector)
+	if err != nil {
+		return fmt.Errorf("find new OnRamp: %w", err)
+	}
+	if err := a.verifyProdRouterRoutesThrough(e, chainSelector, destSelectors, common.HexToAddress(newRef.Address)); err != nil {
+		return fmt.Errorf("%w (Phase 3 must execute first)", err)
+	}
+	return nil
+}
+
+// VerifyLegacyOnRampOnProdRouter implements [ccvadapters.OnRampUpgrader].
+func (a *EVMOnRampUpgrader) VerifyLegacyOnRampOnProdRouter(e cldf.Environment, chainSelector uint64, destSelectors []uint64) error {
+	legacyRef, err := a.LegacyOnRampRef(e, chainSelector)
+	if err != nil {
+		return err
+	}
+	if err := a.verifyProdRouterRoutesThrough(e, chainSelector, destSelectors, common.HexToAddress(legacyRef.Address)); err != nil {
+		return fmt.Errorf("%w (the prod Router must still route through the legacy OnRamp before promotion)", err)
+	}
+	return nil
+}
+
+// filterBySelectors returns the subset of (selectors, configs) whose selector appears in want,
+// preserving want's order. Any selector in want that has no matching config is an error.
+func filterBySelectors(selectors []uint64, configs []onramp.DestChainConfigArgs, want []uint64) ([]onramp.DestChainConfigArgs, error) {
+	if len(selectors) != len(configs) {
+		return nil, fmt.Errorf("mismatched selectors/configs lengths: selectors=%d configs=%d", len(selectors), len(configs))
+	}
+	bySelector := make(map[uint64]onramp.DestChainConfigArgs, len(selectors))
+	for i, sel := range selectors {
+		if _, exists := bySelector[sel]; exists {
+			return nil, fmt.Errorf("duplicate dest chain selector %d in OnRamp config list", sel)
+		}
+		bySelector[sel] = configs[i]
+	}
+	out := make([]onramp.DestChainConfigArgs, 0, len(want))
+	for _, sel := range want {
+		cfg, ok := bySelector[sel]
+		if !ok {
+			return nil, fmt.Errorf("dest chain %d has no config on the OnRamp", sel)
+		}
+		out = append(out, cfg)
+	}
+	return out, nil
+}
+
+// verifyProdRouterRoutesThrough returns an error unless the prod Router routes every
+// selector in destSelectors through wantOnRamp.
+func (a *EVMOnRampUpgrader) verifyProdRouterRoutesThrough(e cldf.Environment, chainSelector uint64, destSelectors []uint64, wantOnRamp common.Address) error {
+	chain, ok := e.BlockChains.EVMChains()[chainSelector]
+	if !ok {
+		return fmt.Errorf("no EVM chain found for selector %d", chainSelector)
+	}
+
+	prodRouterAddr, err := resolveProdRouter(e.DataStore, chainSelector)
+	if err != nil {
+		return err
+	}
+
+	var mismatched []uint64
+	for _, destSel := range destSelectors {
+		report, err := cldf_ops.ExecuteOperation(e.OperationsBundle, router.GetOnRamp, chain, contract.FunctionInput[uint64]{
+			ChainSelector: chainSelector,
+			Address:       prodRouterAddr,
+			Args:          destSel,
+		})
+		if err != nil {
+			return fmt.Errorf("read prod Router OnRamp for dest chain %d: %w", destSel, err)
+		}
+		if report.Output != wantOnRamp {
+			mismatched = append(mismatched, destSel)
+		}
+	}
+	if len(mismatched) > 0 {
+		return fmt.Errorf("prod Router does not route dest chains %v through %s", mismatched, wantOnRamp.Hex())
+	}
+	return nil
+}
+
+// VerifyNewOnRampOwner implements [ccvadapters.OnRampUpgrader].
+func (a *EVMOnRampUpgrader) VerifyNewOnRampOwner(e cldf.Environment, chainSelector uint64, expectedOwner string) error {
+	chain, ok := e.BlockChains.EVMChains()[chainSelector]
+	if !ok {
+		return fmt.Errorf("no EVM chain found for selector %d", chainSelector)
+	}
+
+	newRef, err := canonicalOnRampRef(e.DataStore, chainSelector)
+	if err != nil {
+		return fmt.Errorf("find new OnRamp: %w", err)
+	}
+
+	report, err := cldf_ops.ExecuteOperation(e.OperationsBundle, onramp.Owner, chain, contract.FunctionInput[struct{}]{
+		ChainSelector: chainSelector,
+		Address:       common.HexToAddress(newRef.Address),
+		Args:          struct{}{},
+	})
+	if err != nil {
+		return fmt.Errorf("read new OnRamp owner: %w", err)
+	}
+	if want := common.HexToAddress(expectedOwner); report.Output != want {
+		return fmt.Errorf("new OnRamp is owned by %s, expected %s (Phase 1's ownership transfer must execute first)",
+			report.Output.Hex(), want.Hex())
+	}
+	return nil
+}
+
+func (a *EVMOnRampUpgrader) findOldOnRamp(ds datastore.DataStore, chainSelector uint64) (datastore.AddressRef, error) {
+	ref, err := canonicalOnRampRef(ds, chainSelector)
+	if err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("find old OnRamp on chain %d: %w", chainSelector, err)
+	}
+	return ref, nil
+}
+
+// canonicalOnRampRef resolves the canonical (unqualified) OnRamp ref for a chain.
+func canonicalOnRampRef(ds datastore.DataStore, chainSelector uint64) (datastore.AddressRef, error) {
+	return datastore_utils.FindAndFormatCanonicalRef(ds, datastore.AddressRef{
+		Type:    datastore.ContractType(onramp.ContractType),
+		Version: onramp.Version,
+	}, chainSelector, toAddressRef)
+}
+
+func (a *EVMOnRampUpgrader) readOldOnRampConfigs(
+	b cldf_ops.Bundle,
+	chain cldf_evm.Chain,
+	chainSelector uint64,
+	oldAddr common.Address,
+) (oldOnRampConfig, error) {
+	staticCfg, err := readStaticConfig(b, chain, chainSelector, oldAddr)
+	if err != nil {
+		return oldOnRampConfig{}, err
+	}
+	dynamicCfg, err := readDynamicConfig(b, chain, chainSelector, oldAddr)
+	if err != nil {
+		return oldOnRampConfig{}, err
+	}
+	selectors, args, err := readAllDestChainConfigs(b, chain, chainSelector, oldAddr)
+	if err != nil {
+		return oldOnRampConfig{}, err
+	}
+	return oldOnRampConfig{
+		StaticConfig:        staticCfg,
+		DynamicConfig:       dynamicCfg,
+		DestChainConfigs:    selectors,
+		DestChainConfigArgs: args,
+	}, nil
+}
+
+func (a *EVMOnRampUpgrader) deployNewOnRamp(
+	e cldf.Environment,
+	chain cldf_evm.Chain,
+	chainSelector uint64,
+	cfg oldOnRampConfig,
+	rmnProxyAddr common.Address,
+) (datastore.AddressRef, error) {
+	existingAddrs := e.DataStore.Addresses().Filter(datastore.AddressRefByChainSelector(chainSelector))
+	ref, err := contract.MaybeDeployContract(e.OperationsBundle, onramp.Deploy, chain, contract.DeployInput[onramp.ConstructorArgs]{
+		TypeAndVersion: cldf.NewTypeAndVersion(onramp.ContractType, *onramp.Version),
+		ChainSelector:  chainSelector,
+		Qualifier:      ptr.To(upgradeQualifier),
+		Args: onramp.ConstructorArgs{
+			StaticConfig: onramp.StaticConfig{
+				ChainSelector:         chainSelector,
+				RmnRemote:             rmnProxyAddr,
+				TokenAdminRegistry:    cfg.StaticConfig.TokenAdminRegistry,
+				MaxUSDCentsPerMessage: cfg.StaticConfig.MaxUSDCentsPerMessage,
+			},
+			DynamicConfig: onramp.DynamicConfig{
+				FeeQuoter:     cfg.DynamicConfig.FeeQuoter,
+				FeeAggregator: cfg.DynamicConfig.FeeAggregator,
+			},
+		},
+	}, existingAddrs)
+	if err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("deploy new OnRamp: %w", err)
+	}
+	ref.Qualifier = ""
+	return ref, nil
+}
+
+// applyDestChainConfigsWithRouter rewrites each dest chain config to route
+// through routerAddr and applies them to the OnRamp at newAddr.
+func (a *EVMOnRampUpgrader) applyDestChainConfigsWithRouter(
+	e cldf.Environment,
+	chain cldf_evm.Chain,
+	chainSelector uint64,
+	newAddr common.Address,
+	destChainArgs []onramp.DestChainConfigArgs,
+	routerAddr common.Address,
+) (contract.WriteOutput, error) {
+	routerArgs := make([]onramp.DestChainConfigArgs, len(destChainArgs))
+	for i, arg := range destChainArgs {
+		routerArgs[i] = arg
+		routerArgs[i].Router = routerAddr
+	}
+
+	applyReport, err := cldf_ops.ExecuteOperation(e.OperationsBundle, onramp.ApplyDestChainConfigUpdates, chain, contract.FunctionInput[[]onramp.DestChainConfigArgs]{
+		ChainSelector: chainSelector,
+		Address:       newAddr,
+		Args:          routerArgs,
+	})
+	if err != nil {
+		return contract.WriteOutput{}, fmt.Errorf("apply dest chain configs to new OnRamp: %w", err)
+	}
+	return applyReport.Output, nil
+}
+
+func (a *EVMOnRampUpgrader) applyDynamicConfig(
+	b cldf_ops.Bundle,
+	chain cldf_evm.Chain,
+	chainSelector uint64,
+	newAddr common.Address,
+	oldDynamicCfg onramp.DynamicConfig,
+) (contract.WriteOutput, error) {
+	desired := onramp.DynamicConfig{
+		FeeQuoter:              oldDynamicCfg.FeeQuoter,
+		ReentrancyGuardEntered: false,
+		FeeAggregator:          oldDynamicCfg.FeeAggregator,
+	}
+	if oldDynamicCfg == desired {
+		return contract.WriteOutput{}, nil
+	}
+	report, err := cldf_ops.ExecuteOperation(b, onramp.SetDynamicConfig, chain, contract.FunctionInput[onramp.DynamicConfig]{
+		ChainSelector: chainSelector,
+		Address:       newAddr,
+		Args:          desired,
+	})
+	if err != nil {
+		return contract.WriteOutput{}, fmt.Errorf("set dynamic config on new OnRamp: %w", err)
+	}
+	return report.Output, nil
+}
+
+func (a *EVMOnRampUpgrader) applyRouterUpdates(
+	e cldf.Environment,
+	chain cldf_evm.Chain,
+	chainSelector uint64,
+	newAddr common.Address,
+	destChainSelectors []uint64,
+	routerAddr common.Address,
+) (contract.WriteOutput, error) {
+	onRampUpdates := make([]router.OnRamp, 0, len(destChainSelectors))
+	for _, sel := range destChainSelectors {
+		onRampUpdates = append(onRampUpdates, router.OnRamp{
+			DestChainSelector: sel,
+			OnRamp:            newAddr,
+		})
+	}
+
+	report, err := cldf_ops.ExecuteOperation(e.OperationsBundle, router.ApplyRampUpdates, chain, contract.FunctionInput[router.ApplyRampsUpdatesArgs]{
+		ChainSelector: chainSelector,
+		Address:       routerAddr,
+		Args: router.ApplyRampsUpdatesArgs{
+			OnRampUpdates: onRampUpdates,
+		},
+	})
+	if err != nil {
+		return contract.WriteOutput{}, fmt.Errorf("apply ramp updates on router %s: %w", routerAddr.Hex(), err)
+	}
+	return report.Output, nil
+}
+
+func readStaticConfig(b cldf_ops.Bundle, chain cldf_evm.Chain, chainSelector uint64, addr common.Address) (onramp.StaticConfig, error) {
+	report, err := cldf_ops.ExecuteOperation(b, onramp.GetStaticConfig, chain, contract.FunctionInput[struct{}]{
+		ChainSelector: chainSelector,
+		Address:       addr,
+		Args:          struct{}{},
+	})
+	if err != nil {
+		return onramp.StaticConfig{}, fmt.Errorf("read static config from OnRamp: %w", err)
+	}
+	return report.Output, nil
+}
+
+func readDynamicConfig(b cldf_ops.Bundle, chain cldf_evm.Chain, chainSelector uint64, addr common.Address) (onramp.DynamicConfig, error) {
+	report, err := cldf_ops.ExecuteOperation(b, onramp.GetDynamicConfig, chain, contract.FunctionInput[struct{}]{
+		ChainSelector: chainSelector,
+		Address:       addr,
+		Args:          struct{}{},
+	})
+	if err != nil {
+		return onramp.DynamicConfig{}, fmt.Errorf("read dynamic config from OnRamp: %w", err)
+	}
+	return report.Output, nil
+}
+
+func readAllDestChainConfigs(b cldf_ops.Bundle, chain cldf_evm.Chain, chainSelector uint64, addr common.Address) ([]uint64, []onramp.DestChainConfigArgs, error) {
+	report, err := cldf_ops.ExecuteOperation(b, onramp.GetAllDestChainConfigs, chain, contract.FunctionInput[struct{}]{
+		ChainSelector: chainSelector,
+		Address:       addr,
+		Args:          struct{}{},
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("read all dest chain configs: %w", err)
+	}
+	result := report.Output
+	if len(result.Ret0) == 0 {
+		if len(result.Ret1) != 0 {
+			return nil, nil, fmt.Errorf("mismatched getAllDestChainConfigs result lengths on OnRamp %s: selectors=%d configs=%d", addr.Hex(), len(result.Ret0), len(result.Ret1))
+		}
+		return nil, nil, fmt.Errorf("no dest chain configs found on OnRamp %s", addr.Hex())
+	}
+	if len(result.Ret0) != len(result.Ret1) {
+		return nil, nil, fmt.Errorf("mismatched getAllDestChainConfigs result lengths on OnRamp %s: selectors=%d configs=%d", addr.Hex(), len(result.Ret0), len(result.Ret1))
+	}
+
+	selectors := result.Ret0
+	args := make([]onramp.DestChainConfigArgs, len(selectors))
+	for i, cfg := range result.Ret1 {
+		args[i] = onramp.DestChainConfigArgs{
+			DestChainSelector:         selectors[i],
+			Router:                    cfg.Router,
+			AddressBytesLength:        cfg.AddressBytesLength,
+			TokenReceiverAllowed:      cfg.TokenReceiverAllowed,
+			MessageNetworkFeeUSDCents: cfg.MessageNetworkFeeUSDCents,
+			TokenNetworkFeeUSDCents:   cfg.TokenNetworkFeeUSDCents,
+			BaseExecutionGasCost:      cfg.BaseExecutionGasCost,
+			DefaultCCVs:               cfg.DefaultCCVs,
+			LaneMandatedCCVs:          cfg.LaneMandatedCCVs,
+			DefaultExecutor:           cfg.DefaultExecutor,
+			OffRamp:                   cfg.OffRamp,
+		}
+	}
+	return selectors, args, nil
+}
+
+func resolveRMNProxy(ds datastore.DataStore, chainSelector uint64) (common.Address, error) {
+	addr, err := datastore_utils.FindAndFormatCanonicalRef(ds, datastore.AddressRef{
+		Type:    datastore.ContractType(rmnproxyops.ContractType),
+		Version: semver.MustParse("1.0.0"),
+	}, chainSelector, evmds.ToEVMAddress)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("resolve RMNProxy on chain %d: %w", chainSelector, err)
+	}
+	return addr, nil
+}
+
+func resolveTestRouter(ds datastore.DataStore, chainSelector uint64) (common.Address, error) {
+	bytes, err := datastore_utils.FindAndFormatCanonicalRef(ds, datastore.AddressRef{
+		Type:    datastore.ContractType(router.TestRouterContractType),
+		Version: router.Version,
+	}, chainSelector, evmds.ToEVMAddressBytes)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("resolve TestRouter on chain %d: %w", chainSelector, err)
+	}
+	return common.BytesToAddress(bytes), nil
+}
+
+// PromoteOnrampToProdRouter implements [ccvadapters.OnRampUpgrader].
+func (a *EVMOnRampUpgrader) PromoteOnrampToProdRouter(e cldf.Environment, chainSelector uint64, destSelectors []uint64) ([]mcms_types.BatchOperation, error) {
+	prodRouterAddr, err := resolveProdRouter(e.DataStore, chainSelector)
+	if err != nil {
+		return nil, err
+	}
+	return a.promoteOnrampToRouter(e, chainSelector, destSelectors, prodRouterAddr)
+}
+
+// PromoteOnrampToTestRouter implements [ccvadapters.OnRampUpgrader].
+func (a *EVMOnRampUpgrader) PromoteOnrampToTestRouter(e cldf.Environment, chainSelector uint64, destSelectors []uint64) ([]mcms_types.BatchOperation, error) {
+	testRouterAddr, err := resolveTestRouter(e.DataStore, chainSelector)
+	if err != nil {
+		return nil, err
+	}
+	return a.promoteOnrampToRouter(e, chainSelector, destSelectors, testRouterAddr)
+}
+
+// promoteOnrampToRouter points destSelectors' dest chain configs and routerAddr at the new OnRamp.
+func (a *EVMOnRampUpgrader) promoteOnrampToRouter(e cldf.Environment, chainSelector uint64, destSelectors []uint64, routerAddr common.Address) ([]mcms_types.BatchOperation, error) {
+	chain, ok := e.BlockChains.EVMChains()[chainSelector]
+	if !ok {
+		return nil, fmt.Errorf("no EVM chain found for selector %d", chainSelector)
+	}
+	if len(destSelectors) == 0 {
+		return nil, nil
+	}
+
+	newRef, err := canonicalOnRampRef(e.DataStore, chainSelector)
+	if err != nil {
+		return nil, fmt.Errorf("find new OnRamp: %w", err)
+	}
+	newAddr := common.HexToAddress(newRef.Address)
+
+	allSelectors, allConfigs, err := readAllDestChainConfigs(e.OperationsBundle, chain, chainSelector, newAddr)
+	if err != nil {
+		return nil, err
+	}
+	configs, err := filterBySelectors(allSelectors, allConfigs, destSelectors)
+	if err != nil {
+		return nil, err
+	}
+
+	var writes []contract.WriteOutput
+
+	// Update dest chain configs to use routerAddr.
+	onRampWrite, err := a.applyDestChainConfigsWithRouter(e, chain, chainSelector, newAddr, configs, routerAddr)
+	if err != nil {
+		return nil, err
+	}
+	writes = append(writes, onRampWrite)
+
+	// Wire routerAddr to route through the new OnRamp.
+	routerWrite, err := a.applyRouterUpdates(e, chain, chainSelector, newAddr, destSelectors, routerAddr)
+	if err != nil {
+		return nil, err
+	}
+	writes = append(writes, routerWrite)
+
+	batchOp, err := contract.NewBatchOperationFromWrites(writes)
+	if err != nil {
+		return nil, fmt.Errorf("build batch op: %w", err)
+	}
+	if len(batchOp.Transactions) > 0 {
+		return []mcms_types.BatchOperation{batchOp}, nil
+	}
+	return nil, nil
+}
+
+func resolveProdRouter(ds datastore.DataStore, chainSelector uint64) (common.Address, error) {
+	bytes, err := datastore_utils.FindAndFormatCanonicalRef(ds, datastore.AddressRef{
+		Type:    datastore.ContractType(router.ContractType),
+		Version: router.Version,
+	}, chainSelector, evmds.ToEVMAddressBytes)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("resolve prod Router on chain %d: %w", chainSelector, err)
+	}
+	return common.BytesToAddress(bytes), nil
+}
+
+func toAddressRef(ref datastore.AddressRef) (datastore.AddressRef, error) {
+	return ref, nil
+}

--- a/chains/evm/deployment/v2_0_0/adapters/upgrade_onramp.go
+++ b/chains/evm/deployment/v2_0_0/adapters/upgrade_onramp.go
@@ -230,14 +230,27 @@ func (a *EVMOnRampUpgrader) LegacyOnRampRef(e cldf.Environment, chainSelector ui
 }
 
 // VerifyPromotedToProdRouter implements [ccvadapters.OnRampUpgrader].
-func (a *EVMOnRampUpgrader) VerifyPromotedToProdRouter(e cldf.Environment, chainSelector uint64, destSelectors []uint64) error {
+func (a *EVMOnRampUpgrader) VerifyPromotedToRouters(e cldf.Environment, chainSelector uint64, prodDestSelectors []uint64, testDestSelectors []uint64) error {
 	newRef, err := canonicalOnRampRef(e.DataStore, chainSelector)
 	if err != nil {
 		return fmt.Errorf("find new OnRamp: %w", err)
 	}
-	if err := a.verifyProdRouterRoutesThrough(e, chainSelector, destSelectors, common.HexToAddress(newRef.Address)); err != nil {
+	routerAddr, err := resolveProdRouter(e.DataStore, chainSelector)
+	if err != nil {
+		return err
+	}
+	if err := a.verifyRouterRoutesThrough(e, chainSelector, prodDestSelectors, common.HexToAddress(newRef.Address), routerAddr); err != nil {
 		return fmt.Errorf("%w (Phase 3 must execute first)", err)
 	}
+
+	routerAddr, err = resolveTestRouter(e.DataStore, chainSelector)
+	if err != nil {
+		return err
+	}
+	if err := a.verifyRouterRoutesThrough(e, chainSelector, testDestSelectors, common.HexToAddress(newRef.Address), routerAddr); err != nil {
+		return fmt.Errorf("%w (Phase 3 must execute first)", err)
+	}
+
 	return nil
 }
 
@@ -247,7 +260,11 @@ func (a *EVMOnRampUpgrader) VerifyLegacyOnRampOnProdRouter(e cldf.Environment, c
 	if err != nil {
 		return err
 	}
-	if err := a.verifyProdRouterRoutesThrough(e, chainSelector, destSelectors, common.HexToAddress(legacyRef.Address)); err != nil {
+	routerAddr, err := resolveProdRouter(e.DataStore, chainSelector)
+	if err != nil {
+		return err
+	}
+	if err := a.verifyRouterRoutesThrough(e, chainSelector, destSelectors, common.HexToAddress(legacyRef.Address), routerAddr); err != nil {
 		return fmt.Errorf("%w (the prod Router must still route through the legacy OnRamp before promotion)", err)
 	}
 	return nil
@@ -279,22 +296,17 @@ func filterBySelectors(selectors []uint64, configs []onramp.DestChainConfigArgs,
 
 // verifyProdRouterRoutesThrough returns an error unless the prod Router routes every
 // selector in destSelectors through wantOnRamp.
-func (a *EVMOnRampUpgrader) verifyProdRouterRoutesThrough(e cldf.Environment, chainSelector uint64, destSelectors []uint64, wantOnRamp common.Address) error {
+func (a *EVMOnRampUpgrader) verifyRouterRoutesThrough(e cldf.Environment, chainSelector uint64, destSelectors []uint64, wantOnRamp common.Address, routerAddr common.Address) error {
 	chain, ok := e.BlockChains.EVMChains()[chainSelector]
 	if !ok {
 		return fmt.Errorf("no EVM chain found for selector %d", chainSelector)
-	}
-
-	prodRouterAddr, err := resolveProdRouter(e.DataStore, chainSelector)
-	if err != nil {
-		return err
 	}
 
 	var mismatched []uint64
 	for _, destSel := range destSelectors {
 		report, err := cldf_ops.ExecuteOperation(e.OperationsBundle, router.GetOnRamp, chain, contract.FunctionInput[uint64]{
 			ChainSelector: chainSelector,
-			Address:       prodRouterAddr,
+			Address:       routerAddr,
 			Args:          destSel,
 		})
 		if err != nil {

--- a/chains/evm/deployment/v2_0_0/adapters/upgrade_onramp.go
+++ b/chains/evm/deployment/v2_0_0/adapters/upgrade_onramp.go
@@ -16,7 +16,6 @@ import (
 	evmds "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/datastore"
 	rmnproxyops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/rmn_proxy"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/operations/router"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/offramp"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/onramp"
 	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	ccvadapters "github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/adapters"
@@ -71,64 +70,6 @@ func (a *EVMOnRampUpgrader) VerifyOnrampRequireUpgrade(e cldf.Environment, chain
 			"OnRamp %s already uses RMNProxy %s as RmnRemote; nothing to upgrade", oldAddr.Hex(), rmnProxyAddr.Hex())
 	}
 	return nil
-}
-
-// EnsureOffRampOnTestRouter implements [ccvadapters.OnRampUpgrader].
-func (a *EVMOnRampUpgrader) EnsureOffRampOnTestRouter(e cldf.Environment, destChainSelector uint64, sourceChainSelector uint64) ([]mcms_types.BatchOperation, error) {
-	chain, ok := e.BlockChains.EVMChains()[destChainSelector]
-	if !ok {
-		return nil, fmt.Errorf("no EVM chain found for selector %d", destChainSelector)
-	}
-
-	testRouterAddr, err := resolveTestRouter(e.DataStore, destChainSelector)
-	if err != nil {
-		return nil, err
-	}
-
-	offRampAddr, err := datastore_utils.FindAndFormatCanonicalRef(e.DataStore, datastore.AddressRef{
-		Type:    datastore.ContractType(offramp.ContractType),
-		Version: offramp.Version,
-	}, destChainSelector, evmds.ToEVMAddress)
-	if err != nil {
-		return nil, fmt.Errorf("resolve OffRamp on chain %d: %w", destChainSelector, err)
-	}
-
-	currentReport, err := cldf_ops.ExecuteOperation(e.OperationsBundle, router.GetOffRamps, chain, contract.FunctionInput[any]{
-		ChainSelector: destChainSelector,
-		Address:       testRouterAddr,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("get OffRamps from TestRouter on chain %d: %w", destChainSelector, err)
-	}
-
-	for _, current := range currentReport.Output {
-		if current.SourceChainSelector == sourceChainSelector && current.OffRamp == offRampAddr {
-			return nil, nil
-		}
-	}
-
-	report, err := cldf_ops.ExecuteOperation(e.OperationsBundle, router.ApplyRampUpdates, chain, contract.FunctionInput[router.ApplyRampsUpdatesArgs]{
-		ChainSelector: destChainSelector,
-		Address:       testRouterAddr,
-		Args: router.ApplyRampsUpdatesArgs{
-			OffRampAdds: []router.OffRamp{{
-				SourceChainSelector: sourceChainSelector,
-				OffRamp:             offRampAddr,
-			}},
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("add OffRamp to TestRouter on chain %d: %w", destChainSelector, err)
-	}
-
-	batchOp, err := contract.NewBatchOperationFromWrites([]contract.WriteOutput{report.Output})
-	if err != nil {
-		return nil, fmt.Errorf("build batch op: %w", err)
-	}
-	if len(batchOp.Transactions) > 0 {
-		return []mcms_types.BatchOperation{batchOp}, nil
-	}
-	return nil, nil
 }
 
 // ExistingOnRampUpgrade implements [ccvadapters.OnRampUpgrader].

--- a/chains/evm/deployment/v2_0_0/adapters/upgrade_onramp.go
+++ b/chains/evm/deployment/v2_0_0/adapters/upgrade_onramp.go
@@ -72,8 +72,117 @@ func (a *EVMOnRampUpgrader) VerifyOnrampRequireUpgrade(e cldf.Environment, chain
 	return nil
 }
 
+// ExistingOnRampUpgrade implements [ccvadapters.OnRampUpgrader].
+//
+// Phase 1 is considered already started when a legacy-qualified OnRamp ref
+// exists. In that state the canonical OnRamp must be the replacement OnRamp
+// and must already use RMNProxy as its RmnRemote.
+//
+// This method does not mutate any state. It is used by Phase 1 to distinguish
+// a first execution from a retry or a later destination-lane batch.
+func (a *EVMOnRampUpgrader) ExistingOnRampUpgrade(
+	e cldf.Environment,
+	chainSelector uint64,
+) (ccvadapters.OnRampUpgradeResult, bool, error) {
+	legacyRefs := e.DataStore.Addresses().Filter(
+		datastore.AddressRefByChainSelector(chainSelector),
+		datastore.AddressRefByType(datastore.ContractType(onramp.ContractType)),
+		datastore.AddressRefByVersion(onramp.Version),
+		datastore.AddressRefByQualifier(legacyQualifier),
+	)
+
+	if len(legacyRefs) == 0 {
+		return ccvadapters.OnRampUpgradeResult{}, false, nil
+	}
+
+	if len(legacyRefs) != 1 {
+		return ccvadapters.OnRampUpgradeResult{}, false, fmt.Errorf(
+			"expected exactly one legacy OnRamp on chain %d, found %d",
+			chainSelector,
+			len(legacyRefs),
+		)
+	}
+
+	legacyRef := legacyRefs[0]
+
+	newRef, err := canonicalOnRampRef(e.DataStore, chainSelector)
+	if err != nil {
+		return ccvadapters.OnRampUpgradeResult{}, false, fmt.Errorf(
+			"Phase 1 upgrade state is inconsistent on chain %d: legacy OnRamp %s exists but canonical OnRamp cannot be resolved: %w",
+			chainSelector,
+			legacyRef.Address,
+			err,
+		)
+	}
+
+	if common.HexToAddress(newRef.Address) == common.HexToAddress(legacyRef.Address) {
+		return ccvadapters.OnRampUpgradeResult{}, false, fmt.Errorf(
+			"Phase 1 upgrade state is inconsistent on chain %d: canonical and legacy OnRamp both resolve to %s",
+			chainSelector,
+			newRef.Address,
+		)
+	}
+
+	chain, ok := e.BlockChains.EVMChains()[chainSelector]
+	if !ok {
+		return ccvadapters.OnRampUpgradeResult{}, false, fmt.Errorf(
+			"no EVM chain found for selector %d",
+			chainSelector,
+		)
+	}
+
+	rmnProxyAddr, err := resolveRMNProxy(e.DataStore, chainSelector)
+	if err != nil {
+		return ccvadapters.OnRampUpgradeResult{}, false, err
+	}
+
+	newStaticConfig, err := readStaticConfig(
+		e.OperationsBundle,
+		chain,
+		chainSelector,
+		common.HexToAddress(newRef.Address),
+	)
+	if err != nil {
+		return ccvadapters.OnRampUpgradeResult{}, false, fmt.Errorf(
+			"read canonical OnRamp while recovering Phase 1: %w",
+			err,
+		)
+	}
+
+	if newStaticConfig.RmnRemote != rmnProxyAddr {
+		return ccvadapters.OnRampUpgradeResult{}, false, fmt.Errorf(
+			"Phase 1 upgrade state is inconsistent on chain %d: legacy OnRamp %s exists but canonical OnRamp %s has RmnRemote %s, expected RMNProxy %s",
+			chainSelector,
+			legacyRef.Address,
+			newRef.Address,
+			newStaticConfig.RmnRemote.Hex(),
+			rmnProxyAddr.Hex(),
+		)
+	}
+
+	return ccvadapters.OnRampUpgradeResult{
+		NewOnRampRef:    newRef,
+		LegacyOnRampRef: legacyRef,
+		BatchOps:        nil,
+		Reused:          true,
+	}, true, nil
+}
+
 // DeployNewOnRamp implements [ccvadapters.OnRampUpgrader].
-func (a *EVMOnRampUpgrader) DeployNewOnRamp(e cldf.Environment, chainSelector uint64) (ccvadapters.OnRampUpgradeResult, error) {
+func (a *EVMOnRampUpgrader) DeployNewOnRamp(
+	e cldf.Environment,
+	chainSelector uint64,
+) (ccvadapters.OnRampUpgradeResult, error) {
+	// A retry of Phase 1, or a later destination-lane batch for the same source
+	// chain, must reuse the already-deployed canonical/legacy pair.
+	existing, found, err := a.ExistingOnRampUpgrade(e, chainSelector)
+	if err != nil {
+		return ccvadapters.OnRampUpgradeResult{}, err
+	}
+	if found {
+		return existing, nil
+	}
+
 	chain, ok := e.BlockChains.EVMChains()[chainSelector]
 	if !ok {
 		return ccvadapters.OnRampUpgradeResult{}, fmt.Errorf("no EVM chain found for selector %d", chainSelector)
@@ -87,11 +196,6 @@ func (a *EVMOnRampUpgrader) DeployNewOnRamp(e cldf.Environment, chainSelector ui
 
 	legacyRef := oldRef
 	legacyRef.Qualifier = legacyQualifier
-
-	existingLegacy, err := a.LegacyOnRampRef(e, chainSelector)
-	if err == nil && existingLegacy.Address != "" {
-		legacyRef = existingLegacy
-	}
 
 	cfg, err := a.readOldOnRampConfigs(e.OperationsBundle, chain, chainSelector, oldAddr)
 	if err != nil {
@@ -108,10 +212,8 @@ func (a *EVMOnRampUpgrader) DeployNewOnRamp(e cldf.Environment, chainSelector ui
 	}
 	newAddr := common.HexToAddress(newRef.Address)
 
-	// Copy each dest chain config verbatim, including its current Router (already populated
-	// in cfg.DestChainConfigArgs by readAllDestChainConfigs). Neither router is repointed at
-	// the new OnRamp here — that only happens once the verifier jobs observe both OnRamps
-	// (Phase 1.5), so this write can never affect live traffic.
+	// Copy each dest chain config verbatim, including DefaultCCVs,
+	// LaneMandatedCCVs and its current Router.
 	applyReport, err := cldf_ops.ExecuteOperation(e.OperationsBundle, onramp.ApplyDestChainConfigUpdates, chain, contract.FunctionInput[[]onramp.DestChainConfigArgs]{
 		ChainSelector: chainSelector,
 		Address:       newAddr,
@@ -135,10 +237,16 @@ func (a *EVMOnRampUpgrader) DeployNewOnRamp(e cldf.Environment, chainSelector ui
 		return ccvadapters.OnRampUpgradeResult{}, fmt.Errorf("build batch op from writes: %w", err)
 	}
 
+	batchOps := make([]mcms_types.BatchOperation, 0, 1)
+	if len(batchOp.Transactions) > 0 {
+		batchOps = append(batchOps, batchOp)
+	}
+
 	return ccvadapters.OnRampUpgradeResult{
 		NewOnRampRef:    newRef,
 		LegacyOnRampRef: legacyRef,
-		BatchOps:        []mcms_types.BatchOperation{batchOp},
+		BatchOps:        batchOps,
+		Reused:          false,
 	}, nil
 }
 

--- a/chains/evm/deployment/v2_0_0/adapters/upgrade_onramp_test.go
+++ b/chains/evm/deployment/v2_0_0/adapters/upgrade_onramp_test.go
@@ -1,0 +1,640 @@
+package adapters_test
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	evm_datastore_utils "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/datastore"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
+	rmnproxyops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/rmn_proxy"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/operations/router"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/adapters"
+	evmchangesets "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/changesets"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/create2_factory"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/onramp"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/testsetup"
+	changesets "github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
+	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
+	ccvadapters "github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/adapters"
+	v2changesets "github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/changesets"
+)
+
+var upgradeTestChains = []uint64{
+	chainsel.TEST_90000001.Selector,
+	chainsel.TEST_90000002.Selector,
+	chainsel.TEST_90000003.Selector,
+}
+
+func deployUpgradeLaneContracts(
+	t *testing.T,
+	e *deployment.Environment,
+	chainSelector uint64,
+	ds datastore.MutableDataStore,
+	deployTestRouter bool,
+) {
+	t.Helper()
+	evmChain := e.BlockChains.EVMChains()[chainSelector]
+
+	create2Ref, err := contract.MaybeDeployContract(
+		e.OperationsBundle, create2_factory.Deploy, evmChain,
+		contract.DeployInput[create2_factory.ConstructorArgs]{
+			TypeAndVersion: deployment.NewTypeAndVersion(create2_factory.ContractType, *semver.MustParse("2.0.0")),
+			ChainSelector:  chainSelector,
+			Args:           create2_factory.ConstructorArgs{AllowList: []common.Address{evmChain.DeployerKey.From}},
+		}, nil,
+	)
+	require.NoError(t, err)
+
+	deployOut, err := evmchangesets.DeployChainContracts(changesets.GetRegistry()).Apply(*e, changesets.WithMCMS[evmchangesets.DeployChainContractsCfg]{
+		Cfg: evmchangesets.DeployChainContractsCfg{
+			ChainSel:         chainSelector,
+			CREATE2Factory:   common.HexToAddress(create2Ref.Address),
+			Params:           contractParamsForLaneTopologyTest(),
+			DeployTestRouter: deployTestRouter,
+			DeployerKeyOwned: true,
+		},
+		MCMS: mcms.Input{},
+	})
+	require.NoError(t, err)
+	require.NoError(t, ds.Merge(deployOut.DataStore.Seal()))
+}
+
+// setupDeployNewOnRampTest deploys 2.0.0 contracts on 3 simulated chains connected to each other,
+// configures lanes between all pairs, and returns a ready-to-use environment.
+func setupDeployNewOnRampTest(t *testing.T) *deployment.Environment {
+	t.Helper()
+	e, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, upgradeTestChains),
+	)
+	require.NoError(t, err)
+
+	ds := datastore.NewMemoryDataStore()
+
+	// Deploy chain contracts on each chain (with TestRouter for the upgrade target).
+	for _, sel := range upgradeTestChains {
+		e.OperationsBundle = testsetup.BundleWithFreshReporter(e.OperationsBundle)
+		err = testsetup.SeedUltraFastCurseMCMS(ds, sel)
+		require.NoError(t, err)
+
+		err = ds.Merge(e.DataStore)
+		require.NoError(t, err)
+		e.DataStore = ds.Seal()
+
+		deployUpgradeLaneContracts(t, e, sel, ds, sel == upgradeTestChains[0])
+	}
+	e.DataStore = ds.Seal()
+
+	// Configure lanes between all pairs so each OnRamp has dest chain configs.
+	deployer := e.BlockChains.EVMChains()[upgradeTestChains[0]].DeployerKey.From.Hex()
+	e.OperationsBundle = testsetup.BundleWithFreshReporter(e.OperationsBundle)
+	cs := v2changesets.ConfigureChainsForLanesFromTopology(
+		ccvadapters.GetCommitteeVerifierContractRegistry(),
+		ccvadapters.GetChainFamilyRegistry(),
+		changesets.GetRegistry(),
+	)
+	lanes := make([]v2changesets.CrossFamilyLanePair, 0, len(upgradeTestChains)-1)
+	for _, remoteSel := range upgradeTestChains[1:] {
+		lanes = append(lanes, v2changesets.CrossFamilyLanePair{
+			ChainA: upgradeTestChains[0],
+			ChainB: remoteSel,
+		})
+	}
+	_, err = cs.Apply(*e, v2changesets.ConfigureChainsForLanesFromTopologyConfig{
+		Topology: bidirectionalLaneTopology(deployer, upgradeTestChains...),
+		BuildLanesCrossFamilyConfig: v2changesets.BuildLanesCrossFamilyConfig{
+			Lanes: lanes,
+			MCMS:  mcms.Input{},
+		},
+	})
+	require.NoError(t, err)
+
+	return e
+}
+
+func initialStateAssertions(t *testing.T, e deployment.Environment) datastore.AddressRef {
+	t.Helper()
+	ref, err := datastore_utils.FindAndFormatCanonicalRef(e.DataStore, datastore.AddressRef{
+		Type:    datastore.ContractType(onramp.ContractType),
+		Version: onramp.Version,
+	}, upgradeTestChains[0], func(r datastore.AddressRef) (datastore.AddressRef, error) {
+		return r, nil
+	})
+	require.NoError(t, err)
+	return ref
+}
+
+func upgradeStateAssertions(t *testing.T, e deployment.Environment, result ccvadapters.OnRampUpgradeResult) {
+	t.Helper()
+	chain := e.BlockChains.EVMChains()[upgradeTestChains[0]]
+	b := testsetup.BundleWithFreshReporter(e.OperationsBundle)
+
+	// New OnRamp static config.
+	newOnRampAddr := common.HexToAddress(result.NewOnRampRef.Address)
+	staticReport, err := operations.ExecuteOperation(b, onramp.GetStaticConfig, chain, contract.FunctionInput[struct{}]{
+		ChainSelector: chain.Selector,
+		Address:       newOnRampAddr,
+		Args:          struct{}{},
+	})
+	require.NoError(t, err)
+
+	rmnProxyAddr, err := datastore_utils.FindAndFormatCanonicalRef(e.DataStore, datastore.AddressRef{
+		Type:    datastore.ContractType(rmnproxyops.ContractType),
+		Version: semver.MustParse("1.0.0"),
+	}, upgradeTestChains[0], evm_datastore_utils.ToEVMAddress)
+	require.NoError(t, err)
+	assert.Equal(t, rmnProxyAddr, staticReport.Output.RmnRemote, "new OnRamp should use RMNProxy address")
+
+	// Phase 1 makes no router writes: TestRouter must not yet route to the new OnRamp for
+	// any dest chain, since that would cut prod-router-class lanes over before the verifier
+	// jobs observe both OnRamps.
+	testRouterAddr, err := datastore_utils.FindAndFormatCanonicalRef(e.DataStore, datastore.AddressRef{
+		Type:    datastore.ContractType(router.TestRouterContractType),
+		Version: router.Version,
+	}, upgradeTestChains[0], evm_datastore_utils.ToEVMAddress)
+	require.NoError(t, err)
+
+	for _, remoteSel := range upgradeTestChains[1:] {
+		onRampReport, err := operations.ExecuteOperation(b, router.GetOnRamp, chain, contract.FunctionInput[uint64]{
+			ChainSelector: chain.Selector,
+			Address:       testRouterAddr,
+			Args:          remoteSel,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, common.Address{}, onRampReport.Output,
+			"TestRouter should not yet route dest %d after Phase 1", remoteSel)
+	}
+
+	// New OnRamp dest chain configs should be copied verbatim from the legacy OnRamp,
+	// i.e. still use the prod Router (this test's lanes are all prod-router class).
+	prodRouterAddr, err := datastore_utils.FindAndFormatCanonicalRef(e.DataStore, datastore.AddressRef{
+		Type:    datastore.ContractType(router.ContractType),
+		Version: router.Version,
+	}, upgradeTestChains[0], evm_datastore_utils.ToEVMAddress)
+	require.NoError(t, err)
+	for _, remoteSel := range upgradeTestChains[1:] {
+		destCfg, err := operations.ExecuteOperation(b, onramp.GetDestChainConfig, chain, contract.FunctionInput[uint64]{
+			ChainSelector: chain.Selector,
+			Address:       newOnRampAddr,
+			Args:          remoteSel,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, prodRouterAddr, destCfg.Output.Router,
+			"new OnRamp dest config for %d should still use the prod Router after Phase 1", remoteSel)
+	}
+}
+
+// stagedOnTestRouterAssertions asserts that PromoteOnrampToTestRouter has wired the
+// TestRouter (and the new OnRamp's dest chain configs) to route dest chains to the new OnRamp,
+// without touching the prod Router.
+func stagedOnTestRouterAssertions(t *testing.T, e deployment.Environment, result ccvadapters.OnRampUpgradeResult) {
+	t.Helper()
+	chain := e.BlockChains.EVMChains()[upgradeTestChains[0]]
+	b := testsetup.BundleWithFreshReporter(e.OperationsBundle)
+
+	newOnRampAddr := common.HexToAddress(result.NewOnRampRef.Address)
+
+	testRouterAddr, err := datastore_utils.FindAndFormatCanonicalRef(e.DataStore, datastore.AddressRef{
+		Type:    datastore.ContractType(router.TestRouterContractType),
+		Version: router.Version,
+	}, upgradeTestChains[0], evm_datastore_utils.ToEVMAddress)
+	require.NoError(t, err)
+
+	for _, remoteSel := range upgradeTestChains[1:] {
+		onRampReport, err := operations.ExecuteOperation(b, router.GetOnRamp, chain, contract.FunctionInput[uint64]{
+			ChainSelector: chain.Selector,
+			Address:       testRouterAddr,
+			Args:          remoteSel,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, newOnRampAddr, onRampReport.Output,
+			"TestRouter should map dest %d to new OnRamp", remoteSel)
+	}
+
+	for _, remoteSel := range upgradeTestChains[1:] {
+		destCfg, err := operations.ExecuteOperation(b, onramp.GetDestChainConfig, chain, contract.FunctionInput[uint64]{
+			ChainSelector: chain.Selector,
+			Address:       newOnRampAddr,
+			Args:          remoteSel,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, testRouterAddr, destCfg.Output.Router,
+			"new OnRamp dest config for %d should use TestRouter", remoteSel)
+	}
+}
+
+func promoteStateAssertions(t *testing.T, e deployment.Environment, result ccvadapters.OnRampUpgradeResult) {
+	t.Helper()
+	chain := e.BlockChains.EVMChains()[upgradeTestChains[0]]
+	b := testsetup.BundleWithFreshReporter(e.OperationsBundle)
+
+	newOnRampAddr := common.HexToAddress(result.NewOnRampRef.Address)
+
+	prodRouterAddr, err := datastore_utils.FindAndFormatCanonicalRef(e.DataStore, datastore.AddressRef{
+		Type:    datastore.ContractType(router.ContractType),
+		Version: router.Version,
+	}, upgradeTestChains[0], evm_datastore_utils.ToEVMAddress)
+	require.NoError(t, err)
+
+	// Prod Router should route to the new OnRamp for each dest chain.
+	for _, remoteSel := range upgradeTestChains[1:] {
+		onRampReport, err := operations.ExecuteOperation(b, router.GetOnRamp, chain, contract.FunctionInput[uint64]{
+			ChainSelector: chain.Selector,
+			Address:       prodRouterAddr,
+			Args:          remoteSel,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, newOnRampAddr, onRampReport.Output,
+			"prod Router should map dest %d to new OnRamp", remoteSel)
+	}
+
+	// New OnRamp dest chain configs should use prod Router.
+	for _, remoteSel := range upgradeTestChains[1:] {
+		destCfg, err := operations.ExecuteOperation(b, onramp.GetDestChainConfig, chain, contract.FunctionInput[uint64]{
+			ChainSelector: chain.Selector,
+			Address:       newOnRampAddr,
+			Args:          remoteSel,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, prodRouterAddr, destCfg.Output.Router,
+			"new OnRamp dest config for %d should use prod Router", remoteSel)
+	}
+}
+
+func TestUpgradeOnrampFullFlowForInitialOnrampBehindTestRouter(t *testing.T) {
+	e := setupDeployNewOnRampTest(t)
+
+	existingOnRamp := initialStateAssertions(t, *e)
+	adapter := adapters.EVMOnRampUpgrader{}
+
+	result, err := adapter.DeployNewOnRamp(*e, upgradeTestChains[0])
+	require.NoError(t, err)
+
+	// Merge new OnRamp ref into the environment datastore so subsequent calls
+	// (PromoteOnrampToProdRouter) can find the canonical OnRamp.
+	mergeDS := datastore.NewMemoryDataStore()
+	require.NoError(t, mergeDS.Addresses().Add(result.NewOnRampRef))
+	require.NoError(t, mergeDS.Addresses().Add(result.LegacyOnRampRef))
+	ds := datastore.NewMemoryDataStore()
+	require.NoError(t, ds.Merge(e.DataStore))
+	require.NoError(t, ds.Merge(mergeDS.Seal()))
+	e.DataStore = ds.Seal()
+
+	// Legacy ref should match the old OnRamp address.
+	assert.Equal(t, existingOnRamp.Address, result.LegacyOnRampRef.Address)
+	assert.Equal(t, "legacy", result.LegacyOnRampRef.Qualifier)
+
+	// New ref should be canonical (empty qualifier).
+	assert.Equal(t, "", result.NewOnRampRef.Qualifier)
+	assert.NotEqual(t, existingOnRamp.Address, result.NewOnRampRef.Address)
+
+	upgradeStateAssertions(t, *e, result)
+}
+
+func TestUpgradeOnrampFullFlowForInitialOnrampNotBehindProdRouter(t *testing.T) {
+	e := setupDeployNewOnRampTest(t)
+
+	existingOnRamp := initialStateAssertions(t, *e)
+	adapter := adapters.EVMOnRampUpgrader{}
+
+	result, err := adapter.DeployNewOnRamp(*e, upgradeTestChains[0])
+	require.NoError(t, err)
+
+	// Merge new OnRamp ref into the environment datastore so PromoteOnrampToProdRouter
+	// can find the canonical OnRamp.
+	mergeDS := datastore.NewMemoryDataStore()
+	require.NoError(t, mergeDS.Addresses().Add(result.NewOnRampRef))
+	require.NoError(t, mergeDS.Addresses().Add(result.LegacyOnRampRef))
+	newDS := datastore.NewMemoryDataStore()
+	require.NoError(t, newDS.Merge(e.DataStore))
+	require.NoError(t, newDS.Merge(mergeDS.Seal()))
+	e.DataStore = newDS.Seal()
+
+	assert.Equal(t, existingOnRamp.Address, result.LegacyOnRampRef.Address)
+	assert.Equal(t, "legacy", result.LegacyOnRampRef.Qualifier)
+	assert.Equal(t, "", result.NewOnRampRef.Qualifier)
+	assert.NotEqual(t, existingOnRamp.Address, result.NewOnRampRef.Address)
+
+	upgradeStateAssertions(t, *e, result)
+
+	// Stage on the TestRouter first (Phase 2) — this must not touch the prod Router.
+	e.OperationsBundle = testsetup.BundleWithFreshReporter(e.OperationsBundle)
+	_, err = adapter.PromoteOnrampToTestRouter(*e, upgradeTestChains[0], upgradeTestChains[1:])
+	require.NoError(t, err)
+	stagedOnTestRouterAssertions(t, *e, result)
+
+	// Now promote to prod router (Phase 3).
+	e.OperationsBundle = testsetup.BundleWithFreshReporter(e.OperationsBundle)
+	_, err = adapter.PromoteOnrampToProdRouter(*e, upgradeTestChains[0], upgradeTestChains[1:])
+	require.NoError(t, err)
+
+	promoteStateAssertions(t, *e, result)
+}
+
+func TestDeployNewOnRampIdempotent(t *testing.T) {
+	e := setupDeployNewOnRampTest(t)
+	adapter := adapters.EVMOnRampUpgrader{}
+
+	result, err := adapter.DeployNewOnRamp(*e, upgradeTestChains[0])
+	require.NoError(t, err)
+
+	// Merge new OnRamp ref into the environment datastore so subsequent calls
+	// (PromoteOnrampToProdRouter) can find the canonical OnRamp.
+	mergeDS := datastore.NewMemoryDataStore()
+	require.NoError(t, mergeDS.Addresses().Add(result.NewOnRampRef))
+	require.NoError(t, mergeDS.Addresses().Add(result.LegacyOnRampRef))
+	ds := datastore.NewMemoryDataStore()
+	require.NoError(t, ds.Merge(e.DataStore))
+	require.NoError(t, ds.Merge(mergeDS.Seal()))
+	e.DataStore = ds.Seal()
+
+	// Re-deploying should return the same canonical OnRamp ref and no writes.
+	result2, err := adapter.DeployNewOnRamp(*e, upgradeTestChains[0])
+	require.NoError(t, err)
+	assert.Equal(t, result.NewOnRampRef.Address, result2.NewOnRampRef.Address, "New OnRamp ref should be canonical and unchanged on re-deploy")
+	assert.Equal(t, result.LegacyOnRampRef.Address, result2.LegacyOnRampRef.Address, "Legacy OnRamp ref should be unchanged on re-deploy")
+	assert.Len(t, result2.BatchOps, 1, "BatchOps still contains DestChainConfig writes")
+}
+
+func TestGetOffRampSourceOnRamps(t *testing.T) {
+	e := setupDeployNewOnRampTest(t)
+	adapter := &adapters.ChainFamilyAdapter{}
+
+	// Fresh reporter: the setup bundle's reporter still holds the lane-config read
+	// from when the whitelist was empty, and ExecuteOperation dedupes on it.
+	e.OperationsBundle = testsetup.BundleWithFreshReporter(e.OperationsBundle)
+
+	// The lane setup whitelists chain0's canonical OnRamp on chain1's OffRamp,
+	// in wire format (32-byte left-padded).
+	onRampRef := initialStateAssertions(t, *e)
+	expected := hexutil.Encode(common.LeftPadBytes(common.HexToAddress(onRampRef.Address).Bytes(), 32))
+
+	got, err := adapter.GetOffRampSourceOnRamps(*e, upgradeTestChains[1], upgradeTestChains[0])
+	require.NoError(t, err)
+	require.Equal(t, []string{expected}, got)
+}
+
+func TestLegacyOnRampRef(t *testing.T) {
+	e := setupDeployNewOnRampTest(t)
+	adapter := adapters.EVMOnRampUpgrader{}
+
+	// No legacy ref exists before an upgrade.
+	_, err := adapter.LegacyOnRampRef(*e, upgradeTestChains[0])
+	require.Error(t, err)
+
+	existingOnRamp := initialStateAssertions(t, *e)
+	result, err := adapter.DeployNewOnRamp(*e, upgradeTestChains[0])
+	require.NoError(t, err)
+
+	// Merge new/legacy refs so the datastore reflects the post-upgrade state.
+	mergeUpgradeRefs(t, e, result)
+
+	ref, err := adapter.LegacyOnRampRef(*e, upgradeTestChains[0])
+	require.NoError(t, err)
+	assert.Equal(t, existingOnRamp.Address, ref.Address)
+	assert.Equal(t, "legacy", ref.Qualifier)
+}
+
+// mergeUpgradeRefs merges the upgrade result refs into the environment datastore,
+// simulating the CLD merge that happens after a changeset executes.
+func mergeUpgradeRefs(t *testing.T, e *deployment.Environment, result ccvadapters.OnRampUpgradeResult) {
+	t.Helper()
+	mergeDS := datastore.NewMemoryDataStore()
+	require.NoError(t, mergeDS.Addresses().Add(result.NewOnRampRef))
+	require.NoError(t, mergeDS.Addresses().Add(result.LegacyOnRampRef))
+	ds := datastore.NewMemoryDataStore()
+	require.NoError(t, ds.Merge(e.DataStore))
+	require.NoError(t, ds.Merge(mergeDS.Seal()))
+	e.DataStore = ds.Seal()
+}
+
+// TestDeployNewOnRampAlreadyFixed guards against a pointless migration: the canonical
+// OnRamp already uses the RMNProxy, so there is nothing to upgrade.
+func TestDeployNewOnRampAlreadyFixed(t *testing.T) {
+	e := setupDeployNewOnRampTest(t)
+	adapter := adapters.EVMOnRampUpgrader{}
+
+	result, err := adapter.DeployNewOnRamp(*e, upgradeTestChains[0])
+	require.NoError(t, err)
+	mergeUpgradeRefs(t, e, result)
+
+	err = adapter.VerifyOnrampRequireUpgrade(*e, upgradeTestChains[0])
+	require.ErrorContains(t, err, "already uses RMNProxy")
+}
+
+func TestVerifyPromotedToProdRouter(t *testing.T) {
+	e := setupDeployNewOnRampTest(t)
+	adapter := adapters.EVMOnRampUpgrader{}
+
+	result, err := adapter.DeployNewOnRamp(*e, upgradeTestChains[0])
+	require.NoError(t, err)
+	mergeUpgradeRefs(t, e, result)
+
+	// Not yet promoted: the prod Router still routes through the old OnRamp.
+	e.OperationsBundle = testsetup.BundleWithFreshReporter(e.OperationsBundle)
+	err = adapter.VerifyPromotedToProdRouter(*e, upgradeTestChains[0], upgradeTestChains[1:])
+	require.ErrorContains(t, err, "Phase 3 must execute first")
+
+	_, err = adapter.PromoteOnrampToProdRouter(*e, upgradeTestChains[0], upgradeTestChains[1:])
+	require.NoError(t, err)
+
+	e.OperationsBundle = testsetup.BundleWithFreshReporter(e.OperationsBundle)
+	require.NoError(t, adapter.VerifyPromotedToProdRouter(*e, upgradeTestChains[0], upgradeTestChains[1:]))
+}
+
+func TestVerifyLegacyOnRampOnProdRouter(t *testing.T) {
+	e := setupDeployNewOnRampTest(t)
+	adapter := adapters.EVMOnRampUpgrader{}
+
+	result, err := adapter.DeployNewOnRamp(*e, upgradeTestChains[0])
+	require.NoError(t, err)
+	mergeUpgradeRefs(t, e, result)
+
+	// Until Phase 2 executes, the prod Router still routes through the legacy OnRamp.
+	e.OperationsBundle = testsetup.BundleWithFreshReporter(e.OperationsBundle)
+	require.NoError(t, adapter.VerifyLegacyOnRampOnProdRouter(*e, upgradeTestChains[0], upgradeTestChains[1:]))
+
+	_, err = adapter.PromoteOnrampToProdRouter(*e, upgradeTestChains[0], upgradeTestChains[1:])
+	require.NoError(t, err)
+
+	// After promotion the prod Router points at the new OnRamp instead.
+	e.OperationsBundle = testsetup.BundleWithFreshReporter(e.OperationsBundle)
+	require.ErrorContains(t,
+		adapter.VerifyLegacyOnRampOnProdRouter(*e, upgradeTestChains[0], upgradeTestChains[1:]),
+		"prod Router does not route")
+}
+
+func TestVerifyNewOnRampOwner(t *testing.T) {
+	e := setupDeployNewOnRampTest(t)
+	adapter := adapters.EVMOnRampUpgrader{}
+
+	result, err := adapter.DeployNewOnRamp(*e, upgradeTestChains[0])
+	require.NoError(t, err)
+	mergeUpgradeRefs(t, e, result)
+
+	// The new OnRamp is deployer-owned until Phase 1's ownership transfer executes.
+	deployer := e.BlockChains.EVMChains()[upgradeTestChains[0]].DeployerKey.From.Hex()
+	e.OperationsBundle = testsetup.BundleWithFreshReporter(e.OperationsBundle)
+	require.NoError(t, adapter.VerifyNewOnRampOwner(*e, upgradeTestChains[0], deployer))
+	require.ErrorContains(t,
+		adapter.VerifyNewOnRampOwner(*e, upgradeTestChains[0], "0x000000000000000000000000000000000000dEaD"),
+		"owned by")
+}
+
+// resolveRouterAddrForTest resolves a router address of the given contract type on the
+// upgrade target chain.
+func resolveRouterAddrForTest(t *testing.T, e deployment.Environment, contractType datastore.ContractType) common.Address {
+	t.Helper()
+	addr, err := datastore_utils.FindAndFormatCanonicalRef(e.DataStore, datastore.AddressRef{
+		Type:    contractType,
+		Version: router.Version,
+	}, upgradeTestChains[0], evm_datastore_utils.ToEVMAddress)
+	require.NoError(t, err)
+	return addr
+}
+
+// setDestChainRouter repoints destSel's Router on the OnRamp at onRampAddr, leaving every other
+// field of that dest config — and every other dest config — untouched. The lane-config changesets
+// only ever write a single router for a whole chain, so this is how the tests below build a
+// mixed-router fixture (and simulate Phase 2's TestRouter staging) without a full reconfiguration.
+func setDestChainRouter(
+	t *testing.T,
+	e *deployment.Environment,
+	onRampAddr common.Address,
+	destSel uint64,
+	routerAddr common.Address,
+) {
+	t.Helper()
+	chain := e.BlockChains.EVMChains()[upgradeTestChains[0]]
+
+	e.OperationsBundle = testsetup.BundleWithFreshReporter(e.OperationsBundle)
+	report, err := operations.ExecuteOperation(e.OperationsBundle, onramp.GetAllDestChainConfigs, chain, contract.FunctionInput[struct{}]{
+		ChainSelector: chain.Selector,
+		Address:       onRampAddr,
+		Args:          struct{}{},
+	})
+	require.NoError(t, err)
+
+	selectors := report.Output.Ret0
+	require.NotEmpty(t, selectors, "OnRamp %s has no dest chain configs to update", onRampAddr.Hex())
+
+	args := make([]onramp.DestChainConfigArgs, len(selectors))
+	for i, cfg := range report.Output.Ret1 {
+		args[i] = onramp.DestChainConfigArgs{
+			DestChainSelector:         selectors[i],
+			Router:                    cfg.Router,
+			AddressBytesLength:        cfg.AddressBytesLength,
+			TokenReceiverAllowed:      cfg.TokenReceiverAllowed,
+			MessageNetworkFeeUSDCents: cfg.MessageNetworkFeeUSDCents,
+			TokenNetworkFeeUSDCents:   cfg.TokenNetworkFeeUSDCents,
+			BaseExecutionGasCost:      cfg.BaseExecutionGasCost,
+			DefaultCCVs:               cfg.DefaultCCVs,
+			LaneMandatedCCVs:          cfg.LaneMandatedCCVs,
+			DefaultExecutor:           cfg.DefaultExecutor,
+			OffRamp:                   cfg.OffRamp,
+		}
+		if selectors[i] == destSel {
+			args[i].Router = routerAddr
+		}
+	}
+
+	e.OperationsBundle = testsetup.BundleWithFreshReporter(e.OperationsBundle)
+	_, err = operations.ExecuteOperation(e.OperationsBundle, onramp.ApplyDestChainConfigUpdates, chain, contract.FunctionInput[[]onramp.DestChainConfigArgs]{
+		ChainSelector: chain.Selector,
+		Address:       onRampAddr,
+		Args:          args,
+	})
+	require.NoError(t, err)
+
+	// The reporter memoizes reads by (operation, chain, address, args), so a stale
+	// pre-write dest-config report would otherwise be served to the next caller.
+	e.OperationsBundle = testsetup.BundleWithFreshReporter(e.OperationsBundle)
+}
+
+// The lane setup wires every lane through the prod Router, so a freshly set up chain has no
+// TestRouter-class lanes at all.
+func TestClassifyDestChains_AllProdRouterClass(t *testing.T) {
+	e := setupDeployNewOnRampTest(t)
+	adapter := adapters.EVMOnRampUpgrader{}
+
+	class, err := adapter.ClassifyDestChains(*e, upgradeTestChains[0])
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, upgradeTestChains[1:], class.ProdRouterDests)
+	assert.Empty(t, class.TestRouterDests)
+}
+
+// A chain may serve both lane classes at once: chain1 fronted by the TestRouter (where the
+// TestRouter *is* that lane's production path) and chain2 by the prod Router. Each must land in
+// its own bucket so the phases can drive the right workflow per dest.
+func TestClassifyDestChains_MixedRouterClasses(t *testing.T) {
+	e := setupDeployNewOnRampTest(t)
+	adapter := adapters.EVMOnRampUpgrader{}
+
+	onRamp := common.HexToAddress(initialStateAssertions(t, *e).Address)
+	testRouterAddr := resolveRouterAddrForTest(t, *e, datastore.ContractType(router.TestRouterContractType))
+	setDestChainRouter(t, e, onRamp, upgradeTestChains[1], testRouterAddr)
+
+	class, err := adapter.ClassifyDestChains(*e, upgradeTestChains[0])
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []uint64{upgradeTestChains[2]}, class.ProdRouterDests)
+	assert.ElementsMatch(t, []uint64{upgradeTestChains[1]}, class.TestRouterDests)
+}
+
+func TestClassifyDestChains_AllTestRouterClass(t *testing.T) {
+	e := setupDeployNewOnRampTest(t)
+	adapter := adapters.EVMOnRampUpgrader{}
+
+	onRamp := common.HexToAddress(initialStateAssertions(t, *e).Address)
+	testRouterAddr := resolveRouterAddrForTest(t, *e, datastore.ContractType(router.TestRouterContractType))
+	for _, destSel := range upgradeTestChains[1:] {
+		setDestChainRouter(t, e, onRamp, destSel, testRouterAddr)
+	}
+
+	class, err := adapter.ClassifyDestChains(*e, upgradeTestChains[0])
+	require.NoError(t, err)
+
+	assert.Empty(t, class.ProdRouterDests)
+	assert.ElementsMatch(t, upgradeTestChains[1:], class.TestRouterDests)
+}
+
+// Regression: classification must read the legacy-qualified OnRamp once Phase 1 has run.
+// Phase 1 makes the *new* OnRamp canonical, and Phase 2 then repoints its prod-class dest configs
+// at the TestRouter for staging. Classifying off the canonical ref would therefore see
+// Router == TestRouter and misclassify those dests as TestRouter-class, so Phase 3 would promote
+// them back to the TestRouter instead of the prod Router — leaving prod traffic on the legacy OnRamp.
+func TestClassifyDestChains_UsesLegacyRefAfterStaging(t *testing.T) {
+	e := setupDeployNewOnRampTest(t)
+	adapter := adapters.EVMOnRampUpgrader{}
+
+	result, err := adapter.DeployNewOnRamp(*e, upgradeTestChains[0])
+	require.NoError(t, err)
+	mergeUpgradeRefs(t, e, result)
+
+	// Simulate Phase 2 staging: the new (canonical) OnRamp's dest configs now point at the
+	// TestRouter, while the legacy OnRamp still records their original prod Router.
+	newOnRamp := common.HexToAddress(result.NewOnRampRef.Address)
+	testRouterAddr := resolveRouterAddrForTest(t, *e, datastore.ContractType(router.TestRouterContractType))
+	for _, destSel := range upgradeTestChains[1:] {
+		setDestChainRouter(t, e, newOnRamp, destSel, testRouterAddr)
+	}
+
+	class, err := adapter.ClassifyDestChains(*e, upgradeTestChains[0])
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, upgradeTestChains[1:], class.ProdRouterDests,
+		"staged dests must stay prod-router class so Phase 3 promotes them to the prod Router")
+	assert.Empty(t, class.TestRouterDests)
+}

--- a/chains/evm/deployment/v2_0_0/adapters/upgrade_onramp_test.go
+++ b/chains/evm/deployment/v2_0_0/adapters/upgrade_onramp_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -381,11 +380,11 @@ func TestGetOffRampSourceOnRamps(t *testing.T) {
 	// The lane setup whitelists chain0's canonical OnRamp on chain1's OffRamp,
 	// in wire format (32-byte left-padded).
 	onRampRef := initialStateAssertions(t, *e)
-	expected := hexutil.Encode(common.LeftPadBytes(common.HexToAddress(onRampRef.Address).Bytes(), 32))
+	expected := common.LeftPadBytes(common.HexToAddress(onRampRef.Address).Bytes(), 32)
 
 	got, err := adapter.GetOffRampSourceOnRamps(*e, upgradeTestChains[1], upgradeTestChains[0])
 	require.NoError(t, err)
-	require.Equal(t, []string{expected}, got)
+	require.Equal(t, [][]byte{expected}, got)
 }
 
 func TestLegacyOnRampRef(t *testing.T) {

--- a/chains/evm/deployment/v2_0_0/adapters/upgrade_onramp_test.go
+++ b/chains/evm/deployment/v2_0_0/adapters/upgrade_onramp_test.go
@@ -443,14 +443,14 @@ func TestVerifyPromotedToProdRouter(t *testing.T) {
 
 	// Not yet promoted: the prod Router still routes through the old OnRamp.
 	e.OperationsBundle = testsetup.BundleWithFreshReporter(e.OperationsBundle)
-	err = adapter.VerifyPromotedToProdRouter(*e, upgradeTestChains[0], upgradeTestChains[1:])
+	err = adapter.VerifyPromotedToRouters(*e, upgradeTestChains[0], upgradeTestChains[1:], []uint64{})
 	require.ErrorContains(t, err, "Phase 3 must execute first")
 
 	_, err = adapter.PromoteOnrampToProdRouter(*e, upgradeTestChains[0], upgradeTestChains[1:])
 	require.NoError(t, err)
 
 	e.OperationsBundle = testsetup.BundleWithFreshReporter(e.OperationsBundle)
-	require.NoError(t, adapter.VerifyPromotedToProdRouter(*e, upgradeTestChains[0], upgradeTestChains[1:]))
+	require.NoError(t, adapter.VerifyPromotedToRouters(*e, upgradeTestChains[0], upgradeTestChains[1:], []uint64{}))
 }
 
 func TestVerifyLegacyOnRampOnProdRouter(t *testing.T) {

--- a/chains/evm/deployment/v2_0_0/adapters/upgrade_onramp_test.go
+++ b/chains/evm/deployment/v2_0_0/adapters/upgrade_onramp_test.go
@@ -358,13 +358,16 @@ func TestDeployNewOnRampIdempotent(t *testing.T) {
 	require.NoError(t, ds.Merge(e.DataStore))
 	require.NoError(t, ds.Merge(mergeDS.Seal()))
 	e.DataStore = ds.Seal()
-
+	e.OperationsBundle = testsetup.BundleWithFreshReporter(e.OperationsBundle)
 	// Re-deploying should return the same canonical OnRamp ref and no writes.
 	result2, err := adapter.DeployNewOnRamp(*e, upgradeTestChains[0])
 	require.NoError(t, err)
 	assert.Equal(t, result.NewOnRampRef.Address, result2.NewOnRampRef.Address, "New OnRamp ref should be canonical and unchanged on re-deploy")
 	assert.Equal(t, result.LegacyOnRampRef.Address, result2.LegacyOnRampRef.Address, "Legacy OnRamp ref should be unchanged on re-deploy")
-	assert.Len(t, result2.BatchOps, 1, "BatchOps still contains DestChainConfig writes")
+	require.True(t, result2.Reused)
+	assert.Equal(t, result.NewOnRampRef.Address, result2.NewOnRampRef.Address)
+	assert.Equal(t, result.LegacyOnRampRef.Address, result2.LegacyOnRampRef.Address)
+	assert.Empty(t, result2.BatchOps, "reusing an existing Phase 1 upgrade must not emit deployment/config writes")
 }
 
 func TestGetOffRampSourceOnRamps(t *testing.T) {

--- a/chains/evm/deployment/v2_0_0/operations/onramp/onramp.go
+++ b/chains/evm/deployment/v2_0_0/operations/onramp/onramp.go
@@ -101,6 +101,20 @@ func (c *OnRampContract) GetStaticConfig(opts *bind.CallOpts) (StaticConfig, err
 	return *abi.ConvertType(out[0], new(StaticConfig)).(*StaticConfig), nil
 }
 
+func (c *OnRampContract) GetAllDestChainConfigs(opts *bind.CallOpts) (GetAllDestChainConfigsResult, error) {
+	var out []any
+	err := c.contract.Call(opts, &out, "getAllDestChainConfigs")
+	outstruct := new(GetAllDestChainConfigsResult)
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Ret0 = *abi.ConvertType(out[0], new([]uint64)).(*[]uint64)
+	outstruct.Ret1 = *abi.ConvertType(out[1], new([]DestChainConfig)).(*[]DestChainConfig)
+
+	return *outstruct, nil
+}
+
 type DestChainConfig struct {
 	Router                    common.Address
 	MessageNumber             uint64
@@ -133,6 +147,11 @@ type DynamicConfig struct {
 	FeeQuoter              common.Address
 	ReentrancyGuardEntered bool
 	FeeAggregator          common.Address
+}
+
+type GetAllDestChainConfigsResult struct {
+	Ret0 []uint64
+	Ret1 []DestChainConfig
 }
 
 type StaticConfig struct {
@@ -247,5 +266,16 @@ var GetStaticConfig = contract.NewRead(contract.ReadParams[struct{}, StaticConfi
 	NewContract:  NewOnRampContract,
 	CallContract: func(c *OnRampContract, opts *bind.CallOpts, args struct{}) (StaticConfig, error) {
 		return c.GetStaticConfig(opts)
+	},
+})
+
+var GetAllDestChainConfigs = contract.NewRead(contract.ReadParams[struct{}, GetAllDestChainConfigsResult, *OnRampContract]{
+	Name:         "onramp:get-all-dest-chain-configs",
+	Version:      Version,
+	Description:  "Calls getAllDestChainConfigs on the contract",
+	ContractType: ContractType,
+	NewContract:  NewOnRampContract,
+	CallContract: func(c *OnRampContract, opts *bind.CallOpts, args struct{}) (GetAllDestChainConfigsResult, error) {
+		return c.GetAllDestChainConfigs(opts)
 	},
 })

--- a/chains/evm/deployment/v2_0_0/operations/onramp/onramp_owner.go
+++ b/chains/evm/deployment/v2_0_0/operations/onramp/onramp_owner.go
@@ -1,0 +1,20 @@
+package onramp
+
+import (
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
+)
+
+// getOnRampOwner reads the owner of the OnRamp. It lives here rather than in the
+// generated operations package (operations-gen output must not be edited).
+var Owner = contract.NewRead(contract.ReadParams[struct{}, common.Address, *OnRampContract]{
+	Name:         "onramp:owner",
+	Version:      Version,
+	Description:  "Returns the owner of the OnRamp",
+	ContractType: ContractType,
+	NewContract:  NewOnRampContract,
+	CallContract: func(c *OnRampContract, opts *bind.CallOpts, _ struct{}) (common.Address, error) {
+		return c.Owner(opts)
+	},
+})

--- a/chains/evm/go.mod
+++ b/chains/evm/go.mod
@@ -27,6 +27,7 @@ require (
 	golang.org/x/exp v0.0.0-20260508232706-74f9aab9d74a
 	golang.org/x/sync v0.22.0
 	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/utils v0.0.0-20241210054802-24370beab758
 )
 
 require (
@@ -336,7 +337,6 @@ require (
 	k8s.io/client-go v0.32.3 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250318190949-c8a335a9a2ff // indirect
-	k8s.io/utils v0.0.0-20241210054802-24370beab758 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.6.0 // indirect


### PR DESCRIPTION
This pull request add the EVM adapters require for the Onramp Upgrade changesets

It deploy a new Onramp and mark the old one with the legacy qualifier. It copies over the config from the old onramp to the new except the RMN proxy address which is set to the RmnRemote property of the config.

When deploying it first add the new onramp to all dest offramp (while keeping the legacy onramp allowlisted)

For TestRouter lanes the onramp is promoted directly without using a TestVerifier

For ProdRouter lanes the onramp is first configured with a test verifier and configured behind the TestRouter first.