### PR TITLE
feat(reader): ccip reader and config poller metrics

### DIFF
--- a/commit/factory.go
+++ b/commit/factory.go
@@ -190,6 +190,8 @@ func (p *PluginFactory) NewReportingPlugin(ctx context.Context, config ocr3types
 		return nil, ocr3types.ReportingPluginInfo{}, fmt.Errorf("validate ocr config: %w", err)
 	}
 
+	bhClient := beholder.GetClient().ForPackage("ocr3-ccip-commit")
+
 	ccipReader, err := readerpkg.NewCCIPChainReader(
 		ctx,
 		logutil.WithComponent(lggr, "CCIPReader"),
@@ -200,6 +202,7 @@ func (p *PluginFactory) NewReportingPlugin(ctx context.Context, config ocr3types
 		p.ocrConfig.Config.OfframpAddress,
 		p.addrCodec,
 		offchainConfig.PopulateTxHashEnabled,
+		bhClient.Meter,
 	)
 	if err != nil {
 		return nil, ocr3types.ReportingPluginInfo{}, fmt.Errorf("failed to create CCIP chain reader: %w", err)
@@ -234,8 +237,6 @@ func (p *PluginFactory) NewReportingPlugin(ctx context.Context, config ocr3types
 		offchainConfig.PriceFeedChainSelector,
 		p.addrCodec,
 	)
-
-	bhClient := beholder.GetClient().ForPackage("ocr3-ccip-commit")
 
 	metricsReporter, err := metrics.NewPromReporter(lggr, p.ocrConfig.Config.ChainSelector, bhClient)
 	if err != nil {

--- a/docs/metrics/reader-metrics.md
+++ b/docs/metrics/reader-metrics.md
@@ -76,11 +76,13 @@ All plugin-generic, keyed by `{queryName}`. ✅ = implemented; everything else i
 
 | Metric | Status | Why |
 |---|---|---|
-| `ccip_reader_read_all_ok_total{query}` / `ccip_reader_read_empty_total{query}` / `ccip_reader_read_partial_total{query}` | Proposed | Splits "errored" from the two false-idle shapes — "returned nothing" and "returned a subset." The single highest-value signal this layer could emit. |
-| `ccip_reader_chain_gap_total{query,chain,state="requested\|returned\|dropped\|misconfigured"}` | Proposed | Count of source chains requested vs returned vs silently dropped in `NextSeqNum` / `GetChainsFeeComponents` / `GetWrappedNativeTokenPriceUSD`, so a subset is a visible gap rather than buried behind `Debugw`. |
-| `ccip_reader_query_last_success_timestamp{query}` gauge | Proposed | Per-member staleness for reads that feed caches (RMN remote config, curse, config digest, source chain config, router address via the configPoller). A stuck cache looks healthy indefinitely today. |
-| `ccip_reader_msg_dropped_total{query,reason}` | Proposed | Reads that *did* return data but dropped rows on validation/cast (onRamp-address-changed mid-query, type/count mismatch, event validation drop). Data present but trimmed. |
-| `ccip_reader_chain_fee_components` | Proposed | Port of the existing promauto gauge (chainFee `exec`/`da`) to beholder; it is the only value-level gauge in this layer and is NOP-invisible today. |
+| `ccip_reader_read_outcome{chainID,query,outcome="ok"\|"empty"\|"error"}` | ✅ Implemented | Per-query classification ok/empty/error — the false-idle primitive (empty-with-no-error). |
+| `ccip_reader_read_empty{query,chain}` / `ccip_reader_read_partial{query,chain}` | ✅ Implemented | Splits "errored" from the two false-idle shapes — "returned nothing" and "returned a subset." |
+| `ccip_reader_chain_gap{query,chain,state}` | ✅ Implemented | Count of source chains in each state (`returned` vs `not_found`/`disabled`/`misconfigured`/`error`/`invalid`/`missing`/`stale`/...), so a subset is a visible gap rather than buried behind `Debugw`. |
+| `ccip_reader_chain_fee_components{chainFamily,chainID,feeType}` | ✅ Implemented | Beholder port of the existing promauto gauge (chainFee `exec`/`da`) — now NOP-visible. |
+| `ccip_reader_read_all_ok{query}` | Proposed | Folded into `read_outcome{outcome="ok"}`; not a separate instrument. |
+| `ccip_reader_msg_dropped{query,reason}` | Instrument added; no call site yet | Reads that returned data but dropped rows on validation/cast. Registered but not yet recorded anywhere — wire when the accessor wrapper lands. |
+| `ccip_reader_query_last_success_timestamp{query}` | Proposed | Per-member staleness for cache-feeding reads; the config-poller last-success timestamp below covers the poller side only. |
 | `ccip_reader_txhash_blanked_total` | Proposed (Low) | A deliberate data wipe (`populateTxHashEnabled=false`) with no count today. |
 
 ## Proposed metrics at a glance — accessor / price layer
@@ -98,11 +100,12 @@ All plugin-generic, keyed by `{queryName}`. ✅ = implemented; everything else i
 
 | Metric | Status | Why |
 |---|---|---|
-| `ccip_reader_config_cache_age_seconds{chain,kind="chain\|source"}` gauge | Proposed | The poller's whole job is freshness, and for that exact number it computes `time.Since(chainConfigRefresh)` and **discards it into `Debugw`** (`config_poller_v2.go:232`). Expose it so every behind-the-cache read (`GetRMNRemoteConfig`, `GetRmnCurseInfo`, `GetOffRampConfigDigest`, `GetOffRampSourceChainConfigs`, router address) can be judged for staleness. |
-| `ccip_reader_config_poll_success_total{chain}` / `ccip_reader_config_poll_failure_total{chain}` / `ccip_reader_config_poll_duration{chain}` | Proposed | Per-chain refresh accounting. Today `refreshAllKnownChains` (388-409) collapses every chain's outcome into one `Warnw` + a single `consecutiveFailedPolls` counter with no chain label — you can't tell *which* chain is failing. |
-| `ccip_reader_config_cache_overwritten_empty_total{kind}` | Proposed | Flags when a refresh **time-stamps an empty snapshot as fresh** and serves it to every consumer — the single highest-value config-poller finding (see full findings). |
-| `ccip_reader_config_poller_last_success_timestamp{chain}` gauge | Proposed | The background polling goroutine has no liveness signal of its own; if it wedges, every cache silently goes stale forever. Last-success turns "wedge" from invisible into page-able. |
-| `ccip_reader_config_miss_refresh_duration{chain}` | Proposed | Synchronous batch refreshes triggered on read-path cache misses (`GetChainConfig:240`, `GetOfframpSourceChainConfigs:333`) can stall the caller; latency is unmetered. |
+| `ccip_reader_config_cache_age_seconds{chain,kind="chain"\|"source"}` gauge | ✅ Implemented | The poller's whole job is freshness, and for that exact number it computed `time.Since(chainConfigRefresh)` and **discarded it into `Debugw`** (`config_poller_v2.go`). Now exported so every behind-the-cache read (curse, RMN config, config digest, router address) can be judged for staleness. |
+| `ccip_reader_config_poll_success{chain}` / `ccip_reader_config_poll_failure{chain}` | ✅ Implemented | Per-chain refresh accounting, replacing the single chain-unlabeled `consecutiveFailedPolls` counter — now you can tell *which* chain is failing. |
+| `ccip_reader_config_cache_overwritten_empty{kind}` | ✅ Implemented (+ write guard) | Flags when a refresh **time-stamped an empty snapshot as fresh**; the code now also refuses to write/mark-fresh an empty snapshot (the bug fix in this branch). |
+| `ccip_reader_config_poller_last_success_timestamp{chain}` gauge | ✅ Implemented | The background polling goroutine's liveness via last-success staleness — a wedged poller is now page-able instead of invisible. |
+| `ccip_reader_config_poll_duration{chain}` / `ccip_reader_config_miss_refresh_duration{chain}` | Proposed | Per-poll and read-path miss-refresh latency; not implemented here. |
+| `ccip_reader_config_cache_overwritten_empty{kind="source"}` | Proposed (source-cache variant) | The guard/metric cover the chain snapshot; the source-channel configs partial-overwrite is untouched. |
 
 ## How this extends the runbooks (all additive)
 

--- a/docs/metrics/reader-metrics.md
+++ b/docs/metrics/reader-metrics.md
@@ -77,8 +77,8 @@ All plugin-generic, keyed by `{queryName}`. ✅ = implemented; everything else i
 | Metric | Status | Why |
 |---|---|---|
 | `ccip_reader_read_outcome{chainID,query,outcome="ok"\|"empty"\|"error"}` | ✅ Implemented | Per-query classification ok/empty/error — the false-idle primitive (empty-with-no-error). |
-| `ccip_reader_read_empty{query,chain}` / `ccip_reader_read_partial{query,chain}` | ✅ Implemented | Splits "errored" from the two false-idle shapes — "returned nothing" and "returned a subset." |
-| `ccip_reader_chain_gap{query,chain,state}` | ✅ Implemented | Count of source chains in each state (`returned` vs `not_found`/`disabled`/`misconfigured`/`error`/`invalid`/`missing`/`stale`/...), so a subset is a visible gap rather than buried behind `Debugw`. |
+| `ccip_reader_read_empty{query,chain}` | ✅ Implemented | "Returned nothing with no error" — the single-chain false-idle primitive, wired at the concrete reads (`MsgsBetweenSeqNums`, `LatestMsgSeqNum`, `GetChainFeePriceUpdate`) where the source chain is known. |
+| `ccip_reader_chain_gap{query,chain,state}` | ✅ Implemented | Count of source chains in each state (`returned` vs `not_found`/`disabled`/`misconfigured`/`error`/`invalid`/`missing`/`stale`/`count_mismatch`/...). `count_mismatch` = a message read whose count doesn't match its requested range (partial/incomplete). This is the per-lane subset signal AND its reason. (Consolidated: the originally-proposed `ccip_reader_read_partial` counter was folded into `chain_gap{state!="returned"}` to avoid duplicate instrumentation.) |
 | `ccip_reader_chain_fee_components{chainFamily,chainID,feeType}` | ✅ Implemented | Beholder port of the existing promauto gauge (chainFee `exec`/`da`) — now NOP-visible. |
 | `ccip_reader_read_all_ok{query}` | Proposed | Folded into `read_outcome{outcome="ok"}`; not a separate instrument. |
 | `ccip_reader_msg_dropped{query,reason}` | Instrument added; no call site yet | Reads that returned data but dropped rows on validation/cast. Registered but not yet recorded anywhere — wire when the accessor wrapper lands. |
@@ -123,14 +123,14 @@ is reading is empty or garbage.** When `onramp_max_seq_num` is flat, the runbook
 distinguish "no new messages (true idle)" from "every oracle's onramp read is returning empty
 (false idle)." The reader's own counters can:
 
-`read_empty`/`read_partial`/`chain_gap`/`value_staleness` firing on the same query across oracles →
+`read_empty`/`chain_gap`/`value_staleness` firing on the same query across oracles →
 the onramp is stalled **because the read returns nothing**, and the outcome-level tree is moot.
 This is effectively a **second heartbeat — data-source liveness** — orthogonal to process liveness,
 and genuinely new: nothing in the current runbooks can answer "commit plugin healthy but fed
 garbage" vs "commit plugin itself broken."
 
 The runbook should therefore gain a *data-layer gate* step (run before the processor step tree, or
-as the top of step2): if any reader `read_empty`/`read_partial`/`chain_gap`/`value_staleness` series
+as the top of step2): if any reader `read_empty`/`chain_gap`/`value_staleness` series
 for the lane (or dest chain) is non-zero, branch straight to `REPORT: chain-infra-oncall`, before
 consensus or transmission logic is implicated.
 
@@ -140,12 +140,12 @@ consensus or transmission logic is implicated.
   which only fires for a handful of typed reasons. `chain_gap{NextSeqNum,state="misconfigured"}`,
   `read_empty` and `msg_dropped{MsgsBetweenSeqNums}` catch the *untyped* silent degradations
   (no-bindings, empty event index, cast/validation drops) that observation-errors never sees.
-- **step2b — consensus dropped.** `read_partial`/`read_empty` are the *per-oracle substrate* feeding
+- **step2b — consensus dropped.** `read_empty` / non-"returned" `chain_gap` are the *per-oracle substrate* feeding
   `consensus_dropped{reason=insufficient_agreement|split}`. They let the runbook answer whether the
   disagreement was "because N oracles literally couldn't read the lane" vs "oracles read fine but
   observed different things" — before or in parallel with the consensus signal.
 - **step3 / Scenario 3 (H1 vs H2).** Currently H1/H2 are inferred from silhouettes
-  (`fchain_read_errors`, `config_digest_mismatch`). `read_partial`/`read_empty` on the underlying
+  (`fchain_read_errors`, `config_digest_mismatch`). `read_empty` / non-"returned" `chain_gap` on the underlying
   source-chain queries give the **direct data-level observation** behind a consensus failure, for
   **all lanes at once**, rather than the single fChain the round needs. With the `node_id`/`csa_public_key`
   labels (see [known boundaries](#known-boundaries-and-deferred-work) below) this cleanly splits
@@ -160,7 +160,7 @@ consensus or transmission logic is implicated.
   a stale or empty digest cache *manufactures* `config_digest_mismatch` pages across the DON. Poller
   freshness turns that branch from "mismatch = config sync issue" into "mismatch **and** the digest
   read is stale → reader issue, not config issue."
-- **Scenario 2 — report-content rejections.** `read_partial`/`msg_dropped` on `MsgsBetweenSeqNums`
+- **Scenario 2 — report-content rejections.** `read_empty`/`msg_dropped` on `MsgsBetweenSeqNums`
   explain *why* a built report is missing messages → spurious
   `empty_root`/`invalid_seqnum_range`/`stale` rejections. Splits "report-builder bug" (processor)
   from "reader-supplied partial data" (data layer).
@@ -175,7 +175,7 @@ consensus or transmission logic is implicated.
   "fee/price pipeline healthy?" branch that does not exist today — including the
   `config_cache_overwritten_empty` class where a value is time-stamped fresh around empty data.
 - **Temporal root-cause arrow.** Because data-layer failures are upstream of their consequences, a
-  "did `read_partial`/`read_empty` appear *before* `pending_messages`/`consensus_dropped` climbed?"
+  "did `read_empty`/non-"returned" `chain_gap` appear *before* `pending_messages`/`consensus_dropped` climbed?"
   ordering comparison gives a **causation direction**: "the read broke first, the pipeline
   consequence followed" vs "reads are fine, the breakdown is inside the pipeline." Purely from
   timestamp ordering — no extra instrumentation.
@@ -185,7 +185,7 @@ consensus or transmission logic is implicated.
 ### 4. The proactive payoff (`commit-plugin-health.md`)
 
 The triage runbook is reactive — it needs a *missed* message to fire. Monitor-by-freshness metrics
-(`chain_gap`, `value_staleness`, `read_partial`, `config_cache_age`) let the health runbook find a
+(`chain_gap`, `value_staleness`, `read_empty`, `config_cache_age`) let the health runbook find a
 silently-degraded lane **before a message is missed** — the incident in the making. Outcome-level
 metrics cannot do this, because they legitimately don't move while nothing has been dropped yet.
 
@@ -209,7 +209,7 @@ metrics cannot do this, because they legitimately don't move while nothing has b
   EVM log poller that pulls over HTTP vs websockets. Those lower-level components should export
   their own health metrics and are to be reviewed in a later session; this docs does not solve for
   them.
-- Keep `read_empty`/`read_partial`/`chain_gap` sovereign from the *correctness* of the batch — a
+- Keep `read_empty`/`chain_gap` sovereign from the *correctness* of the batch — a
   partial read is not yet "wrong data," and a full read is not yet "correct data." Combined with the
   metric-reference note that "no such metric" must be treated as *unknown*, not `0`, the reference
   table below should be folded into the runbooks' reference tables as the metrics are implemented.
@@ -417,7 +417,8 @@ per-oracle-vs-DON-wide distinction queryable (see [known boundaries](#known-boun
 
 | metric | otel_type | key labels | proposed registration |
 |---|---|---|---|
-| `ccip_reader_read_all_ok` / `ccip_reader_read_empty` / `ccip_reader_read_partial` | Counter | `query` | beholder |
+| `ccip_reader_read_outcome` | Counter | `chainID,query,outcome` | beholder |
+| `ccip_reader_read_empty` | Counter | `query,chain` | beholder |
 | `ccip_reader_chain_gap` | Counter | `query,chain,state` | beholder |
 | `ccip_reader_query_last_success_timestamp` | Gauge | `query` | beholder |
 | `ccip_reader_msg_dropped` | Counter | `query,reason` | beholder |

--- a/docs/metrics/reader-metrics.md
+++ b/docs/metrics/reader-metrics.md
@@ -1,0 +1,432 @@
+- [Metrics coverage assessment — commit data-source layer (reader + accessor)](#metrics-coverage-assessment--commit-data-source-layer-reader--accessor)
+   * [What exists today](#what-exists-today)
+   * [Cross-cutting themes (repeat across both layers)](#cross-cutting-themes-repeat-across-both-layers)
+   * [Proposed metrics at a glance — reader layer](#proposed-metrics-at-a-glance--reader-layer)
+   * [Proposed metrics at a glance — accessor / price layer](#proposed-metrics-at-a-glance--accessor--price-layer)
+   * [Proposed metrics at a glance — config poller](#proposed-metrics-at-a-glance--config-poller)
+   * [How this extends the runbooks (all additive)](#how-this-extends-the-runbooks-all-additive)
+   * [Full findings — CCIP reader (`pkg/reader`)](#full-findings--ccip-reader-pkgreader)
+   * [Full findings — default chain accessor & price reader (`pkg/chainaccessor`)](#full-findings--default-chain-accessor--price-reader-pkgchainaccessor)
+   * [Full findings — config poller (`pkg/reader/config_poller_v2.go`)](#full-findings--config-poller-pkgreaderconfig_poller_v2go)
+
+# Metrics coverage assessment — commit data-source layer (reader + accessor)
+
+This is the counterpart to `commit-metrics.md` for the data that *goes into* the commit
+processors. Where that doc covered what the processors compute and discard, this one covers
+the reads that feed them: the CCIP reader (`pkg/reader/ccip.go`, interface
+`pkg/reader/ccip_interface.go`) and the chain accessor it sits on
+(`pkg/chainaccessor/default_accessor.go`, `config_processors.go`, `default_price_reader.go`).
+
+**Ground rule (same as `commit-metrics.md`):** the presence of a log line — even a "stable
+identifier" some log-analysis tooling keyed on — is never a reason to exclude a signal. Worse,
+much of what matters here is only at `Debugw`, or recorded only as an `Infow` on an *empty*
+result, i.e. effectively invisible in production. Most of the failure paths found below convert
+an error into an empty/partial result with a `nil` error, so the read looks "fine, just quiet."
+Logs are the last resort and the primary excuse for why this layer has been so hard to debug;
+this is the layer where "healthy but idle" usually originates.
+
+**Scope note that shapes naming:** this layer is **shared with execute** (`CommitReportsGTETimestamp`,
+`ExecutedMessages`, `Nonces`, `Sync` are used only by execute; the rest feed commit). Measurements
+here must therefore be **plugin-generic** — `ccip_reader_*` / `ccip_chainaccessor_*` with a
+`query`/`method` label — *not* `ccip_commit_*`. This is the same principle as the shared
+`consensus.go` fix in `commit-metrics.md`: don't hardcode a plugin prefix into code that another
+plugin also runs.
+
+## What exists today
+
+Three instrumentation layers, and one of them has none at all. Every one of the three that does
+exist is `promauto` (self-hosted Prometheus scrape only) — **none of them reach beholder**, which
+is the only channel NOP-run nodes emit into production. That single fact is the biggest gap.
+
+| Layer | File | Metrics today | Blind spot |
+|---|---|---|---|
+| Contract reader (below accessor) | `pkg/contractreader/observed.go` | `CrErrors`, `CrBatchRequestsDurations`, `CrDirectRequestsDurations`, `CrBatchSizes` (promauto) | Only fires on a **top-level** `err` return. Blind to the accessor's swallowed→empty/`nil` paths and to per-row/per-chain `continue` drops. |
+| Chain accessor | `pkg/chainaccessor/*` | **none** | 100% logs-only. This is the layer with the worst silent-empty producers. |
+| CCIP reader | `pkg/reader/observed_ccip.go` | `ccip_reader_query_duration{query}` histogram, `ccip_reader_data_set_size{query}` gauge, `ccip_reader_chain_fee_components` gauge (promauto) | Duration + *result-size* only — never the actual values, never errors, never staleness, never per-chain partials. Its own comment (`observed_ccip.go:67-68`) calls the accessor layer a future TODO: *"Every CCIPReader (and Chain Accessor Layer in the future) should be decorated with the observedCCIPReader."* |
+| Config poller (background cache) | `pkg/reader/config_poller_v2.go` | **none** | Cache-age is computed and thrown away (`Debugw`); freshness timestamps are internal-only; the only health signal is a `Warnw`-and-service-health-buffer counter (`consecutiveFailedPolls`). Nothing is exported; a stale or wedged poller is invisible. |
+
+`observedCCIPReader` wraps the live reader (`NewCCIPChainReader`, `pkg/reader/ccip_interface.go:83-113`)
+and measures via `withObservedQueryAndResult` (`observed_ccip.go:332-359`): latency always counted,
+data size only when `err == nil` and a size fn exists. Error is only `Debugw`. So even the one thin
+promauto layer that exists tells you *how slow a read was*, never *what went wrong*.
+
+## Cross-cutting themes (repeat across both layers)
+
+1. **Error → empty/`nil` conversion (the false-idle factory).** ~25 distinct paths in the
+   accessor turn a failure into an empty/partial result with a `nil` error (catalogued in the full
+   findings). The commit plugin then reads "nothing" exactly as it reads "quiet chain."
+2. **Batch fan-out swallows partials.** Cross-chain reads run one goroutine per chain
+   (`pkg/reader/ccip.go:459,513`); each skipped chain is a log line at best.
+3. **Two silent cache layers.** The `configPoller` (30s background poll; `reader/ccip.go:33`)
+   caches router addresses, curse state, RMN remote config, source chain configs;
+   the chainfee **async observer** (`commit/chainfee/observation_async.go:180-302`) freezes the
+   *last successful* fee/price snapshot in memory on reader failure
+   (`Debugw "returning cached value"`). Neither signals staleness, and the config poller's freshness
+   timestamps — its entire reason for existing — are never exposed (see the
+   [config-poller findings](#full-findings--config-poller-pkgreaderconfig_poller_v2go)).
+   A stuck fee pump or a stale but "healthy" poller looks perfectly fine. This was already flagged
+   in `commit-metrics.md`; the root cause is here, and it is un-instrumented.
+4. **Empty-vs-broken is not distinguishable** for every read that returns `[]` / `0` / empty map
+   with a `nil` error.
+5. **Zero beholder anywhere**; the accessor has zero metrics of any kind.
+
+## Proposed metrics at a glance — reader layer
+
+All plugin-generic, keyed by `{queryName}`. ✅ = implemented; everything else is proposed.
+
+| Metric | Status | Why |
+|---|---|---|
+| `ccip_reader_read_all_ok_total{query}` / `ccip_reader_read_empty_total{query}` / `ccip_reader_read_partial_total{query}` | Proposed | Splits "errored" from the two false-idle shapes — "returned nothing" and "returned a subset." The single highest-value signal this layer could emit. |
+| `ccip_reader_chain_gap_total{query,chain,state="requested\|returned\|dropped\|misconfigured"}` | Proposed | Count of source chains requested vs returned vs silently dropped in `NextSeqNum` / `GetChainsFeeComponents` / `GetWrappedNativeTokenPriceUSD`, so a subset is a visible gap rather than buried behind `Debugw`. |
+| `ccip_reader_query_last_success_timestamp{query}` gauge | Proposed | Per-member staleness for reads that feed caches (RMN remote config, curse, config digest, source chain config, router address via the configPoller). A stuck cache looks healthy indefinitely today. |
+| `ccip_reader_msg_dropped_total{query,reason}` | Proposed | Reads that *did* return data but dropped rows on validation/cast (onRamp-address-changed mid-query, type/count mismatch, event validation drop). Data present but trimmed. |
+| `ccip_reader_chain_fee_components` | Proposed | Port of the existing promauto gauge (chainFee `exec`/`da`) to beholder; it is the only value-level gauge in this layer and is NOP-invisible today. |
+| `ccip_reader_txhash_blanked_total` | Proposed (Low) | A deliberate data wipe (`populateTxHashEnabled=false`) with no count today. |
+
+## Proposed metrics at a glance — accessor / price layer
+
+| Metric | Status | Why |
+|---|---|---|
+| `ccip_chainaccessor_batch_result_total{source,operation,outcome="ok\|empty\|partial\|error"}` | Proposed | One counter per batch call that explicitly tags the silent-empty outcomes (notably `GetChainFeePriceUpdate` → empty/`nil`). |
+| `ccip_chainaccessor_row_drops_total{source,operation,reason}` | Proposed | Aggregates the ~20 per-row/per-chain/per-token `continue` drops (Nonces per-addr, fee-update per-chain, feed-price per-contract, event per-msg). |
+| `ccip_chainaccessor_empty_read_total{source,operation}` | Proposed | The "returned empty, `nil` error" set (`LatestMessageTo`, `ExecutedMessages`, `MsgsBetweenSeqNums`, `CommitReportsGTETimestamp`) — the false-idle primitives. |
+| `ccip_chainaccessor_finality_violated_total` | Proposed | `ErrFinalityViolated` is real but surfaced only as an unmetered error at this layer. |
+| `ccip_chainaccessor_value_staleness_seconds{chain,source="feecomponents\|nativeprice\|chainfee\|feedprice\|quoter"}` | Proposed | Read age per chain since last successful value — the antidote to the configPoller/async-observer cache layers that freeze last-success silently. |
+| `ccip_chainaccessor_no_bindings_total{source}` | Proposed (Low) | An intended-quiet case (address-discovery race) that is indistinguishable from "disabled" today; worth counting so discovery lag is visible. |
+
+## Proposed metrics at a glance — config poller
+
+| Metric | Status | Why |
+|---|---|---|
+| `ccip_reader_config_cache_age_seconds{chain,kind="chain\|source"}` gauge | Proposed | The poller's whole job is freshness, and for that exact number it computes `time.Since(chainConfigRefresh)` and **discards it into `Debugw`** (`config_poller_v2.go:232`). Expose it so every behind-the-cache read (`GetRMNRemoteConfig`, `GetRmnCurseInfo`, `GetOffRampConfigDigest`, `GetOffRampSourceChainConfigs`, router address) can be judged for staleness. |
+| `ccip_reader_config_poll_success_total{chain}` / `ccip_reader_config_poll_failure_total{chain}` / `ccip_reader_config_poll_duration{chain}` | Proposed | Per-chain refresh accounting. Today `refreshAllKnownChains` (388-409) collapses every chain's outcome into one `Warnw` + a single `consecutiveFailedPolls` counter with no chain label — you can't tell *which* chain is failing. |
+| `ccip_reader_config_cache_overwritten_empty_total{kind}` | Proposed | Flags when a refresh **time-stamps an empty snapshot as fresh** and serves it to every consumer — the single highest-value config-poller finding (see full findings). |
+| `ccip_reader_config_poller_last_success_timestamp{chain}` gauge | Proposed | The background polling goroutine has no liveness signal of its own; if it wedges, every cache silently goes stale forever. Last-success turns "wedge" from invisible into page-able. |
+| `ccip_reader_config_miss_refresh_duration{chain}` | Proposed | Synchronous batch refreshes triggered on read-path cache misses (`GetChainConfig:240`, `GetOfframpSourceChainConfigs:333`) can stall the caller; latency is unmetered. |
+
+## How this extends the runbooks (all additive)
+
+These signals sit **one causal level upstream** of the processor metrics the runbooks currently
+read. Today the runbook is built entirely on *outcomes* — finished values the plugin already
+computed (`onramp_max_seq_num`, `consensus_dropped`, `pending_messages`) — which can only tell you
+*where* the pipeline is stuck, not *why the data feeding it went bad*. This section maps, step by
+step and scenario by scenario, what the new metrics add.
+
+### 1. A data-layer gate *before* the outcome tree (the highest-value addition)
+
+step0's heartbeat only answers "is the process alive?" There is a failure mode it cannot see:
+**process alive, rounds advancing normally, every outcome metric reading healthy — and the data it
+is reading is empty or garbage.** When `onramp_max_seq_num` is flat, the runbook cannot currently
+distinguish "no new messages (true idle)" from "every oracle's onramp read is returning empty
+(false idle)." The reader's own counters can:
+
+`read_empty`/`read_partial`/`chain_gap`/`value_staleness` firing on the same query across oracles →
+the onramp is stalled **because the read returns nothing**, and the outcome-level tree is moot.
+This is effectively a **second heartbeat — data-source liveness** — orthogonal to process liveness,
+and genuinely new: nothing in the current runbooks can answer "commit plugin healthy but fed
+garbage" vs "commit plugin itself broken."
+
+The runbook should therefore gain a *data-layer gate* step (run before the processor step tree, or
+as the top of step2): if any reader `read_empty`/`read_partial`/`chain_gap`/`value_staleness` series
+for the lane (or dest chain) is non-zero, branch straight to `REPORT: chain-infra-oncall`, before
+consensus or transmission logic is implicated.
+
+### 2. Where it strengthens existing steps / scenarios
+
+- **step2 — "onramp read is lagging."** Today this uses `ccip_commit_merkleroot_observation_errors`,
+  which only fires for a handful of typed reasons. `chain_gap{NextSeqNum,state="misconfigured"}`,
+  `read_empty` and `msg_dropped{MsgsBetweenSeqNums}` catch the *untyped* silent degradations
+  (no-bindings, empty event index, cast/validation drops) that observation-errors never sees.
+- **step2b — consensus dropped.** `read_partial`/`read_empty` are the *per-oracle substrate* feeding
+  `consensus_dropped{reason=insufficient_agreement|split}`. They let the runbook answer whether the
+  disagreement was "because N oracles literally couldn't read the lane" vs "oracles read fine but
+  observed different things" — before or in parallel with the consensus signal.
+- **step3 / Scenario 3 (H1 vs H2).** Currently H1/H2 are inferred from silhouettes
+  (`fchain_read_errors`, `config_digest_mismatch`). `read_partial`/`read_empty` on the underlying
+  source-chain queries give the **direct data-level observation** behind a consensus failure, for
+  **all lanes at once**, rather than the single fChain the round needs. With the `node_id`/`csa_public_key`
+  labels (see [known boundaries](#known-boundaries-and-deferred-work) below) this cleanly splits
+  "DON-wide data-source failure" (all nodes empty) from "single bad node's RPC" (one series empty).
+- **step4 — cursing.** `ccip_commit_rmn_curse_active` / `source_chain_cursed` are served from the
+  **config poller cache** (`GetRmnCurseInfo`). If the poller froze or served an empty snapshot (the
+  `config_cache_overwritten_empty` bug), step4 can **false-page on a curse already lifted** or miss a
+  new one. `config_cache_age_seconds` / `config_poller_last_success_timestamp` let step4 say *"this
+  curse reading is N minutes stale — re-read before acting"* (and the exculpatory mirror: don't trust
+  a "halt" read from a stale cache).
+- **step5 / Scenario 2 — `config_digest_mismatch`.** `GetOffRampConfigDigest` is also poller-cached;
+  a stale or empty digest cache *manufactures* `config_digest_mismatch` pages across the DON. Poller
+  freshness turns that branch from "mismatch = config sync issue" into "mismatch **and** the digest
+  read is stale → reader issue, not config issue."
+- **Scenario 2 — report-content rejections.** `read_partial`/`msg_dropped` on `MsgsBetweenSeqNums`
+  explain *why* a built report is missing messages → spurious
+  `empty_root`/`invalid_seqnum_range`/`stale` rejections. Splits "report-builder bug" (processor)
+  from "reader-supplied partial data" (data layer).
+
+### 3. Net-new branches that do not exist today
+
+- **Chainfee / tokenprice health.** These processors have almost no runbook presence, and their
+  silent-kill mode is exactly what this assessment surfaces: `GetChainFeePriceUpdate` /
+  `GetChainsFeeComponents` / `GetWrappedNativeTokenPriceUSD` returning empty/partial → the async
+  cache freezes → plugin looks healthy-idle. `batch_result{outcome="empty"}` +
+  `value_staleness_seconds{chain,source="chainfee|tokenprice"}` create a first-class
+  "fee/price pipeline healthy?" branch that does not exist today — including the
+  `config_cache_overwritten_empty` class where a value is time-stamped fresh around empty data.
+- **Temporal root-cause arrow.** Because data-layer failures are upstream of their consequences, a
+  "did `read_partial`/`read_empty` appear *before* `pending_messages`/`consensus_dropped` climbed?"
+  ordering comparison gives a **causation direction**: "the read broke first, the pipeline
+  consequence followed" vs "reads are fine, the breakdown is inside the pipeline." Purely from
+  timestamp ordering — no extra instrumentation.
+- **Report-content integrity** (as in §2/Scenario 2 above) doubles as a standalone health check on
+  `MsgsBetweenSeqNums`: reads returning a subset are a warning even before any report is rejected.
+
+### 4. The proactive payoff (`commit-plugin-health.md`)
+
+The triage runbook is reactive — it needs a *missed* message to fire. Monitor-by-freshness metrics
+(`chain_gap`, `value_staleness`, `read_partial`, `config_cache_age`) let the health runbook find a
+silently-degraded lane **before a message is missed** — the incident in the making. Outcome-level
+metrics cannot do this, because they legitimately don't move while nothing has been dropped yet.
+
+---
+
+## Known boundaries and deferred work
+
+- **Complementary, not replacing.** The reader/accessor metrics say "the data entering the pipeline
+  is bad"; the processor/consensus/transmission metrics say "how the pipeline reacted." Both are
+  needed — the reader metrics alone still cannot distinguish a genuine message drought from a bad
+  read. This is documented as goal-complementary: more useful signal is better.
+- **`node_id` / `csa_public_key` labels resolve the per-oracle-vs-DON-wide question.** Every proposed
+  beholder metric should carry a `node_id` and a `csa_public_key` label (`csa_public_key` is unique per node, the
+  same value the heartbeat metrics already use). This turns §3's H1-vs-H2, and the data-layer-gate's
+  "across oracles" check, into a real query instead of a hope: poll `group by (csa_public_key)` — a single
+  bad node's empty read is one series, a DON-wide data failure is every series.
+- **Event non-indexing is explicitly out of scope here.** These reader/accessor metrics make an
+  empty result *visible and countable*, but they do not make it self-verifying: `read_empty` says
+  "returned no data," not "should have returned data." Detecting a genuinely *un-indexed* event
+  stream (the hardest false-idle) is the job of the components *below* this abstraction — e.g. an
+  EVM log poller that pulls over HTTP vs websockets. Those lower-level components should export
+  their own health metrics and are to be reviewed in a later session; this docs does not solve for
+  them.
+- Keep `read_empty`/`read_partial`/`chain_gap` sovereign from the *correctness* of the batch — a
+  partial read is not yet "wrong data," and a full read is not yet "correct data." Combined with the
+  metric-reference note that "no such metric" must be treated as *unknown*, not `0`, the reference
+  table below should be folded into the runbooks' reference tables as the metrics are implemented.
+
+---
+
+## Full findings — CCIP reader (`pkg/reader`)
+
+Source: `pkg/reader/ccip.go` (`ccipChainReader`), interface `pkg/reader/ccip_interface.go`,
+wrapper `observed_ccip.go`. Every read funnels through `getChainAccessor` into the accessor; the
+reader itself holds **no error counter or aggregate metric of its own** — observability is wholly
+a function of which log level each method uses, at what frequency.
+
+### High
+
+- **`NextSeqNum` is commit-merkleroot critical-path and hides dropped chains behind a 30-minute
+  rate limit.** `ccip.go:346-412`: `fetchFreshSourceChainConfigsViaAccessor` (direct, cached-bypass
+  read) returns a **subset** — chains that are not-found / disabled / misconfigured are silently
+  dropped into buckets and only surfaced via
+  `LogWhenExceedFrequency` (`readerLogFrequency = 30min`, `ccip.go:330,395-409`). Disabled/config-not-found
+  are `Debugw`; only the misconfigured bucket gets `Errorw` with the sentinel
+  `MsgMisconfiguredSourceChainsSkipped` (`ccip.go:334-341`, explicitly tied in the comment to "a
+  plugin looking falsely idle"). A single dropped lane can be invisible for 30 minutes during an
+  incident window, and the returned subset is indistinguishable from "all chains fine" to an
+  outcome-only consumer. → `ccip_reader_chain_gap_total{query="NextSeqNum",chain,state=...}`.
+
+- **`GetChainsFeeComponents` / `GetWrappedNativeTokenPriceUSD` return subsets and swallow causes.**
+  `ccip.go:440-485` (chainfee critical path): per-chain failures are dropped from the result map;
+  accessor-missing is rate-limited `Debugw` (451-453), timeout `Warnw` (462), other `Errorw` (464);
+  non-positive fee validation `Errorw` (469-476). An empty return is "all chains failed"
+  indistinguishable from "zero chains requested" (`ccip.go:445`). `ccip.go:495-573`
+  (chainfee critical path): per-chain native-price reads in goroutines; two rate-limited `Debugw`
+  miss/error necks (`519-521`, `530-532`), zero/empty native address `Debug` (539-541),
+  `Timestamp == 0` stale → `Warnw MsgNoNativeTokenPriceAvailable` (555-557). The chainfee async
+  observer then freezes whatever survived with `Debugw "returning cached value"` and never marks it
+  stale (`observation_async.go:274-302`) — the classic "healthy but idle" chainfee state, rooted
+  here. → `ccip_reader_chain_gap_total{query=...}` + value-staleness gauges.
+
+- **Chain fee price updates can be wholly empty with `nil` error.** `GetChainFeePriceUpdate`
+  `ccip.go:580-604`: accessor-miss → `Errorw`, `return nil` (583-586); query error → `Errorw`,
+  `return nil` (593-596). Signature returns `map` with no `error`; the accessor failure mode farther
+  down turns a full dest-chain failure into an empty map + `nil` (see accessor #34). The caller
+  (`getChainFeePriceUpdates`, `observation_async.go:99-106`) treats `nil` and empty identically,
+  so a complete dest-chain failure reads as a legitimately idle chain. → accessor
+  `batch_result{outcome="empty"}`.
+
+- **`printReports` destroys evidence for combined reports.** `ccip.go:187-206`: reports carrying a
+  root have their price updates stripped before the `Debugw` (196-200) — deliberately, to save log
+  space, but it means commit logs can never reconstruct a combined report's token/gas price data.
+  → Low/Med: log-only concern worth flagging; the reader should rely on a value gauge, not the log.
+
+### Med
+
+- **`DiscoverContracts` silently drops source chains.** `ccip.go:754-833`: per-source-chain missing
+  reader `Errorw` + `continue` (788-791), config fetch fail `Errorw` + `continue` (801-805); the
+  result is best-effort with no discovered-vs-requested accounting. → `ccip_reader_chain_gap_total{query="DiscoverContracts",...}`.
+- **`Sync` skips `ErrChainAccessorNotFound` with no log, and one bind failure fails the whole Sync
+  error path.** `ccip.go:880-883` (no log), `886-897` (errgroup `Wait()` returns the first error
+  even though discovery swallows it). → reader-global counters.
+- **Config-poller-cached reads have no per-read freshness.** `GetRMNRemoteConfig` (618-648),
+  `GetRmnCurseInfo` (652-661, comment: "Curse requires a dedicated cache, but for now fetching it
+  in background..."), `GetOffRampConfigDigest` (1064-1078),
+  `GetOffRampSourceChainsConfig` (937-977) all return background-polled data
+  (`defaultRefreshPeriod = 30s`, `ccip.go:33`). Staleness governed solely by the poller's warn-only
+  consecutive-failure counter. → `ccip_reader_query_last_success_timestamp`.
+- **TxHash blanked when `populateTxHashEnabled=false`.** `ccip.go:278-282` — an analysis-relevant
+  field wiped with no count. → `ccip_reader_txhash_blanked_total` (Low).
+
+### Low
+
+- **`GetExpectedNextSequenceNumber` is deprecated/dead** (`ccip_interface.go:179`, unused in
+  commit/execute). Skip instrumentation.
+
+- **`Close` / `GetLatestPriceSeqNr` error surfacing is correct** (bad for metrics-only purposes —
+  caller-loggable).
+
+## Full findings — default chain accessor & price reader (`pkg/chainaccessor`)
+
+Sources: `default_accessor.go`, `config_processors.go`, `default_price_reader.go`. **None of the
+three contain any metric — zero `prometheus`/`otel`/`beholder`/`meter` usage (confirmed; the only
+"counter" hits are a local `int` variable).** The adjacent instrumentation is one layer below
+(`contractreader/observed.go`, which is blind to swallowed paths) and one layer above
+(`observed_ccip.go`, which measures only duration/size).
+
+There is also **no quorum / BFT aggregation anywhere in this layer**: `DefaultAccessor` is a thin
+single-reader facade (one per node), and "N-of-M" agreement or block-number alignment simply does
+not exist here. Each oracle independently reads its own RPC; the only finality touchpoint is the
+downstream health-check error `ErrFinalityViolated` (`contractreader/extended.go:126-129,169-172,205-207`).
+
+### High — the silent-empty "false idle" producers (all log-only, no metric)
+
+- **`GetChainFeePriceUpdate` batch failure → empty map, `nil`.** `default_accessor.go:834-837`
+  (`Errorw`, `return make(...), nil`) and missing FeeQuoter → empty `nil` (850-853). This is the
+  chainfee processor's data source; a dest-chain RPC/batch failure reads as "no price changes
+  anywhere." **The single most valuable item in this whole assessment.**
+- **Event reads return empty/`nil` on quiet.** `LatestMessageTo` → `0, nil` (444-446),
+  `ExecutedMessages` → `nil, nil` when no seqs, empty map `nil` on empty (583-586, 620),
+  `MsgsBetweenSeqNums` → `[], nil` (356-360), `CommitReportsGTETimestamp` → empty `[]`, `nil`
+  (561, 1005-1009). A slow or empty event index is indistinguishable from a genuinely quiet chain,
+  and the differencing log lines are Debug/Info.
+- **`GetAllConfigsLegacy` → empty `ChainConfigSnapshot`, `nil` error on component failure.**
+  `default_accessor.go:122-132` (Debug for no-bindings / Errorw otherwise, then
+  `standardConfigs = ChainConfigSnapshot{}` and `nil`, `141`). This degrades the cached Router /
+  curse / RMN config input silently.
+- **Per-row drops across every read, aggregated nowhere.** Nonces per-addr
+  (`731,739,745`), fee-update per-chain (`878-912`), commit-report validation/parse
+  (`967-971,982-986,988-992`), feed-price per-contract (`default_price_reader.go:64-99`),
+  fee-quoter token perdropped (`128-131` empty-`nil`, `157-171`, `237-264`),
+  source-chain config rows (`config_processors.go:87-105`). Each is a `continue` with a log; the
+  aggregate "rows dropped" does not exist.
+
+### Med
+
+- **Finality violation is real but unmetered at this layer.** `ErrFinalityViolated` bubbles as a
+  top-level error (loud) but is only folded into the block-level `CrErrors` when it happens to be
+  the outer `err`; a per-chain swallowed one is invisible. → `ccip_chainaccessor_finality_violated_total`.
+- **no-bindings (address-discovery race) is intended-quiet but indistinguishable from disabled.**
+  `config_processors.go:317-321,87-90`; `default_accessor.go:117-119` Debug. → low-count gauge.
+- **Config poller staleness is warn-only.** `config_poller_v2.go:403-408` consecutive-failure
+  counter with `Warnw` past `MaxFailedPolls`; no freshness/reorg-invalidation signal.
+- **33 error paths return an error with no log and no metric** (loud-but-unmetered; e.g.
+  `default_accessor.go:74-80,276-309,352-354,370-372,432-457,478-481,509-512,554-556,599-608,721-723,931-933`,
+  `config_processors.go:122-278`, `default_price_reader.go:57-59,65,123-131,150-152,237-264`).
+  These don't *cause* false-idle, but they are the errors that would aid diagnosis and are invisible
+  today.
+
+### Priority for instrumentation (in order)
+
+1. `GetChainFeePriceUpdate` batch → empty/`nil` (`default_accessor.go:834-837,850-853`).
+2. Silent-empty primitive reads: `LatestMessageTo`, `ExecutedMessages`, `MsgsBetweenSeqNums`,
+   `CommitReportsGTETimestamp` (`default_accessor.go:444-446,356-360,583-586,561,1005-1009`).
+3. Per-row/`continue` drops (`default_accessor.go:731-749,878-912,967-992`;
+   `config_processors.go:87-105`; `default_price_reader.go:64-99,157-171`).
+4. `GetAllConfigsLegacy` empty-snapshot-on-failure (`default_accessor.go:122-141`).
+5. Reader-layer chain-gap + last-success freshness for the two cache layers.
+
+---
+
+## Full findings — config poller (`pkg/reader/config_poller_v2.go`)
+
+Source background service (`configPollerV2`, created in `ccip.go:111-116` with
+`defaultRefreshPeriod = 30s`, started at `ccip.go:127-133`). It is the cache behind
+`GetRMNRemoteConfig`, `GetRmnCurseInfo`, `GetOffRampConfigDigest`, `GetOffRampSourceChainConfigs`,
+the router address read in `GetWrappedNativeTokenPriceUSD`, and `DiscoverContracts` — i.e. almost
+everything the commit plugin reads that isn't a seq-num/price. Its health *is* the plugin's view of
+on-chain config, and none of it is observable.
+
+### High
+
+- **A refresh can time-stamp an *empty* snapshot as fresh and serve it to every consumer.**
+  `batchRefreshChainAndSourceConfigs` (421-485) unconditionally writes
+  `cache.chainConfigData = chainConfigSnapshot; cache.chainConfigRefresh = time.Now()` (457-460).
+  The snapshot comes from `accessor.GetAllConfigsLegacy`, which — per the accessor findings — can
+  return an **empty `ChainConfigSnapshot` with `nil` error** on component failure
+  (`default_accessor.go:122-141`). End result: the cache records `chainConfigRefresh = now` around
+  empty/garbage data. Every downstream read (`GetChainConfig` at 213-248 short-circuits on a non-zero
+  refresh time, 228-233) then serves the empty snapshot **as fresh**, indefinitely — this silently
+  reads like "config is fine, nothing written," the deepest false-idle in this layer. Nothing marks
+  it; the only trace is the poller's `Debugw "Batch refreshed configs"` (478-483) that happens to log
+  the (empty) snapshot. → `ccip_reader_config_cache_overwritten_empty_total{kind="chain"}`,
+  plus guarding the write: only overwrite on a non-empty snapshot.
+
+- **Cache freshness is internal-only.** Every `chainCache` tracks `chainConfigRefresh` /
+  `sourceChainRefresh` (`config_poller_v2.go:79-85`), and `GetChainConfig` computes the one number
+  that matters — `time.Since(chainConfigRefresh)` as `cacheAge` — then throws it into `Debugw`
+  (232). Nothing exports it. A config that stopped refreshing looks identical to one refreshing every
+  30s. → `ccip_reader_config_cache_age_seconds{chain,kind}`.
+
+- **No per-chain poll accounting.** `refreshAllKnownChains` (388-409) refreshes every cached+known
+  chain and folds all outcomes into a single `refreshFailed` bool and the
+  `consecutiveFailedPolls` atomic (`Warnw` per-chain at 398, aggregate at 402-408). You can see
+  *"10 consecutive failures somewhere"* but not *which* chain, or that only one lane's config broke
+  while the rest are fine (exactly the lane-scoped failure the runbooks care about). →
+  `ccip_reader_config_poll_success_total{chain}` / `ccip_reader_config_poll_failure_total{chain}`.
+
+### Med
+
+- **A wedged background goroutine is invisible.** `startBackgroundPolling` (172-185) is a bare
+  `ticker.C` loop with no liveness/`lastSuccess` signal. If the goroutine dies or the ticker wedges,
+  every cache ages out silently with no pageability. `HealthReport` (145-153) only appends to the
+  service error buffer after `consecutiveFailedPolls >= MaxFailedPolls` *and* only counts failures
+  that reached `refreshAllKnownChains`. → `ccip_reader_config_poller_last_success_timestamp{chain}`.
+- **`sourceChainRefresh` is one timestamp for all source chains** (`85`), so a partial source-config
+  refresh (some chains updated, others missed) is indistinguishable from a full one. Per-source-chain
+  freshness is lost; `GetOffRampSourceChainConfigs` (304-346) returns only cached configs it happens
+  to have. → per-`{chain}` staleness would need per-chain timestamps.
+- **Read-path miss refreshes are synchronous and unmetered.** `GetChainConfig` (240) and
+  `GetOfframpSourceChainConfigs` (333) perform the batch refresh inline on a cache miss (with a
+  timeout), delaying the read; latency/outcome of these synchronous refreshes is not counted. →
+  `ccip_reader_config_miss_refresh_duration{chain}`.
+
+### Low
+
+- **`consecutiveFailedPolls` is never growing a metric.** It has its intended `Warnw` + service-health
+  purpose (403-408, `HealthReport`); graduating the counter into a gauge is a cosmetic, low-cardinality
+  win (`ccip_reader_config_poll_consecutive_failures`).
+
+---
+
+## Metric reference (to be added to runbook reference tables as metrics land)
+
+**Label convention:** every proposed beholder metric below carries `node_id` and `csa_public_key` labels
+(unique per node) in addition to the per-metric labels listed — this is what makes the
+per-oracle-vs-DON-wide distinction queryable (see [known boundaries](#known-boundaries-and-deferred-work)).
+
+| metric | otel_type | key labels | proposed registration |
+|---|---|---|---|
+| `ccip_reader_read_all_ok` / `ccip_reader_read_empty` / `ccip_reader_read_partial` | Counter | `query` | beholder |
+| `ccip_reader_chain_gap` | Counter | `query,chain,state` | beholder |
+| `ccip_reader_query_last_success_timestamp` | Gauge | `query` | beholder |
+| `ccip_reader_msg_dropped` | Counter | `query,reason` | beholder |
+| `ccip_reader_chain_fee_components` | Gauge | `chainFamily,chainID,feeType` | dual (already promauto) |
+| `ccip_chainaccessor_batch_result` | Counter | `source,operation,outcome` | beholder |
+| `ccip_chainaccessor_row_drops` | Counter | `source,operation,reason` | beholder |
+| `ccip_chainaccessor_empty_read` | Counter | `source,operation` | beholder |
+| `ccip_chainaccessor_finality_violated` | Counter | `source` | beholder |
+| `ccip_chainaccessor_value_staleness_seconds` | Gauge | `chain,source` | beholder |
+| `ccip_chainaccessor_no_bindings` | Counter | `source` | beholder (Low) |
+| `ccip_reader_config_cache_age_seconds` | Gauge | `chain,kind` | beholder |
+| `ccip_reader_config_poll_success_total` / `ccip_reader_config_poll_failure_total` | Counter | `chain` | beholder |
+| `ccip_reader_config_cache_overwritten_empty` | Counter | `kind` | beholder |
+| `ccip_reader_config_poller_last_success_timestamp` | Gauge | `chain` | beholder |
+| `ccip_reader_config_miss_refresh_duration` | Histogram | `chain` | beholder |

--- a/docs/runbooks/commit-plugin-health.md
+++ b/docs/runbooks/commit-plugin-health.md
@@ -227,9 +227,9 @@ checks:
     group: cursing_consensus
     always_emitted: false
     query: 'sum(rate(ccip_commit_consensus_dropped_total{chainID=~"$destChain"}[5m])) by (objectName, reason)'
-    severity: {warn_if: "any series > 0", ok_if: "all series == 0 (including empty result)"}
+    severity: {warn_if: 'result > 0 and not (objectName="RMNRemoteConfig" and reason="insufficient_agreement")', info_if: 'result > 0 and objectName="RMNRemoteConfig" and reason="insufficient_agreement"', ok_if: "all series == 0 (including empty result)"}
     owner: ccip-commit-oncall
-    note: "per-key consensus drop breakdown. reason='split' on objectName='fChain' is H2 (oracles disagree). reason='insufficient_agreement' on objectName='fChain' is H1 when fchain_read_errors is also spiking (too few oracles could report). reason='threshold_not_defined' is a config/data mismatch. For chain-keyed objectNames (MerkleRoot, OnRampMaxSeqNums, etc.) the metric also carries source_network_name, so you can drill down to the affected lane. Empty result is OK, not UNKNOWN"
+    note: "per-key consensus drop breakdown. reason='split' on objectName='fChain' is H2 (oracles disagree). reason='insufficient_agreement' on objectName='fChain' is H1 when fchain_read_errors is also spiking (too few oracles could report). reason='threshold_not_defined' is a config/data mismatch. For chain-keyed objectNames (MerkleRoot, OnRampMaxSeqNums, etc.) the metric also carries source_network_name, so you can drill down to the affected lane. EXCEPTION: objectName='RMNRemoteConfig', reason='insufficient_agreement' is EXPECTED benign noise when RMN is disabled (the RMN remote config is empty, so the DON can never agree on a meaningful value) -- report as INFO, do NOT let it drive the WARN/overall verdict. Empty result is OK, not UNKNOWN"
 
   - id: live_oracle_count
     group: cursing_consensus
@@ -325,7 +325,7 @@ checks:
     query: 'sum by (kind) (rate(ccip_reader_config_cache_overwritten_empty_total[5m]))'
     severity: {warn_if: "any series > 0", ok_if: "all series == 0 (including empty result)"}
     owner: chain-infra-oncall
-    note: "accessor returned an EMPTY chain-config snapshot (no-bindings / empty-batch). Per-event this is NOT a page: a single occurrence is benign and the guard refuses to clobber a good cache for it. Only actionable when SUSTAINED -- which is captured by config_cache_stale (age > 90s), not by this counter alone. Use this to explain WHY the cache went stale (empty snapshot) and which chains. WARN + see config_cache_stale for severity"
+    note: "accessor returned an EMPTY chain-config snapshot (no-bindings / empty-batch). Per-event this is NOT a page: a single occurrence is benign and the guard refuses to clobber a good cache for it. Only actionable when SUSTAINED -- which is captured by config_cache_stale (age > 90s), not by this counter alone. Use this to explain WHY the cache went stale (empty snapshot) and which chains. In dev/no-binding environments this can fire chronically as expected noise (unbound RMN/optional contracts); treat it as a signal only when accompanied by config_cache_stale climbing. WARN + see config_cache_stale for severity"
 ```
 
 ## Groups
@@ -361,7 +361,10 @@ a low oracle count is a root cause `fchain_read_errors` is structurally unable t
 own. `consensus_dropped` then names the *kind* of failure: `reason="split"` on `objectName="fChain"`
 points to H2 (oracles disagree), while `reason="insufficient_agreement"` on `objectName="fChain"`
 points to H1 (too few oracles could even report). `reason="threshold_not_defined"` is a config/data
-mismatch.
+mismatch. One chronic exception to treat as INFO, not a finding: on an **RMN-disabled** deployment,
+`objectName="RMNRemoteConfig", reason="insufficient_agreement"` fires constantly because the RMN
+remote config is empty and the DON can never agree on a meaningful value — ignore it here (it's a
+real signal only if RMN is actually enabled).
 
 ### Data source (reader + config poller)
 
@@ -404,6 +407,9 @@ two explicit combination rules:
   `reason="split"` on `objectName="fChain"` is H2 (oracles disagree). `reason="insufficient_agreement"`
   on `objectName="fChain"` together with `fchain_read_errors` spiking is H1 (home-chain read outage).
   `reason="threshold_not_defined"` is a config/data mismatch independent of H1/H2.
+  Do NOT fold `objectName="RMNRemoteConfig", reason="insufficient_agreement"` into `concerns` at all
+  when RMN is disabled — it is expected chronic noise, and its only relevance is as a hint that the
+  config-poller was serving an empty RMN remote config (cross-check `config_cache_overwritten_empty`).
 - **A `data_source` finding firing at the same time as an outcome check (`pending_messages`
   climbing, `reader_read_*` alongside `consensus_dropped`, `config_cache_stale` alongside a curse
   or digest-mismatch reading) is the SAME incident, and the data-source check is the **root

--- a/docs/runbooks/commit-plugin-health.md
+++ b/docs/runbooks/commit-plugin-health.md
@@ -307,9 +307,9 @@ checks:
     group: data_source
     always_emitted: true
     query: 'max by (chain, kind) (ccip_reader_config_cache_age_seconds)'
-    severity: {crit_if: 'kind="chain" and result > 60', ok_if: 'all kind="chain" result <= 60', info: 'kind="source" values (report, no verdict)'}
+    severity: {crit_if: 'kind="chain" and result > 90', ok_if: 'all kind="chain" result <= 90', info: 'kind="source" values (report, no verdict)'}
     owner: chain-infra-oncall
-    note: "how stale the config-poller cache is. Behind every cached read (GetRMNRemoteConfig, GetRmnCurseInfo, config digest, router address), so staleness here manufactures bad curse/mismatch/stale conclusions in the checks above. refresh_period is 30s; ~60s+ means the poll is failing"
+    note: "how stale the config-poller cache is. This is the SUSTAINED signal for config-refresh failure: because the code refuses to advance the refresh timestamp on an empty snapshot, the age only climbs across MULTIPLE consecutive empty/failed polls -- a single intermittent empty (flip-flop) is absorbed by the next good poll and keeps age low. CRIT at >90s (3x the 30s refresh period) means the poller genuinely cannot refresh, so every cached read (GetRMNRemoteConfig, GetRmnCurseInfo, config digest, router address) is running on hollow/stale data. Tie to config_cache_overwritten_empty / config_poll_failure to name why"
 
   - id: config_poller_liveness
     group: data_source
@@ -331,9 +331,9 @@ checks:
     group: data_source
     always_emitted: false
     query: 'sum by (kind) (rate(ccip_reader_config_cache_overwritten_empty_total[5m]))'
-    severity: {crit_if: "any series > 0", ok_if: "all series == 0 (including empty result)"}
-    owner: ccip-commit-oncall
-    note: "a refresh time-stamped an EMPTY chain-config snapshot as fresh and served it to every consumer (now guarded in code, but a prior occurrence means the cache was serving empty-as-healthy). This is a reader/config-poller bug, not an infra issue -- escalate to the reader owners"
+    severity: {warn_if: "any series > 0", ok_if: "all series == 0 (including empty result)"}
+    owner: chain-infra-oncall
+    note: "accessor returned an EMPTY chain-config snapshot (no-bindings / empty-batch). Per-event this is NOT a page: a single occurrence is benign and the guard refuses to clobber a good cache for it. Only actionable when SUSTAINED -- which is captured by config_cache_stale (age > 90s), not by this counter alone. Use this to explain WHY the cache went stale (empty snapshot) and which chains. WARN + see config_cache_stale for severity"
 ```
 
 ## Groups
@@ -374,9 +374,13 @@ mismatch.
 ### Data source (reader + config poller)
 
 This group is **upstream of the whole checklist**: it tests whether the commit plugin is healthy
-*but being fed empty/partial/stale data*. The `config_cache_overwritten_empty` check is the one
-`CRIT` here that is a **reader/config-poller bug** (empty snapshot served as fresh), not infra;
-escalate it to the reader owners. `config_cache_stale` and `config_poller_liveness` are the two
+*but being fed empty/partial/stale data*. The `CRIT` here is **`config_cache_stale`** (sustained:
+cache age > 90s = the poller genuinely cannot refresh), which is the thing that makes every cached
+read (curse, RMN config, config digest, router address) run on hollow data. `config_cache_overwritten_empty`
+alone is only `WARN` — a single empty snapshot is benign (the guard refuses to clobber a good cache),
+and per-event empties only matter when they're *sustained*, which `config_cache_stale` already
+captures. Use the empty counter + `config_poll_failure` to explain *why* the cache went stale and
+which chain(s). `config_cache_stale` and `config_poller_liveness` are the two
 `always_emitted: true` checks in this group, so an empty result on them is `UNKNOWN` (pipeline
 broken), and they're the ones to check before trusting the *cached* inputs behind step4
 (cursing) and the config-digest mismatch check above.

--- a/docs/runbooks/commit-plugin-health.md
+++ b/docs/runbooks/commit-plugin-health.md
@@ -11,6 +11,7 @@ inputs:
 related:
   - docs/runbooks/uncommitted-message.md   # incident triage for one specific stuck message
   - docs/metrics/commit-metrics.md         # design rationale + full metric-by-metric findings
+  - docs/metrics/reader-metrics.md         # data-source (reader + config poller) metrics & gaps
   - devenv/dashboards/commit-plugin.json   # Grafana rendering of this runbook (Health section)
 status: living
 ---
@@ -58,6 +59,12 @@ label key from each check's own query; don't assume one spelling applies file-wi
 per-node identity present on *every* commit metric series (confirmed against a live devenv, not
 just inferred). `live_oracle_count` is the only check that groups by it; nothing else in this
 checklist needs to.
+
+The `data_source` group (reader + config poller) breaks both conventions above: those metrics are
+shared with **execute**, carry **no** dest `chainID` label, and key on `chain` = the **numeric chain
+selector** plus `query`/`kind`/`state`. Filter them by the metric's own labels, not by
+`source_network_name`/`chainID`. They still inherit `node_id` + `csa_public_key` from the beholder
+client (like every commit series), so per-node vs DON-wide grouping works the same way.
 
 ### Empty result sets: the rule that actually matters
 
@@ -264,6 +271,69 @@ checks:
     severity: {info: true}
     owner: ccip-commit-oncall
     note: "recorded once per transmission-check attempt; empty result means zero transmission cycles in the window, which is itself informational (report as INFO with value \"no data\"), not UNKNOWN. Rising attempts alongside report_transmission_gave_up firing is the actionable combination, not this alone"
+
+  # --- data source (reader + config poller) ---
+  # These are shared with execute and live in the reader/config-poller layers (see
+  # docs/metrics/reader-metrics.md). Unlike the commit metrics above, `chain` is the NUMERIC
+  # chain selector (not source_network_name) and there's no dest `chainID` label to filter on;
+  # every series carries `node_id` + `csa_public_key` inherited from the beholder client.
+  # They answer "is the plugin fine but being fed empty/partial/stale data?" -- upstream of,
+  # and a root cause for, several of the outcome checks above.
+  - id: reader_read_empty
+    group: data_source
+    always_emitted: false
+    query: 'sum by (query, chain) (rate(ccip_reader_read_empty_total[5m]))'
+    severity: {warn_if: "any series > 0", ok_if: "all series == 0 (including empty result)"}
+    owner: chain-infra-oncall
+    note: "a read returned nothing with no error -- the false-idle primitive. Empty result here is OK (the event never happened). Correlate `chain` (numeric selector) to a lane and split node-local vs DON-wide by csa_public_key"
+
+  - id: reader_read_partial
+    group: data_source
+    always_emitted: false
+    query: 'sum by (query, chain) (rate(ccip_reader_read_partial_total[5m]))'
+    severity: {warn_if: "any series > 0", ok_if: "all series == 0 (including empty result)"}
+    owner: chain-infra-oncall
+    note: "a read returned a non-empty subset of what was requested (some chains silently dropped)"
+
+  - id: reader_chain_gap
+    group: data_source
+    always_emitted: false
+    query: 'sum by (query, chain, state) (rate(ccip_reader_chain_gap_total[5m]))'
+    severity: {warn_if: 'any series with state!="returned" > 0', ok_if: 'all series with state="returned" or empty result'}
+    owner: chain-infra-oncall
+    note: "per-chain outcome of a multi-chain read. Actionable states: not_found|disabled|misconfigured|error|invalid|missing|stale|no_accessor|config_error|no_native_token"
+
+  - id: config_cache_stale
+    group: data_source
+    always_emitted: true
+    query: 'max by (chain, kind) (ccip_reader_config_cache_age_seconds)'
+    severity: {crit_if: 'kind="chain" and result > 60', ok_if: 'all kind="chain" result <= 60', info: 'kind="source" values (report, no verdict)'}
+    owner: chain-infra-oncall
+    note: "how stale the config-poller cache is. Behind every cached read (GetRMNRemoteConfig, GetRmnCurseInfo, config digest, router address), so staleness here manufactures bad curse/mismatch/stale conclusions in the checks above. refresh_period is 30s; ~60s+ means the poll is failing"
+
+  - id: config_poller_liveness
+    group: data_source
+    always_emitted: true
+    query: 'min by (chain) (ccip_reader_config_poller_last_success_timestamp)'
+    severity: {crit_if: "time() - result > 90", ok_if: "time() - result <= 90"}
+    owner: chain-infra-oncall
+    note: "last successful background config poll per chain; a wedged/missing poller goroutine makes every cache silently go stale. Uses last-success staleness, not rate(), for the same detection-lag reason as live_oracle_count"
+
+  - id: config_poll_failure
+    group: data_source
+    always_emitted: false
+    query: 'sum by (chain) (rate(ccip_reader_config_poll_failure_total[5m]))'
+    severity: {warn_if: "any series > 0", ok_if: "all series == 0 (including empty result)"}
+    owner: chain-infra-oncall
+    note: "background config refresh failures -- exactly the per-chain accounting that a warn-only log used to hide (which chain, not just 'somewhere')"
+
+  - id: config_cache_overwritten_empty
+    group: data_source
+    always_emitted: false
+    query: 'sum by (kind) (rate(ccip_reader_config_cache_overwritten_empty_total[5m]))'
+    severity: {crit_if: "any series > 0", ok_if: "all series == 0 (including empty result)"}
+    owner: ccip-commit-oncall
+    note: "a refresh time-stamped an EMPTY chain-config snapshot as fresh and served it to every consumer (now guarded in code, but a prior occurrence means the cache was serving empty-as-healthy). This is a reader/config-poller bug, not an infra issue -- escalate to the reader owners"
 ```
 
 ## Groups
@@ -301,6 +371,16 @@ points to H2 (oracles disagree), while `reason="insufficient_agreement"` on `obj
 points to H1 (too few oracles could even report). `reason="threshold_not_defined"` is a config/data
 mismatch.
 
+### Data source (reader + config poller)
+
+This group is **upstream of the whole checklist**: it tests whether the commit plugin is healthy
+*but being fed empty/partial/stale data*. The `config_cache_overwritten_empty` check is the one
+`CRIT` here that is a **reader/config-poller bug** (empty snapshot served as fresh), not infra;
+escalate it to the reader owners. `config_cache_stale` and `config_poller_liveness` are the two
+`always_emitted: true` checks in this group, so an empty result on them is `UNKNOWN` (pipeline
+broken), and they're the ones to check before trusting the *cached* inputs behind step4
+(cursing) and the config-digest mismatch check above.
+
 ### Report transmission
 
 `report_transmission_gave_up` is `CRIT`. `report_validation_rejected` is split by reason:
@@ -328,6 +408,12 @@ two explicit combination rules:
   `reason="split"` on `objectName="fChain"` is H2 (oracles disagree). `reason="insufficient_agreement"`
   on `objectName="fChain"` together with `fchain_read_errors` spiking is H1 (home-chain read outage).
   `reason="threshold_not_defined"` is a config/data mismatch independent of H1/H2.
+- **A `data_source` finding firing at the same time as an outcome check (`pending_messages`
+  climbing, `reader_read_*` alongside `consensus_dropped`, `config_cache_stale` alongside a curse
+  or digest-mismatch reading) is the SAME incident, and the data-source check is the **root
+  cause**.** Fold it in as the named cause with the outcome check as the symptom — do not report
+  them as two unrelated problems (a plugin fed empty/partial/stale data is not broken; the reader
+  layer feeding it is).
 
 `UNKNOWN` is never silently dropped to `OK` — but per the [empty-result rule](#empty-result-sets-the-rule-that-actually-matters),
 most checks should legitimately resolve `UNKNOWN` only when an `always_emitted: true` check comes

--- a/docs/runbooks/commit-plugin-health.md
+++ b/docs/runbooks/commit-plugin-health.md
@@ -287,21 +287,13 @@ checks:
     owner: chain-infra-oncall
     note: "a read returned nothing with no error -- the false-idle primitive. Empty result here is OK (the event never happened). Correlate `chain` (numeric selector) to a lane and split node-local vs DON-wide by csa_public_key"
 
-  - id: reader_read_partial
-    group: data_source
-    always_emitted: false
-    query: 'sum by (query, chain) (rate(ccip_reader_read_partial_total[5m]))'
-    severity: {warn_if: "any series > 0", ok_if: "all series == 0 (including empty result)"}
-    owner: chain-infra-oncall
-    note: "a read returned a non-empty subset of what was requested (some chains silently dropped)"
-
   - id: reader_chain_gap
     group: data_source
     always_emitted: false
     query: 'sum by (query, chain, state) (rate(ccip_reader_chain_gap_total[5m]))'
     severity: {warn_if: 'any series with state!="returned" > 0', ok_if: 'all series with state="returned" or empty result'}
     owner: chain-infra-oncall
-    note: "per-chain outcome of a multi-chain read. Actionable states: not_found|disabled|misconfigured|error|invalid|missing|stale|no_accessor|config_error|no_native_token"
+    note: "per-chain outcome of a chain read -- serves as BOTH the subset flag and its reason. Actionable (non-returned) states: not_found|disabled|misconfigured|error|invalid|missing|stale|no_accessor|config_error|no_native_token|count_mismatch. count_mismatch = a message read came back with a count that doesn't match the requested range (partial/incomplete data). A read returning a subset = any requested chain in a non-returned state. (Consolidated: the separate ccip_reader_read_partial counter was removed; subset detection is chain_gap{state!=\"returned\"}.)"
 
   - id: config_cache_stale
     group: data_source

--- a/docs/runbooks/commit-plugin-health.md
+++ b/docs/runbooks/commit-plugin-health.md
@@ -66,6 +66,12 @@ selector** plus `query`/`kind`/`state`. Filter them by the metric's own labels, 
 `source_network_name`/`chainID`. They still inherit `node_id` + `csa_public_key` from the beholder
 client (like every commit series), so per-node vs DON-wide grouping works the same way.
 
+**One exception inside the group itself:** `ccip_reader_read_outcome` is recorded at the
+`observedCCIPReader` wrapper level (every reader call, not just the per-source-chain ones), so it
+carries `chainID` matching the **destination** chain — the same convention as the commit metrics
+above, not the `chain`-numeric-selector convention the rest of `data_source` uses. Filter it with
+`chainID=~"$destChain"`, not `chain`.
+
 ### Empty result sets: the rule that actually matters
 
 An empty Prometheus/PromQL result (zero series returned) is **not** the same as "all series are
@@ -279,6 +285,14 @@ checks:
   # every series carries `node_id` + `csa_public_key` inherited from the beholder client.
   # They answer "is the plugin fine but being fed empty/partial/stale data?" -- upstream of,
   # and a root cause for, several of the outcome checks above.
+  - id: reader_read_outcome_error
+    group: data_source
+    always_emitted: false
+    query: 'sum by (query) (rate(ccip_reader_read_outcome_total{chainID=~"$destChain", outcome="error"}[5m]))'
+    severity: {warn_if: "any series > 0", ok_if: "all series == 0 (including empty result)"}
+    owner: chain-infra-oncall
+    note: "the consolidated ok/empty/error classification recorded at the observedCCIPReader wrapper for every reader call. This is the ERROR leg specifically -- a query that returned a hard error, not just an empty/partial result (that's reader_read_empty/reader_chain_gap below). Empty result here is OK (never happened). Filters by chainID=~\"$destChain\" (destination chain), NOT by `chain` numeric selector -- see the label key cheat sheet exception above. Split node-local vs DON-wide by csa_public_key before escalating"
+
   - id: reader_read_empty
     group: data_source
     always_emitted: false
@@ -369,7 +383,10 @@ real signal only if RMN is actually enabled).
 ### Data source (reader + config poller)
 
 This group is **upstream of the whole checklist**: it tests whether the commit plugin is healthy
-*but being fed empty/partial/stale data*. The `CRIT` here is **`config_cache_stale`** (sustained:
+*but being fed empty/partial/stale data*. `reader_read_outcome_error` is the consolidated
+error-leg signal (a query failed outright) and is complementary to `reader_read_empty`/
+`reader_chain_gap` below it (which cover the empty/partial leg) — a query can show up in one
+without the other, check both. The `CRIT` here is **`config_cache_stale`** (sustained:
 cache age > 90s = the poller genuinely cannot refresh), which is the thing that makes every cached
 read (curse, RMN config, config digest, router address) run on hollow data. `config_cache_overwritten_empty`
 alone is only `WARN` — a single empty snapshot is benign (the guard refuses to clobber a good cache),

--- a/docs/runbooks/uncommitted-message.md
+++ b/docs/runbooks/uncommitted-message.md
@@ -12,6 +12,7 @@ inputs:
   fRoleDON: {type: integer, required: false, description: "optional. If known, expected live oracle count for destChain's DON is 3*fRoleDON+1 and the consensus threshold is 2*fRoleDON+1. Omit if uncertain (e.g. local devenvs with a possible bootstrap-node offset) -- scenario3's H0 check reports the raw live oracle count either way, it just can't grade it against a threshold without this."}
 related:
   - docs/metrics/commit-metrics.md        # design rationale + full metric-by-metric findings
+  - docs/metrics/reader-metrics.md        # data-source (reader + config poller) metrics & gaps
   - devenv/dashboards/commit-plugin.json  # Grafana rendering of this runbook (Guided Debug section)
 status: living
 ---
@@ -116,8 +117,21 @@ steps:
       - 'sum(rate(ccip_commit_offramp_consensus_insufficient_total{source_network_name=~"$sourceChain"}[5m]))'
     condition: "any result > 0"
     if_true:  {action: "REPORT:ccip-commit-oncall", reason: "DON could not reach consensus on a per-chain value for this lane. For ccip_commit_consensus_dropped: reason='split' means disagreeing oracles, reason='insufficient_agreement' means too few oracles observed the key, reason='threshold_not_defined' is a config/data mismatch. ccip_commit_offramp_consensus_insufficient means the DON could not agree on OffRampNextSeqNums for this lane. The message cannot advance until the disagreement resolves."}
+    if_false: {action: "CONTINUE:step2c"}
+    automatable: true
+
+  - id: step2c
+    check: reader_data_source
+    queries:
+      - 'sum by (query, chain) (rate(ccip_reader_read_partial_total{query=~"NextSeqNum|MsgsBetweenSeqNums|GetChainsFeeComponents|GetChainFeePriceUpdate"}[5m]))'
+      - 'sum by (query, chain) (rate(ccip_reader_read_empty_total{query=~"NextSeqNum|MsgsBetweenSeqNums|LatestMsgSeqNum"}[5m]))'
+      - 'sum by (query, chain, state) (rate(ccip_reader_chain_gap_total{query=~"NextSeqNum|GetChainsFeeComponents|GetChainFeePriceUpdate"}[5m]))'
+      - 'max by (chain, kind) (ccip_reader_config_cache_age_seconds)'
+    condition: "any read_partial/read_empty/chain_gap series > 0, or any config_cache_age_seconds{kind=\"chain\"} > 60"
+    if_true:  {action: "REPORT:chain-infra-oncall", reason: "the plugin DATA SOURCE is degrading, which is upstream of -- and distinct from -- onramp-lag/consensus/transmission. Reads are returning empty/partial (chain not returned, or a subset returned) or the config-poller cache went stale. This is the root cause the onramp-gauge stall looks like, not a commit-plugin bug. For ccip_reader_chain_gap, the actionable state values per (query,chain) are not_found|disabled|misconfigured|error|invalid|missing|stale. Split node-local (one csa_public_key) from DON-wide (all series) before escalating.", followup_query: 'count by (csa_public_key) (ccip_reader_chain_gap_total{query="NextSeqNum"})'}
     if_false: {action: "CONTINUE:step3"}
     automatable: true
+    note: "ccip_reader_* / config-poller metrics are shared with execute and keyed by `chain` = the NUMERIC chain selector (NOT source_network_name) and by `query`; correlate `chain` to the incident lane via its selector. Every series carries node_id + csa_public_key inherited from the beholder client, so group by them to distinguish a single bad node from a DON-wide data/index/RPC failure. See docs/metrics/reader-metrics.md."
 
   - id: step3
     check: consensus_observation_failed
@@ -134,7 +148,7 @@ steps:
       - 'max(ccip_commit_rmn_curse_active{chain_id=~"$destChain", curse_type="destination"})'
       - 'max(ccip_commit_source_chain_cursed{source_network_name=~"$sourceChain"})'
     condition: "any result == 1"
-    if_true:  {action: "REPORT:curse-owner", reason: "chain A or B is cursed; likely intentional/incident-flagged, hand off to whoever owns the curse"}
+    if_true:  {action: "REPORT:curse-owner", reason: "chain A or B is cursed; likely intentional/incident-flagged, hand off to whoever owns the curse. NOTE: curse state is served from the config-poller cache (GetRmnCurseInfo) -- if ccip_reader_config_cache_age_seconds{chain=<destSelector>,kind=\"chain\"} is high, the curse reading itself may be stale (a lifted curse still reporting active, or a fresh one unobserved); say so when reporting", followup_query: 'ccip_reader_config_cache_age_seconds{kind="chain"}'}
     if_false: {action: "CONTINUE:step5"}
     automatable: true
 
@@ -151,7 +165,7 @@ steps:
     query: 'sum(rate(ccip_commit_report_validation_rejected_total{chainID=~"$destChain", phase="should_transmit"}[15m])) by (reason)'
     condition: "any reason count > 0"
     if_true:
-      config_digest_mismatch:  {action: "REPORT:ccip-commit-oncall", reason: "config sync issue; cross-check ccip_commit_config_digest_mismatch"}
+      config_digest_mismatch:  {action: "REPORT:ccip-commit-oncall", reason: "config sync issue; cross-check ccip_commit_config_digest_mismatch. Before trusting this, verify the digest is not coming from a stale config-poller cache -- ccip_reader_config_cache_age_seconds{kind=\"chain\"} high or ccip_reader_config_poller_last_success_timestamp old would make a mismatch read manufactured by stale data, i.e. a chain-reader issue, not a config-sync one"}
       config_digest_check_error: {action: "REPORT:chain-infra-oncall", reason: "error *reading* the offramp's config digest (RPC/read failure), distinct from an actual mismatch -- chain-B read/infra issue, not a config sync issue"}
       stale:                   {action: "STOP", reason: "often benign — a different overlapping report already landed; re-check step1, the gauge may have just moved"}
       dest_not_supported:      {action: "REPORT:ccip-commit-oncall", reason: "transmission-schedule/config bug"}
@@ -274,6 +288,28 @@ sum(rate(ccip_commit_offramp_consensus_insufficient_total{source_network_name=~"
 
 Any of these `> 0` for the lane → the message cannot advance until the disagreement resolves.
 Report and stop. All flat (including empty) → continue.
+
+### step2c — is the problem upstream in the data source instead?
+
+The on/offramp gauges and consensus signals are *outcomes* — they can't tell "plugin is broken" from
+"plugin is fine but being fed empty/partial data." This step checks the data source directly:
+
+```promql
+sum by (query, chain) (rate(ccip_reader_read_partial_total{query=~"NextSeqNum|MsgsBetweenSeqNums|GetChainsFeeComponents|GetChainFeePriceUpdate"}[5m]))
+sum by (query, chain) (rate(ccip_reader_read_empty_total{query=~"NextSeqNum|MsgsBetweenSeqNums|LatestMsgSeqNum"}[5m]))
+sum by (query, chain, state) (rate(ccip_reader_chain_gap_total{query=~"NextSeqNum|GetChainsFeeComponents|GetChainFeePriceUpdate"}[5m]))
+max by (chain, kind) (ccip_reader_config_cache_age_seconds)
+```
+
+Any `> 0` (or any `config_cache_age_seconds{kind="chain"}` above ~60s) → the **data layer** feeding the
+commit plugin is degrading, so this is a `chain-infra`/reader problem, not a commit-plugin defect. Still
+split single-node (group by `csa_public_key`) vs DON-wide before escalating. All flat → continue.
+The `chain` label here is the **numeric chain selector** (not `source_network_name`); `query` names the
+read. These `ccip_reader_*`/config-poller metrics are shared with execute — see
+`docs/metrics/reader-metrics.md`.
+
+> This is the data-layer *gate*: it belongs before the consensus/transmission tree (steps 3-5), which is
+> exactly where a reader that silently returns empty/partial would be misattributed to the plugin.
 
 ### step3 — is the round producing outcomes at all?
 
@@ -433,6 +469,28 @@ everything else is Beholder-only.
 Note the label-casing inconsistency in the source (`chainFamily`/`chainID` vs.
 `chain_family`/`chain_id`) — copy the exact casing from this table per metric, it's not
 uniform across the file.
+
+### Reader / config-poller metrics (shared with execute)
+
+These are the data-source signals used by step2c/step4/scenario2 above, defined in the reader and
+config-poller layers rather than the commit plugin. Every series is **beholder-only** and carries
+`node_id` + `csa_public_key` **inherited** from the beholder client. Two label conventions differ
+from the commit metrics above: `chain` is the **numeric chain selector** (not `source_network_name`),
+and `query` names the specific read. Design + gap rationale: `docs/metrics/reader-metrics.md`.
+
+| metric | otel_type | key labels | registration |
+|---|---|---|---|
+| `ccip_reader_read_outcome` | Counter | `chainID,query,outcome="ok"\|"empty"\|"error"` | beholder-only |
+| `ccip_reader_read_empty` | Counter | `query,chain` | beholder-only |
+| `ccip_reader_read_partial` | Counter | `query,chain` | beholder-only |
+| `ccip_reader_chain_gap` | Counter | `query,chain,state` | beholder-only |
+| `ccip_reader_msg_dropped` | Counter | `query,reason` | beholder-only |
+| `ccip_reader_chain_fee_components` | Gauge | `chainFamily,chainID,feeType` | beholder-only (also promauto) |
+| `ccip_reader_config_cache_age_seconds` | Gauge | `chain,kind="chain"\|"source"` | beholder-only |
+| `ccip_reader_config_poll_success` | Counter | `chain` | beholder-only |
+| `ccip_reader_config_poll_failure` | Counter | `chain` | beholder-only |
+| `ccip_reader_config_cache_overwritten_empty` | Counter | `kind` | beholder-only |
+| `ccip_reader_config_poller_last_success_timestamp` | Gauge | `chain` | beholder-only |
 
 ## Known gaps
 

--- a/docs/runbooks/uncommitted-message.md
+++ b/docs/runbooks/uncommitted-message.md
@@ -127,7 +127,7 @@ steps:
       - 'sum by (query, chain) (rate(ccip_reader_read_empty_total{query=~"NextSeqNum|MsgsBetweenSeqNums|LatestMsgSeqNum"}[5m]))'
       - 'sum by (query, chain, state) (rate(ccip_reader_chain_gap_total{query=~"NextSeqNum|GetChainsFeeComponents|GetChainFeePriceUpdate"}[5m]))'
       - 'max by (chain, kind) (ccip_reader_config_cache_age_seconds)'
-    condition: "any read_partial/read_empty/chain_gap series > 0, or any config_cache_age_seconds{kind=\"chain\"} > 60"
+    condition: "any read_partial/read_empty/chain_gap series > 0, or any config_cache_age_seconds{kind=\"chain\"} > 90 (3x refresh period = sustained refresh failure, not a single empty poll)"
     if_true:  {action: "REPORT:chain-infra-oncall", reason: "the plugin DATA SOURCE is degrading, which is upstream of -- and distinct from -- onramp-lag/consensus/transmission. Reads are returning empty/partial (chain not returned, or a subset returned) or the config-poller cache went stale. This is the root cause the onramp-gauge stall looks like, not a commit-plugin bug. For ccip_reader_chain_gap, the actionable state values per (query,chain) are not_found|disabled|misconfigured|error|invalid|missing|stale. Split node-local (one csa_public_key) from DON-wide (all series) before escalating.", followup_query: 'count by (csa_public_key) (ccip_reader_chain_gap_total{query="NextSeqNum"})'}
     if_false: {action: "CONTINUE:step3"}
     automatable: true
@@ -301,7 +301,8 @@ sum by (query, chain, state) (rate(ccip_reader_chain_gap_total{query=~"NextSeqNu
 max by (chain, kind) (ccip_reader_config_cache_age_seconds)
 ```
 
-Any `> 0` (or any `config_cache_age_seconds{kind="chain"}` above ~60s) → the **data layer** feeding the
+Any `> 0` (or any `config_cache_age_seconds{kind="chain"}` above ~90s — sustained, 3x refresh; a
+single intermittent empty snap isn't enough) → the **data layer** feeding the
 commit plugin is degrading, so this is a `chain-infra`/reader problem, not a commit-plugin defect. Still
 split single-node (group by `csa_public_key`) vs DON-wide before escalating. All flat → continue.
 The `chain` label here is the **numeric chain selector** (not `source_network_name`); `query` names the

--- a/docs/runbooks/uncommitted-message.md
+++ b/docs/runbooks/uncommitted-message.md
@@ -123,12 +123,11 @@ steps:
   - id: step2c
     check: reader_data_source
     queries:
-      - 'sum by (query, chain) (rate(ccip_reader_read_partial_total{query=~"NextSeqNum|MsgsBetweenSeqNums|GetChainsFeeComponents|GetChainFeePriceUpdate"}[5m]))'
       - 'sum by (query, chain) (rate(ccip_reader_read_empty_total{query=~"NextSeqNum|MsgsBetweenSeqNums|LatestMsgSeqNum"}[5m]))'
-      - 'sum by (query, chain, state) (rate(ccip_reader_chain_gap_total{query=~"NextSeqNum|GetChainsFeeComponents|GetChainFeePriceUpdate"}[5m]))'
+      - 'sum by (query, chain, state) (rate(ccip_reader_chain_gap_total{query=~"NextSeqNum|MsgsBetweenSeqNums|GetChainsFeeComponents|GetChainFeePriceUpdate", state!="returned"}[5m]))'
       - 'max by (chain, kind) (ccip_reader_config_cache_age_seconds)'
-    condition: "any read_partial/read_empty/chain_gap series > 0, or any config_cache_age_seconds{kind=\"chain\"} > 90 (3x refresh period = sustained refresh failure, not a single empty poll)"
-    if_true:  {action: "REPORT:chain-infra-oncall", reason: "the plugin DATA SOURCE is degrading, which is upstream of -- and distinct from -- onramp-lag/consensus/transmission. Reads are returning empty/partial (chain not returned, or a subset returned) or the config-poller cache went stale. This is the root cause the onramp-gauge stall looks like, not a commit-plugin bug. For ccip_reader_chain_gap, the actionable state values per (query,chain) are not_found|disabled|misconfigured|error|invalid|missing|stale. Split node-local (one csa_public_key) from DON-wide (all series) before escalating.", followup_query: 'count by (csa_public_key) (ccip_reader_chain_gap_total{query="NextSeqNum"})'}
+    condition: "any read_empty series > 0, any chain_gap series with state!=\"returned\" > 0, or any config_cache_age_seconds{kind=\"chain\"} > 90 (3x refresh period = sustained refresh failure, not a single empty poll)"
+    if_true:  {action: "REPORT:chain-infra-oncall", reason: "the plugin DATA SOURCE is degrading, which is upstream of -- and distinct from -- onramp-lag/consensus/transmission. Reads are returning empty (nothing) or partial (chains not returned, or a message read whose count doesn't match its range) or the config-poller cache went stale. This is the root cause the onramp-gauge stall looks like, not a commit-plugin bug. For ccip_reader_chain_gap, the actionable state values per (query,chain) are not_found|disabled|misconfigured|error|invalid|missing|stale|count_mismatch. Split node-local (one csa_public_key) from DON-wide (all series) before escalating.", followup_query: 'count by (csa_public_key) (ccip_reader_chain_gap_total{query="NextSeqNum"})'}
     if_false: {action: "CONTINUE:step3"}
     automatable: true
     note: "ccip_reader_* / config-poller metrics are shared with execute and keyed by `chain` = the NUMERIC chain selector (NOT source_network_name) and by `query`; correlate `chain` to the incident lane via its selector. Every series carries node_id + csa_public_key inherited from the beholder client, so group by them to distinguish a single bad node from a DON-wide data/index/RPC failure. See docs/metrics/reader-metrics.md."
@@ -295,13 +294,12 @@ The on/offramp gauges and consensus signals are *outcomes* — they can't tell "
 "plugin is fine but being fed empty/partial data." This step checks the data source directly:
 
 ```promql
-sum by (query, chain) (rate(ccip_reader_read_partial_total{query=~"NextSeqNum|MsgsBetweenSeqNums|GetChainsFeeComponents|GetChainFeePriceUpdate"}[5m]))
 sum by (query, chain) (rate(ccip_reader_read_empty_total{query=~"NextSeqNum|MsgsBetweenSeqNums|LatestMsgSeqNum"}[5m]))
-sum by (query, chain, state) (rate(ccip_reader_chain_gap_total{query=~"NextSeqNum|GetChainsFeeComponents|GetChainFeePriceUpdate"}[5m]))
+sum by (query, chain, state) (rate(ccip_reader_chain_gap_total{query=~"NextSeqNum|MsgsBetweenSeqNums|GetChainsFeeComponents|GetChainFeePriceUpdate", state!="returned"}[5m]))
 max by (chain, kind) (ccip_reader_config_cache_age_seconds)
 ```
 
-Any `> 0` (or any `config_cache_age_seconds{kind="chain"}` above ~90s — sustained, 3x refresh; a
+Any `read_empty` or non-`returned` `chain_gap` `> 0` (or any `config_cache_age_seconds{kind="chain"}` above ~90s — sustained, 3x refresh; a
 single intermittent empty snap isn't enough) → the **data layer** feeding the
 commit plugin is degrading, so this is a `chain-infra`/reader problem, not a commit-plugin defect. Still
 split single-node (group by `csa_public_key`) vs DON-wide before escalating. All flat → continue.
@@ -483,7 +481,6 @@ and `query` names the specific read. Design + gap rationale: `docs/metrics/reade
 |---|---|---|---|
 | `ccip_reader_read_outcome` | Counter | `chainID,query,outcome="ok"\|"empty"\|"error"` | beholder-only |
 | `ccip_reader_read_empty` | Counter | `query,chain` | beholder-only |
-| `ccip_reader_read_partial` | Counter | `query,chain` | beholder-only |
 | `ccip_reader_chain_gap` | Counter | `query,chain,state` | beholder-only |
 | `ccip_reader_msg_dropped` | Counter | `query,reason` | beholder-only |
 | `ccip_reader_chain_fee_components` | Gauge | `chainFamily,chainID,feeType` | beholder-only (also promauto) |

--- a/docs/runbooks/uncommitted-message.md
+++ b/docs/runbooks/uncommitted-message.md
@@ -171,8 +171,8 @@ steps:
       dest_support_check_error: {action: "REPORT:chain-infra-oncall", reason: "error *checking* dest-chain support (RPC/read failure), distinct from a real config gap"}
       cursed:                  {action: "CONTINUE:step4", reason: "converges with step4"}
       cursed_check_error:      {action: "REPORT:chain-infra-oncall", reason: "error *checking* the curse state (RPC/read failure), not an actual curse -- don't conflate with step4's cursed=1 case"}
-      empty_root:              {action: "REPORT:ccip-commit-oncall", reason: "report-builder produced an empty merkle root; likely a bug upstream in the merkleroot processor, not an infra issue"}
-      invalid_seqnum_range:    {action: "REPORT:ccip-commit-oncall", reason: "report-builder produced start>end seqnums; likely a bug upstream in the merkleroot processor"}
+      empty_root:              {action: "REPORT:ccip-commit-oncall", reason: "report-builder produced an empty merkle root. Before treating this as a merkleroot-processor bug, check whether the reader supplied incomplete data for this lane: ccip_reader_read_empty_total{query=\"MsgsBetweenSeqNums\"} or ccip_reader_chain_gap_total{query=\"MsgsBetweenSeqNums\", state!=\"returned\"} firing for this chain around the same time means the reader handed the processor a subset (or nothing) to build from -- a reader-layer/chain-infra issue, not a processor bug. Both flat → likely genuinely a bug upstream in the merkleroot processor.", followup_query: 'sum by (chain, state) (rate(ccip_reader_chain_gap_total{query=\"MsgsBetweenSeqNums\", state!=\"returned\"}[15m]))'}
+      invalid_seqnum_range:    {action: "REPORT:ccip-commit-oncall", reason: "report-builder produced start>end seqnums. Same reader-layer check as empty_root above: ccip_reader_chain_gap_total{query=\"MsgsBetweenSeqNums\", state=\"count_mismatch\"} in particular means the reader returned a message count that didn't match its requested range -- a partial read manufacturing an invalid range, not a processor bug. Rule that out before reporting this as a merkleroot-processor defect.", followup_query: 'sum by (chain) (rate(ccip_reader_chain_gap_total{query=\"MsgsBetweenSeqNums\", state=\"count_mismatch\"}[15m]))'}
       decode_report:           {action: "REPORT:ccip-commit-oncall", reason: "report codec failure; check for a report-codec/chainlink-common version skew across the DON"}
       decode_report_info:      {action: "REPORT:ccip-commit-oncall", reason: "same as decode_report but for the report-info envelope"}
       root_blessing_mismatch:  {action: "REPORT:ccip-commit-oncall", reason: "root blessing validation failed; check on-chain blessing state for the roots in this report. RMN signing itself is dead code (RMNEnabled hardcoded off) but this specific check still runs"}
@@ -214,11 +214,15 @@ steps:
 
   - id: scenario3c
     check: h1_vs_h2
-    query: 'sum(rate(ccip_commit_fchain_read_errors_total{chainID=~"$destChain"}[5m]))'
-    condition: "result spiking broadly across oracles"
-    if_true:  {action: "REPORT:home-chain-infra-oncall", reason: "H1 — too few oracles could read FChain; home-chain RPC/read outage"}
-    if_false: {action: "REPORT:ccip-commit-oncall", reason: "H2 — oracles likely disagree (split vote). Confirm with ccip_commit_consensus_dropped{objectName=\"fChain\", reason=\"split\"} and corroborate with ccip_commit_config_digest_mismatch flipping for a subset of oracles around the same time. If scenario3b (H0) wasn't able to rule out insufficient participation (fRoleDON unknown), treat this H2 conclusion as low-confidence, not a firm diagnosis.", followup_query: 'ccip_commit_config_digest_mismatch{chain_id=~\"$destChain\"}'}
+    queries:
+      - 'sum(rate(ccip_commit_fchain_read_errors_total{chainID=~"$destChain"}[5m]))'
+      - 'sum by (query, chain, csa_public_key) (rate(ccip_reader_read_empty_total[5m]))'
+      - 'sum by (query, chain, state, csa_public_key) (rate(ccip_reader_chain_gap_total{state!="returned"}[5m]))'
+    condition: "fchain_read_errors spiking broadly across oracles, OR reader read_empty/non-returned chain_gap firing across most/all csa_public_key values for the same query"
+    if_true:  {action: "REPORT:home-chain-infra-oncall", reason: "H1 — too few oracles could read FChain; home-chain RPC/read outage. The reader-layer series (grouped by csa_public_key) give the direct data-level observation behind this: if read_empty/chain_gap fire for the SAME query across (nearly) every csa_public_key, that's DON-wide data-source failure, not one node's RPC -- report it as such rather than as a bare fchain_read_errors count. If only one or two csa_public_key values show up, that's a single bad node, not a DON-wide outage; say so explicitly, it changes the remediation."}
+    if_false: {action: "REPORT:ccip-commit-oncall", reason: "H2 — oracles likely disagree (split vote). Confirm with ccip_commit_consensus_dropped{objectName=\"fChain\", reason=\"split\"} and corroborate with ccip_commit_config_digest_mismatch flipping for a subset of oracles around the same time. If the reader-layer series above are flat (no read_empty/chain_gap), that corroborates H2 -- oracles are reading fine, they're just disagreeing on the value. If scenario3b (H0) wasn't able to rule out insufficient participation (fRoleDON unknown), treat this H2 conclusion as low-confidence, not a firm diagnosis.", followup_query: 'ccip_commit_config_digest_mismatch{chain_id=~\"$destChain\"}'}
     automatable: true
+    note: "the reader-layer queries are shared with execute and keyed by `chain` (numeric selector, not source_network_name/chainID) -- see docs/metrics/reader-metrics.md and the data-layer note on step2c. Grouping by csa_public_key here is what turns 'H1 or H2' from a guess into a query: a bad read on every node's series is DON-wide; a bad read on one node's series is that node's RPC, regardless of what fchain_read_errors alone says."
 ```
 
 ## Steps
@@ -365,8 +369,18 @@ sum(rate(ccip_commit_report_validation_rejected_total{chainID=~"$destChain", pha
 - `cursed` → converges with step4.
 - `cursed_check_error` → RPC/read error checking curse state, not an actual curse — don't
   conflate with step4's `cursed=1`.
-- `empty_root` / `invalid_seqnum_range` → the report-builder produced an invalid report; likely a
-  bug upstream in the merkleroot processor, not an infra issue.
+- `empty_root` / `invalid_seqnum_range` → the report-builder produced an invalid report. Before
+  attributing this to the merkleroot processor, rule out a reader-supplied partial read for this
+  lane:
+  ```promql
+  sum by (chain, state) (rate(ccip_reader_chain_gap_total{query="MsgsBetweenSeqNums", state!="returned"}[15m]))
+  sum by (chain) (rate(ccip_reader_read_empty_total{query="MsgsBetweenSeqNums"}[15m]))
+  ```
+  `chain_gap{state="count_mismatch"}` in particular means the reader returned a message count
+  that didn't match its requested range — that alone can manufacture `invalid_seqnum_range`
+  without any bug in the processor. Any of these firing for the lane around the same time → this
+  is a reader-layer/chain-infra issue, not a processor bug. All flat → likely a genuine bug
+  upstream in the merkleroot processor.
 - `decode_report` / `decode_report_info` → report/report-info codec failure; check for a
   report-codec or `chainlink-common` version skew across the DON.
 - `root_blessing_mismatch` → on-chain root blessing validation failed for this report. RMN
@@ -422,7 +436,16 @@ fails is the DON not reaching 2·fRoleDON+1 agreement on a single FChain value f
   ```promql
   sum(rate(ccip_commit_fchain_read_errors_total{chainID=~"$destChain"}[5m]))
   ```
-  Spiking broadly across oracles → home-chain RPC/read outage.
+  Spiking broadly across oracles → home-chain RPC/read outage. Corroborate with the reader layer,
+  grouped by node so "DON-wide" vs "one bad RPC" is a query, not a guess:
+  ```promql
+  sum by (query, chain, csa_public_key) (rate(ccip_reader_read_empty_total[5m]))
+  sum by (query, chain, state, csa_public_key) (rate(ccip_reader_chain_gap_total{state!="returned"}[5m]))
+  ```
+  Firing across (nearly) every `csa_public_key` for the same query → DON-wide data-source failure,
+  not a split vote. Firing for one or two `csa_public_key` values only → that node's RPC, not a
+  DON-wide condition — say so explicitly, it changes who fixes it. Both flat → corroborates H2
+  below (oracles are reading fine, they're just disagreeing).
 - **H2 — oracles disagree (split vote).** Check `ccip_commit_consensus_dropped{objectName="fChain", reason="split"}`:
   ```promql
   sum(rate(ccip_commit_consensus_dropped_total{chainID=~"$destChain", objectName="fChain", reason="split"}[5m])) by (key)
@@ -479,7 +502,7 @@ and `query` names the specific read. Design + gap rationale: `docs/metrics/reade
 
 | metric | otel_type | key labels | registration |
 |---|---|---|---|
-| `ccip_reader_read_outcome` | Counter | `chainID,query,outcome="ok"\|"empty"\|"error"` | beholder-only |
+| `ccip_reader_read_outcome` | Counter | `chainID,query,outcome="ok"\|"empty"\|"error"` | beholder-only |¹
 | `ccip_reader_read_empty` | Counter | `query,chain` | beholder-only |
 | `ccip_reader_chain_gap` | Counter | `query,chain,state` | beholder-only |
 | `ccip_reader_msg_dropped` | Counter | `query,reason` | beholder-only |
@@ -489,6 +512,11 @@ and `query` names the specific read. Design + gap rationale: `docs/metrics/reade
 | `ccip_reader_config_poll_failure` | Counter | `chain` | beholder-only |
 | `ccip_reader_config_cache_overwritten_empty` | Counter | `kind` | beholder-only |
 | `ccip_reader_config_poller_last_success_timestamp` | Gauge | `chain` | beholder-only |
+
+¹ `ccip_reader_read_outcome` is the one exception to the "`chain` = numeric selector" convention
+above: it's recorded at the `observedCCIPReader` wrapper level for every reader call, so `chainID`
+is the **destination** chain, matching the commit-metric convention, not the numeric-selector one.
+Filter it with `chainID=~"$destChain"`.
 
 ## Known gaps
 

--- a/execute/factory.go
+++ b/execute/factory.go
@@ -151,6 +151,8 @@ func (p PluginFactory) NewReportingPlugin(
 		readerFacades[chain] = cr
 	}
 
+	bhClient := beholder.GetClient().ForPackage("ocr3-ccip-execute")
+
 	ccipReader, err := readerpkg.NewCCIPChainReader(
 		ctx,
 		logutil.WithComponent(lggr, "CCIPReader"),
@@ -161,6 +163,7 @@ func (p PluginFactory) NewReportingPlugin(
 		p.ocrConfig.Config.OfframpAddress,
 		p.addrCodec,
 		offchainConfig.PopulateTxHashEnabled,
+		bhClient.Meter,
 	)
 	if err != nil {
 		return nil, ocr3types.ReportingPluginInfo{}, fmt.Errorf("failed to create ccip reader: %w", err)
@@ -180,8 +183,6 @@ func (p PluginFactory) NewReportingPlugin(
 	if err != nil {
 		return nil, ocr3types.ReportingPluginInfo{}, fmt.Errorf("failed to create token data observer: %w", err)
 	}
-
-	bhClient := beholder.GetClient().ForPackage("ocr3-ccip-execute")
 
 	metricsReporter, err := metrics.NewPromReporter(lggr, p.ocrConfig.Config.ChainSelector, bhClient)
 	if err != nil {

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -27,6 +27,9 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/pkg/addressbook"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
 	"github.com/smartcontractkit/chainlink-ccip/pkg/logutil"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/reader/rcmetrics"
+
+	"go.opentelemetry.io/otel/metric"
 )
 
 // Default refresh period for cache if not specified
@@ -46,6 +49,8 @@ type ccipChainReader struct {
 	addrCodec             cciptypes.AddressCodec
 	donAddressBook        *addressbook.Book
 	populateTxHashEnabled bool
+
+	rcMetrc rcmetrics.ReaderMetrics
 }
 
 func newCCIPChainReaderInternal(
@@ -70,6 +75,7 @@ func newCCIPChainReaderInternal(
 		addrCodec,
 		nil,
 		populateTxHashEnabled,
+		nil,
 	)
 }
 
@@ -84,6 +90,7 @@ func newCCIPChainReaderWithConfigPollerInternal(
 	addrCodec cciptypes.AddressCodec,
 	configPoller ConfigPoller,
 	populateTxHashEnabled bool,
+	meter metric.Meter,
 ) (*ccipChainReader, error) {
 	var crs = make(map[cciptypes.ChainSelector]contractreader.Extended)
 	for chainSelector, cr := range contractReaders {
@@ -96,6 +103,15 @@ func newCCIPChainReaderWithConfigPollerInternal(
 		panic(fmt.Sprintf("failed to convert offramp address to string: %v", err))
 	}
 
+	rcMetrc, err := rcmetrics.NewReaderMetrics(meter)
+	if err != nil {
+		return nil, fmt.Errorf("init reader metrics: %w", err)
+	}
+	configPollerMetrics, err := rcmetrics.NewConfigPollerMetrics(meter)
+	if err != nil {
+		return nil, fmt.Errorf("init config poller metrics: %w", err)
+	}
+
 	reader := &ccipChainReader{
 		lggr:                  lggr,
 		contractReaders:       crs,
@@ -106,13 +122,14 @@ func newCCIPChainReaderWithConfigPollerInternal(
 		addrCodec:             addrCodec,
 		donAddressBook:        addressbook.NewBook(),
 		populateTxHashEnabled: populateTxHashEnabled,
+		rcMetrc:               rcMetrc,
 	}
 
 	// Initialize cache with readers
 	if configPoller != nil {
 		reader.configPoller = configPoller
 	} else {
-		reader.configPoller = newConfigPollerV2(lggr, chainAccessors, destChain, defaultRefreshPeriod)
+		reader.configPoller = newConfigPollerV2(lggr, chainAccessors, destChain, defaultRefreshPeriod, configPollerMetrics)
 	}
 
 	contracts := cciptypes.ContractAddresses{
@@ -363,33 +380,41 @@ func (r *ccipChainReader) NextSeqNum(
 		minSeqNrMissing []cciptypes.ChainSelector
 	)
 	for _, chain := range chains {
+		chainLabel := rcmetrics.ChainLabel(chain)
+
 		cfg, exists := cfgs[chain]
 		if !exists {
 			configNotFound = append(configNotFound, chain)
+			r.rcMetrc.RecordChainGap("NextSeqNum", chainLabel, "not_found")
 			continue
 		}
 
 		if !cfg.IsEnabled {
 			disabledChains = append(disabledChains, chain)
+			r.rcMetrc.RecordChainGap("NextSeqNum", chainLabel, "disabled")
 			continue
 		}
 
 		if len(cfg.OnRamp) == 0 {
 			onRampMissing = append(onRampMissing, chain)
+			r.rcMetrc.RecordChainGap("NextSeqNum", chainLabel, "misconfigured")
 			continue
 		}
 
 		if len(cfg.Router) == 0 {
 			routerMissing = append(routerMissing, chain)
+			r.rcMetrc.RecordChainGap("NextSeqNum", chainLabel, "misconfigured")
 			continue
 		}
 
 		if cfg.MinSeqNr == 0 {
 			minSeqNrMissing = append(minSeqNrMissing, chain)
+			r.rcMetrc.RecordChainGap("NextSeqNum", chainLabel, "misconfigured")
 			continue
 		}
 
 		res[chain] = cciptypes.SeqNum(cfg.MinSeqNr)
+		r.rcMetrc.RecordChainGap("NextSeqNum", chainLabel, "returned")
 	}
 
 	logutil.LogWhenExceedFrequency(&nextSeqNumLastLog, readerLogFrequency, func() {
@@ -446,8 +471,10 @@ func (r *ccipChainReader) GetChainsFeeComponents(
 
 	for _, chain := range chains {
 		func(chain cciptypes.ChainSelector) {
+			chainLabel := rcmetrics.ChainLabel(chain)
 			chainAccessor, err := getChainAccessor(r.accessors, chain)
 			if err != nil {
+				r.rcMetrc.RecordChainGap("GetChainsFeeComponents", chainLabel, "no_accessor")
 				logutil.LogWhenExceedFrequency(&getChainsFeeComponentsAccessorLastLog, readerLogFrequency, func() {
 					lggr.Debugw("failed to get chain accessor", logutil.FieldChain, chain, "err", err)
 				})
@@ -458,6 +485,7 @@ func (r *ccipChainReader) GetChainsFeeComponents(
 			defer chainCancel()
 			feeComponent, err := chainAccessor.GetChainFeeComponents(chainCtx)
 			if err != nil {
+				r.rcMetrc.RecordChainGap("GetChainsFeeComponents", chainLabel, "error")
 				if errors.Is(err, context.DeadlineExceeded) {
 					lggr.Warnw("timed out getting chain fee components", logutil.FieldChain, chain)
 				} else {
@@ -468,10 +496,12 @@ func (r *ccipChainReader) GetChainsFeeComponents(
 
 			if feeComponent.ExecutionFee == nil || feeComponent.ExecutionFee.Cmp(big.NewInt(0)) <= 0 {
 				lggr.Errorw("execution fee is nil or non positive", logutil.FieldChain, chain)
+				r.rcMetrc.RecordChainGap("GetChainsFeeComponents", chainLabel, "invalid")
 				return
 			}
 			if feeComponent.DataAvailabilityFee == nil || feeComponent.DataAvailabilityFee.Cmp(big.NewInt(0)) < 0 {
 				lggr.Errorw("data availability fee is nil or negative", logutil.FieldChain, chain)
+				r.rcMetrc.RecordChainGap("GetChainsFeeComponents", chainLabel, "invalid")
 				return
 			}
 
@@ -479,6 +509,7 @@ func (r *ccipChainReader) GetChainsFeeComponents(
 				ExecutionFee:        feeComponent.ExecutionFee,
 				DataAvailabilityFee: feeComponent.DataAvailabilityFee,
 			}
+			r.rcMetrc.RecordChainGap("GetChainsFeeComponents", chainLabel, "returned")
 		}(chain)
 	}
 	return feeComponents
@@ -516,6 +547,7 @@ func (r *ccipChainReader) GetWrappedNativeTokenPriceUSD(
 
 			chainAccessor, err := getChainAccessor(r.accessors, chain)
 			if err != nil {
+				r.rcMetrc.RecordChainGap("GetWrappedNativeTokenPriceUSD", rcmetrics.ChainLabel(chain), "no_accessor")
 				logutil.LogWhenExceedFrequency(&wrappedNativeTokenPriceAccessorLastLog, readerLogFrequency, func() {
 					lggr.Debugw("chain accessor not found, chain native price skipped", logutil.FieldChain, chain, "err", err)
 				})
@@ -524,6 +556,7 @@ func (r *ccipChainReader) GetWrappedNativeTokenPriceUSD(
 
 			config, err := r.configPoller.GetChainConfig(chainCtx, chain)
 			if err != nil {
+				r.rcMetrc.RecordChainGap("GetWrappedNativeTokenPriceUSD", rcmetrics.ChainLabel(chain), "config_error")
 				if errors.Is(err, context.DeadlineExceeded) {
 					lggr.Warnw("timed out getting chain config for native token address", logutil.FieldChain, chain)
 				} else {
@@ -536,6 +569,7 @@ func (r *ccipChainReader) GetWrappedNativeTokenPriceUSD(
 			nativeTokenAddress := config.Router.WrappedNativeAddress
 
 			if cciptypes.UnknownAddress(nativeTokenAddress).IsZeroOrEmpty() {
+				r.rcMetrc.RecordChainGap("GetWrappedNativeTokenPriceUSD", rcmetrics.ChainLabel(chain), "no_native_token")
 				lggr.Debug("Native token address is zero or empty. Ignore for disabled chains otherwise "+
 					"check for router misconfiguration", "chain", chain, "address", nativeTokenAddress.String())
 				return
@@ -543,6 +577,7 @@ func (r *ccipChainReader) GetWrappedNativeTokenPriceUSD(
 
 			price, err := chainAccessor.GetTokenPriceUSD(chainCtx, cciptypes.UnknownAddress(nativeTokenAddress))
 			if err != nil {
+				r.rcMetrc.RecordChainGap("GetWrappedNativeTokenPriceUSD", rcmetrics.ChainLabel(chain), "error")
 				if errors.Is(err, context.DeadlineExceeded) {
 					lggr.Warnw(MsgTimedOutGettingNativeTokenPrice, logutil.FieldChain, chain, "address", nativeTokenAddress.String())
 				} else {
@@ -553,10 +588,12 @@ func (r *ccipChainReader) GetWrappedNativeTokenPriceUSD(
 			}
 
 			if price.Timestamp == 0 {
+				r.rcMetrc.RecordChainGap("GetWrappedNativeTokenPriceUSD", rcmetrics.ChainLabel(chain), "stale")
 				lggr.Warnw(MsgNoNativeTokenPriceAvailable, logutil.FieldChain, chain)
 				return
 			}
 			if price.Value == nil || price.Value.Cmp(big.NewInt(0)) <= 0 {
+				r.rcMetrc.RecordChainGap("GetWrappedNativeTokenPriceUSD", rcmetrics.ChainLabel(chain), "invalid")
 				lggr.Errorw(MsgNativeTokenPriceNilOrNonPositive, logutil.FieldChain, chain)
 				return
 			}
@@ -564,6 +601,7 @@ func (r *ccipChainReader) GetWrappedNativeTokenPriceUSD(
 			mu.Lock()
 			prices[chain] = cciptypes.NewBigInt(price.Value)
 			mu.Unlock()
+			r.rcMetrc.RecordChainGap("GetWrappedNativeTokenPriceUSD", rcmetrics.ChainLabel(chain), "returned")
 		})
 	}
 
@@ -598,6 +636,20 @@ func (r *ccipChainReader) GetChainFeePriceUpdate(ctx context.Context, selectors 
 	var result = make(map[cciptypes.ChainSelector]cciptypes.TimestampedBig, len(updates))
 	for chain, update := range updates {
 		result[chain] = cciptypes.TimeStampedBigFromUnix(update)
+	}
+
+	// Reconcile requested vs returned: a chain missing from the result is a silent
+	// gap (the accessor does not log which chains it failed to include).
+	for _, chain := range selectors {
+		chainLabel := rcmetrics.ChainLabel(chain)
+		if _, ok := result[chain]; ok {
+			r.rcMetrc.RecordChainGap("GetChainFeePriceUpdate", chainLabel, "returned")
+		} else {
+			r.rcMetrc.RecordChainGap("GetChainFeePriceUpdate", chainLabel, "missing")
+		}
+	}
+	if len(result) == 0 {
+		r.rcMetrc.RecordReadEmpty("GetChainFeePriceUpdate", rcmetrics.ChainLabel(r.destChain))
 	}
 
 	return result

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -297,6 +297,26 @@ func (r *ccipChainReader) MsgsBetweenSeqNums(
 		}
 	}
 
+	// An empty message read with no error is the false-idle primitive: "no messages
+	// to this dest in this range" is indistinguishable on its own from "the on-ramp
+	// event index returned nothing". Surface it so the data-source gate can tell the
+	// reader failing to deliver data apart from a genuinely quiet lane.
+	if len(messages) == 0 {
+		r.rcMetrc.RecordReadEmpty("MsgsBetweenSeqNums", rcmetrics.ChainLabel(sourceChainSelector))
+	}
+
+	// A message read whose count doesn't match the requested range means the read
+	// came back partial/incomplete (messages missing from an indexed range). This
+	// mirrors the commit merkleroot observer's msg-count check (observation.go) at
+	// the data-source layer, so the (plugin-generic) chain_gap signal names it before
+	// it reaches a consensus/root stage. Aligned to the same expression so the two
+	// never disagree.
+	if uint64(len(messages)) != uint64(seqNumRange.End()-seqNumRange.Start()+1) {
+		r.rcMetrc.RecordChainGap("MsgsBetweenSeqNums", rcmetrics.ChainLabel(sourceChainSelector), "count_mismatch")
+	} else {
+		r.rcMetrc.RecordChainGap("MsgsBetweenSeqNums", rcmetrics.ChainLabel(sourceChainSelector), "returned")
+	}
+
 	return messages, nil
 }
 
@@ -317,6 +337,14 @@ func (r *ccipChainReader) LatestMsgSeqNum(
 
 	lggr.Debugw("chain reader returning latest onramp sequence number",
 		logutil.FieldSeqNum, seqNum, logutil.FieldSourceChain, chain)
+
+	// seq 0 with no error = the on-ramp event index returned nothing for "latest
+	// message to dest" -> indistinguishable from "no message ever sent" upstream.
+	// Surface it so the data-source gate can see a possibly-empty read.
+	if seqNum == 0 {
+		r.rcMetrc.RecordReadEmpty("LatestMsgSeqNum", rcmetrics.ChainLabel(chain))
+	}
+
 	return seqNum, nil
 }
 

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"maps"
 	"math/big"
+	"os"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -278,6 +279,16 @@ func (r *ccipChainReader) MsgsBetweenSeqNums(
 	messages, err := sourceChainAccessor.MsgsBetweenSeqNums(ctx, r.destChain, seqNumRange)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call MsgsBetweenSeqNums on sourceChainAccessor: %w", err)
+	}
+
+	// TEST-ONLY fault injection: simulate a data-source miss by replacing the result with
+	// empty (no error), so a sent message is observed on the onramp but never built into a
+	// commit root. Placed AFTER the accessor call so the read_empty / chain_gap{count_mismatch}
+	// instrumentation below still records it (an early return would skip it). Must NEVER merge.
+	if os.Getenv("CCIP_TEST_FORCE_EMPTY_MSGS") != "" {
+		r.lggr.Warnw("TEST ONLY: forcing empty MsgsBetweenSeqNums to simulate a data-source miss",
+			"chain", sourceChainSelector, "range", seqNumRange)
+		messages = nil
 	}
 
 	onRampAddressAfterQuery, err := sourceChainAccessor.GetContractAddress(consts.ContractNameOnRamp)

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -62,7 +62,6 @@ func newCCIPChainReaderInternal(
 	destChain cciptypes.ChainSelector,
 	offrampAddress []byte,
 	addrCodec cciptypes.AddressCodec,
-	populateTxHashEnabled bool,
 ) (*ccipChainReader, error) {
 	return newCCIPChainReaderWithConfigPollerInternal(
 		ctx,
@@ -74,7 +73,7 @@ func newCCIPChainReaderInternal(
 		offrampAddress,
 		addrCodec,
 		nil,
-		populateTxHashEnabled,
+		false, // test/deprecated-only helper; production passes the real value via NewCCIPChainReader
 		nil,
 	)
 }

--- a/pkg/reader/ccip.go
+++ b/pkg/reader/ccip.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"maps"
 	"math/big"
-	"os"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -279,16 +278,6 @@ func (r *ccipChainReader) MsgsBetweenSeqNums(
 	messages, err := sourceChainAccessor.MsgsBetweenSeqNums(ctx, r.destChain, seqNumRange)
 	if err != nil {
 		return nil, fmt.Errorf("failed to call MsgsBetweenSeqNums on sourceChainAccessor: %w", err)
-	}
-
-	// TEST-ONLY fault injection: simulate a data-source miss by replacing the result with
-	// empty (no error), so a sent message is observed on the onramp but never built into a
-	// commit root. Placed AFTER the accessor call so the read_empty / chain_gap{count_mismatch}
-	// instrumentation below still records it (an early return would skip it). Must NEVER merge.
-	if os.Getenv("CCIP_TEST_FORCE_EMPTY_MSGS") != "" {
-		r.lggr.Warnw("TEST ONLY: forcing empty MsgsBetweenSeqNums to simulate a data-source miss",
-			"chain", sourceChainSelector, "range", seqNumRange)
-		messages = nil
 	}
 
 	onRampAddressAfterQuery, err := sourceChainAccessor.GetContractAddress(consts.ContractNameOnRamp)

--- a/pkg/reader/ccip_interface.go
+++ b/pkg/reader/ccip_interface.go
@@ -13,6 +13,8 @@ import (
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	"github.com/smartcontractkit/chainlink-ccip/pkg/contractreader"
+
+	"go.opentelemetry.io/otel/metric"
 )
 
 var (
@@ -90,8 +92,14 @@ func NewCCIPChainReader(
 	offrampAddress []byte,
 	addrCodec cciptypes.AddressCodec,
 	populateTxHashEnabled bool,
+	meters ...metric.Meter,
 ) (CCIPReader, error) {
-	reader, err := newCCIPChainReaderInternal(
+	var meter metric.Meter
+	if len(meters) > 0 {
+		meter = meters[0]
+	}
+
+	reader, err := newCCIPChainReaderWithConfigPollerInternal(
 		ctx,
 		lggr,
 		chainAccessors,
@@ -100,7 +108,9 @@ func NewCCIPChainReader(
 		destChain,
 		offrampAddress,
 		addrCodec,
+		nil,
 		populateTxHashEnabled,
+		meter,
 	)
 	if err != nil {
 		return nil, err
@@ -109,7 +119,8 @@ func NewCCIPChainReader(
 		reader,
 		lggr,
 		destChain,
-	), nil
+		meter,
+	)
 }
 
 // NewCCIPReaderWithExtendedContractReaders can be used when you want to directly provide contractreader.Extended

--- a/pkg/reader/ccip_interface.go
+++ b/pkg/reader/ccip_interface.go
@@ -144,7 +144,6 @@ func NewCCIPReaderWithExtendedContractReaders(
 		destChain,
 		offrampAddress,
 		addrCodec,
-		false, // populateTxHashEnabled - default to false for deprecated test function
 	)
 	if err != nil {
 		// Panic here since right now this is only called from tests in core

--- a/pkg/reader/ccip_test.go
+++ b/pkg/reader/ccip_test.go
@@ -1241,6 +1241,7 @@ func TestCCIPChainReader_GetWrappedNativeTokenPriceUSD(t *testing.T) {
 			internal.NewMockAddressCodecHex(t),
 			mockCache,
 			false,
+			nil,
 		)
 		require.NoError(t, err)
 
@@ -1290,6 +1291,7 @@ func TestCCIPChainReader_GetWrappedNativeTokenPriceUSD(t *testing.T) {
 			internal.NewMockAddressCodecHex(t),
 			mockCache,
 			false,
+			nil,
 		)
 		require.NoError(t, err)
 
@@ -1333,6 +1335,7 @@ func TestCCIPChainReader_GetWrappedNativeTokenPriceUSD(t *testing.T) {
 			internal.NewMockAddressCodecHex(t),
 			mockCache,
 			false,
+			nil,
 		)
 		require.NoError(t, err)
 
@@ -1398,6 +1401,7 @@ func TestCCIPChainReader_GetWrappedNativeTokenPriceUSD(t *testing.T) {
 			internal.NewMockAddressCodecHex(t),
 			mockCache,
 			false,
+			nil,
 		)
 		require.NoError(t, err)
 
@@ -1766,6 +1770,7 @@ func Test_ccipChainReader_MsgsBetweenSeqNums_TxHash(t *testing.T) {
 				internal.NewMockAddressCodecHex(t),
 				mockCache,
 				tc.populateTxHashEnabled,
+				nil,
 			)
 			require.NoError(t, err)
 

--- a/pkg/reader/ccip_test.go
+++ b/pkg/reader/ccip_test.go
@@ -99,7 +99,6 @@ func TestCCIPChainReader_Sync_HappyPath_BindsContractsSuccessfully(t *testing.T)
 		destChain,
 		offRamp,
 		mockAddrCodec,
-		false,
 	)
 	require.NoError(t, err)
 
@@ -161,7 +160,6 @@ func TestCCIPChainReader_Sync_HappyPath_SkipsEmptyAddress(t *testing.T) {
 		destChain,
 		offRamp,
 		mockAddrCodec,
-		false,
 	)
 	require.NoError(t, err)
 
@@ -218,7 +216,6 @@ func TestCCIPChainReader_Sync_HappyPath_DontSupportAllChains(t *testing.T) {
 		destChain,
 		offRamp,
 		mockAddrCodec,
-		false,
 	)
 	require.NoError(t, err)
 
@@ -280,7 +277,6 @@ func TestCCIPChainReader_Sync_BindError(t *testing.T) {
 		destChain,
 		offRamp,
 		mockAddrCodec,
-		false,
 	)
 	require.NoError(t, err)
 
@@ -620,7 +616,6 @@ func TestCCIPChainReader_getFeeQuoterTokenPriceUSD(t *testing.T) {
 		map[cciptypes.ChainSelector]contractreader.ContractReaderFacade{
 			chainC: readermocks.NewMockContractReaderFacade(t),
 		}, contractWriters, chainC, offrampAddress, mockAddrCodec,
-		false,
 	)
 	require.NoError(t, err)
 
@@ -674,7 +669,6 @@ func TestCCIPFeeComponents_HappyPath(t *testing.T) {
 		chainC,
 		offRampAddress,
 		internal.NewMockAddressCodecHex(t),
-		false,
 	)
 	require.NoError(t, err)
 
@@ -738,7 +732,6 @@ func TestCCIPFeeComponents_HungRPCOnOneChainDoesNotBlockOthers(t *testing.T) {
 		chainB,
 		offRampAddress,
 		internal.NewMockAddressCodecHex(t),
-		false,
 	)
 	require.NoError(t, err)
 
@@ -1019,7 +1012,6 @@ func TestCCIPChainReader_Nonces(t *testing.T) {
 				chainB,
 				offRampAddress,
 				internal.NewMockAddressCodecHex(t),
-				false,
 			)
 			require.NoError(t, err)
 
@@ -1447,7 +1439,6 @@ func TestCCIPChainReader_GetChainFeePriceUpdate(t *testing.T) {
 			chainB,
 			offRampAddress,
 			internal.NewMockAddressCodecHex(t),
-			false,
 		)
 		require.NoError(t, err)
 
@@ -1504,7 +1495,6 @@ func TestCCIPChainReader_GetChainFeePriceUpdate(t *testing.T) {
 			destChain,
 			offRampAddress,
 			internal.NewMockAddressCodecHex(t),
-			false,
 		)
 		require.NoError(t, err)
 
@@ -1540,7 +1530,6 @@ func TestCCIPChainReader_GetChainFeePriceUpdate(t *testing.T) {
 			destChain,
 			offRampAddress,
 			internal.NewMockAddressCodecHex(t),
-			false,
 		)
 		require.NoError(t, err)
 
@@ -1581,7 +1570,6 @@ func TestCCIPChainReader_GetChainFeePriceUpdate(t *testing.T) {
 			destChain,
 			offRampAddress,
 			internal.NewMockAddressCodecHex(t),
-			false,
 		)
 		require.NoError(t, err)
 
@@ -1623,7 +1611,6 @@ func TestCCIPChainReader_GetChainFeePriceUpdate(t *testing.T) {
 			destChain,
 			offRampAddress,
 			internal.NewMockAddressCodecHex(t),
-			false,
 		)
 		require.NoError(t, err)
 
@@ -1644,7 +1631,6 @@ func TestCCIPChainReader_GetChainFeePriceUpdate(t *testing.T) {
 			destChain,
 			[]byte("0x3"),
 			internal.NewMockAddressCodecHex(t),
-			false,
 		)
 		require.NoError(t, err)
 

--- a/pkg/reader/config_poller_v2.go
+++ b/pkg/reader/config_poller_v2.go
@@ -3,6 +3,7 @@ package reader
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -12,6 +13,7 @@ import (
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	"github.com/smartcontractkit/chainlink-ccip/pkg/logutil"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/reader/rcmetrics"
 )
 
 // Analyzer-relevant log messages emitted by the config poller.
@@ -68,6 +70,8 @@ type configPollerV2 struct {
 	stopChan               chan struct{}
 	wg                     sync.WaitGroup
 	consecutiveFailedPolls atomic.Uint32
+
+	metrics rcmetrics.ConfigPollerMetrics
 }
 
 // chainCache represents the cache for a single chain.
@@ -100,6 +104,7 @@ func newConfigPollerV2(
 	accessors map[cciptypes.ChainSelector]cciptypes.ChainAccessor,
 	destChainSelector cciptypes.ChainSelector,
 	refreshPeriod time.Duration,
+	metrics rcmetrics.ConfigPollerMetrics,
 ) *configPollerV2 {
 	return &configPollerV2{
 		chainCaches:       make(map[cciptypes.ChainSelector]*chainCache),
@@ -109,6 +114,7 @@ func newConfigPollerV2(
 		lggr:              lggr,
 		knownSourceChains: make(map[cciptypes.ChainSelector]struct{}),
 		stopChan:          make(chan struct{}),
+		metrics:           metrics,
 	}
 }
 
@@ -226,10 +232,12 @@ func (c *configPollerV2) GetChainConfig(
 	// Check if we have any data in cache
 	cache.chainConfigMu.RLock()
 	if !cache.chainConfigRefresh.IsZero() {
+		age := time.Since(cache.chainConfigRefresh)
+		c.metrics.RecordCacheAge(rcmetrics.ChainLabel(chainSel), "chain", int64(age.Seconds()))
 		defer cache.chainConfigMu.RUnlock()
 		c.lggr.Debugw("Returning cached chain config",
 			logutil.FieldChain, chainSel,
-			"cacheAge", time.Since(cache.chainConfigRefresh))
+			"cacheAge", age)
 		return cache.chainConfigData, nil
 	}
 	cache.chainConfigMu.RUnlock()
@@ -320,6 +328,7 @@ func (c *configPollerV2) GetOfframpSourceChainConfigs(
 
 	// If all chains are in cache, return them immediately
 	if len(missingChains) == 0 {
+		c.recordSourceCacheAge(destChainCache)
 		destChainCache.sourceChainMu.RUnlock()
 		c.lggr.Debugw("All source chain configs found in cache",
 			logutil.FieldDestChain, c.destChainSelector,
@@ -337,6 +346,7 @@ func (c *configPollerV2) GetOfframpSourceChainConfigs(
 	// Re-acquire the lock to return only the cached configs that were requested
 	destChainCache.sourceChainMu.RLock()
 	defer destChainCache.sourceChainMu.RUnlock()
+	c.recordSourceCacheAge(destChainCache)
 	result := make(map[cciptypes.ChainSelector]StaticSourceChainConfig)
 	for _, chain := range filteredSourceChains {
 		if cfg, exists := destChainCache.staticSourceChainConfigs[chain]; exists {
@@ -344,6 +354,17 @@ func (c *configPollerV2) GetOfframpSourceChainConfigs(
 		}
 	}
 	return result, nil
+}
+
+// recordSourceCacheAge emits the source-chain config cache freshness. The caller
+// must hold destChainCache.sourceChainMu (read or write) — it reads the guard
+// timestamp and must not race a refresh overwrite.
+func (c *configPollerV2) recordSourceCacheAge(cache *chainCache) {
+	if cache.sourceChainRefresh.IsZero() {
+		return
+	}
+	c.metrics.RecordCacheAge(rcmetrics.ChainLabel(c.destChainSelector), "source",
+		int64(time.Since(cache.sourceChainRefresh).Seconds()))
 }
 
 // getOrCreateChainCache safely retrieves an existing cache or creates a new one for the specified chain.
@@ -389,13 +410,19 @@ func (c *configPollerV2) refreshAllKnownChains() {
 	chainsToRefresh := c.getChainsToRefresh()
 
 	refreshFailed := false
+	now := time.Now()
 	for _, chain := range chainsToRefresh {
 		ctx, cancel := context.WithTimeout(context.Background(), bgRefreshTimeout)
+		chainLabel := rcmetrics.ChainLabel(chain)
 		c.lggr.Debugw("Issuing background refresh for known chain",
 			logutil.FieldChain, chain, logutil.FieldDestChain, c.destChainSelector)
 		if err := c.batchRefreshChainAndSourceConfigs(ctx, chain); err != nil {
 			refreshFailed = true
+			c.metrics.RecordPollFailure(chainLabel)
 			c.lggr.Warnw("Failed to batch refresh configs", logutil.FieldChain, chain, "error", err)
+		} else {
+			c.metrics.RecordPollSuccess(chainLabel)
+			c.metrics.RecordLastSuccess(chainLabel, now.Unix())
 		}
 		cancel()
 	}
@@ -453,10 +480,21 @@ func (c *configPollerV2) batchRefreshChainAndSourceConfigs(
 		return fmt.Errorf("failed to get chain cache for chain %s", chainSel)
 	}
 
-	// Acquire ChainConfigSnapshot lock and update
+	// Acquire ChainConfigSnapshot lock and update. Guard against the accessor
+	// returning an *empty* snapshot with a nil error (see reader-metrics.md:
+	// GetAllConfigsLegacy can do this on a "partial" failure): writing that here
+	// would time-stamp empty data as fresh and serve it to every consumer. Keep
+	// the previously-good cache and do NOT mark it fresh so the gap stays visible
+	// to RecordCacheAge instead of being masked.
 	cache.chainConfigMu.Lock()
-	cache.chainConfigData = chainConfigSnapshot
-	cache.chainConfigRefresh = time.Now()
+	if reflect.DeepEqual(chainConfigSnapshot, cciptypes.ChainConfigSnapshot{}) {
+		c.metrics.RecordOverwrittenEmpty("chain")
+		c.lggr.Warnw("chain config snapshot returned empty, keeping existing cached config",
+			logutil.FieldChain, chainSel)
+	} else {
+		cache.chainConfigData = chainConfigSnapshot
+		cache.chainConfigRefresh = time.Now()
+	}
 	cache.chainConfigMu.Unlock()
 
 	// Acquire StaticSourceChainConfigs lock and update

--- a/pkg/reader/config_poller_v2_test.go
+++ b/pkg/reader/config_poller_v2_test.go
@@ -17,6 +17,7 @@ import (
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs/testhelpers/rand"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/reader/rcmetrics"
 
 	mock_ccipocr3 "github.com/smartcontractkit/chainlink-ccip/mocks/chainlink_common/ccipocr3"
 )
@@ -45,11 +46,15 @@ func setupConfigPollerV2(t *testing.T) (*configPollerV2, map[cciptypes.ChainSele
 		chainAccessors[chain] = accessor
 	}
 
+	pollerMetrics, err := rcmetrics.NewConfigPollerMetrics(nil)
+	require.NoError(t, err)
+
 	cPollerV2 := newConfigPollerV2(
 		logger.Test(t),
 		chainAccessors,
 		destChain,            // destination chain
 		100*time.Millisecond, // short refresh period for testing
+		pollerMetrics,
 	)
 
 	return cPollerV2, accessors

--- a/pkg/reader/observed_ccip.go
+++ b/pkg/reader/observed_ccip.go
@@ -2,6 +2,7 @@ package reader
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -15,6 +16,9 @@ import (
 	cciptypes "github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
 
 	"github.com/smartcontractkit/chainlink-ccip/internal/libs"
+	"github.com/smartcontractkit/chainlink-ccip/pkg/reader/rcmetrics"
+
+	"go.opentelemetry.io/otel/metric"
 )
 
 const (
@@ -78,14 +82,27 @@ type observedCCIPReader struct {
 	queryHistogram   *prometheus.HistogramVec
 	dataSetSizeGauge *prometheus.GaugeVec
 	chainFeesGauge   *prometheus.GaugeVec
+
+	// Beholder instrumentation (never nil; NoOp when no meter configured).
+	obMetrics rcmetrics.ObservedReaderMetrics
 }
 
 func NewObservedCCIPReader(
 	reader CCIPReader,
 	lggr logger.Logger,
 	destChainSelector cciptypes.ChainSelector,
-) CCIPReader {
+	meters ...metric.Meter,
+) (CCIPReader, error) {
 	chainFamily, chainID, _ := libs.GetChainInfoFromSelector(destChainSelector)
+
+	var meter metric.Meter
+	if len(meters) > 0 {
+		meter = meters[0]
+	}
+	obMetrics, err := rcmetrics.NewObservedReaderMetrics(meter)
+	if err != nil {
+		return nil, fmt.Errorf("init observed reader metrics: %w", err)
+	}
 
 	return &observedCCIPReader{
 		CCIPReader: reader,
@@ -98,7 +115,9 @@ func NewObservedCCIPReader(
 		queryHistogram:   PromQueryHistogram,
 		dataSetSizeGauge: PromDataSetSizeGauge,
 		chainFeesGauge:   PromChainFeeGauge,
-	}
+
+		obMetrics: obMetrics,
+	}, nil
 }
 
 func (o *observedCCIPReader) CommitReportsGTETimestamp(
@@ -308,12 +327,14 @@ func (o *observedCCIPReader) trackChainFeeComponents(
 			o.chainFeesGauge.
 				WithLabelValues(chainFamily, chainID, execCostLabel).
 				Set(execFeeFloat)
+			o.obMetrics.RecordChainFee(chainFamily, chainID, execCostLabel, int64(execFeeFloat))
 		}
 		if v.DataAvailabilityFee != nil {
 			dataFeeFloat, _ := new(big.Float).SetInt(v.DataAvailabilityFee).Float64()
 			o.chainFeesGauge.
 				WithLabelValues(chainFamily, chainID, dataCostLabel).
 				Set(dataFeeFloat)
+			o.obMetrics.RecordChainFee(chainFamily, chainID, dataCostLabel, int64(dataFeeFloat))
 		}
 
 		o.lggr.Debugw(
@@ -343,11 +364,15 @@ func withObservedQueryAndResult[T any](
 		WithLabelValues(o.destChainFamily, o.destChain, queryName).
 		Observe(float64(duration))
 
+	size := float64(0)
 	if err == nil && dataSizeFn != nil {
+		size = dataSizeFn(results)
 		o.dataSetSizeGauge.
 			WithLabelValues(o.destChainFamily, o.destChain, queryName).
-			Set(dataSizeFn(results))
+			Set(size)
 	}
+
+	o.recordReadOutcome(queryName, err, dataSizeFn != nil, size)
 
 	o.lggr.Debugw("observed CCIP Reader query",
 		"duration", duration,
@@ -356,6 +381,20 @@ func withObservedQueryAndResult[T any](
 	)
 
 	return results, err
+}
+
+// recordReadOutcome classifies a reader query into ok/empty/error. Reads that
+// have no size fn can't distinguish empty from ok, so they're reported as ok
+// unless they errored.
+func (o *observedCCIPReader) recordReadOutcome(queryName string, err error, hasSizeFn bool, size float64) {
+	outcome := "ok"
+	switch {
+	case err != nil:
+		outcome = "error"
+	case hasSizeFn && size == 0:
+		outcome = "empty"
+	}
+	o.obMetrics.RecordReadOutcome(o.destChain, queryName, outcome)
 }
 
 func sliceLength[T any](slice []T) float64 {

--- a/pkg/reader/observed_ccip_test.go
+++ b/pkg/reader/observed_ccip_test.go
@@ -44,7 +44,8 @@ func Test_GetChainsFeeComponents(t *testing.T) {
 	}
 
 	origin := mock_reader.NewMockCCIPReader(t)
-	r := reader.NewObservedCCIPReader(origin, logger.Test(t), selector1)
+	r, err := reader.NewObservedCCIPReader(origin, logger.Test(t), selector1)
+	require.NoError(t, err)
 
 	origin.EXPECT().
 		GetChainsFeeComponents(mock.Anything, mock.Anything).
@@ -125,7 +126,8 @@ func Test_CommitReportsGTETimestamp(t *testing.T) {
 			cleanupMetrics()()
 
 			origin := mock_reader.NewMockCCIPReader(t)
-			r := reader.NewObservedCCIPReader(origin, logger.Test(t), chainSelector)
+			r, errObs := reader.NewObservedCCIPReader(origin, logger.Test(t), chainSelector)
+			require.NoError(t, errObs)
 
 			origin.EXPECT().
 				CommitReportsGTETimestamp(ctx, mock.Anything, mock.Anything, mock.Anything).
@@ -156,7 +158,8 @@ func Test_LatestMsgSeqNum(t *testing.T) {
 	t.Cleanup(cleanupMetrics())
 
 	origin := mock_reader.NewMockCCIPReader(t)
-	r := reader.NewObservedCCIPReader(origin, logger.Test(t), chainSelector)
+	r, errObs := reader.NewObservedCCIPReader(origin, logger.Test(t), chainSelector)
+	require.NoError(t, errObs)
 
 	seqNr := cciptypes.SeqNum(1234)
 	success := cciptypes.ChainSelector(rand.RandomInt64())

--- a/pkg/reader/rcmetrics/noop.go
+++ b/pkg/reader/rcmetrics/noop.go
@@ -9,7 +9,6 @@ type NoopReaderMetrics struct{}
 
 func (NoopReaderMetrics) RecordChainGap(string, string, string) {}
 func (NoopReaderMetrics) RecordReadEmpty(string, string)        {}
-func (NoopReaderMetrics) RecordReadPartial(string, string)      {}
 func (NoopReaderMetrics) RecordMsgDropped(string, string)       {}
 
 // NoopObservedReaderMetrics is a no-op ObservedReaderMetrics.

--- a/pkg/reader/rcmetrics/noop.go
+++ b/pkg/reader/rcmetrics/noop.go
@@ -1,0 +1,36 @@
+package rcmetrics
+
+// NoOp implementations of the metrics interfaces. Returned by the New* constructors
+// when no beholder meter is configured, so callers never hold a nil value and
+// can call the record methods unconditionally. Each receiver is a no-op.
+
+// NoopReaderMetrics is a no-op ReaderMetrics.
+type NoopReaderMetrics struct{}
+
+func (NoopReaderMetrics) RecordChainGap(string, string, string) {}
+func (NoopReaderMetrics) RecordReadEmpty(string, string)        {}
+func (NoopReaderMetrics) RecordReadPartial(string, string)      {}
+func (NoopReaderMetrics) RecordMsgDropped(string, string)       {}
+
+// NoopObservedReaderMetrics is a no-op ObservedReaderMetrics.
+type NoopObservedReaderMetrics struct{}
+
+func (NoopObservedReaderMetrics) RecordReadOutcome(string, string, string)     {}
+func (NoopObservedReaderMetrics) RecordChainFee(string, string, string, int64) {}
+
+// NoopConfigPollerMetrics is a no-op ConfigPollerMetrics.
+type NoopConfigPollerMetrics struct{}
+
+func (NoopConfigPollerMetrics) RecordCacheAge(string, string, int64) {}
+func (NoopConfigPollerMetrics) RecordPollSuccess(string)             {}
+func (NoopConfigPollerMetrics) RecordPollFailure(string)             {}
+func (NoopConfigPollerMetrics) RecordOverwrittenEmpty(string)        {}
+func (NoopConfigPollerMetrics) RecordLastSuccess(string, int64)      {}
+
+// NoopAccessorMetrics is a no-op AccessorMetrics.
+type NoopAccessorMetrics struct{}
+
+func (NoopAccessorMetrics) RecordBatchResult(string, string, string) {}
+func (NoopAccessorMetrics) RecordEmptyRead(string, string)           {}
+func (NoopAccessorMetrics) RecordRowDrop(string, string, string)     {}
+func (NoopAccessorMetrics) RecordFinalityViolated(string)            {}

--- a/pkg/reader/rcmetrics/rcmetrics.go
+++ b/pkg/reader/rcmetrics/rcmetrics.go
@@ -1,0 +1,300 @@
+// Package rcmetrics holds the beholder instruments for the CCIP reader's
+// data-source layer (the CcipReader, the chain accessor wrapper, and the
+// config poller cache). This layer is shared by both the commit and execute
+// plugins, so every instrument is plugin-generic (no ccip_commit_* prefix).
+//
+// Each metrics set is an interface with a NoOp implementation (noop.go) so
+// callers never hold a nil value: the New* constructors return NoOp when no
+// beholder meter is available (e.g. in tests). This keeps call sites free of
+// nil-guards and makes the receivers easy to mock in future tests.
+//
+// The constructors return an error if an instrument fails to register; callers
+// must propagate it rather than ignore it (a registration failure would silently
+// drop the metric otherwise).
+package rcmetrics
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/types/ccipocr3"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// ReaderMetrics instruments the CcipReader's concrete methods (per-chain reads).
+type ReaderMetrics interface {
+	// RecordChainGap records, per read (query), how many source chains ended up in
+	// each state once the requested set is reconciled against what was returned.
+	RecordChainGap(query, chain, state string)
+	// RecordReadEmpty records a query that returned nothing with no error.
+	RecordReadEmpty(query, chain string)
+	// RecordReadPartial records a query that returned a subset of the requested set.
+	RecordReadPartial(query, chain string)
+	// RecordMsgDropped records a read record dropped on validation/cast.
+	RecordMsgDropped(query, reason string)
+}
+
+// readerMetrics implements ReaderMetrics against a beholder meter.
+type readerMetrics struct {
+	chainGap    metric.Int64Counter
+	readEmpty   metric.Int64Counter
+	readPartial metric.Int64Counter
+	msgDropped  metric.Int64Counter
+}
+
+// NewReaderMetrics registers the reader instruments against m. Returns a NoOp
+// implementation (and no error) when m is nil.
+func NewReaderMetrics(m metric.Meter) (ReaderMetrics, error) {
+	if m == nil {
+		return NoopReaderMetrics{}, nil
+	}
+	rm := &readerMetrics{}
+	var err error
+	if rm.chainGap, err = m.Int64Counter("ccip_reader_chain_gap"); err != nil {
+		return nil, fmt.Errorf("register ccip_reader_chain_gap: %w", err)
+	}
+	if rm.readEmpty, err = m.Int64Counter("ccip_reader_read_empty"); err != nil {
+		return nil, fmt.Errorf("register ccip_reader_read_empty: %w", err)
+	}
+	if rm.readPartial, err = m.Int64Counter("ccip_reader_read_partial"); err != nil {
+		return nil, fmt.Errorf("register ccip_reader_read_partial: %w", err)
+	}
+	if rm.msgDropped, err = m.Int64Counter("ccip_reader_msg_dropped"); err != nil {
+		return nil, fmt.Errorf("register ccip_reader_msg_dropped: %w", err)
+	}
+	return rm, nil
+}
+
+func (r *readerMetrics) RecordChainGap(query, chain, state string) {
+	r.chainGap.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("query", query),
+		attribute.String("chain", chain),
+		attribute.String("state", state),
+	))
+}
+
+func (r *readerMetrics) RecordReadEmpty(query, chain string) {
+	r.readEmpty.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("query", query),
+		attribute.String("chain", chain),
+	))
+}
+
+func (r *readerMetrics) RecordReadPartial(query, chain string) {
+	r.readPartial.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("query", query),
+		attribute.String("chain", chain),
+	))
+}
+
+func (r *readerMetrics) RecordMsgDropped(query, reason string) {
+	r.msgDropped.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("query", query),
+		attribute.String("reason", reason),
+	))
+}
+
+// ObservedReaderMetrics instruments the observedCCIPReader (per-query outcomes).
+type ObservedReaderMetrics interface {
+	// RecordReadOutcome records a reader query classified as ok/empty/error.
+	RecordReadOutcome(chainID, query, outcome string)
+	// RecordChainFee records an observed chain fee component (exec/da) value.
+	RecordChainFee(chainFamily, chainID, feeType string, value int64)
+}
+
+// observedReaderMetrics implements ObservedReaderMetrics against a meter.
+type observedReaderMetrics struct {
+	readOutcome metric.Int64Counter
+	bhChainFee  metric.Int64Gauge
+}
+
+// NewObservedReaderMetrics registers the observed-reader instruments against m.
+// Returns a NoOp implementation (and no error) when m is nil.
+func NewObservedReaderMetrics(m metric.Meter) (ObservedReaderMetrics, error) {
+	if m == nil {
+		return NoopObservedReaderMetrics{}, nil
+	}
+	om := &observedReaderMetrics{}
+	var err error
+	if om.readOutcome, err = m.Int64Counter("ccip_reader_read_outcome"); err != nil {
+		return nil, fmt.Errorf("register ccip_reader_read_outcome: %w", err)
+	}
+	if om.bhChainFee, err = m.Int64Gauge("ccip_reader_chain_fee_components"); err != nil {
+		return nil, fmt.Errorf("register ccip_reader_chain_fee_components: %w", err)
+	}
+	return om, nil
+}
+
+func (o *observedReaderMetrics) RecordReadOutcome(chainID, query, outcome string) {
+	o.readOutcome.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("chainID", chainID),
+		attribute.String("query", query),
+		attribute.String("outcome", outcome),
+	))
+}
+
+func (o *observedReaderMetrics) RecordChainFee(chainFamily, chainID, feeType string, value int64) {
+	o.bhChainFee.Record(context.Background(), value, metric.WithAttributes(
+		attribute.String("chainFamily", chainFamily),
+		attribute.String("chainID", chainID),
+		attribute.String("feeType", feeType),
+	))
+}
+
+// ConfigPollerMetrics instruments the config poller background cache.
+type ConfigPollerMetrics interface {
+	// RecordCacheAge gauges how stale the served cache is, per chain/kind.
+	RecordCacheAge(chain, kind string, ageSeconds int64)
+	// RecordPollSuccess / RecordPollFailure count background refresh outcomes per chain.
+	RecordPollSuccess(chain string)
+	RecordPollFailure(chain string)
+	// RecordOverwrittenEmpty counts refreshes that time-stamped empty data as fresh.
+	RecordOverwrittenEmpty(kind string)
+	// RecordLastSuccess records the last successful refresh (epoch seconds) per chain.
+	RecordLastSuccess(chain string, epochSeconds int64)
+}
+
+// configPollerMetrics implements ConfigPollerMetrics against a meter.
+type configPollerMetrics struct {
+	cacheAgeSeconds      metric.Int64Gauge
+	pollSuccess          metric.Int64Counter
+	pollFailure          metric.Int64Counter
+	overwrittenEmpty     metric.Int64Counter
+	lastSuccessTimestamp metric.Int64Gauge
+}
+
+// NewConfigPollerMetrics registers the config poller instruments against m.
+// Returns a NoOp implementation (and no error) when m is nil.
+func NewConfigPollerMetrics(m metric.Meter) (ConfigPollerMetrics, error) {
+	if m == nil {
+		return NoopConfigPollerMetrics{}, nil
+	}
+	cm := &configPollerMetrics{}
+	var err error
+	if cm.cacheAgeSeconds, err = m.Int64Gauge("ccip_reader_config_cache_age_seconds"); err != nil {
+		return nil, fmt.Errorf("register ccip_reader_config_cache_age_seconds: %w", err)
+	}
+	if cm.pollSuccess, err = m.Int64Counter("ccip_reader_config_poll_success"); err != nil {
+		return nil, fmt.Errorf("register ccip_reader_config_poll_success: %w", err)
+	}
+	if cm.pollFailure, err = m.Int64Counter("ccip_reader_config_poll_failure"); err != nil {
+		return nil, fmt.Errorf("register ccip_reader_config_poll_failure: %w", err)
+	}
+	if cm.overwrittenEmpty, err = m.Int64Counter("ccip_reader_config_cache_overwritten_empty"); err != nil {
+		return nil, fmt.Errorf("register ccip_reader_config_cache_overwritten_empty: %w", err)
+	}
+	if cm.lastSuccessTimestamp, err = m.Int64Gauge("ccip_reader_config_poller_last_success_timestamp"); err != nil {
+		return nil, fmt.Errorf("register ccip_reader_config_poller_last_success_timestamp: %w", err)
+	}
+	return cm, nil
+}
+
+func (c *configPollerMetrics) RecordCacheAge(chain, kind string, ageSeconds int64) {
+	c.cacheAgeSeconds.Record(context.Background(), ageSeconds, metric.WithAttributes(
+		attribute.String("chain", chain),
+		attribute.String("kind", kind),
+	))
+}
+
+func (c *configPollerMetrics) RecordPollSuccess(chain string) {
+	c.pollSuccess.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("chain", chain),
+	))
+}
+
+func (c *configPollerMetrics) RecordPollFailure(chain string) {
+	c.pollFailure.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("chain", chain),
+	))
+}
+
+func (c *configPollerMetrics) RecordOverwrittenEmpty(kind string) {
+	c.overwrittenEmpty.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("kind", kind),
+	))
+}
+
+func (c *configPollerMetrics) RecordLastSuccess(chain string, epochSeconds int64) {
+	c.lastSuccessTimestamp.Record(context.Background(), epochSeconds, metric.WithAttributes(
+		attribute.String("chain", chain),
+	))
+}
+
+// AccessorMetrics instruments the chain accessor wrapper (per-operation reads).
+// Retained for the interface-based pattern even though the accessor wrapper is
+// not yet wired; the NoOp fallback keeps callers nil-free when it lands.
+type AccessorMetrics interface {
+	RecordBatchResult(operation, chain, outcome string)
+	RecordEmptyRead(operation, chain string)
+	RecordRowDrop(operation, chain, reason string)
+	RecordFinalityViolated(chain string)
+}
+
+// accessorMetrics implements AccessorMetrics against a meter.
+type accessorMetrics struct {
+	batchResult      metric.Int64Counter
+	emptyRead        metric.Int64Counter
+	rowDrops         metric.Int64Counter
+	finalityViolated metric.Int64Counter
+}
+
+// NewAccessorMetrics registers the accessor instruments against m.
+// Returns a NoOp implementation (and no error) when m is nil.
+func NewAccessorMetrics(m metric.Meter) (AccessorMetrics, error) {
+	if m == nil {
+		return NoopAccessorMetrics{}, nil
+	}
+	am := &accessorMetrics{}
+	var err error
+	if am.batchResult, err = m.Int64Counter("ccip_reader_batch_result"); err != nil {
+		return nil, fmt.Errorf("register ccip_reader_batch_result: %w", err)
+	}
+	if am.emptyRead, err = m.Int64Counter("ccip_reader_accessor_empty_read"); err != nil {
+		return nil, fmt.Errorf("register ccip_reader_accessor_empty_read: %w", err)
+	}
+	if am.rowDrops, err = m.Int64Counter("ccip_reader_accessor_row_drops"); err != nil {
+		return nil, fmt.Errorf("register ccip_reader_accessor_row_drops: %w", err)
+	}
+	if am.finalityViolated, err = m.Int64Counter("ccip_reader_accessor_finality_violated"); err != nil {
+		return nil, fmt.Errorf("register ccip_reader_accessor_finality_violated: %w", err)
+	}
+	return am, nil
+}
+
+func (a *accessorMetrics) RecordBatchResult(operation, chain, outcome string) {
+	a.batchResult.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("operation", operation),
+		attribute.String("chain", chain),
+		attribute.String("outcome", outcome),
+	))
+}
+
+func (a *accessorMetrics) RecordEmptyRead(operation, chain string) {
+	a.emptyRead.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("operation", operation),
+		attribute.String("chain", chain),
+	))
+}
+
+func (a *accessorMetrics) RecordRowDrop(operation, chain, reason string) {
+	a.rowDrops.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("operation", operation),
+		attribute.String("chain", chain),
+		attribute.String("reason", reason),
+	))
+}
+
+func (a *accessorMetrics) RecordFinalityViolated(chain string) {
+	a.finalityViolated.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("chain", chain),
+	))
+}
+
+// ChainLabel resolves a chain selector to a human-readable label for metric
+// cardinality, falling back to the numeric selector when unknown.
+func ChainLabel(sel ccipocr3.ChainSelector) string {
+	return strconv.FormatUint(uint64(sel), 10)
+}

--- a/pkg/reader/rcmetrics/rcmetrics.go
+++ b/pkg/reader/rcmetrics/rcmetrics.go
@@ -31,18 +31,15 @@ type ReaderMetrics interface {
 	RecordChainGap(query, chain, state string)
 	// RecordReadEmpty records a query that returned nothing with no error.
 	RecordReadEmpty(query, chain string)
-	// RecordReadPartial records a query that returned a subset of the requested set.
-	RecordReadPartial(query, chain string)
 	// RecordMsgDropped records a read record dropped on validation/cast.
 	RecordMsgDropped(query, reason string)
 }
 
 // readerMetrics implements ReaderMetrics against a beholder meter.
 type readerMetrics struct {
-	chainGap    metric.Int64Counter
-	readEmpty   metric.Int64Counter
-	readPartial metric.Int64Counter
-	msgDropped  metric.Int64Counter
+	chainGap   metric.Int64Counter
+	readEmpty  metric.Int64Counter
+	msgDropped metric.Int64Counter
 }
 
 // NewReaderMetrics registers the reader instruments against m. Returns a NoOp
@@ -58,9 +55,6 @@ func NewReaderMetrics(m metric.Meter) (ReaderMetrics, error) {
 	}
 	if rm.readEmpty, err = m.Int64Counter("ccip_reader_read_empty"); err != nil {
 		return nil, fmt.Errorf("register ccip_reader_read_empty: %w", err)
-	}
-	if rm.readPartial, err = m.Int64Counter("ccip_reader_read_partial"); err != nil {
-		return nil, fmt.Errorf("register ccip_reader_read_partial: %w", err)
 	}
 	if rm.msgDropped, err = m.Int64Counter("ccip_reader_msg_dropped"); err != nil {
 		return nil, fmt.Errorf("register ccip_reader_msg_dropped: %w", err)
@@ -78,13 +72,6 @@ func (r *readerMetrics) RecordChainGap(query, chain, state string) {
 
 func (r *readerMetrics) RecordReadEmpty(query, chain string) {
 	r.readEmpty.Add(context.Background(), 1, metric.WithAttributes(
-		attribute.String("query", query),
-		attribute.String("chain", chain),
-	))
-}
-
-func (r *readerMetrics) RecordReadPartial(query, chain string) {
-	r.readPartial.Add(context.Background(), 1, metric.WithAttributes(
 		attribute.String("query", query),
 		attribute.String("chain", chain),
 	))


### PR DESCRIPTION
This PR adds missing metric data for the CCIP reader and the config poller. The chain accessor is the next one up the stack. The document explaining the methodology and tracking this is in docs/metrics/reader-metrics.md - reviewers can read that first. The code implements the metrics marked as "High prio" in that doc.

Note that these abstractions _cannot_ expose chain-specific data. There will have to be a separate analysis (scheduled for after the plugin is instrumented) of the available metrics for e.g. EVM, Solana, etc. that can be used to complement these metrics here.

One fix this PR has: the config_poller_v2 was previously overwriting a potentially nonempty cache with empty data - this has been fixed to not do that, emit a metric + a warn log.

Still TODO:

- [x] Use the new metrics to run health checks on healthy and unhealthy dons: done on a fresh healthy DON, and for a fault-injected unhealthy DON which was fault-injected to return an empty msg range for MsgsBetweenSeqNums, see https://github.com/smartcontractkit/chainlink-ccip/pull/2248/commits/720a22e7b49dabfe0a44b9afcab13f2ef7d7ad41, reverted https://github.com/smartcontractkit/chainlink-ccip/pull/2248/commits/b8144f32d554df8ed37865fcbe12effbcc24f436)
- [x] Use the new metrics to triage a DON with an appropriate injected fault (fault in the same commit as above)