### PR TITLE
feat(plugincommon): consensus drop reason reporting

### DIFF
--- a/commit/chainfee/metrics.go
+++ b/commit/chainfee/metrics.go
@@ -1,0 +1,29 @@
+package chainfee
+
+import (
+	"time"
+
+	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
+	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
+)
+
+// MetricsReporter exposes the metrics methods used by the chainfee processor.
+// It embeds the generic processor metrics and adds chainfee-specific reporters so
+// future metrics can be added here without widening the shared plugincommon interface.
+type MetricsReporter interface {
+	plugincommon.MetricsReporter
+
+	// TrackConsensusDropped reports a key that was dropped during shared consensus
+	// aggregation (e.g. fChain, ChainFeeUpdates, FeeComponents). The reason
+	// distinguishes "threshold not defined", "insufficient agreement", and "split".
+	TrackConsensusDropped(objectName string, key string, reason string)
+}
+
+// NoopMetrics is a no-op MetricsReporter for tests.
+type NoopMetrics struct{}
+
+func (n NoopMetrics) TrackProcessorLatency(string, string, time.Duration, error) {}
+
+func (n NoopMetrics) TrackProcessorOutput(string, plugincommon.MethodType, plugintypes.Trackable) {}
+
+func (n NoopMetrics) TrackConsensusDropped(string, string, string) {}

--- a/commit/chainfee/metrics.go
+++ b/commit/chainfee/metrics.go
@@ -3,6 +3,8 @@ package chainfee
 import (
 	"time"
 
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
 )
@@ -16,7 +18,9 @@ type MetricsReporter interface {
 	// TrackConsensusDropped reports a key that was dropped during shared consensus
 	// aggregation (e.g. fChain, ChainFeeUpdates, FeeComponents). The reason
 	// distinguishes "threshold not defined", "insufficient agreement", and "split".
-	TrackConsensusDropped(objectName string, key string, reason string)
+	// sourceChain is the chain selector the key represents, if any, so the metric can
+	// carry a human-readable source_network_name label for chain-keyed objectNames.
+	TrackConsensusDropped(objectName string, key string, reason string, sourceChain cciptypes.ChainSelector)
 }
 
 // NoopMetrics is a no-op MetricsReporter for tests.
@@ -26,4 +30,4 @@ func (n NoopMetrics) TrackProcessorLatency(string, string, time.Duration, error)
 
 func (n NoopMetrics) TrackProcessorOutput(string, plugincommon.MethodType, plugintypes.Trackable) {}
 
-func (n NoopMetrics) TrackConsensusDropped(string, string, string) {}
+func (n NoopMetrics) TrackConsensusDropped(string, string, string, cciptypes.ChainSelector) {}

--- a/commit/chainfee/observation_test.go
+++ b/commit/chainfee/observation_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/asynclib"
-	plugincommon2 "github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
 	"github.com/smartcontractkit/chainlink-ccip/mocks/internal_/plugincommon"
 	reader2 "github.com/smartcontractkit/chainlink-ccip/mocks/internal_/reader"
 	"github.com/smartcontractkit/chainlink-ccip/mocks/pkg/reader"
@@ -133,7 +132,7 @@ func Test_processor_Observation(t *testing.T) {
 				ccipReader:      ccipReader,
 				oracleID:        oracleID,
 				homeChain:       homeChain,
-				metricsReporter: plugincommon2.NoopReporter{},
+				metricsReporter: NoopMetrics{},
 				obs:             newBaseObserver(ccipReader, tc.dstChain, oracleID, cs),
 				runner:          asynclib.NewRunner(),
 				// Non-zero so the async runner's per-round timeout doesn't fire before the (fast)
@@ -348,7 +347,7 @@ func Test_unique_chain_filter_in_Observation(t *testing.T) {
 				ccipReader:      ccipReader,
 				oracleID:        oracleID,
 				homeChain:       homeChain,
-				metricsReporter: plugincommon2.NoopReporter{},
+				metricsReporter: NoopMetrics{},
 				obs:             newBaseObserver(ccipReader, tc.dstChain, oracleID, cs),
 				runner:          asynclib.NewRunner(),
 				// Non-zero so the async runner's per-round timeout doesn't fire before the (fast)

--- a/commit/chainfee/outcome.go
+++ b/commit/chainfee/outcome.go
@@ -211,18 +211,12 @@ func (p *processor) getConsensusObservation(
 }
 
 func reportChainFeeConsensusDrops(
-	reporter plugincommon.MetricsReporter,
+	reporter MetricsReporter,
 	objectName string,
 	drops map[cciptypes.ChainSelector]consensus.ConsensusDropReason,
 ) {
-	r, ok := reporter.(interface {
-		TrackConsensusDropped(objectName string, key string, reason string)
-	})
-	if !ok {
-		return
-	}
 	for chain, reason := range drops {
-		r.TrackConsensusDropped(
+		reporter.TrackConsensusDropped(
 			objectName,
 			strconv.FormatUint(uint64(chain), 10),
 			reason.String(),

--- a/commit/chainfee/outcome.go
+++ b/commit/chainfee/outcome.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -138,7 +139,8 @@ func (p *processor) getConsensusObservation(
 	// consensus on the fChain map uses the role DON F value
 	// because all nodes can observe the home chain.
 	donThresh := consensus.MakeConstantThreshold[cciptypes.ChainSelector](consensus.TwoFPlus1(p.fRoleDON))
-	fChains := consensus.GetConsensusMap(lggr, "fChain", aggObs.FChain, donThresh)
+	fChains, fChainDrops := consensus.GetConsensusMap(lggr, "fChain", aggObs.FChain, donThresh)
+	reportChainFeeConsensusDrops(p.metricsReporter, "fChain", fChainDrops)
 
 	fDestChain, exists := fChains[p.destChain]
 	if !exists {
@@ -153,17 +155,18 @@ func (p *processor) getConsensusObservation(
 	}
 	timestamp := consensus.Median(aggObs.Timestamps, consensus.TimestampComparator)
 
-	chainFeeUpdatesConsensus := consensus.GetConsensusMapAggregator(
+	chainFeeUpdatesConsensus, chainFeeUpdatesDrops := consensus.GetConsensusMapAggregator(
 		lggr,
 		"ChainFeeUpdates",
 		aggObs.ChainFeeUpdates,
 		consensus.MakeConstantThreshold[cciptypes.ChainSelector](consensus.TwoFPlus1(fDestChain)),
 		chainFeeUpdateAggregator,
 	)
+	reportChainFeeConsensusDrops(p.metricsReporter, "ChainFeeUpdates", chainFeeUpdatesDrops)
 
 	twoFChainPlus1 := consensus.MakeMultiThreshold(fChains, consensus.TwoFPlus1)
 
-	feeComponents := consensus.GetConsensusMapAggregator(
+	feeComponents, feeComponentsDrops := consensus.GetConsensusMapAggregator(
 		lggr,
 		"FeeComponents",
 		aggObs.FeeComponents,
@@ -182,8 +185,9 @@ func (p *processor) getConsensusObservation(
 			}
 		},
 	)
+	reportChainFeeConsensusDrops(p.metricsReporter, "FeeComponents", feeComponentsDrops)
 
-	nativeTokenPrices := consensus.GetConsensusMapAggregator(
+	nativeTokenPrices, nativeTokenPricesDrops := consensus.GetConsensusMapAggregator(
 		lggr,
 		"NativeTokenPrices",
 		aggObs.NativeTokenPrices,
@@ -193,6 +197,7 @@ func (p *processor) getConsensusObservation(
 			return consensus.Median(vals, consensus.BigIntComparator)
 		},
 	)
+	reportChainFeeConsensusDrops(p.metricsReporter, "NativeTokenPrices", nativeTokenPricesDrops)
 
 	consensusObs := Observation{
 		FChain:            fChains,
@@ -203,6 +208,26 @@ func (p *processor) getConsensusObservation(
 	}
 
 	return consensusObs, nil
+}
+
+func reportChainFeeConsensusDrops(
+	reporter plugincommon.MetricsReporter,
+	objectName string,
+	drops map[cciptypes.ChainSelector]consensus.ConsensusDropReason,
+) {
+	r, ok := reporter.(interface {
+		TrackConsensusDropped(objectName string, key string, reason string)
+	})
+	if !ok {
+		return
+	}
+	for chain, reason := range drops {
+		r.TrackConsensusDropped(
+			objectName,
+			strconv.FormatUint(uint64(chain), 10),
+			reason.String(),
+		)
+	}
 }
 
 func aggregateObservations(aos []plugincommon.AttributedObservation[Observation]) AggregateObservation {

--- a/commit/chainfee/outcome.go
+++ b/commit/chainfee/outcome.go
@@ -220,6 +220,7 @@ func reportChainFeeConsensusDrops(
 			objectName,
 			strconv.FormatUint(uint64(chain), 10),
 			reason.String(),
+			chain,
 		)
 	}
 }

--- a/commit/chainfee/outcome_test.go
+++ b/commit/chainfee/outcome_test.go
@@ -415,7 +415,7 @@ func TestProcessor_Outcome(t *testing.T) {
 				cfg: pluginconfig.CommitOffchainConfig{
 					RemoteGasPriceBatchWriteFrequency: tt.chainFeeWriteFrequency,
 				},
-				metricsReporter: plugincommon.NoopReporter{},
+				metricsReporter: NoopMetrics{},
 				homeChain:       homeChainMock,
 			}
 

--- a/commit/chainfee/outcome_test.go
+++ b/commit/chainfee/outcome_test.go
@@ -164,9 +164,10 @@ type FeeInfo struct {
 func TestGetConsensusObservation(t *testing.T) {
 	lggr := logger.Test(t)
 	p := &processor{
-		lggr:      lggr,
-		destChain: internal.EvmChainSelector,
-		fRoleDON:  1,
+		lggr:            lggr,
+		destChain:       internal.EvmChainSelector,
+		fRoleDON:        1,
+		metricsReporter: NoopMetrics{},
 	}
 
 	// 3 oracles, same observations, will pass destChain 2f+1 for chain selector 1

--- a/commit/chainfee/processor.go
+++ b/commit/chainfee/processor.go
@@ -24,7 +24,7 @@ type processor struct {
 	ccipReader      readerpkg.CCIPReader
 	cfg             pluginconfig.CommitOffchainConfig
 	chainSupport    plugincommon.ChainSupport
-	metricsReporter plugincommon.MetricsReporter
+	metricsReporter MetricsReporter
 	fRoleDON        int
 	obs             observer
 	runner          *asynclib.Runner
@@ -39,7 +39,7 @@ func NewProcessor(
 	offChainConfig pluginconfig.CommitOffchainConfig,
 	chainSupport plugincommon.ChainSupport,
 	fRoleDON int,
-	metricsReporter plugincommon.MetricsReporter,
+	metricsReporter MetricsReporter,
 ) plugincommon.PluginProcessor[Query, Observation, Outcome] {
 	var obs observer
 	baseObs := newBaseObserver(

--- a/commit/merkleroot/observation.go
+++ b/commit/merkleroot/observation.go
@@ -2,8 +2,10 @@ package merkleroot
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"sort"
 	"strings"
@@ -366,8 +368,11 @@ func (p *Processor) getObservation(
 			lggr.Debugw("fetched RMN-enabled chains from rmnHome", "rmnEnabledChains", rmnEnabledChains)
 		}
 
+		merkleRoots := p.observer.ObserveMerkleRoots(ctx, previousOutcome.RangesSelectedForReport)
+		applyTestConsensusSabotage(lggr, p.oracleID, merkleRoots)
+
 		return Observation{
-			MerkleRoots:      p.observer.ObserveMerkleRoots(ctx, previousOutcome.RangesSelectedForReport),
+			MerkleRoots:      merkleRoots,
 			FChain:           p.observer.ObserveFChain(ctx),
 			RMNEnabledChains: rmnEnabledChains,
 		}, nextState, nil
@@ -380,6 +385,25 @@ func (p *Processor) getObservation(
 		return Observation{},
 			nextState,
 			fmt.Errorf("unexpected nextState=%d with prevOutcome=%d", nextState, previousOutcome.OutcomeType)
+	}
+}
+
+// TEST-ONLY fault injection: force a per-lane merkle-root consensus failure so the commit DON
+// agrees with nothing and keeps dropping the source chain(s) (DropReasonInsufficientAgreement),
+// which is what the uncommitted-message runbook's step2b detects. Must never merge to main.
+//
+// When CCIP_TEST_FORCE_MERKLEROOT_CONSENSUS_FAILURE is set, every oracle reports a distinct,
+// still-valid merkle root (keyed on its own oracleID), so no single root ever reaches the 2f+1
+// consensus threshold and the round degrades to ReportEmpty while the source lane stays uncommitted.
+func applyTestConsensusSabotage(lggr logger.Logger, oracleID commontypes.OracleID, roots []cciptypes.MerkleRootChain) {
+	if os.Getenv("CCIP_TEST_FORCE_MERKLEROOT_CONSENSUS_FAILURE") == "" {
+		return
+	}
+	for i := range roots {
+		h := sha256.Sum256(append([]byte{byte(oracleID)}, roots[i].MerkleRoot[:]...))
+		roots[i].MerkleRoot = h
+		lggr.Warnw("TEST ONLY: sabotaged merkle root to force a consensus failure",
+			"oracleID", oracleID, "chain", roots[i].ChainSel, "root", h)
 	}
 }
 

--- a/commit/merkleroot/observation.go
+++ b/commit/merkleroot/observation.go
@@ -2,10 +2,8 @@ package merkleroot
 
 import (
 	"context"
-	"crypto/sha256"
 	"errors"
 	"fmt"
-	"os"
 	"slices"
 	"sort"
 	"strings"
@@ -368,11 +366,8 @@ func (p *Processor) getObservation(
 			lggr.Debugw("fetched RMN-enabled chains from rmnHome", "rmnEnabledChains", rmnEnabledChains)
 		}
 
-		merkleRoots := p.observer.ObserveMerkleRoots(ctx, previousOutcome.RangesSelectedForReport)
-		applyTestConsensusSabotage(lggr, p.oracleID, merkleRoots)
-
 		return Observation{
-			MerkleRoots:      merkleRoots,
+			MerkleRoots:      p.observer.ObserveMerkleRoots(ctx, previousOutcome.RangesSelectedForReport),
 			FChain:           p.observer.ObserveFChain(ctx),
 			RMNEnabledChains: rmnEnabledChains,
 		}, nextState, nil
@@ -385,25 +380,6 @@ func (p *Processor) getObservation(
 		return Observation{},
 			nextState,
 			fmt.Errorf("unexpected nextState=%d with prevOutcome=%d", nextState, previousOutcome.OutcomeType)
-	}
-}
-
-// TEST-ONLY fault injection: force a per-lane merkle-root consensus failure so the commit DON
-// agrees with nothing and keeps dropping the source chain(s) (DropReasonInsufficientAgreement),
-// which is what the uncommitted-message runbook's step2b detects. Must never merge to main.
-//
-// When CCIP_TEST_FORCE_MERKLEROOT_CONSENSUS_FAILURE is set, every oracle reports a distinct,
-// still-valid merkle root (keyed on its own oracleID), so no single root ever reaches the 2f+1
-// consensus threshold and the round degrades to ReportEmpty while the source lane stays uncommitted.
-func applyTestConsensusSabotage(lggr logger.Logger, oracleID commontypes.OracleID, roots []cciptypes.MerkleRootChain) {
-	if os.Getenv("CCIP_TEST_FORCE_MERKLEROOT_CONSENSUS_FAILURE") == "" {
-		return
-	}
-	for i := range roots {
-		h := sha256.Sum256(append([]byte{byte(oracleID)}, roots[i].MerkleRoot[:]...))
-		roots[i].MerkleRoot = h
-		lggr.Warnw("TEST ONLY: sabotaged merkle root to force a consensus failure",
-			"oracleID", oracleID, "chain", roots[i].ChainSel, "root", h)
 	}
 }
 

--- a/commit/merkleroot/outcome.go
+++ b/commit/merkleroot/outcome.go
@@ -569,6 +569,7 @@ func reportChainSelectorDrops(
 			objectName,
 			strconv.FormatUint(uint64(chain), 10),
 			reason.String(),
+			chain,
 		)
 	}
 }

--- a/commit/merkleroot/outcome.go
+++ b/commit/merkleroot/outcome.go
@@ -530,10 +530,18 @@ func getConsensusObservation(
 		return consensusObservation{}, fmt.Errorf("no consensus value for fDestChain(%d): %v", fDestChain, fChain)
 	}
 
-	merkleRoots, merkleRootDrops := consensus.GetConsensusMap(lggr, "MerkleRoot", aggObs.MerkleRoots, twoFChainPlus1)
+	merkleRoots, merkleRootDrops := consensus.GetConsensusMap(
+		lggr,
+		"MerkleRoot",
+		aggObs.MerkleRoots,
+		twoFChainPlus1)
 	reportChainSelectorDrops(metricsReporter, "MerkleRoot", merkleRootDrops)
 
-	rmnEnabledChains, rmnEnabledDrops := consensus.GetConsensusMap(lggr, "RMNEnabledChains", aggObs.RMNEnabledChains, twoFChainPlus1)
+	rmnEnabledChains, rmnEnabledDrops := consensus.GetConsensusMap(
+		lggr,
+		"RMNEnabledChains",
+		aggObs.RMNEnabledChains,
+		twoFChainPlus1)
 	reportChainSelectorDrops(metricsReporter, "RMNEnabledChains", rmnEnabledDrops)
 
 	onRampMaxSeqNums, onRampDrops := consensus.GetOrderedConsensus(
@@ -543,7 +551,11 @@ func getConsensusObservation(
 		fChain)
 	reportChainSelectorDrops(metricsReporter, "OnRampMaxSeqNums", onRampDrops)
 
-	rmnRemoteConfig, rmnRemoteDrops := consensus.GetConsensusMap(lggr, "RMNRemoteConfig", rmnRemoteConfigs, twoFChainPlus1)
+	rmnRemoteConfig, rmnRemoteDrops := consensus.GetConsensusMap(
+		lggr,
+		"RMNRemoteConfig",
+		rmnRemoteConfigs,
+		twoFChainPlus1)
 	reportChainSelectorDrops(metricsReporter, "RMNRemoteConfig", rmnRemoteDrops)
 
 	consensusObs := consensusObservation{

--- a/commit/merkleroot/outcome.go
+++ b/commit/merkleroot/outcome.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"slices"
 	"sort"
+	"strconv"
 	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
@@ -506,7 +507,8 @@ func getConsensusObservation(
 	// consensus on the fChain map uses the role DON F value
 	// because all nodes can observe the home chain.
 	donThresh := consensus.MakeConstantThreshold[cciptypes.ChainSelector](consensus.TwoFPlus1(fRoleDON))
-	fChains := consensus.GetConsensusMap(lggr, "fChain", aggObs.FChain, donThresh)
+	fChains, fChainDrops := consensus.GetConsensusMap(lggr, "fChain", aggObs.FChain, donThresh)
+	reportChainSelectorDrops(metricsReporter, "fChain", fChainDrops)
 
 	_, exists := fChains[destChain]
 	if !exists {
@@ -528,21 +530,47 @@ func getConsensusObservation(
 		return consensusObservation{}, fmt.Errorf("no consensus value for fDestChain(%d): %v", fDestChain, fChain)
 	}
 
+	merkleRoots, merkleRootDrops := consensus.GetConsensusMap(lggr, "Merkle Root", aggObs.MerkleRoots, twoFChainPlus1)
+	reportChainSelectorDrops(metricsReporter, "Merkle Root", merkleRootDrops)
+
+	rmnEnabledChains, rmnEnabledDrops := consensus.GetConsensusMap(lggr, "RMNEnabledChains", aggObs.RMNEnabledChains, twoFChainPlus1)
+	reportChainSelectorDrops(metricsReporter, "RMNEnabledChains", rmnEnabledDrops)
+
+	onRampMaxSeqNums, onRampDrops := consensus.GetOrderedConsensus(
+		lggr,
+		"OnRamp Max Seq Nums",
+		aggObs.OnRampMaxSeqNums,
+		fChain)
+	reportChainSelectorDrops(metricsReporter, "OnRamp Max Seq Nums", onRampDrops)
+
+	rmnRemoteConfig, rmnRemoteDrops := consensus.GetConsensusMap(lggr, "RMNRemote cfg", rmnRemoteConfigs, twoFChainPlus1)
+	reportChainSelectorDrops(metricsReporter, "RMNRemote cfg", rmnRemoteDrops)
+
 	consensusObs := consensusObservation{
-		MerkleRoots:      consensus.GetConsensusMap(lggr, "Merkle Root", aggObs.MerkleRoots, twoFChainPlus1),
-		RMNEnabledChains: consensus.GetConsensusMap(lggr, "RMNEnabledChains", aggObs.RMNEnabledChains, twoFChainPlus1),
-		OnRampMaxSeqNums: consensus.GetOrderedConsensus(
-			lggr,
-			"OnRamp Max Seq Nums",
-			aggObs.OnRampMaxSeqNums,
-			fChain),
+		MerkleRoots:      merkleRoots,
+		RMNEnabledChains: rmnEnabledChains,
+		OnRampMaxSeqNums: onRampMaxSeqNums,
 		OffRampNextSeqNums: getOffRampNextSequenceNumbersConsensus(
 			lggr, uint(fDestChain), aggObs.OffRampNextSeqNums, metricsReporter),
-		RMNRemoteConfig: consensus.GetConsensusMap(lggr, "RMNRemote cfg", rmnRemoteConfigs, twoFChainPlus1),
+		RMNRemoteConfig: rmnRemoteConfig,
 		FChain:          fChains,
 	}
 
 	return consensusObs, nil
+}
+
+func reportChainSelectorDrops(
+	metricsReporter MetricsReporter,
+	objectName string,
+	drops map[cciptypes.ChainSelector]consensus.ConsensusDropReason,
+) {
+	for chain, reason := range drops {
+		metricsReporter.TrackConsensusDropped(
+			objectName,
+			strconv.FormatUint(uint64(chain), 10),
+			reason.String(),
+		)
+	}
 }
 
 // getOffRampNextSequenceNumbersConsensus accepts a list of offramp sequence number observations per chain

--- a/commit/merkleroot/outcome.go
+++ b/commit/merkleroot/outcome.go
@@ -530,21 +530,21 @@ func getConsensusObservation(
 		return consensusObservation{}, fmt.Errorf("no consensus value for fDestChain(%d): %v", fDestChain, fChain)
 	}
 
-	merkleRoots, merkleRootDrops := consensus.GetConsensusMap(lggr, "Merkle Root", aggObs.MerkleRoots, twoFChainPlus1)
-	reportChainSelectorDrops(metricsReporter, "Merkle Root", merkleRootDrops)
+	merkleRoots, merkleRootDrops := consensus.GetConsensusMap(lggr, "MerkleRoot", aggObs.MerkleRoots, twoFChainPlus1)
+	reportChainSelectorDrops(metricsReporter, "MerkleRoot", merkleRootDrops)
 
 	rmnEnabledChains, rmnEnabledDrops := consensus.GetConsensusMap(lggr, "RMNEnabledChains", aggObs.RMNEnabledChains, twoFChainPlus1)
 	reportChainSelectorDrops(metricsReporter, "RMNEnabledChains", rmnEnabledDrops)
 
 	onRampMaxSeqNums, onRampDrops := consensus.GetOrderedConsensus(
 		lggr,
-		"OnRamp Max Seq Nums",
+		"OnRampMaxSeqNums",
 		aggObs.OnRampMaxSeqNums,
 		fChain)
-	reportChainSelectorDrops(metricsReporter, "OnRamp Max Seq Nums", onRampDrops)
+	reportChainSelectorDrops(metricsReporter, "OnRampMaxSeqNums", onRampDrops)
 
-	rmnRemoteConfig, rmnRemoteDrops := consensus.GetConsensusMap(lggr, "RMNRemote cfg", rmnRemoteConfigs, twoFChainPlus1)
-	reportChainSelectorDrops(metricsReporter, "RMNRemote cfg", rmnRemoteDrops)
+	rmnRemoteConfig, rmnRemoteDrops := consensus.GetConsensusMap(lggr, "RMNRemoteConfig", rmnRemoteConfigs, twoFChainPlus1)
+	reportChainSelectorDrops(metricsReporter, "RMNRemoteConfig", rmnRemoteDrops)
 
 	consensusObs := consensusObservation{
 		MerkleRoots:      merkleRoots,

--- a/commit/merkleroot/types.go
+++ b/commit/merkleroot/types.go
@@ -303,6 +303,11 @@ type MetricsReporter interface {
 	// because fewer than 2*fDestChain+1 oracles agreed on its offRamp next sequence number. From outside,
 	// this looks identical to "no new messages on this lane".
 	TrackOffRampConsensusInsufficient(sourceChain cciptypes.ChainSelector)
+
+	// TrackConsensusDropped reports a key that was dropped during shared consensus
+	// aggregation (e.g. fChain, Merkle Root, OnRamp Max Seq Nums). The reason
+	// distinguishes "threshold not defined", "insufficient agreement", and "split".
+	TrackConsensusDropped(objectName string, key string, reason string)
 }
 
 type NoopMetrics struct{}
@@ -340,3 +345,5 @@ func (n NoopMetrics) TrackOffRampLaneStatus(cciptypes.ChainSelector, string, boo
 func (n NoopMetrics) TrackSeqNumInvariantViolation(cciptypes.ChainSelector, string) {}
 
 func (n NoopMetrics) TrackOffRampConsensusInsufficient(cciptypes.ChainSelector) {}
+
+func (n NoopMetrics) TrackConsensusDropped(string, string, string) {}

--- a/commit/merkleroot/types.go
+++ b/commit/merkleroot/types.go
@@ -307,7 +307,9 @@ type MetricsReporter interface {
 	// TrackConsensusDropped reports a key that was dropped during shared consensus
 	// aggregation (e.g. fChain, Merkle Root, OnRamp Max Seq Nums). The reason
 	// distinguishes "threshold not defined", "insufficient agreement", and "split".
-	TrackConsensusDropped(objectName string, key string, reason string)
+	// sourceChain is the chain selector the key represents, if any, so the metric can
+	// carry a human-readable source_network_name label for chain-keyed objectNames.
+	TrackConsensusDropped(objectName string, key string, reason string, sourceChain cciptypes.ChainSelector)
 }
 
 type NoopMetrics struct{}
@@ -346,4 +348,4 @@ func (n NoopMetrics) TrackSeqNumInvariantViolation(cciptypes.ChainSelector, stri
 
 func (n NoopMetrics) TrackOffRampConsensusInsufficient(cciptypes.ChainSelector) {}
 
-func (n NoopMetrics) TrackConsensusDropped(string, string, string) {}
+func (n NoopMetrics) TrackConsensusDropped(string, string, string, cciptypes.ChainSelector) {}

--- a/commit/metrics/prom.go
+++ b/commit/metrics/prom.go
@@ -143,6 +143,7 @@ type PromReporter struct {
 	bhOffRampLaneStatus          metric.Int64Gauge
 	bhSeqNumInvariantViolation   metric.Int64Counter
 	bhOffRampConsensusInsuff     metric.Int64Counter
+	bhConsensusDropped           metric.Int64Counter
 }
 
 //nolint:gocyclo
@@ -246,6 +247,10 @@ func NewPromReporter(
 	if err != nil {
 		return nil, fmt.Errorf("failed to register ccip_commit_offramp_consensus_insufficient counter: %w", err)
 	}
+	consensusDropped, err := bhClient.Meter.Int64Counter("ccip_commit_consensus_dropped")
+	if err != nil {
+		return nil, fmt.Errorf("failed to register ccip_commit_consensus_dropped counter: %w", err)
+	}
 
 	return &PromReporter{
 		lggr:        lggr,
@@ -289,6 +294,7 @@ func NewPromReporter(
 		bhOffRampLaneStatus:          offRampLaneStatus,
 		bhSeqNumInvariantViolation:   seqNumInvariantViolation,
 		bhOffRampConsensusInsuff:     offRampConsensusInsuff,
+		bhConsensusDropped:           consensusDropped,
 	}, nil
 }
 
@@ -597,4 +603,14 @@ func (p *PromReporter) TrackSeqNumInvariantViolation(sourceChain cciptypes.Chain
 
 func (p *PromReporter) TrackOffRampConsensusInsufficient(sourceChain cciptypes.ChainSelector) {
 	p.bhOffRampConsensusInsuff.Add(context.Background(), 1, metric.WithAttributes(p.sourceChainAttrs(sourceChain)...))
+}
+
+func (p *PromReporter) TrackConsensusDropped(objectName string, key string, reason string) {
+	p.bhConsensusDropped.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("chainFamily", p.chainFamily),
+		attribute.String("chainID", p.chainID),
+		attribute.String("objectName", objectName),
+		attribute.String("key", key),
+		attribute.String("reason", reason),
+	))
 }

--- a/commit/metrics/prom.go
+++ b/commit/metrics/prom.go
@@ -605,12 +605,18 @@ func (p *PromReporter) TrackOffRampConsensusInsufficient(sourceChain cciptypes.C
 	p.bhOffRampConsensusInsuff.Add(context.Background(), 1, metric.WithAttributes(p.sourceChainAttrs(sourceChain)...))
 }
 
-func (p *PromReporter) TrackConsensusDropped(objectName string, key string, reason string) {
-	p.bhConsensusDropped.Add(context.Background(), 1, metric.WithAttributes(
+func (p *PromReporter) TrackConsensusDropped(
+	objectName string, key string, reason string, sourceChain cciptypes.ChainSelector,
+) {
+	attrs := []attribute.KeyValue{
 		attribute.String("chainFamily", p.chainFamily),
 		attribute.String("chainID", p.chainID),
 		attribute.String("objectName", objectName),
 		attribute.String("key", key),
 		attribute.String("reason", reason),
-	))
+	}
+	if sourceChain != 0 {
+		attrs = append(attrs, p.sourceChainAttrs(sourceChain)...)
+	}
+	p.bhConsensusDropped.Add(context.Background(), 1, metric.WithAttributes(attrs...))
 }

--- a/commit/metrics/reporter.go
+++ b/commit/metrics/reporter.go
@@ -61,6 +61,12 @@ type Reporter interface {
 	TrackOffRampLaneStatus(sourceChain cciptypes.ChainSelector, status string, active bool)
 	TrackSeqNumInvariantViolation(sourceChain cciptypes.ChainSelector, violationType string)
 	TrackOffRampConsensusInsufficient(sourceChain cciptypes.ChainSelector)
+
+	// TrackConsensusDropped reports a key that was dropped during shared consensus
+	// aggregation, with a reason that distinguishes config errors, insufficient
+	// agreement, and split votes. objectName is the logical name of the map being
+	// aggregated (e.g. "fChain", "Merkle Root"); key is the dropped map key.
+	TrackConsensusDropped(objectName string, key string, reason string)
 }
 
 type CommitPluginReporter interface {
@@ -69,6 +75,10 @@ type CommitPluginReporter interface {
 	TrackConfigDigestMismatch(mismatch bool)
 	TrackPluginHeartbeat(phase string)
 	TrackReportValidationRejected(phase string, reason string)
+
+	// TrackConsensusDropped is documented on Reporter. It is exposed here because the
+	// commit plugin's top-level Outcome() also runs consensus on the main FChain map.
+	TrackConsensusDropped(objectName string, key string, reason string)
 }
 
 type Noop struct{}
@@ -118,6 +128,8 @@ func (n *Noop) TrackOffRampLaneStatus(cciptypes.ChainSelector, string, bool) {}
 func (n *Noop) TrackSeqNumInvariantViolation(cciptypes.ChainSelector, string) {}
 
 func (n *Noop) TrackOffRampConsensusInsufficient(cciptypes.ChainSelector) {}
+
+func (n *Noop) TrackConsensusDropped(string, string, string) {}
 
 var _ Reporter = &PromReporter{}
 var _ CommitPluginReporter = &PromReporter{}

--- a/commit/metrics/reporter.go
+++ b/commit/metrics/reporter.go
@@ -66,7 +66,9 @@ type Reporter interface {
 	// aggregation, with a reason that distinguishes config errors, insufficient
 	// agreement, and split votes. objectName is the logical name of the map being
 	// aggregated (e.g. "fChain", "Merkle Root"); key is the dropped map key.
-	TrackConsensusDropped(objectName string, key string, reason string)
+	// sourceChain is the chain selector the key represents, if any, so the metric can
+	// carry a human-readable source_network_name label for chain-keyed objectNames.
+	TrackConsensusDropped(objectName string, key string, reason string, sourceChain cciptypes.ChainSelector)
 }
 
 type CommitPluginReporter interface {
@@ -78,7 +80,7 @@ type CommitPluginReporter interface {
 
 	// TrackConsensusDropped is documented on Reporter. It is exposed here because the
 	// commit plugin's top-level Outcome() also runs consensus on the main FChain map.
-	TrackConsensusDropped(objectName string, key string, reason string)
+	TrackConsensusDropped(objectName string, key string, reason string, sourceChain cciptypes.ChainSelector)
 }
 
 type Noop struct{}
@@ -129,7 +131,7 @@ func (n *Noop) TrackSeqNumInvariantViolation(cciptypes.ChainSelector, string) {}
 
 func (n *Noop) TrackOffRampConsensusInsufficient(cciptypes.ChainSelector) {}
 
-func (n *Noop) TrackConsensusDropped(string, string, string) {}
+func (n *Noop) TrackConsensusDropped(string, string, string, cciptypes.ChainSelector) {}
 
 var _ Reporter = &PromReporter{}
 var _ CommitPluginReporter = &PromReporter{}

--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -600,7 +600,10 @@ func (p *Plugin) getMainOutcomeAndCacheInvalidation(
 	}
 
 	donThresh := consensus.MakeConstantThreshold[cciptypes.ChainSelector](consensus.TwoFPlus1(p.reportingCfg.F))
-	fChainConsensus := consensus.GetConsensusMap(lggr, "mainFChain", fChainObservations, donThresh)
+	fChainConsensus, fChainDrops := consensus.GetConsensusMap(lggr, "mainFChain", fChainObservations, donThresh)
+	for chain, reason := range fChainDrops {
+		p.metricsReporter.TrackConsensusDropped("mainFChain", fmt.Sprintf("%d", chain), reason.String())
+	}
 	fDestChain, ok := fChainConsensus[p.destChain]
 	if !ok {
 		return committypes.MainOutcome{}, false, fmt.Errorf("no fDestChain for %d: %v", p.destChain, fChainObservations)

--- a/commit/plugin.go
+++ b/commit/plugin.go
@@ -602,7 +602,7 @@ func (p *Plugin) getMainOutcomeAndCacheInvalidation(
 	donThresh := consensus.MakeConstantThreshold[cciptypes.ChainSelector](consensus.TwoFPlus1(p.reportingCfg.F))
 	fChainConsensus, fChainDrops := consensus.GetConsensusMap(lggr, "mainFChain", fChainObservations, donThresh)
 	for chain, reason := range fChainDrops {
-		p.metricsReporter.TrackConsensusDropped("mainFChain", fmt.Sprintf("%d", chain), reason.String())
+		p.metricsReporter.TrackConsensusDropped("mainFChain", fmt.Sprintf("%d", chain), reason.String(), chain)
 	}
 	fDestChain, ok := fChainConsensus[p.destChain]
 	if !ok {

--- a/commit/tokenprice/metrics.go
+++ b/commit/tokenprice/metrics.go
@@ -3,6 +3,8 @@ package tokenprice
 import (
 	"time"
 
+	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
 	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
 )
@@ -16,7 +18,9 @@ type MetricsReporter interface {
 	// TrackConsensusDropped reports a key that was dropped during shared consensus
 	// aggregation (e.g. fChain, FeedTokenPrices, FeeQuoterUpdates). The reason
 	// distinguishes "threshold not defined", "insufficient agreement", and "split".
-	TrackConsensusDropped(objectName string, key string, reason string)
+	// sourceChain is the chain selector the key represents, if any, so the metric can
+	// carry a human-readable source_network_name label for chain-keyed objectNames.
+	TrackConsensusDropped(objectName string, key string, reason string, sourceChain cciptypes.ChainSelector)
 }
 
 // NoopMetrics is a no-op MetricsReporter for tests.
@@ -26,4 +30,4 @@ func (n NoopMetrics) TrackProcessorLatency(string, string, time.Duration, error)
 
 func (n NoopMetrics) TrackProcessorOutput(string, plugincommon.MethodType, plugintypes.Trackable) {}
 
-func (n NoopMetrics) TrackConsensusDropped(string, string, string) {}
+func (n NoopMetrics) TrackConsensusDropped(string, string, string, cciptypes.ChainSelector) {}

--- a/commit/tokenprice/metrics.go
+++ b/commit/tokenprice/metrics.go
@@ -1,0 +1,29 @@
+package tokenprice
+
+import (
+	"time"
+
+	"github.com/smartcontractkit/chainlink-ccip/internal/plugincommon"
+	"github.com/smartcontractkit/chainlink-ccip/internal/plugintypes"
+)
+
+// MetricsReporter exposes the metrics methods used by the tokenprice processor.
+// It embeds the generic processor metrics and adds tokenprice-specific reporters so
+// future metrics can be added here without widening the shared plugincommon interface.
+type MetricsReporter interface {
+	plugincommon.MetricsReporter
+
+	// TrackConsensusDropped reports a key that was dropped during shared consensus
+	// aggregation (e.g. fChain, FeedTokenPrices, FeeQuoterUpdates). The reason
+	// distinguishes "threshold not defined", "insufficient agreement", and "split".
+	TrackConsensusDropped(objectName string, key string, reason string)
+}
+
+// NoopMetrics is a no-op MetricsReporter for tests.
+type NoopMetrics struct{}
+
+func (n NoopMetrics) TrackProcessorLatency(string, string, time.Duration, error) {}
+
+func (n NoopMetrics) TrackProcessorOutput(string, plugincommon.MethodType, plugintypes.Trackable) {}
+
+func (n NoopMetrics) TrackConsensusDropped(string, string, string) {}

--- a/commit/tokenprice/observation_test.go
+++ b/commit/tokenprice/observation_test.go
@@ -93,7 +93,7 @@ func Test_Observation(t *testing.T) {
 					tokenPriceReader,
 					homeChain,
 					f,
-					plugincommon.NoopReporter{},
+					NoopMetrics{},
 				)
 			},
 			expObs: Observation{
@@ -145,7 +145,7 @@ func Test_Observation(t *testing.T) {
 					tokenPriceReader,
 					homeChain,
 					f,
-					plugincommon.NoopReporter{},
+					NoopMetrics{},
 				)
 			},
 			expObs: Observation{

--- a/commit/tokenprice/outcome.go
+++ b/commit/tokenprice/outcome.go
@@ -108,7 +108,7 @@ func reportTokenPriceConsensusDrops[K comparable](
 	keyToString func(K) string,
 ) {
 	for key, reason := range drops {
-		reporter.TrackConsensusDropped(objectName, keyToString(key), reason.String())
+		reporter.TrackConsensusDropped(objectName, keyToString(key), reason.String(), 0)
 	}
 }
 

--- a/commit/tokenprice/outcome.go
+++ b/commit/tokenprice/outcome.go
@@ -102,19 +102,13 @@ func (p *processor) getConsensusObservation(
 }
 
 func reportTokenPriceConsensusDrops[K comparable](
-	reporter plugincommon.MetricsReporter,
+	reporter MetricsReporter,
 	objectName string,
 	drops map[K]consensus.ConsensusDropReason,
 	keyToString func(K) string,
 ) {
-	r, ok := reporter.(interface {
-		TrackConsensusDropped(objectName string, key string, reason string)
-	})
-	if !ok {
-		return
-	}
 	for key, reason := range drops {
-		r.TrackConsensusDropped(objectName, keyToString(key), reason.String())
+		reporter.TrackConsensusDropped(objectName, keyToString(key), reason.String())
 	}
 }
 

--- a/commit/tokenprice/outcome.go
+++ b/commit/tokenprice/outcome.go
@@ -2,6 +2,7 @@ package tokenprice
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
@@ -40,7 +41,10 @@ func (p *processor) getConsensusObservation(
 	// consensus on the fChain map uses the role DON F value
 	// because all nodes can observe the home chain.
 	donThresh := consensus.MakeConstantThreshold[cciptypes.ChainSelector](consensus.TwoFPlus1(p.fRoleDON))
-	fChains := consensus.GetConsensusMap(lggr, "fChain", aggObs.FChain, donThresh)
+	fChains, fChainDrops := consensus.GetConsensusMap(lggr, "fChain", aggObs.FChain, donThresh)
+	reportTokenPriceConsensusDrops(
+		p.metricsReporter, "fChain", fChainDrops,
+		func(k cciptypes.ChainSelector) string { return strconv.FormatUint(uint64(k), 10) })
 
 	fDestChain, exists := fChains[p.destChain]
 	if !exists {
@@ -61,7 +65,7 @@ func (p *processor) getConsensusObservation(
 			fmt.Errorf("no consensus value for f for FeedChain: %d", p.offChainCfg.PriceFeedChainSelector)
 	}
 
-	feedPricesConsensus := consensus.GetConsensusMapAggregator(
+	feedPricesConsensus, feedPricesDrops := consensus.GetConsensusMapAggregator(
 		lggr,
 		"FeedTokenPrices",
 		aggObs.FeedTokenPrices,
@@ -70,8 +74,11 @@ func (p *processor) getConsensusObservation(
 			return consensus.Median(vals, consensus.TokenPriceComparator)
 		},
 	)
+	reportTokenPriceConsensusDrops(
+		p.metricsReporter, "FeedTokenPrices", feedPricesDrops,
+		func(k cciptypes.UnknownEncodedAddress) string { return string(k) })
 
-	feeQuoterUpdatesConsensus := consensus.GetConsensusMapAggregator(
+	feeQuoterUpdatesConsensus, feeQuoterUpdatesDrops := consensus.GetConsensusMapAggregator(
 		lggr,
 		"FeeQuoterUpdates",
 		aggObs.FeeQuoterTokenUpdates,
@@ -80,6 +87,9 @@ func (p *processor) getConsensusObservation(
 		// and the median prices as price value
 		consensus.TimestampedBigAggregator,
 	)
+	reportTokenPriceConsensusDrops(
+		p.metricsReporter, "FeeQuoterUpdates", feeQuoterUpdatesDrops,
+		func(k cciptypes.UnknownEncodedAddress) string { return string(k) })
 
 	consensusObs := ConsensusObservation{
 		FChain:                fChains,
@@ -89,6 +99,23 @@ func (p *processor) getConsensusObservation(
 	}
 
 	return consensusObs, nil
+}
+
+func reportTokenPriceConsensusDrops[K comparable](
+	reporter plugincommon.MetricsReporter,
+	objectName string,
+	drops map[K]consensus.ConsensusDropReason,
+	keyToString func(K) string,
+) {
+	r, ok := reporter.(interface {
+		TrackConsensusDropped(objectName string, key string, reason string)
+	})
+	if !ok {
+		return
+	}
+	for key, reason := range drops {
+		r.TrackConsensusDropped(objectName, keyToString(key), reason.String())
+	}
 }
 
 // selectTokensForUpdate checks which tokens need to be updated based on the observed token prices and

--- a/commit/tokenprice/outcome_test.go
+++ b/commit/tokenprice/outcome_test.go
@@ -63,10 +63,11 @@ var offChainCfg = pluginconfig.CommitOffchainConfig{
 func TestGetConsensusObservation(t *testing.T) {
 	lggr := logger.Test(t)
 	p := &processor{
-		lggr:        lggr,
-		destChain:   destChainSel,
-		offChainCfg: offChainCfg,
-		fRoleDON:    1,
+		lggr:            lggr,
+		destChain:       destChainSel,
+		offChainCfg:     offChainCfg,
+		fRoleDON:        1,
+		metricsReporter: NoopMetrics{},
 	}
 
 	// 3 oracles, same observations, will pass destChain 2f+1 and fail feedChain 2f+1

--- a/commit/tokenprice/outcome_test.go
+++ b/commit/tokenprice/outcome_test.go
@@ -142,7 +142,7 @@ func TestOutcome(t *testing.T) {
 		destChain:       destChainSel,
 		offChainCfg:     offChainCfg,
 		fRoleDON:        1,
-		metricsReporter: plugincommon.NoopReporter{},
+		metricsReporter: NoopMetrics{},
 	}
 
 	outcome, err := p.Outcome(ctx, Outcome{}, Query{}, []plugincommon.AttributedObservation[Observation]{
@@ -176,7 +176,7 @@ func TestOutcome_EmptyObservations(t *testing.T) {
 		destChain:       destChainSel,
 		offChainCfg:     offChainCfg,
 		fRoleDON:        fChains[destChainSel], // Use f from fChains for the destination chain
-		metricsReporter: plugincommon.NoopReporter{},
+		metricsReporter: NoopMetrics{},
 	}
 
 	// Prepare attributed observations with only minimal data

--- a/commit/tokenprice/processor.go
+++ b/commit/tokenprice/processor.go
@@ -27,7 +27,7 @@ type processor struct {
 	chainSupport     plugincommon.ChainSupport
 	tokenPriceReader pkgreader.PriceReader
 	homeChain        reader.HomeChain
-	metricsReporter  plugincommon.MetricsReporter
+	metricsReporter  MetricsReporter
 	fRoleDON         int
 	obs              observer
 	runner           *asynclib.Runner
@@ -42,7 +42,7 @@ func NewProcessor(
 	tokenPriceReader pkgreader.PriceReader,
 	homeChain reader.HomeChain,
 	fRoleDON int,
-	metricsReporter plugincommon.MetricsReporter,
+	metricsReporter MetricsReporter,
 ) plugincommon.PluginProcessor[Query, Observation, Outcome] {
 	var obs observer
 	baseObs := newBaseObserver(

--- a/docs/metrics/commit-metrics.md
+++ b/docs/metrics/commit-metrics.md
@@ -57,7 +57,7 @@ Every metric proposed in this doc, with a one/two-line "why" — the full ration
 
 | Metric | Status | Why |
 |---|---|---|
-| `ccip_commit_consensus_dropped{objectName,key,reason}` | ✅ Implemented | Splits "no threshold configured" (config bug) from "insufficient agreement" (routine) from "split vote" (integrity signal) — previously collapsed into one `TODO: metrics` log line. |
+| `ccip_commit_consensus_dropped{objectName,key,reason,source_network_name}` | ✅ Implemented | Splits "no threshold configured" (config bug) from "insufficient agreement" (routine) from "split vote" (integrity signal) — previously collapsed into one `TODO: metrics` log line. `source_network_name` is included for chain-keyed objectNames. |
 
 ### Merkle root processor — High
 

--- a/docs/metrics/commit-metrics.md
+++ b/docs/metrics/commit-metrics.md
@@ -57,7 +57,7 @@ Every metric proposed in this doc, with a one/two-line "why" — the full ration
 
 | Metric | Status | Why |
 |---|---|---|
-| `ccip_commit_consensus_dropped{objectName,key,reason}` (needs an additive `GetConsensusMap` return value) | Reviewed design, not implemented | Splits "no threshold configured" (config bug) from "insufficient agreement" (routine) from "split vote" (integrity signal) — currently collapsed into one `TODO: metrics` log line. |
+| `ccip_commit_consensus_dropped{objectName,key,reason}` | ✅ Implemented | Splits "no threshold configured" (config bug) from "insufficient agreement" (routine) from "split vote" (integrity signal) — previously collapsed into one `TODO: metrics` log line. |
 
 ### Merkle root processor — High
 
@@ -117,7 +117,7 @@ These aren't owned by any single processor — they're the outer round loop and 
 
 ### Shared: consensus aggregation (`internal/plugincommon/consensus/consensus.go`)
 
-Used by commit (`chainfee`, `merkleroot`, `plugin.go`, `report.go`), `execute/plugin_functions.go`, **and** `internal/plugincommon/discovery/processor.go` — this is genuinely shared infra, not commit-specific, which shapes the recommended fix below. Reviewed design, not yet implemented.
+Used by commit (`chainfee`, `merkleroot`, `plugin.go`, `report.go`), `execute/plugin_functions.go`, **and** `internal/plugincommon/discovery/processor.go` — this is genuinely shared infra, not commit-specific, which shapes the recommended fix below. ✅ Implemented.
 
 **High**
 - **`GetConsensusMap` collapses three distinguishable outcomes into one `Debugw`/`Warnw` line, both marked `// TODO: metrics`** (`consensus.go:34-56`). `NewMinObservation.GetValid()` (`min_observation.go:57-66`) buckets observations by identical value and returns every distinct value that independently cleared the threshold, which means there are three cases today, not two:

--- a/docs/runbooks/commit-plugin-health.md
+++ b/docs/runbooks/commit-plugin-health.md
@@ -222,7 +222,7 @@ checks:
     query: 'sum(rate(ccip_commit_consensus_dropped_total{chainID=~"$destChain"}[5m])) by (objectName, reason)'
     severity: {warn_if: "any series > 0", ok_if: "all series == 0 (including empty result)"}
     owner: ccip-commit-oncall
-    note: "per-key consensus drop breakdown. reason='split' on objectName='fChain' is H2 (oracles disagree). reason='insufficient_agreement' on objectName='fChain' is H1 when fchain_read_errors is also spiking (too few oracles could report). reason='threshold_not_defined' is a config/data mismatch. Empty result is OK, not UNKNOWN"
+    note: "per-key consensus drop breakdown. reason='split' on objectName='fChain' is H2 (oracles disagree). reason='insufficient_agreement' on objectName='fChain' is H1 when fchain_read_errors is also spiking (too few oracles could report). reason='threshold_not_defined' is a config/data mismatch. For chain-keyed objectNames (MerkleRoot, OnRampMaxSeqNums, etc.) the metric also carries source_network_name, so you can drill down to the affected lane. Empty result is OK, not UNKNOWN"
 
   - id: live_oracle_count
     group: cursing_consensus

--- a/docs/runbooks/commit-plugin-health.md
+++ b/docs/runbooks/commit-plugin-health.md
@@ -216,6 +216,14 @@ checks:
     owner: ccip-commit-oncall
     note: "the only way a whole round fails: DON can't reach 2*fRoleDON+1 agreement on FChain for the dest chain. Destination-chain-wide by construction, not lane-specific"
 
+  - id: consensus_dropped
+    group: cursing_consensus
+    always_emitted: false
+    query: 'sum(rate(ccip_commit_consensus_dropped_total{chainID=~"$destChain"}[5m])) by (objectName, reason)'
+    severity: {warn_if: "any series > 0", ok_if: "all series == 0 (including empty result)"}
+    owner: ccip-commit-oncall
+    note: "per-key consensus drop breakdown. reason='split' on objectName='fChain' is H2 (oracles disagree). reason='insufficient_agreement' on objectName='fChain' is H1 when fchain_read_errors is also spiking (too few oracles could report). reason='threshold_not_defined' is a config/data mismatch. Empty result is OK, not UNKNOWN"
+
   - id: live_oracle_count
     group: cursing_consensus
     always_emitted: true
@@ -288,7 +296,10 @@ absence is the expected/healthy state, not a gap in coverage. If it does fire, c
 `live_oracle_count` before `fchain_read_errors`: an oracle that never started can't emit
 `fchain_read_errors` at all (only a *surviving* oracle's own read failures are counted there), so
 a low oracle count is a root cause `fchain_read_errors` is structurally unable to surface on its
-own.
+own. `consensus_dropped` then names the *kind* of failure: `reason="split"` on `objectName="fChain"`
+points to H2 (oracles disagree), while `reason="insufficient_agreement"` on `objectName="fChain"`
+points to H1 (too few oracles could even report). `reason="threshold_not_defined"` is a config/data
+mismatch.
 
 ### Report transmission
 
@@ -312,6 +323,11 @@ two explicit combination rules:
   in that situation is expected (dead oracles can't emit it), not evidence that points elsewhere.
   Don't report "H1 ruled out, likely a split vote" if `live_oracle_count` already found the real
   cause — that conclusion would be actively wrong, not just unconfirmed.
+- **`consensus_dropped` (`WARN`) firing at the same time as `consensus_observation_failed`
+  (`CRIT`) should be folded into the same `concerns` entry and used to name the failure mode.**
+  `reason="split"` on `objectName="fChain"` is H2 (oracles disagree). `reason="insufficient_agreement"`
+  on `objectName="fChain"` together with `fchain_read_errors` spiking is H1 (home-chain read outage).
+  `reason="threshold_not_defined"` is a config/data mismatch independent of H1/H2.
 
 `UNKNOWN` is never silently dropped to `OK` — but per the [empty-result rule](#empty-result-sets-the-rule-that-actually-matters),
 most checks should legitimately resolve `UNKNOWN` only when an `always_emitted: true` check comes

--- a/docs/runbooks/uncommitted-message.md
+++ b/docs/runbooks/uncommitted-message.md
@@ -352,12 +352,14 @@ fails is the DON not reaching 2·fRoleDON+1 agreement on a single FChain value f
   sum(rate(ccip_commit_fchain_read_errors_total{chainID=~"$destChain"}[5m]))
   ```
   Spiking broadly across oracles → home-chain RPC/read outage.
-- **H2 — oracles disagree (split vote).** Check `ccip_commit_consensus_dropped{objectName="fChain", reason="split"}`. This is genuine disagreement among oracles that DID submit a value — not the same as H0's "too few submitted at all."
-  Corroborate with:
+- **H2 — oracles disagree (split vote).** Check `ccip_commit_consensus_dropped{objectName="fChain", reason="split"}`:
+  ```promql
+  sum(rate(ccip_commit_consensus_dropped_total{chainID=~"$destChain", objectName="fChain", reason="split"}[5m])) by (key)
+  ```
+  This is genuine disagreement among oracles that DID submit a value — not the same as H0's "too few submitted at all." Corroborate with `ccip_commit_config_digest_mismatch` flipping for a subset of oracles around the same time:
   ```promql
   ccip_commit_config_digest_mismatch{chain_id=~"$destChain"}
   ```
-  flipping for a subset of oracles around the same time.
 
 ## Metric reference
 

--- a/docs/runbooks/uncommitted-message.md
+++ b/docs/runbooks/uncommitted-message.md
@@ -23,8 +23,9 @@ status: living
    * [Steps](#steps)
       + [step0 — is the plugin alive at all?](#step0-is-the-plugin-alive-at-all)
       + [step1 — is this even a commit-plugin problem?](#step1-is-this-even-a-commit-plugin-problem)
-      + [step2 — has the plugin observed it on-chain yet?](#step2-has-the-plugin-observed-it-on-chain-yet)
-      + [step3 — is the round producing outcomes at all?](#step3-is-the-round-producing-outcomes-at-all)
+       + [step2 — has the plugin observed it on-chain yet?](#step2-has-the-plugin-observed-it-on-chain-yet)
+       + [step2b — can the DON agree on this chain's per-chain values?](#step2b-can-the-don-agree-on-this-chains-per-chain-values)
+       + [step3 — is the round producing outcomes at all?](#step3-is-the-round-producing-outcomes-at-all)
       + [step4 — is chain A or B cursed?](#step4-is-chain-a-or-b-cursed)
       + [step5 — is a report being built but never landing?](#step5-is-a-report-being-built-but-never-landing)
    * [Deep dives](#deep-dives)
@@ -105,6 +106,16 @@ steps:
     query: 'max by (source_network_name) (ccip_commit_onramp_max_seq_num{source_network_name=~"$sourceChain"})'
     condition: "result < $seqNum"
     if_true:  {action: "REPORT:chain-infra-oncall", reason: "onramp read is lagging; check ccip_commit_merkleroot_observation_errors_total by reason (no_bindings/timeout/rpc_error) for the source-chain read/infra issue", followup_query: 'sum(rate(ccip_commit_merkleroot_observation_errors_total{source_network_name=~"$sourceChain"}[5m])) by (reason)'}
+    if_false: {action: "CONTINUE:step2b"}
+    automatable: true
+
+  - id: step2b
+    check: per_chain_consensus_dropped
+    queries:
+      - 'sum(rate(ccip_commit_consensus_dropped_total{source_network_name=~"$sourceChain", objectName=~"MerkleRoot|OnRampMaxSeqNums"}[5m])) by (objectName, reason)'
+      - 'sum(rate(ccip_commit_offramp_consensus_insufficient_total{source_network_name=~"$sourceChain"}[5m]))'
+    condition: "any result > 0"
+    if_true:  {action: "REPORT:ccip-commit-oncall", reason: "DON could not reach consensus on a per-chain value for this lane. For ccip_commit_consensus_dropped: reason='split' means disagreeing oracles, reason='insufficient_agreement' means too few oracles observed the key, reason='threshold_not_defined' is a config/data mismatch. ccip_commit_offramp_consensus_insufficient means the DON could not agree on OffRampNextSeqNums for this lane. The message cannot advance until the disagreement resolves."}
     if_false: {action: "CONTINUE:step3"}
     automatable: true
 
@@ -238,6 +249,31 @@ sum(rate(ccip_commit_merkleroot_observation_errors_total{source_network_name=~"$
 (`no_bindings` / `timeout` / `rpc_error` / `msg_count_mismatch` / `hash_error` /
 `address_lookup_error`). This is a source-chain read/infra issue, not commit logic — report and
 stop. `>= $seqNum` → plugin has seen it; continue.
+
+### step2b — can the DON agree on this chain's per-chain values?
+
+The onramp has been observed, but the DON still has to agree on the source-chain values that go
+into the merkle root (onramp max seq nums and merkle roots themselves). If consensus on these
+fails for this lane, the message will not advance even though the onramp read is healthy.
+
+Per-chain consensus failures:
+```promql
+sum(rate(ccip_commit_consensus_dropped_total{source_network_name=~"$sourceChain", objectName=~"MerkleRoot|OnRampMaxSeqNums"}[5m])) by (objectName, reason)
+```
+
+`ccip_commit_consensus_dropped` `reason` values:
+- `split` — two or more distinct values each cleared the threshold (oracles disagree)
+- `insufficient_agreement` — no single value reached the threshold (too few oracles observed the key)
+- `threshold_not_defined` — the consensus code had no threshold configured for this key (config/data mismatch)
+
+OffRampNextSeqNums consensus failures use a dedicated counter (same path conceptually, but a
+custom consensus helper):
+```promql
+sum(rate(ccip_commit_offramp_consensus_insufficient_total{source_network_name=~"$sourceChain"}[5m]))
+```
+
+Any of these `> 0` for the lane → the message cannot advance until the disagreement resolves.
+Report and stop. All flat (including empty) → continue.
 
 ### step3 — is the round producing outcomes at all?
 
@@ -392,7 +428,7 @@ everything else is Beholder-only.
 | `ccip_commit_processor_errors` | Counter | `chainFamily,chainID,processor,method` | dual |
 | `ccip_commit_processor_latency` | Histogram | `chainFamily,chainID,processor,method` | dual |
 | `ccip_commit_loopp_ccip_provider_supported` | Gauge | `chain_family` | dual |
-| `ccip_commit_consensus_dropped` | Counter | `chainFamily,chainID,objectName,key,reason` | beholder-only |
+| `ccip_commit_consensus_dropped` | Counter | `chainFamily,chainID,objectName,key,reason,source_network_name` | beholder-only |
 
 Note the label-casing inconsistency in the source (`chainFamily`/`chainID` vs.
 `chain_family`/`chain_id`) — copy the exact casing from this table per metric, it's not

--- a/docs/runbooks/uncommitted-message.md
+++ b/docs/runbooks/uncommitted-message.md
@@ -62,9 +62,8 @@ This doc is meant to be walked mechanically, not just read. Two things make that
    what a human should look at, don't try to fetch it yourself unless you have another tool for
    it.
 
-If a query's metric doesn't exist on your datasource (e.g. `ccip_commit_consensus_dropped`,
-see [Known gaps](#known-gaps)), treat the result as unknown, not as `0`/flat — say so explicitly
-rather than silently treating "no such metric" as "no signal."
+If a query's metric doesn't exist on your datasource, treat the result as unknown, not as
+`0`/flat — say so explicitly rather than silently treating "no such metric" as "no signal."
 
 ### A note on counter naming
 
@@ -187,14 +186,14 @@ steps:
       full_don:          {action: "CONTINUE:scenario3c", reason: "oracle count isn't the explanation; proceed to H1/H2"}
     if_false: {action: "CONTINUE:scenario3c", reason: "fRoleDON wasn't supplied — report the raw count as context (see note) and proceed to H1/H2 regardless; a human/agent should sanity-check the count against what they know the DON size to be before trusting H1/H2's conclusion"}
     automatable: true
-    note: "csa_public_key uniquely identifies each node in every commit metric series (confirmed empirically, not just in the source) -- this is a direct headcount, not a proxy. Deliberately uses timestamp()-vs-time(), not rate()>0: confirmed by live testing that rate([5m])>0 stays true for up to 5 minutes after a node actually stops (rate() extrapolates across its whole window using the oldest/newest samples it finds), which silently under-counts a fresh outage. timestamp() answers 'did this series get a sample in the last 60s' directly, no extrapolation lag. Distinguishes 'not enough oracles are online' (a category H1/H2 cannot detect at all, since fchain_read_errors only reports a *surviving* oracle's own read failures and has no way to see oracles that never started) from the H1/H2 failure modes below. This is exactly the gap docs/metrics/commit-metrics.md's unimplemented ccip_commit_consensus_dropped{reason=\"insufficient_agreement\"} would otherwise close at the source instead of needing to be inferred from heartbeat cardinality."
+    note: "csa_public_key uniquely identifies each node in every commit metric series (confirmed empirically, not just in the source) -- this is a direct headcount, not a proxy. Deliberately uses timestamp()-vs-time(), not rate()>0: confirmed by live testing that rate([5m])>0 stays true for up to 5 minutes after a node actually stops (rate() extrapolates across its whole window using the oldest/newest samples it finds), which silently under-counts a fresh outage. timestamp() answers 'did this series get a sample in the last 60s' directly, no extrapolation lag. Distinguishes 'not enough oracles are online' (a category H1/H2 cannot detect at all, since fchain_read_errors only reports a *surviving* oracle's own read failures and has no way to see oracles that never started) from the H1/H2 failure modes below. This is now closed at the source by ccip_commit_consensus_dropped{reason=\"insufficient_agreement\"}; the heartbeat headcount is still useful as cross-check."
 
   - id: scenario3c
     check: h1_vs_h2
     query: 'sum(rate(ccip_commit_fchain_read_errors_total{chainID=~"$destChain"}[5m]))'
     condition: "result spiking broadly across oracles"
     if_true:  {action: "REPORT:home-chain-infra-oncall", reason: "H1 — too few oracles could read FChain; home-chain RPC/read outage"}
-    if_false: {action: "REPORT:ccip-commit-oncall", reason: "H2 — oracles likely disagree (split vote). Needs ccip_commit_consensus_dropped{reason=\"split\"}, NOT IMPLEMENTED as of this writing — see Known gaps. Corroborate with ccip_commit_config_digest_mismatch flipping for a subset of oracles around the same time. If scenario3b (H0) wasn't able to rule out insufficient participation (fRoleDON unknown), treat this H2 conclusion as low-confidence, not a firm diagnosis.", followup_query: 'ccip_commit_config_digest_mismatch{chain_id=~"$destChain"}'}
+    if_false: {action: "REPORT:ccip-commit-oncall", reason: "H2 — oracles likely disagree (split vote). Confirm with ccip_commit_consensus_dropped{objectName=\"fChain\", reason=\"split\"} and corroborate with ccip_commit_config_digest_mismatch flipping for a subset of oracles around the same time. If scenario3b (H0) wasn't able to rule out insufficient participation (fRoleDON unknown), treat this H2 conclusion as low-confidence, not a firm diagnosis.", followup_query: 'ccip_commit_config_digest_mismatch{chain_id=~\"$destChain\"}'}
     automatable: true
 ```
 
@@ -353,7 +352,7 @@ fails is the DON not reaching 2·fRoleDON+1 agreement on a single FChain value f
   sum(rate(ccip_commit_fchain_read_errors_total{chainID=~"$destChain"}[5m]))
   ```
   Spiking broadly across oracles → home-chain RPC/read outage.
-- **H2 — oracles disagree (split vote).** *(Needs `ccip_commit_consensus_dropped{objectName="fChain", reason="split"}` — **not implemented**, reviewed design only, see [Known gaps](#known-gaps). This is genuine disagreement among oracles that DID submit a value — not the same as H0's "too few submitted at all.")*
+- **H2 — oracles disagree (split vote).** Check `ccip_commit_consensus_dropped{objectName="fChain", reason="split"}`. This is genuine disagreement among oracles that DID submit a value — not the same as H0's "too few submitted at all."
   Corroborate with:
   ```promql
   ccip_commit_config_digest_mismatch{chain_id=~"$destChain"}
@@ -391,7 +390,7 @@ everything else is Beholder-only.
 | `ccip_commit_processor_errors` | Counter | `chainFamily,chainID,processor,method` | dual |
 | `ccip_commit_processor_latency` | Histogram | `chainFamily,chainID,processor,method` | dual |
 | `ccip_commit_loopp_ccip_provider_supported` | Gauge | `chain_family` | dual |
-| `ccip_commit_consensus_dropped` | — | `objectName,key,reason` | **not implemented** (reviewed design only) |
+| `ccip_commit_consensus_dropped` | Counter | `chainFamily,chainID,objectName,key,reason` | beholder-only |
 
 Note the label-casing inconsistency in the source (`chainFamily`/`chainID` vs.
 `chain_family`/`chain_id`) — copy the exact casing from this table per metric, it's not
@@ -399,7 +398,5 @@ uniform across the file.
 
 ## Known gaps
 
-- `ccip_commit_consensus_dropped` (Scenario 3, H1/H2 split) is **not implemented** — reviewed
-  design only. Any query against it will return no data; that's expected, not a signal.
 - This runbook assumes `RMNEnabled` is hardcoded off (current production state). If that
   changes, the RMN-signature branches dropped from step4 need to be reinstated.

--- a/execute/plugin_functions.go
+++ b/execute/plugin_functions.go
@@ -920,7 +920,7 @@ func getConsensusFChain(
 
 	// consensus on the fChain map uses the role DON F value (all nodes can observe the home chain)
 	donThresh := consensus.MakeConstantThreshold[cciptypes.ChainSelector](consensus.TwoFPlus1(f))
-	fChain := consensus.GetConsensusMap(lggr, "fChain", observedFChains, donThresh)
+	fChain, _ := consensus.GetConsensusMap(lggr, "fChain", observedFChains, donThresh)
 
 	return fChain
 }

--- a/execute/plugin_functions.go
+++ b/execute/plugin_functions.go
@@ -920,6 +920,7 @@ func getConsensusFChain(
 
 	// consensus on the fChain map uses the role DON F value (all nodes can observe the home chain)
 	donThresh := consensus.MakeConstantThreshold[cciptypes.ChainSelector](consensus.TwoFPlus1(f))
+	// TODO: report metrics (execute equivalent of ccip_commit_consensus_dropped).
 	fChain, _ := consensus.GetConsensusMap(lggr, "fChain", observedFChains, donThresh)
 
 	return fChain

--- a/internal/plugincommon/consensus/consensus.go
+++ b/internal/plugincommon/consensus/consensus.go
@@ -28,8 +28,9 @@ func GetConsensusMap[K comparable, T any](
 	objectName string,
 	itemsByKey map[K][]T,
 	minObs MultiThreshold[K],
-) map[K]T {
+) (map[K]T, map[K]ConsensusDropReason) {
 	consensus := make(map[K]T)
+	dropReasons := make(map[K]ConsensusDropReason)
 
 	for key, items := range itemsByKey {
 		if minThresh, exists := minObs.Get(key); exists {
@@ -38,22 +39,27 @@ func GetConsensusMap[K comparable, T any](
 				minObservations.Add(item)
 			}
 			items = minObservations.GetValid()
-			if len(items) != 1 {
-				// TODO: metrics
+			if len(items) == 1 {
+				consensus[key] = items[0]
+			} else {
+				reason := DropReasonInsufficientAgreement
+				if len(items) > 1 {
+					reason = DropReasonSplit
+				}
+				dropReasons[key] = reason
 				lggr.Debugw("could not reach consensus due to not enough observations meeting the minimum threshold",
 					"objectName", objectName,
 					"key", key,
 					"minThreshold", minThresh,
-					"items", items)
-			} else {
-				consensus[key] = items[0]
+					"items", items,
+					"reason", reason)
 			}
 		} else {
-			// TODO: metrics
+			dropReasons[key] = DropReasonThresholdNotDefined
 			lggr.Warnw("min threshold not found defined", "objectName", objectName, "key", key)
 		}
 	}
-	return consensus
+	return consensus, dropReasons
 }
 
 // Aggregator is a function type that aggregates a slice of values into a single value.
@@ -65,11 +71,17 @@ func GetConsensusMapAggregator[K comparable, T any](
 	items map[K][]T,
 	f MultiThreshold[K],
 	agg Aggregator[T],
-) map[K]T {
+) (map[K]T, map[K]ConsensusDropReason) {
 	consensus := make(map[K]T)
+	dropReasons := make(map[K]ConsensusDropReason)
 
 	for key, values := range items {
 		if thresh, ok := f.Get(key); !ok || len(values) < int(thresh) {
+			if !ok {
+				dropReasons[key] = DropReasonThresholdNotDefined
+			} else {
+				dropReasons[key] = DropReasonInsufficientAgreement
+			}
 			lggr.Debugw("could not reach consensus in consensusMapAggregator",
 				"objectName", objectName,
 				"key", key)
@@ -77,7 +89,7 @@ func GetConsensusMapAggregator[K comparable, T any](
 		}
 		consensus[key] = agg(values)
 	}
-	return consensus
+	return consensus, dropReasons
 }
 
 // Median returns the middle element after sorting the provided slice.
@@ -114,17 +126,20 @@ func GetOrderedConsensus[K comparable, T cmp.Ordered](
 	lggr logger.Logger,
 	objectName string,
 	itemsByKey map[K][]T,
-	minObs MultiThreshold[K]) map[K]T {
+	minObs MultiThreshold[K]) (map[K]T, map[K]ConsensusDropReason) {
 	result := make(map[K]T)
+	dropReasons := make(map[K]ConsensusDropReason)
 
 	for key, items := range itemsByKey {
 		if _, exists := minObs.Get(key); !exists {
+			dropReasons[key] = DropReasonThresholdNotDefined
 			lggr.Warnw("could not find threshold value", "objectName", objectName, "key", key)
 			continue
 		}
 
 		minThresh, _ := minObs.Get(key)
 		if minThresh <= 0 {
+			dropReasons[key] = DropReasonInvalidThreshold
 			lggr.Errorw("found a negative or 0 threshold",
 				"objectName", objectName,
 				"key", key,
@@ -133,6 +148,7 @@ func GetOrderedConsensus[K comparable, T cmp.Ordered](
 		}
 
 		if len(items) < 2*int(minThresh)+1 {
+			dropReasons[key] = DropReasonInsufficientAgreement
 			lggr.Errorw(MsgInsufficientObservationsForConsensus,
 				"objectName", objectName,
 				"key", key,
@@ -144,7 +160,7 @@ func GetOrderedConsensus[K comparable, T cmp.Ordered](
 		slices.Sort(items)
 		result[key] = items[minThresh]
 	}
-	return result
+	return result, dropReasons
 }
 
 func TimestampComparator(a, b time.Time) bool {

--- a/internal/plugincommon/consensus/consensus_test.go
+++ b/internal/plugincommon/consensus/consensus_test.go
@@ -52,7 +52,7 @@ func Test_fChainConsensus(t *testing.T) {
 	for _, scenario := range testCases {
 		t.Run(scenario.name, func(t *testing.T) {
 			minObs := MakeConstantThreshold[cciptypes.ChainSelector](Threshold(scenario.f))
-			result := GetConsensusMap(lggr, "fChain", scenario.inputMap, minObs)
+			result, _ := GetConsensusMap(lggr, "fChain", scenario.inputMap, minObs)
 			assert.Equal(t, scenario.expectedOutput, result)
 		})
 	}
@@ -132,7 +132,7 @@ func Test_SeqNumConsensus(t *testing.T) {
 
 	for _, scenario := range testCases {
 		t.Run(scenario.name, func(t *testing.T) {
-			result := GetOrderedConsensus(lggr, "fChain", scenario.inputMap, scenario.thresholds)
+			result, _ := GetOrderedConsensus(lggr, "fChain", scenario.inputMap, scenario.thresholds)
 			require.Equal(t, scenario.expectedOutput, result)
 		})
 	}
@@ -154,7 +154,7 @@ func Test_GetConsensusMapMedianTimestamp(t *testing.T) {
 	}
 
 	threshold := MakeConstantThreshold[int](Threshold(f))
-	timeFinal := GetConsensusMapAggregator(lggr, "time", timeValues, threshold, func(vals []time.Time) time.Time {
+	timeFinal, _ := GetConsensusMapAggregator(lggr, "time", timeValues, threshold, func(vals []time.Time) time.Time {
 		return Median(vals, TimestampComparator)
 	})
 
@@ -180,7 +180,7 @@ func Test_GetConsensusMapMedianInt(t *testing.T) {
 	}
 
 	threshold := MakeConstantThreshold[int](Threshold(f))
-	intFinal := GetConsensusMapAggregator(lggr, "int", intValues, threshold, func(vals []int) int {
+	intFinal, _ := GetConsensusMapAggregator(lggr, "int", intValues, threshold, func(vals []int) int {
 		return Median(vals, func(a, b int) bool {
 			return a < b
 		})
@@ -416,7 +416,7 @@ func Test_GetConsensusMapAggregator(t *testing.T) {
 			threshold := MakeMultiThreshold(tc.thresholdMap, func(i int) Threshold {
 				return Threshold(tc.thresholdMap[i])
 			})
-			result := GetConsensusMapAggregator(lggr, "test", tc.inputMap, threshold, func(vals []int) int {
+			result, _ := GetConsensusMapAggregator(lggr, "test", tc.inputMap, threshold, func(vals []int) int {
 				return Median(vals, func(a, b int) bool {
 					return a < b
 				})
@@ -424,4 +424,96 @@ func Test_GetConsensusMapAggregator(t *testing.T) {
 			assert.Equal(t, tc.expectedOutput, result)
 		})
 	}
+}
+
+func Test_GetConsensusMap_DropReasons(t *testing.T) {
+	lggr := logger.Test(t)
+
+	fChain := map[cciptypes.ChainSelector]int{
+		cciptypes.ChainSelector(1): 3,
+		cciptypes.ChainSelector(2): 3,
+		cciptypes.ChainSelector(3): 3,
+	}
+	threshold := MakeMultiThreshold(fChain, F)
+
+	input := map[cciptypes.ChainSelector][]int{
+		cciptypes.ChainSelector(1): {5, 5, 5, 5, 5},       // consensus reached
+		cciptypes.ChainSelector(2): {5, 5},                 // insufficient agreement
+		cciptypes.ChainSelector(3): {5, 3, 5, 3, 5, 3},       // split vote
+		cciptypes.ChainSelector(4): {5, 5, 5},              // threshold not defined
+	}
+
+	result, drops := GetConsensusMap(lggr, "test", input, threshold)
+
+	assert.Equal(t, map[cciptypes.ChainSelector]int{
+		cciptypes.ChainSelector(1): 5,
+	}, result)
+
+	assert.Equal(t, map[cciptypes.ChainSelector]ConsensusDropReason{
+		cciptypes.ChainSelector(2): DropReasonInsufficientAgreement,
+		cciptypes.ChainSelector(3): DropReasonSplit,
+		cciptypes.ChainSelector(4): DropReasonThresholdNotDefined,
+	}, drops)
+}
+
+func Test_GetOrderedConsensus_DropReasons(t *testing.T) {
+	lggr := logger.Test(t)
+
+	fChain := map[cciptypes.ChainSelector]int{
+		cciptypes.ChainSelector(1): 3,
+		cciptypes.ChainSelector(2): 3,
+		cciptypes.ChainSelector(4): 0,
+	}
+	threshold := MakeMultiThreshold(fChain, F)
+
+	input := map[cciptypes.ChainSelector][]cciptypes.SeqNum{
+		cciptypes.ChainSelector(1): {1, 2, 3, 4, 5, 6, 7}, // consensus at f=3
+		cciptypes.ChainSelector(2): {1, 2, 3},             // insufficient agreement
+		cciptypes.ChainSelector(4): {1, 2, 3, 4, 5, 6, 7}, // invalid threshold
+		cciptypes.ChainSelector(5): {1, 2, 3, 4, 5, 6, 7}, // threshold not defined
+	}
+
+	result, drops := GetOrderedConsensus(lggr, "test", input, threshold)
+
+	assert.Equal(t, map[cciptypes.ChainSelector]cciptypes.SeqNum{
+		cciptypes.ChainSelector(1): 4,
+	}, result)
+
+	assert.Equal(t, map[cciptypes.ChainSelector]ConsensusDropReason{
+		cciptypes.ChainSelector(2): DropReasonInsufficientAgreement,
+		cciptypes.ChainSelector(4): DropReasonInvalidThreshold,
+		cciptypes.ChainSelector(5): DropReasonThresholdNotDefined,
+	}, drops)
+}
+
+func Test_GetConsensusMapAggregator_DropReasons(t *testing.T) {
+	lggr := logger.Test(t)
+
+	thresholdMap := map[int]int{
+		1: 3,
+		2: 3,
+		3: 3,
+	}
+	threshold := MakeMultiThreshold(thresholdMap, func(i int) Threshold {
+		return Threshold(thresholdMap[i])
+	})
+
+	input := map[int][]int{
+		1: {5, 5, 5, 5, 5}, // consensus reached
+		2: {5, 5},           // insufficient agreement
+		4: {5, 5, 5},       // threshold not defined
+	}
+
+	result, drops := GetConsensusMapAggregator(lggr, "test", input, threshold, func(vals []int) int {
+		return Median(vals, func(a, b int) bool { return a < b })
+	})
+
+	assert.Equal(t, map[int]int{
+		1: 5,
+	}, result)
+
+	assert.Equal(t, map[int]ConsensusDropReason{
+		2: DropReasonInsufficientAgreement,
+		4: DropReasonThresholdNotDefined,
+	}, drops)
 }

--- a/internal/plugincommon/consensus/consensus_test.go
+++ b/internal/plugincommon/consensus/consensus_test.go
@@ -437,10 +437,10 @@ func Test_GetConsensusMap_DropReasons(t *testing.T) {
 	threshold := MakeMultiThreshold(fChain, F)
 
 	input := map[cciptypes.ChainSelector][]int{
-		cciptypes.ChainSelector(1): {5, 5, 5, 5, 5},       // consensus reached
-		cciptypes.ChainSelector(2): {5, 5},                 // insufficient agreement
-		cciptypes.ChainSelector(3): {5, 3, 5, 3, 5, 3},       // split vote
-		cciptypes.ChainSelector(4): {5, 5, 5},              // threshold not defined
+		cciptypes.ChainSelector(1): {5, 5, 5, 5, 5},    // consensus reached
+		cciptypes.ChainSelector(2): {5, 5},             // insufficient agreement
+		cciptypes.ChainSelector(3): {5, 3, 5, 3, 5, 3}, // split vote
+		cciptypes.ChainSelector(4): {5, 5, 5},          // threshold not defined
 	}
 
 	result, drops := GetConsensusMap(lggr, "test", input, threshold)
@@ -500,7 +500,7 @@ func Test_GetConsensusMapAggregator_DropReasons(t *testing.T) {
 
 	input := map[int][]int{
 		1: {5, 5, 5, 5, 5}, // consensus reached
-		2: {5, 5},           // insufficient agreement
+		2: {5, 5},          // insufficient agreement
 		4: {5, 5, 5},       // threshold not defined
 	}
 

--- a/internal/plugincommon/consensus/drop_reason.go
+++ b/internal/plugincommon/consensus/drop_reason.go
@@ -1,0 +1,35 @@
+package consensus
+
+// ConsensusDropReason explains why a key was dropped during consensus aggregation.
+// It is returned alongside the consensus result so callers can route the reason to
+// their own metrics reporter instead of emitting plugin-specific metrics from this
+// shared package.
+type ConsensusDropReason int
+
+const (
+	// DropReasonNone means the key was not dropped.
+	DropReasonNone ConsensusDropReason = iota
+	// DropReasonThresholdNotDefined means the caller did not supply a threshold for the key.
+	DropReasonThresholdNotDefined
+	// DropReasonInsufficientAgreement means no single value reached the required threshold.
+	DropReasonInsufficientAgreement
+	// DropReasonSplit means two or more distinct values each independently reached the threshold.
+	DropReasonSplit
+	// DropReasonInvalidThreshold means the configured threshold was zero or negative.
+	DropReasonInvalidThreshold
+)
+
+func (r ConsensusDropReason) String() string {
+	switch r {
+	case DropReasonThresholdNotDefined:
+		return "threshold_not_defined"
+	case DropReasonInsufficientAgreement:
+		return "insufficient_agreement"
+	case DropReasonSplit:
+		return "split"
+	case DropReasonInvalidThreshold:
+		return "invalid_threshold"
+	default:
+		return ""
+	}
+}

--- a/internal/plugincommon/discovery/processor.go
+++ b/internal/plugincommon/discovery/processor.go
@@ -367,7 +367,7 @@ func (cdp *ContractDiscoveryProcessor) Outcome(
 	// TODO: report metrics (discovery equivalent of ccip_commit_consensus_dropped).
 	feeQuoterConsensus, _ := consensus.GetConsensusMap(
 		lggr,
-		"fee quoter",
+		"feeQuoter",
 		agg.feeQuoterAddrs,
 		fChainThresh,
 	)

--- a/internal/plugincommon/discovery/processor.go
+++ b/internal/plugincommon/discovery/processor.go
@@ -295,7 +295,7 @@ func (cdp *ContractDiscoveryProcessor) Outcome(
 
 	// fChain consensus - uses the role DON F value because all nodes can observe the home chain.
 	donThresh := consensus.MakeConstantThreshold[cciptypes.ChainSelector](consensus.TwoFPlus1(cdp.fRoleDON))
-	fChain := consensus.GetConsensusMap(lggr, "fChain", agg.fChain, donThresh)
+	fChain, _ := consensus.GetConsensusMap(lggr, "fChain", agg.fChain, donThresh)
 	fChainThresh := consensus.MakeMultiThreshold(fChain, consensus.TwoFPlus1)
 
 	// We read onramp addresses from destChain offramp configs
@@ -304,7 +304,7 @@ func (cdp *ContractDiscoveryProcessor) Outcome(
 	} else {
 		destThresh := consensus.MakeConstantThreshold[cciptypes.ChainSelector](consensus.TwoFPlus1(fChain[cdp.dest]))
 
-		onrampConsensus := consensus.GetConsensusMap(
+		onrampConsensus, _ := consensus.GetConsensusMap(
 			lggr,
 			"onramp",
 			agg.onrampAddrs,
@@ -324,7 +324,7 @@ func (cdp *ContractDiscoveryProcessor) Outcome(
 		contracts[consts.ContractNameOnRamp] = onrampConsensus
 	}
 
-	nonceManagerConsensus := consensus.GetConsensusMap(
+	nonceManagerConsensus, _ := consensus.GetConsensusMap(
 		lggr,
 		"nonceManager",
 		agg.nonceManagerAddrs,
@@ -341,7 +341,7 @@ func (cdp *ContractDiscoveryProcessor) Outcome(
 	contracts[consts.ContractNameNonceManager] = nonceManagerConsensus
 
 	// RMNRemote address consensus
-	rmnRemoteConsensus := consensus.GetConsensusMap(
+	rmnRemoteConsensus, _ := consensus.GetConsensusMap(
 		lggr,
 		"rmnRemote",
 		agg.rmnRemoteAddrs,
@@ -360,7 +360,7 @@ func (cdp *ContractDiscoveryProcessor) Outcome(
 	}
 	contracts[consts.ContractNameRMNRemote] = rmnRemoteConsensus
 
-	feeQuoterConsensus := consensus.GetConsensusMap(
+	feeQuoterConsensus, _ := consensus.GetConsensusMap(
 		lggr,
 		"fee quoter",
 		agg.feeQuoterAddrs,
@@ -380,7 +380,7 @@ func (cdp *ContractDiscoveryProcessor) Outcome(
 	contracts[consts.ContractNameFeeQuoter] = feeQuoterConsensus
 
 	// Router address consensus
-	routerConsensus := consensus.GetConsensusMap(
+	routerConsensus, _ := consensus.GetConsensusMap(
 		lggr,
 		"router",
 		agg.routerAddrs,

--- a/internal/plugincommon/discovery/processor.go
+++ b/internal/plugincommon/discovery/processor.go
@@ -295,6 +295,7 @@ func (cdp *ContractDiscoveryProcessor) Outcome(
 
 	// fChain consensus - uses the role DON F value because all nodes can observe the home chain.
 	donThresh := consensus.MakeConstantThreshold[cciptypes.ChainSelector](consensus.TwoFPlus1(cdp.fRoleDON))
+	// TODO: report metrics (discovery equivalent of ccip_commit_consensus_dropped).
 	fChain, _ := consensus.GetConsensusMap(lggr, "fChain", agg.fChain, donThresh)
 	fChainThresh := consensus.MakeMultiThreshold(fChain, consensus.TwoFPlus1)
 
@@ -304,6 +305,7 @@ func (cdp *ContractDiscoveryProcessor) Outcome(
 	} else {
 		destThresh := consensus.MakeConstantThreshold[cciptypes.ChainSelector](consensus.TwoFPlus1(fChain[cdp.dest]))
 
+		// TODO: report metrics (discovery equivalent of ccip_commit_consensus_dropped).
 		onrampConsensus, _ := consensus.GetConsensusMap(
 			lggr,
 			"onramp",
@@ -324,6 +326,7 @@ func (cdp *ContractDiscoveryProcessor) Outcome(
 		contracts[consts.ContractNameOnRamp] = onrampConsensus
 	}
 
+	// TODO: report metrics (discovery equivalent of ccip_commit_consensus_dropped).
 	nonceManagerConsensus, _ := consensus.GetConsensusMap(
 		lggr,
 		"nonceManager",
@@ -341,6 +344,7 @@ func (cdp *ContractDiscoveryProcessor) Outcome(
 	contracts[consts.ContractNameNonceManager] = nonceManagerConsensus
 
 	// RMNRemote address consensus
+	// TODO: report metrics (discovery equivalent of ccip_commit_consensus_dropped).
 	rmnRemoteConsensus, _ := consensus.GetConsensusMap(
 		lggr,
 		"rmnRemote",
@@ -360,6 +364,7 @@ func (cdp *ContractDiscoveryProcessor) Outcome(
 	}
 	contracts[consts.ContractNameRMNRemote] = rmnRemoteConsensus
 
+	// TODO: report metrics (discovery equivalent of ccip_commit_consensus_dropped).
 	feeQuoterConsensus, _ := consensus.GetConsensusMap(
 		lggr,
 		"fee quoter",
@@ -380,6 +385,7 @@ func (cdp *ContractDiscoveryProcessor) Outcome(
 	contracts[consts.ContractNameFeeQuoter] = feeQuoterConsensus
 
 	// Router address consensus
+	// TODO: report metrics (discovery equivalent of ccip_commit_consensus_dropped).
 	routerConsensus, _ := consensus.GetConsensusMap(
 		lggr,
 		"router",


### PR DESCRIPTION
This is a follow up to #2238. In docs/metrics/commit-metrics.md, we describe a way to report consensus failures in the DON. This PR implements that section in the doc.

* Update GetConsensusMap, GetConsensusMapAggregator and GetOrderedConsensus to return the drop reason for each provided key in the event consensus is not reached.
* Update the call sites
* Update the runbooks

Still TODO:

- [x] Test the runbooks in the event of an induced consensus failure in a local devenv DON: deliberately induced a merkle root consensus failure (see commit https://github.com/smartcontractkit/chainlink-ccip/pull/2246/commits/be21158306db6f2c554a1dd94ee05622e1bdd65b, reverted afterwards)