### PR TITLE
feat: migrate liquidity before v2 pool activation

### DIFF
--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -3,7 +3,6 @@ package tokens
 import (
 	"bytes"
 	"fmt"
-	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -43,16 +42,6 @@ type TokenTransferConfig struct {
 	// the zero value, then the finality config will remain unchanged on-chain. Pre-v2 pools will
 	// ignore this parameter as it is not supported on those versions.
 	AllowedFinalityConfig finality.Config `yaml:"allowedFinalityConfig" json:"allowedFinalityConfig"`
-	// LiquidityMigrationAmount, if set, specifies an exact token amount to migrate from the old pool (read from the
-	// TokenAdminRegistry) to the new pool's lockbox. Mutually exclusive with LiquidityMigrationBasisPoints.
-	// When either field is set, a liquidity migration is triggered via TokenExpansion after UpdateAuthorities
-	// transfers pool and lockbox ownership to the MCMS timelock. Migration requires the timelock to own the v2
-	// lockbox (and the legacy pool for rebalancer/withdraw ops). Use TokenExpansion for connect/upgrade flows;
-	// ConfigureTokensForTransfers rejects these fields. For standalone step-2 drains, use MigrateLockReleasePoolLiquidity.
-	LiquidityMigrationAmount *big.Int `yaml:"liquidityMigrationAmount" json:"liquidityMigrationAmount"`
-	// LiquidityMigrationBasisPoints specifies a percentage of the old pool's balance to migrate (1-10000, where 10000 = 100%).
-	// Mutually exclusive with LiquidityMigrationAmount. See LiquidityMigrationAmount for ownership and entry-point requirements.
-	LiquidityMigrationBasisPoints *uint16 `yaml:"liquidityMigrationBasisPoints" json:"liquidityMigrationBasisPoints"`
 	// AutoMigrateRemoteChains is only applicable when migrating a pre-V2 pool to V2. When true, the changeset
 	// fetches the currently active pool from TAR, queries its supported remote chains, and populates RemoteChains
 	// automatically with (token, pool, decimals, rate limits, and MigrationMetadata). Legacy lane fees are read
@@ -108,14 +97,6 @@ func ConfigureTokensForTransfers(tokenRegistry *TokenAdapterRegistry, mcmsRegist
 
 func makeVerify(_ *TokenAdapterRegistry, _ *changesets.MCMSReaderRegistry) func(cldf.Environment, ConfigureTokensForTransfersConfig) error {
 	return func(_ cldf.Environment, cfg ConfigureTokensForTransfersConfig) error {
-		for _, token := range cfg.Tokens {
-			if token.LiquidityMigrationAmount != nil || token.LiquidityMigrationBasisPoints != nil {
-				return fmt.Errorf(
-					"liquidity migration on chain selector %d requires TokenExpansion, which runs migration after UpdateAuthorities transfers pool and lockbox ownership to the MCMS timelock",
-					token.ChainSelector,
-				)
-			}
-		}
 		return nil
 	}
 }

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -12,7 +12,6 @@ import (
 
 	ccipdeploy "github.com/smartcontractkit/chainlink-ccip/deployment/deploy"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/finality"
-	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
 	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
@@ -158,6 +157,16 @@ type DeployTokenPoolInput struct {
 	// with no lockbox reverts with LockBoxNotConfigured on its first transfer.
 	// EVM 2.0.0+ only.
 	LockBoxGroups [][]uint64 `yaml:"lockBoxGroups,omitempty" json:"lockBoxGroups,omitempty"`
+	// LiquidityMigrationAmount, if set, specifies an exact token amount to seed the new pool's
+	// lockbox from the old pool (read from the TokenAdminRegistry). The migration runs during
+	// deploy, before the pool is registered on TAR or ownership-transferred. Mutually exclusive
+	// with LiquidityMigrationBasisPoints. For cleanup drains of orphaned pools, use the
+	// standalone MigrateLockReleasePoolLiquidity changeset instead.
+	LiquidityMigrationAmount *big.Int `yaml:"liquidityMigrationAmount,omitempty" json:"liquidityMigrationAmount,omitempty"`
+	// LiquidityMigrationBasisPoints specifies a percentage of the old pool's balance to seed
+	// (1-10000, where 10000 = 100%). Mutually exclusive with LiquidityMigrationAmount.
+	// See LiquidityMigrationAmount for details.
+	LiquidityMigrationBasisPoints *uint16 `yaml:"liquidityMigrationBasisPoints,omitempty" json:"liquidityMigrationBasisPoints,omitempty"`
 	// below are not specified by the user, filled in by the deployment system to pass to chain operations
 	ChainSelector     uint64
 	ExistingDataStore datastore.DataStore
@@ -349,6 +358,26 @@ func tokenExpansionApply() func(cldf.Environment, TokenExpansionInput) (cldf.Cha
 				}
 				tmpDatastore.Merge(e.DataStore)
 				e.DataStore = tmpDatastore.Seal()
+
+				// Seed liquidity into the new pool's lockbox if migration config is set.
+				// This runs BEFORE processTokenConfigForChain / UpdateAuthorities so the
+				// new pool is not registered in TAR yet, and we can read the legacy pool
+				// address directly from TAR.
+				var registryRef datastore.AddressRef
+				if tc := cfg.TokenExpansionInputPerChain[selector].TokenTransferConfig; tc != nil {
+					registryRef = tc.RegistryRef
+				}
+				seedBatchOps, seedReports, err := buildSeedMigrationBatchOps(
+					e, tokenPoolRegistry, selector, *tokenPool, *tokenRef, registryRef,
+					deployTokenPoolInput.TimelockAddress,
+					deployTokenPoolInput.LiquidityMigrationAmount,
+					deployTokenPoolInput.LiquidityMigrationBasisPoints,
+				)
+				if err != nil {
+					return cldf.ChangesetOutput{}, fmt.Errorf("failed to build seed migration on chain %d: %w", selector, err)
+				}
+				batchOps = append(batchOps, seedBatchOps...)
+				reports = append(reports, seedReports...)
 			}
 			allRemotes[selector] = RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
 				RemoteToken: tokenRef,
@@ -410,16 +439,10 @@ func tokenExpansionApply() func(cldf.Environment, TokenExpansionInput) (cldf.Cha
 				// When no remote chains are given but `autoMigrateRemoteChains` is true, then we should still
 				// proceed to the configure step since remote chain configs (including legacy lane fees) will be
 				// auto-populated via the token pool migrator interface.
-				isLiquidityMigration := ttConfig.LiquidityMigrationAmount != nil || ttConfig.LiquidityMigrationBasisPoints != nil
-				if len(ttConfig.RemoteChains) != 0 || ttConfig.AutoMigrateRemoteChains || isLiquidityMigration {
+				if len(ttConfig.RemoteChains) != 0 || ttConfig.AutoMigrateRemoteChains {
 					allTokenConfigs[selector] = *ttConfig
 				}
 			}
-		}
-
-		legacyPools, err := snapshotLegacyPoolsForMigration(e, tokenPoolRegistry, allTokenConfigs)
-		if err != nil {
-			return cldf.ChangesetOutput{}, fmt.Errorf("failed to snapshot legacy pools for liquidity migration: %w", err)
 		}
 
 		// we process the token configs for transfers, which will register the tokens and token pools on-chain and set the pool on the token if necessary
@@ -456,47 +479,6 @@ func tokenExpansionApply() func(cldf.Environment, TokenExpansionInput) (cldf.Cha
 			}
 			batchOps = append(batchOps, updateAuthoritiesReport.Output.BatchOps...)
 			reports = append(reports, updateAuthoritiesReport.ExecutionReports...)
-		}
-
-		// if applicable, migrate lock release pool liquidity - the V2 EVM sequence expects the
-		// pool to be owned by the timelock, so we need to do this after the ownership transfer
-		for selector, tokenConfig := range allTokenConfigs {
-			if tokenConfig.LiquidityMigrationAmount == nil && tokenConfig.LiquidityMigrationBasisPoints == nil {
-				continue
-			}
-			if tokenConfig.LiquidityMigrationAmount != nil && tokenConfig.LiquidityMigrationBasisPoints != nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("both LiquidityMigrationAmount and LiquidityMigrationBasisPoints are set for chain selector %d, only one can be set", selector)
-			}
-			if cfg.TokenExpansionInputPerChain[selector].SkipOwnershipTransfer {
-				return cldf.ChangesetOutput{}, fmt.Errorf(
-					"liquidity migration on chain selector %d requires UpdateAuthorities (skipOwnershipTransfer is set)",
-					selector,
-				)
-			}
-			tokenPoolAdapter, family, fullPoolRef, _, err := ResolveAdapterAndRefs(e, tokenPoolRegistry, selector, tokenConfig.TokenPoolRef, tokenConfig.TokenRef)
-			if err != nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("failed to resolve adapter and refs for liquidity migration on chain selector %d: %w", selector, err)
-			}
-			if !utils.IsLockReleasePoolType(fullPoolRef.Type.String()) {
-				e.Logger.Warnf("skipping liquidity migration on chain with selector %d because token pool type %s is not a LockRelease pool", selector, fullPoolRef.Type.String())
-				continue
-			}
-			migrationBatchOps, migrationReports, err := buildLiquidityMigrationBatchOps(
-				e,
-				mcmsRegistry,
-				cfg.MCMS,
-				selector,
-				tokenConfig,
-				tokenPoolAdapter,
-				family,
-				fullPoolRef,
-				legacyPools[selector],
-			)
-			if err != nil {
-				return cldf.ChangesetOutput{}, fmt.Errorf("failed to build liquidity migration on chain %d: %w", selector, err)
-			}
-			batchOps = append(batchOps, migrationBatchOps...)
-			reports = append(reports, migrationReports...)
 		}
 
 		return changesets.NewOutputBuilder(e, mcmsRegistry).
@@ -649,110 +631,72 @@ func ResolveAdapter(reg *TokenAdapterRegistry, sel uint64, tokenPoolVersion *sem
 	return adapter, family, nil
 }
 
-// snapshotLegacyPoolsForMigration records the pool currently registered in TAR for each
-// chain that will run liquidity migration. That address is the legacy pool we drain from.
-//
-// The order of operations in this changeset matters: migration runs after UpdateAuthorities
-// (the v2 pool and lockbox need to be timelock-owned), but by that point configure has
-// already registered the v2 pool on TAR. If we queried TAR again at migration time we'd
-// see the new pool and skip the drain.
-//
-// Reordering configure, authority transfer, and migration would be a bigger refactor, so
-// for now we snapshot the legacy pool addresses before configure runs, then use that
-// snapshot when building the migration batch.
-//
-// If TAR already points at the target pool (step-2 or re-run), we don't snapshot — use
-// standalone MigrateLockReleasePoolLiquidity with an explicit OldPoolRef instead.
-func snapshotLegacyPoolsForMigration(e cldf.Environment, reg *TokenAdapterRegistry, configs map[uint64]TokenTransferConfig) (map[uint64][]byte, error) {
-	legacyPools := make(map[uint64][]byte, len(configs))
-	for selector, token := range configs {
-		if token.LiquidityMigrationAmount == nil && token.LiquidityMigrationBasisPoints == nil {
-			continue
-		}
-
-		adapter, _, fullPoolRef, fullTokenRef, err := ResolveAdapterAndRefs(e, reg, selector, token.TokenPoolRef, token.TokenRef)
-		if err != nil {
-			return nil, fmt.Errorf("failed to resolve adapter and refs for chain selector %d: %w", selector, err)
-		}
-
-		registryMigrator, ok := adapter.(TokenPoolMigrator)
-		if !ok {
-			return nil, fmt.Errorf(
-				"adapter for chain selector %d does not support reading active pool from registry, which is required for liquidity migration",
-				selector,
-			)
-		}
-
-		activePool, err := registryMigrator.GetActivePool(e, selector, token.RegistryRef, fullTokenRef)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get active pool for liquidity migration on chain selector %d: %w", selector, err)
-		}
-		if len(activePool) == 0 {
-			e.Logger.Infof("no legacy pool registered for liquidity migration on chain selector %d, skipping snapshot", selector)
-			continue
-		}
-
-		targetPoolBytes, err := adapter.AddressRefToBytes(fullPoolRef)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert target pool ref to bytes on chain selector %d: %w", selector, err)
-		}
-		if bytes.Equal(activePool, targetPoolBytes) {
-			e.Logger.Infof("legacy pool matches target on chain selector %d, skipping liquidity migration snapshot", selector)
-			continue
-		}
-
-		legacyPools[selector] = activePool
-	}
-
-	return legacyPools, nil
-}
-
-func buildLiquidityMigrationBatchOps(
+func buildSeedMigrationBatchOps(
 	e cldf.Environment,
-	mcmsRegistry *changesets.MCMSReaderRegistry,
-	mcmsInput mcms.Input,
+	tokenPoolRegistry *TokenAdapterRegistry,
 	selector uint64,
-	token TokenTransferConfig,
-	adapter TokenAdapter,
-	family string,
-	tokenPool datastore.AddressRef,
-	legacyPool []byte,
+	tokenPool, tokenRef datastore.AddressRef,
+	registryRef datastore.AddressRef,
+	timelockAddr string,
+	amount *big.Int,
+	basisPoints *uint16,
 ) ([]mcms_types.BatchOperation, []cldf_ops.Report[any, any], error) {
-	if token.LiquidityMigrationAmount == nil && token.LiquidityMigrationBasisPoints == nil {
-		return nil, nil, nil
-	}
-	if len(legacyPool) == 0 {
-		e.Logger.Infof("no legacy pool snapshot for liquidity migration on chain selector %d, skipping liquidity migration", selector)
+	if amount == nil && basisPoints == nil {
 		return nil, nil, nil
 	}
 
-	migrationSeq := adapter.MigrateLockReleasePoolLiquiditySequence()
+	tokenPoolAdapter, family, fullPoolRef, fullTokenRef, err := ResolveAdapterAndRefs(e, tokenPoolRegistry, selector, tokenPool, tokenRef)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to resolve adapter and refs for liquidity seed on chain selector %d: %w", selector, err)
+	}
+
+	migrationSeq := tokenPoolAdapter.MigrateLockReleasePoolLiquiditySequence()
 	if migrationSeq == nil {
 		return nil, nil, fmt.Errorf("adapter for chain selector %d does not support liquidity migration", selector)
 	}
-	mcmsReader, ok := mcmsRegistry.GetMCMSReader(family)
+
+	registryMigrator, ok := tokenPoolAdapter.(TokenPoolMigrator)
 	if !ok {
-		return nil, nil, fmt.Errorf("no MCMS reader registered for chain family '%s' on chain %d", family, selector)
+		return nil, nil, fmt.Errorf(
+			"adapter for chain selector %d does not support reading active pool from registry, which is required for liquidity migration",
+			selector,
+		)
 	}
-	timelockRef, err := mcmsReader.GetTimelockRef(e, selector, mcmsInput)
+
+	activePool, err := registryMigrator.GetActivePool(e, selector, registryRef, fullTokenRef)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get timelock address from MCMS config on chain %d: %w", selector, err)
+		return nil, nil, fmt.Errorf("failed to get active pool for liquidity seed on chain selector %d: %w", selector, err)
 	}
+	if len(activePool) == 0 {
+		e.Logger.Infof("no legacy pool registered for liquidity seed on chain selector %d, skipping", selector)
+		return nil, nil, nil
+	}
+
+	targetPoolBytes, err := tokenPoolAdapter.AddressRefToBytes(fullPoolRef)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to convert target pool ref to bytes on chain selector %d: %w", selector, err)
+	}
+	if bytes.Equal(activePool, targetPoolBytes) {
+		e.Logger.Infof("legacy pool matches target on chain selector %d, skipping liquidity seed", selector)
+		return nil, nil, nil
+	}
+
 	normalizer, ok := ccipdeploy.GetAddressNormalizerRegistry().GetAddressNormalizer(family)
 	if !ok {
 		return nil, nil, fmt.Errorf("no address normalizer found for chain family %s on chain selector %d", family, selector)
 	}
-	oldPoolAddr, err := normalizer.BytesToString(legacyPool)
+	oldPoolAddr, err := normalizer.BytesToString(activePool)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to normalize legacy pool address on chain selector %d: %w", selector, err)
 	}
+
 	migrationReport, err := cldf_ops.ExecuteSequence(e.OperationsBundle, migrationSeq, e.BlockChains, MigrateLockReleasePoolLiquidityInput{
 		ChainSelector:   selector,
 		OldPoolAddress:  oldPoolAddr,
-		NewPoolAddress:  tokenPool.Address,
-		TimelockAddress: timelockRef.Address,
-		BasisPoints:     token.LiquidityMigrationBasisPoints,
-		Amount:          token.LiquidityMigrationAmount,
+		NewPoolAddress:  fullPoolRef.Address,
+		TimelockAddress: timelockAddr,
+		BasisPoints:     basisPoints,
+		Amount:          amount,
 		SetPoolConfig:   nil,
 	})
 	if err != nil {

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -319,7 +319,7 @@ func tokenExpansionApply() func(cldf.Environment, TokenExpansionInput) (cldf.Cha
 				deployTokenPoolInput.TokenPoolVersion = input.TokenPoolVersion
 				deployTokenPoolInput.ExistingDataStore = e.DataStore
 				deployTokenPoolInput.ChainSelector = selector
-				if cfg.MCMS.TimelockAction != "" {
+				if cfg.MCMS.TimelockAction != "" || deployTokenPoolInput.LiquidityMigrationAmount != nil || deployTokenPoolInput.LiquidityMigrationBasisPoints != nil {
 					mcmsReader, ok := mcmsRegistry.GetMCMSReader(family)
 					if !ok {
 						return cldf.ChangesetOutput{}, fmt.Errorf("failed to get MCMS reader for chain family '%s'", family)

--- a/integration-tests/deployment/token_expansion_migration_test.go
+++ b/integration-tests/deployment/token_expansion_migration_test.go
@@ -12,12 +12,15 @@ import (
 
 	evm_datastore_utils "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/datastore"
 	bnmERC20ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/burn_mint_erc20"
+	bnmERC20DripOps "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/operations/burn_mint_erc20_with_drip"
 	bnmOpsV2_0_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/burn_mint_token_pool"
 	evmtokensseq "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences/tokens"
 	tarbindings "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_5_0/token_admin_registry"
+	lnrpoolV2_0_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v2_0_0/lock_release_token_pool"
 	tokenpoolV2_0_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v2_0_0/token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/fees"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/finality"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/testhelpers"
 	tokensapi "github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	cciputils "github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
@@ -29,7 +32,9 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	bnmERC20DripBindings "github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/1_5_0/burn_mint_erc20_with_drip"
 
+	evmadpV1_0_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/adapters"
 	evmseqV1_6_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/sequences"
 	testsetupV2_0_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/testsetup"
 
@@ -543,4 +548,181 @@ func runAutoMigrateUpgrade(t *testing.T, oldPoolVersion *semver.Version, opts *a
 	cfgAfter, err := tarA.GetTokenConfig(&bind.CallOpts{Context: t.Context()}, s.tokAddrA)
 	require.NoError(t, err)
 	require.Equal(t, newPoolAddrA, cfgAfter.TokenPool, "TAR should be switched to the new v2.0 pool")
+}
+
+// TestTokenExpansionMigration_DeployWithSeed verifies that deploying a LockRelease pool with
+// LiquidityMigrationBasisPoints on DeployTokenPoolInput seeds liquidity from a legacy pool
+// into the new lockbox without configuring the new pool on TAR or transferring ownership.
+func TestTokenExpansionMigration_DeployWithSeed(t *testing.T) {
+	const (
+		totalLiquidity = 1
+		oldPoolQual    = "MIG_LNR_A_V1"
+		dummyPoolQual  = "MIG_LNR_B_V1"
+		tokenSymbol    = "MIG_SEED_TOK"
+		newPoolQual    = "MIG_LNR_A_V2"
+		migrateAll     = uint16(10000)
+	)
+
+	// Setup test environment
+	selA := chainsel.TEST_90000001.Selector
+	selB := chainsel.TEST_90000002.Selector
+	e, err := environment.New(t.Context(), environment.WithEVMSimulated(t, []uint64{selA, selB}))
+	require.NoError(t, err)
+	chainA, ok := e.BlockChains.EVMChains()[selA]
+	require.True(t, ok)
+
+	// Deploy chain contracts
+	SeedUltraFastCurseMCMS(t, e)
+	cumulative := datastore.NewMemoryDataStore()
+	DeployChainContractsV2_0_0(t, e, cumulative, selA)
+	DeployChainContractsV2_0_0(t, e, cumulative, selB)
+	e.DataStore = cumulative.Seal()
+	DeployMCMS(t, e, selA, []string{cciputils.CLLQualifier})
+	DeployMCMS(t, e, selB, []string{cciputils.CLLQualifier})
+
+	// Deploy legacy pools and tokens - RemoteChains naturally registers both pools on TAR
+	e.OperationsBundle = testsetupV2_0_0.BundleWithFreshReporter(e.OperationsBundle)
+	out1, err := tokensapi.TokenExpansion().Apply(*e, tokensapi.TokenExpansionInput{
+		ChainAdapterVersion: cciputils.Version_1_6_1,
+		MCMS:                mcms.Input{},
+		TokenExpansionInputPerChain: map[uint64]tokensapi.TokenExpansionInputPerChain{
+			selA: {
+				SkipOwnershipTransfer: false,
+				TokenPoolVersion:      cciputils.Version_1_6_1,
+				DeployTokenInput: &tokensapi.DeployTokenInput{
+					Name:          "Seed Test Token",
+					Type:          bnmERC20DripOps.ContractType,
+					Symbol:        tokenSymbol,
+					Decimals:      18,
+					Supply:        new(uint64(totalLiquidity * 100)),
+					ExternalAdmin: chainA.DeployerKey.From.Hex(),
+				},
+				DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
+					TokenPoolQualifier: oldPoolQual,
+					PoolType:           cciputils.LockReleaseTokenPool.String(),
+				},
+				TokenTransferConfig: &tokensapi.TokenTransferConfig{
+					RemoteChains: map[uint64]tokensapi.RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
+						selB: {OutboundRateLimiterConfig: &tokensapi.RateLimiterConfigFloatInput{IsEnabled: true, Capacity: 100, Rate: 10}},
+					},
+				},
+			},
+			selB: {
+				SkipOwnershipTransfer: true,
+				TokenPoolVersion:      cciputils.Version_1_6_1,
+				DeployTokenInput: &tokensapi.DeployTokenInput{
+					Name:          "Dummy Test Token",
+					Type:          bnmERC20DripOps.ContractType,
+					Symbol:        tokenSymbol,
+					Decimals:      18,
+					Supply:        new(uint64(totalLiquidity * 100)),
+					ExternalAdmin: chainA.DeployerKey.From.Hex(),
+				},
+				DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
+					TokenPoolQualifier: dummyPoolQual,
+					PoolType:           cciputils.LockReleaseTokenPool.String(),
+				},
+				TokenTransferConfig: &tokensapi.TokenTransferConfig{
+					RemoteChains: map[uint64]tokensapi.RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
+						selA: {OutboundRateLimiterConfig: &tokensapi.RateLimiterConfigFloatInput{IsEnabled: true, Capacity: 100, Rate: 10}},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	testhelpers.ProcessTimelockProposals(t, *e, out1.MCMSTimelockProposals, false)
+	MergeAddresses(t, e, out1.DataStore)
+
+	// Resolve the deployed token and old pool A
+	tokenFilter := datastore.AddressRef{
+		Type:          datastore.ContractType(bnmERC20DripOps.ContractType),
+		Qualifier:     tokenSymbol,
+		ChainSelector: selA,
+	}
+	tokenResults := e.DataStore.Addresses().Filter(datastore_utils.AddressRefToFilters(tokenFilter)...)
+	require.Len(t, tokenResults, 1)
+	tokenAddr := common.HexToAddress(tokenResults[0].Address)
+
+	oldPoolFilter := datastore.AddressRef{
+		Type:          datastore.ContractType(cciputils.LockReleaseTokenPool.String()),
+		Qualifier:     oldPoolQual,
+		ChainSelector: selA,
+		Version:       cciputils.Version_1_6_1,
+	}
+	oldPoolResults := e.DataStore.Addresses().Filter(datastore_utils.AddressRefToFilters(oldPoolFilter)...)
+	require.Len(t, oldPoolResults, 1)
+	oldPoolAddr := common.HexToAddress(oldPoolResults[0].Address)
+
+	// Fund the old pool A with tokens
+	bnmERC20Drip, err := bnmERC20DripBindings.NewBurnMintERC20WithDrip(tokenAddr, chainA.Client)
+	require.NoError(t, err)
+	tx, err := bnmERC20Drip.Drip(chainA.DeployerKey, oldPoolAddr)
+	require.NoError(t, err)
+	_, err = chainA.Confirm(tx)
+	require.NoError(t, err)
+
+	// Deploy v2 LockRelease pool with seed — no TokenTransferConfig
+	e.OperationsBundle = testsetupV2_0_0.BundleWithFreshReporter(e.OperationsBundle)
+	out2, err := tokensapi.TokenExpansion().Apply(*e, tokensapi.TokenExpansionInput{
+		ChainAdapterVersion: cciputils.Version_2_0_0,
+		MCMS:                NewDefaultInputForMCMS("Deploy v2 pool with seed"),
+		TokenExpansionInputPerChain: map[uint64]tokensapi.TokenExpansionInputPerChain{
+			selA: {
+				SkipOwnershipTransfer: true,
+				TokenPoolVersion:      cciputils.Version_2_0_0,
+				DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
+					TokenPoolQualifier:            newPoolQual,
+					PoolType:                      cciputils.LockReleaseTokenPool.String(),
+					TokenRef:                      &datastore.AddressRef{Address: tokenAddr.Hex()},
+					LiquidityMigrationBasisPoints: new(migrateAll),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	testhelpers.ProcessTimelockProposals(t, *e, out2.MCMSTimelockProposals, false)
+	MergeAddresses(t, e, out2.DataStore)
+
+	// Resolve the new pool address
+	newPoolFilter := datastore.AddressRef{
+		Type:          datastore.ContractType(cciputils.LockReleaseTokenPool.String()),
+		Qualifier:     newPoolQual,
+		ChainSelector: selA,
+		Version:       cciputils.Version_2_0_0,
+	}
+	newPoolResults := e.DataStore.Addresses().Filter(datastore_utils.AddressRefToFilters(newPoolFilter)...)
+	require.Len(t, newPoolResults, 1)
+	newPoolAddr := common.HexToAddress(newPoolResults[0].Address)
+
+	// Resolve TAR address from datastore
+	tarAddr, err := (&evmadpV1_0_0.EVMTokenBase{}).GetTokenAdminRegistryAddress(e.DataStore, selA)
+	require.NoError(t, err)
+
+	// 1. Lockbox holds the seed amount
+	v2Pool, err := lnrpoolV2_0_0.NewLockReleaseTokenPool(newPoolAddr, chainA.Client)
+	require.NoError(t, err)
+	lockboxAddr, err := v2Pool.GetLockBox(&bind.CallOpts{})
+	require.NoError(t, err)
+	require.NotEqual(t, common.Address{}, lockboxAddr)
+	lockboxBal, err := bnmERC20Drip.BalanceOf(&bind.CallOpts{Context: t.Context()}, lockboxAddr)
+	require.NoError(t, err)
+	require.Equal(t, new(big.Int).SetUint64(1e18), lockboxBal, "lockbox should hold the seed amount")
+
+	// 2. Old pool drained
+	oldPoolBal, err := bnmERC20Drip.BalanceOf(&bind.CallOpts{Context: t.Context()}, oldPoolAddr)
+	require.NoError(t, err)
+	require.Zero(t, oldPoolBal.Uint64(), "old pool should be fully drained")
+
+	// 3. TAR still points at old pool A (v2 pool's configure did not run)
+	tar, err := tarbindings.NewTokenAdminRegistry(tarAddr, chainA.Client)
+	require.NoError(t, err)
+	tarPool, err := tar.GetPool(&bind.CallOpts{Context: t.Context()}, tokenAddr)
+	require.NoError(t, err)
+	require.Equal(t, oldPoolAddr, tarPool, "TAR should still point at old pool (configure did not run)")
+
+	// 4. New pool is deployer-owned (UpdateAuthorities did not run)
+	owner, err := v2Pool.Owner(&bind.CallOpts{Context: t.Context()})
+	require.NoError(t, err)
+	require.Equal(t, chainA.DeployerKey.From, owner, "new pool should be deployer-owned")
 }


### PR DESCRIPTION
# TokenExpansion: Decouple liquidity migration from activation

## What this does

The `LiquidityMigrationAmount` / `LiquidityMigrationBasisPoints` fields lived on `TokenTransferConfig`. Setting them forced an entry into `allTokenConfigs`, which in turn triggered configure (`processTokenConfigForChain`)
and UpdateAuthorities — even when the intent was only to deploy + seed, not activate. The snapshot mechanism (`snapshotLegacyPoolsForMigration`) was introduced in [#2185](https://github.com/smartcontractkit/chainlink-ccip/pull/2185) to work around the ordering constraint this created: migration had to run after ownership transfer, but by then configure had already overwritten TAR, so the legacy pool address needed to be snapshotted pre-configure.

### Migration fields move from `TokenTransferConfig` to `DeployTokenPoolInput`

`LiquidityMigrationAmount` and `LiquidityMigrationBasisPoints` are now properties of the pool being deployed, not the connection being configured. `DeployTokenPoolInput` is one-to-one with the pool, eliminating the ambiguity that arises when a single pool has multiple `TokenTransferConfig` entries (one per remote chain). The old fields on `TokenTransferConfig` were removed entirely. This follows the same pattern as the `AllowedFinalityConfig` move in [#2100](https://github.com/smartcontractkit/chainlink-ccip/pull/2100): both are pool-level concerns that were misplaced on a connection-level struct.

### Seed runs during Phase 1, snapshot eliminated

When a `DeployTokenPoolInput` carries a migration field, the seed runs inline after the pool is deployed, before configure and UpdateAuthorities. It reads the old pool address directly from TAR (still the legacy pool at this point), builds the migration batch, and appends it to the proposal. Configure and UpdateAuthorities skip — no `allTokenConfigs` entry is created for a seed-only run. The pool is left deployed, seeded, deployer-owned, and not on TAR.

The old Phase 6 migration loop, the snapshot function, and all supporting code were removed.

### Integration test

`TestTokenExpansionMigration_DeployWithSeed` exercises the seed flow: deploys a legacy LnR pool on chain A (with a dummy counterparty on chain B for natural TAR registration), funds it, then runs a second TokenExpansion with `DeployTokenPoolInput.LiquidityMigrationBasisPoints` and no `TokenTransferConfig`. Asserts:

- Lockbox holds the seed amount
- Old pool drained
- TAR still points at the legacy pool (new pool was never registered)
- New pool is deployer-owned (ownership never transferred)
