### PR TITLE
feat: reverse propagation for autoMigrateRemoteChains

### DIFF
--- a/chains/evm/deployment/v1_0_0/adapters/init.go
+++ b/chains/evm/deployment/v1_0_0/adapters/init.go
@@ -17,6 +17,7 @@ func init() {
 	deployapi.GetTransferOwnershipRegistry().RegisterAdapter(chain_selectors.FamilyEVM, v, &EVMTransferOwnershipAdapter{})
 	mcmsreaderapi.GetRegistry().RegisterMCMSReader(chain_selectors.FamilyEVM, &EVMMCMSReader{})
 	tokensapi.GetTokenAdapterRegistry().RegisterTokenRefResolver(chain_selectors.FamilyEVM, &EVMTokenBase{})
+	tokensapi.GetTokenAdapterRegistry().RegisterTokenAdminRegistryReader(chain_selectors.FamilyEVM, &EVMTokenBase{})
 	tokensapi.GetTokenAdapterRegistry().RegisterTokenAdapter(chain_selectors.FamilyEVM, v, &EVMTokenBase{})
 	feesapi.GetRegistry().RegisterFeeResolver(chain_selectors.FamilyEVM, &EVMFeeResolver{})
 	deployapi.GetAddressNormalizerRegistry().RegisterAddressNormalizer(chain_selectors.FamilyEVM, &EVMAddressNormalizer{})

--- a/chains/evm/deployment/v1_0_0/adapters/token_adapter.go
+++ b/chains/evm/deployment/v1_0_0/adapters/token_adapter.go
@@ -353,12 +353,11 @@ func (a *EVMTokenBase) GetTokenAdminRegistryAddress(ds datastore.DataStore, sele
 	return addr, nil
 }
 
-// GetActivePool returns the pool currently registered for tokenRef in the TokenAdminRegistry (regRef) as raw
-// address bytes, or empty bytes when none is registered. The registry is taken from regRef when set, otherwise
-// resolved from the datastore (matching ConfigureTokenForTransfers) so callers need not pass a registry ref.
-// The read uses WithForceExecute because it reflects mutable on-chain state that may have been read (and cached)
-// earlier in this bundle.
-func (a *EVMTokenBase) GetActivePool(e deployment.Environment, chainSelector uint64, regRef datastore.AddressRef, tokenRef datastore.AddressRef) ([]byte, error) {
+// GetActivePool returns the pool currently registered for tokenRef in the TokenAdminRegistry as raw
+// address bytes, or empty bytes when none is registered. The registry is resolved from the datastore
+// via GetTokenAdminRegistryRef. The read uses WithForceExecute because it reflects mutable on-chain
+// state that may have been read (and cached) earlier in this bundle.
+func (a *EVMTokenBase) GetActivePool(e deployment.Environment, chainSelector uint64, tokenRef datastore.AddressRef) ([]byte, error) {
 	evmChain, ok := e.BlockChains.EVMChains()[chainSelector]
 	if !ok {
 		return nil, fmt.Errorf("chain with selector %d not found", chainSelector)
@@ -369,29 +368,19 @@ func (a *EVMTokenBase) GetActivePool(e deployment.Environment, chainSelector uin
 		return nil, fmt.Errorf("failed to parse token address from ref %v on chain %d: %w", tokenRef, chainSelector, err)
 	}
 
-	var registry common.Address
-	if datastore_utils.IsAddressRefEmpty(regRef) {
-		if addr, err := a.GetTokenAdminRegistryAddress(e.DataStore, chainSelector); err != nil {
-			return nil, fmt.Errorf("failed to resolve TokenAdminRegistry from datastore on chain %d: %w", chainSelector, err)
-		} else {
-			registry = addr
-		}
-	} else {
-		if addr, err := datastore_utils.FindAndFormatRef(e.DataStore, regRef, chainSelector, datastore_utils_evm.ToNonZeroEVMAddress); err != nil {
-			return nil, fmt.Errorf("failed to resolve TokenAdminRegistry from ref %v on chain %d: %w", regRef, chainSelector, err)
-		} else {
-			registry = addr
-		}
+	registryAddr, err := a.GetTokenAdminRegistryAddress(e.DataStore, chainSelector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve TokenAdminRegistry on chain %d: %w", chainSelector, err)
 	}
 
 	report, err := cldf_ops.ExecuteOperation(
 		e.OperationsBundle,
 		tarops.GetTokenConfig, evmChain,
-		contract.FunctionInput[common.Address]{ChainSelector: chainSelector, Address: registry, Args: token},
+		contract.FunctionInput[common.Address]{ChainSelector: chainSelector, Address: registryAddr, Args: token},
 		cldf_ops.WithForceExecute[contract.FunctionInput[common.Address], evm.Chain](),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get token config from registry %s for token %s on chain %d: %w", registry.Hex(), token.Hex(), chainSelector, err)
+		return nil, fmt.Errorf("failed to get token config from registry %s for token %s on chain %d: %w", registryAddr.Hex(), token.Hex(), chainSelector, err)
 	}
 
 	activePool := report.Output.TokenPool
@@ -400,6 +389,22 @@ func (a *EVMTokenBase) GetActivePool(e deployment.Environment, chainSelector uin
 	}
 
 	return activePool.Bytes(), nil
+}
+
+// GetTokenAdminRegistryRef resolves the TokenAdminRegistry ref from the datastore.
+func (a *EVMTokenBase) GetTokenAdminRegistryRef(e deployment.Environment, chainSelector uint64) (datastore.AddressRef, error) {
+	filter := datastore.AddressRef{
+		ChainSelector: chainSelector,
+		Type:          datastore.ContractType(tarops.ContractType),
+		Version:       tarops.Version,
+	}
+
+	ref, err := datastore_utils.FindAndFormatRef(e.DataStore, filter, chainSelector, datastore_utils.FullRef)
+	if err != nil {
+		return datastore.AddressRef{}, fmt.Errorf("failed to find token admin registry ref on chain %d: %w", chainSelector, err)
+	}
+
+	return ref, nil
 }
 
 // GetTimelockAddressCLL looks up the timelock (RBACTimelock) address from the datastore using the CLL qualifier.

--- a/chains/evm/deployment/v1_0_0/adapters/token_adapter.go
+++ b/chains/evm/deployment/v1_0_0/adapters/token_adapter.go
@@ -354,10 +354,11 @@ func (a *EVMTokenBase) GetTokenAdminRegistryAddress(ds datastore.DataStore, sele
 }
 
 // GetActivePool returns the pool currently registered for tokenRef in the TokenAdminRegistry as raw
-// address bytes, or empty bytes when none is registered. The registry is resolved from the datastore
-// via GetTokenAdminRegistryRef. The read uses WithForceExecute because it reflects mutable on-chain
-// state that may have been read (and cached) earlier in this bundle.
-func (a *EVMTokenBase) GetActivePool(e deployment.Environment, chainSelector uint64, tokenRef datastore.AddressRef) ([]byte, error) {
+// address bytes, or empty bytes when none is registered. Overrides are optional registry refs — the
+// first one that resolves from the datastore is used; when none are provided or none resolve, the
+// default TAR from the datastore is used. The read uses WithForceExecute because it reflects mutable
+// on-chain state that may have been read (and cached) earlier in this bundle.
+func (a *EVMTokenBase) GetActivePool(e deployment.Environment, chainSelector uint64, tokenRef datastore.AddressRef, overrides ...datastore.AddressRef) ([]byte, error) {
 	evmChain, ok := e.BlockChains.EVMChains()[chainSelector]
 	if !ok {
 		return nil, fmt.Errorf("chain with selector %d not found", chainSelector)
@@ -368,9 +369,20 @@ func (a *EVMTokenBase) GetActivePool(e deployment.Environment, chainSelector uin
 		return nil, fmt.Errorf("failed to parse token address from ref %v on chain %d: %w", tokenRef, chainSelector, err)
 	}
 
-	registryAddr, err := a.GetTokenAdminRegistryAddress(e.DataStore, chainSelector)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve TokenAdminRegistry on chain %d: %w", chainSelector, err)
+	var registryAddr common.Address
+	for _, override := range overrides {
+		if !datastore_utils.IsAddressRefEmpty(override) {
+			if addr, err := datastore_utils.FindAndFormatRef(e.DataStore, override, chainSelector, datastore_utils_evm.ToNonZeroEVMAddress); err == nil {
+				registryAddr = addr
+				break
+			}
+		}
+	}
+	if registryAddr == (common.Address{}) {
+		registryAddr, err = a.GetTokenAdminRegistryAddress(e.DataStore, chainSelector)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve TokenAdminRegistry on chain %d: %w", chainSelector, err)
+		}
 	}
 
 	report, err := cldf_ops.ExecuteOperation(

--- a/chains/solana/deployment/v1_0_0/adapters/init.go
+++ b/chains/solana/deployment/v1_0_0/adapters/init.go
@@ -5,9 +5,11 @@ import (
 
 	deployapi "github.com/smartcontractkit/chainlink-ccip/deployment/deploy"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/fees"
+	tokensapi "github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 )
 
 func init() {
 	fees.GetRegistry().RegisterFeeResolver(chainsel.FamilySolana, &SolanaFeeResolver{})
 	deployapi.GetAddressNormalizerRegistry().RegisterAddressNormalizer(chainsel.FamilySolana, &SolanaAddressNormalizer{})
+	tokensapi.GetTokenAdapterRegistry().RegisterTokenAdminRegistryReader(chainsel.FamilySolana, &SolanaAdminRegistryReader{})
 }

--- a/chains/solana/deployment/v1_0_0/adapters/tar_reader.go
+++ b/chains/solana/deployment/v1_0_0/adapters/tar_reader.go
@@ -45,8 +45,12 @@ func (a *SolanaAdminRegistryReader) GetActivePool(e deployment.Environment, chai
 	for _, override := range overrides {
 		if !datastore_utils.IsAddressRefEmpty(override) {
 			if ref, err := datastore_utils.FindAndFormatRef(e.DataStore, override, chainSelector, datastore_utils.FullRef); err == nil && ref.Address != "" {
-				router = solana.MustPublicKeyFromBase58(ref.Address)
-				break
+				if parsedRouter, parseErr := solana.PublicKeyFromBase58(ref.Address); parseErr != nil {
+					return nil, fmt.Errorf("invalid router address %q: %w", ref.Address, parseErr)
+				} else {
+					router = parsedRouter
+					break
+				}
 			}
 		}
 	}

--- a/chains/solana/deployment/v1_0_0/adapters/tar_reader.go
+++ b/chains/solana/deployment/v1_0_0/adapters/tar_reader.go
@@ -1,0 +1,92 @@
+package adapters
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
+
+	routerops "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_6_0/operations/router"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v1_6_1/ccip_common"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
+	state "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
+	tokensapi "github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
+	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+)
+
+var _ tokensapi.TokenAdminRegistryReader = (*SolanaAdminRegistryReader)(nil)
+
+type SolanaAdminRegistryReader struct{}
+
+func (a *SolanaAdminRegistryReader) GetActivePool(e deployment.Environment, chainSelector uint64, tokenRef datastore.AddressRef) ([]byte, error) {
+	chain, ok := e.BlockChains.SolanaChains()[chainSelector]
+	if !ok {
+		return nil, fmt.Errorf("chain with selector %d not found", chainSelector)
+	}
+
+	tokenAddress := tokenRef.Address
+	if tokenAddress == "" {
+		if ref, err := datastore_utils.FindAndFormatRef(e.DataStore, tokenRef, chainSelector, datastore_utils.FullRef); err != nil {
+			return nil, fmt.Errorf("failed to resolve token ref for chain %d: %w", chainSelector, err)
+		} else {
+			tokenAddress = ref.Address
+		}
+	}
+
+	mint, err := solana.PublicKeyFromBase58(tokenAddress)
+	if err != nil {
+		return nil, fmt.Errorf("invalid token mint address %q: %w", tokenAddress, err)
+	}
+
+	routerRef, err := a.GetTokenAdminRegistryRef(e, chainSelector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve Router on chain %d: %w", chainSelector, err)
+	}
+
+	tarPDA, _, err := state.FindTokenAdminRegistryPDA(mint, solana.MustPublicKeyFromBase58(routerRef.Address))
+	if err != nil {
+		return nil, fmt.Errorf("failed to derive TAR PDA: %w", err)
+	}
+
+	var tarAccount ccip_common.TokenAdminRegistry
+	if err := chain.GetAccountDataBorshInto(e.OperationsBundle.GetContext(), tarPDA, &tarAccount); err != nil {
+		return nil, nil
+	}
+	if tarAccount.LookupTable.IsZero() {
+		return nil, nil
+	}
+
+	entries, err := common.GetAddressLookupTable(e.OperationsBundle.GetContext(), chain.Client, tarAccount.LookupTable)
+	if errors.Is(err, rpc.ErrNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch lookup table %s: %w", tarAccount.LookupTable.String(), err)
+	}
+	if len(entries) <= 2 {
+		return nil, nil
+	}
+
+	return entries[2].Bytes(), nil
+}
+
+func (a *SolanaAdminRegistryReader) GetTokenAdminRegistryRef(e deployment.Environment, chainSelector uint64) (datastore.AddressRef, error) {
+	_, ok := e.BlockChains.SolanaChains()[chainSelector]
+	if !ok {
+		return datastore.AddressRef{}, fmt.Errorf("chain with selector %d not found", chainSelector)
+	}
+
+	refs := e.DataStore.Addresses().Filter(
+		datastore.AddressRefByChainSelector(chainSelector),
+		datastore.AddressRefByType(datastore.ContractType(routerops.ContractType)),
+		datastore.AddressRefByVersion(routerops.Version),
+	)
+	if len(refs) == 0 {
+		return datastore.AddressRef{}, fmt.Errorf("Router not found in datastore for chain %d", chainSelector)
+	}
+
+	return refs[0], nil
+}

--- a/chains/solana/deployment/v1_0_0/adapters/tar_reader.go
+++ b/chains/solana/deployment/v1_0_0/adapters/tar_reader.go
@@ -21,7 +21,7 @@ var _ tokensapi.TokenAdminRegistryReader = (*SolanaAdminRegistryReader)(nil)
 
 type SolanaAdminRegistryReader struct{}
 
-func (a *SolanaAdminRegistryReader) GetActivePool(e deployment.Environment, chainSelector uint64, tokenRef datastore.AddressRef) ([]byte, error) {
+func (a *SolanaAdminRegistryReader) GetActivePool(e deployment.Environment, chainSelector uint64, tokenRef datastore.AddressRef, overrides ...datastore.AddressRef) ([]byte, error) {
 	chain, ok := e.BlockChains.SolanaChains()[chainSelector]
 	if !ok {
 		return nil, fmt.Errorf("chain with selector %d not found", chainSelector)
@@ -41,12 +41,24 @@ func (a *SolanaAdminRegistryReader) GetActivePool(e deployment.Environment, chai
 		return nil, fmt.Errorf("invalid token mint address %q: %w", tokenAddress, err)
 	}
 
-	routerRef, err := a.GetTokenAdminRegistryRef(e, chainSelector)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve Router on chain %d: %w", chainSelector, err)
+	var router solana.PublicKey
+	for _, override := range overrides {
+		if !datastore_utils.IsAddressRefEmpty(override) {
+			if ref, err := datastore_utils.FindAndFormatRef(e.DataStore, override, chainSelector, datastore_utils.FullRef); err == nil && ref.Address != "" {
+				router = solana.MustPublicKeyFromBase58(ref.Address)
+				break
+			}
+		}
+	}
+	if router.IsZero() {
+		if routerRef, err := a.GetTokenAdminRegistryRef(e, chainSelector); err != nil {
+			return nil, fmt.Errorf("failed to resolve Router on chain %d: %w", chainSelector, err)
+		} else {
+			router = solana.MustPublicKeyFromBase58(routerRef.Address)
+		}
 	}
 
-	tarPDA, _, err := state.FindTokenAdminRegistryPDA(mint, solana.MustPublicKeyFromBase58(routerRef.Address))
+	tarPDA, _, err := state.FindTokenAdminRegistryPDA(mint, router)
 	if err != nil {
 		return nil, fmt.Errorf("failed to derive TAR PDA: %w", err)
 	}

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -186,11 +186,11 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 		// connectivity from B_new to A and C. The reverse propagation is handled later in the code.
 		var discoveredRemotes []DiscoveredRemoteChain
 		if token.AutoMigrateRemoteChains {
-			registryMigrator, ok := adapter.(TokenPoolMigrator)
+			tarReader, ok := tokenRegistry.GetTokenAdminRegistryReader(family)
 			if !ok {
-				return nil, nil, nil, fmt.Errorf("adapter for chain selector %d does not support token pool migration, which is required when autoMigrateRemoteChains is enabled", selector)
+				return nil, nil, nil, fmt.Errorf("no token admin registry reader for chain family %s", family)
 			}
-			activePool, err := registryMigrator.GetActivePool(e, selector, token.RegistryRef, fullTokenRef)
+			activePool, err := tarReader.GetActivePool(e, selector, fullTokenRef)
 			if err != nil {
 				return nil, nil, nil, fmt.Errorf("failed to get active pool for token pool on chain selector %d: %w", selector, err)
 			}
@@ -278,16 +278,13 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 				if err != nil {
 					return nil, nil, nil, fmt.Errorf("failed to normalize remote token address for remote chain selector %d: %w", remoteSelector, err)
 				}
-				remotePools, err := legacyPoolMigrator.GetRemotePools(e, selector, activePool, remoteSelector)
+				remoteRegReader, ok := tokenRegistry.GetTokenAdminRegistryReader(remoteFamily)
+				if !ok {
+					return nil, nil, nil, fmt.Errorf("no admin registry reader for remote chain family %s", remoteFamily)
+				}
+				remotePoolBytes, err := remoteRegReader.GetActivePool(e, remoteSelector, datastore.AddressRef{Address: remoteTokenAddr})
 				if err != nil {
-					return nil, nil, nil, fmt.Errorf("failed to get remote pools for remote chain selector %d: %w", remoteSelector, err)
-				}
-				if len(remotePools) == 0 {
-					return nil, nil, nil, fmt.Errorf("pool has a remote pool registered for chain %d but no remote pool was returned", remoteSelector)
-				}
-				remotePoolBytes := remotePools[0]
-				if len(remotePoolBytes) == 0 {
-					return nil, nil, nil, fmt.Errorf("pool has a remote pool registered for chain %d but it is the zero address", remoteSelector)
+					return nil, nil, nil, fmt.Errorf("failed to get active pool for remote chain selector %d: %w", remoteSelector, err)
 				}
 				remotePoolAddr, err := remoteNormalizer.BytesToString(remotePoolBytes)
 				if err != nil {
@@ -296,6 +293,10 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 				remoteAdapter, _, remotePoolRef, remoteTokenRef, err := ResolveAdapterAndRefs(e, tokenRegistry, remoteSelector, datastore.AddressRef{Address: remotePoolAddr}, datastore.AddressRef{Address: remoteTokenAddr})
 				if err != nil {
 					return nil, nil, nil, fmt.Errorf("failed to resolve adapter and refs for remote chain selector %d: %w", remoteSelector, err)
+				}
+				remotePools, err := legacyPoolMigrator.GetRemotePools(e, selector, activePool, remoteSelector)
+				if err != nil {
+					return nil, nil, nil, fmt.Errorf("failed to get remote pools for remote chain selector %d: %w", remoteSelector, err)
 				}
 				discoveredRemotes = append(discoveredRemotes, DiscoveredRemoteChain{
 					remoteSelector: remoteSelector,

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -278,13 +278,21 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 				if err != nil {
 					return nil, nil, nil, fmt.Errorf("failed to normalize remote token address for remote chain selector %d: %w", remoteSelector, err)
 				}
-				remoteRegReader, ok := tokenRegistry.GetTokenAdminRegistryReader(remoteFamily)
-				if !ok {
-					return nil, nil, nil, fmt.Errorf("no admin registry reader for remote chain family %s", remoteFamily)
-				}
-				remotePoolBytes, err := remoteRegReader.GetActivePool(e, remoteSelector, datastore.AddressRef{Address: remoteTokenAddr})
-				if err != nil {
-					return nil, nil, nil, fmt.Errorf("failed to get active pool for remote chain selector %d: %w", remoteSelector, err)
+				var remotePoolBytes []byte
+				if counterpartCfg, alsoMigrating := cfg[remoteSelector]; alsoMigrating {
+					remotePoolBytes, err = adapter.AddressRefToBytes(counterpartCfg.TokenPoolRef)
+					if err != nil {
+						return nil, nil, nil, fmt.Errorf("failed to convert counterpart pool ref to bytes for chain selector %d: %w", remoteSelector, err)
+					}
+				} else {
+					remoteRegReader, ok := tokenRegistry.GetTokenAdminRegistryReader(remoteFamily)
+					if !ok {
+						return nil, nil, nil, fmt.Errorf("no admin registry reader for remote chain family %s", remoteFamily)
+					}
+					remotePoolBytes, err = remoteRegReader.GetActivePool(e, remoteSelector, datastore.AddressRef{Address: remoteTokenAddr})
+					if err != nil {
+						return nil, nil, nil, fmt.Errorf("failed to get active pool for remote chain selector %d: %w", remoteSelector, err)
+					}
 				}
 				remotePoolAddr, err := remoteNormalizer.BytesToString(remotePoolBytes)
 				if err != nil {

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -190,7 +190,7 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 			if !ok {
 				return nil, nil, nil, fmt.Errorf("no token admin registry reader for chain family %s", family)
 			}
-			activePool, err := tarReader.GetActivePool(e, selector, fullTokenRef)
+			activePool, err := tarReader.GetActivePool(e, selector, fullTokenRef, token.RegistryRef)
 			if err != nil {
 				return nil, nil, nil, fmt.Errorf("failed to get active pool for token pool on chain selector %d: %w", selector, err)
 			}

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -437,6 +437,7 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 			if err != nil {
 				return nil, nil, nil, fmt.Errorf("failed to convert token ref to bytes for reverse propagation on chain selector %d: %w", selector, err)
 			}
+
 			migratedPoolBytes, err := adapter.AddressRefToBytes(tokenPool)
 			if err != nil {
 				return nil, nil, nil, fmt.Errorf("failed to convert new pool ref to bytes for reverse propagation on chain selector %d: %w", selector, err)
@@ -450,8 +451,12 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 					PoolType:          ru.remotePoolRef.Type.String(),
 					RemoteChains: map[uint64]RemoteChainConfig[[]byte, string]{
 						selector: {
-							RemoteToken: migratedTokenBytes,
-							RemotePool:  migratedPoolBytes,
+							// Pad to match on-chain storage format (32-byte left-padded for EVM).
+							// The token comparison in ConfigureTokenPoolForRemoteChain (line 234)
+							// compares against on-chain bytes without padding, so a 20-byte input
+							// would mismatch and trigger a remove+re-add instead of addRemotePool
+							RemoteToken: common.LeftPadBytes(migratedTokenBytes, 32),
+							RemotePool:  common.LeftPadBytes(migratedPoolBytes, 32),
 						},
 					},
 				}

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -173,6 +173,17 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 			}
 		}
 
+		type DiscoveredRemoteChain struct {
+			remoteSelector uint64
+			remotePoolAddr string
+			remoteAdapter  TokenAdapter
+		}
+
+		// When AutoMigrateRemoteChains = true, we read the legacy pool's remote chains and import them into
+		// the new pool. Example: if pools A, B, and C form a fully connected web and we migrate B to B_new,
+		// then the code below will discover that remote pools A and C need to be added to B_new to maintain
+		// connectivity from B_new to A and C. The reverse propagation is handled later in the code.
+		var discoveredRemotes []DiscoveredRemoteChain
 		if token.AutoMigrateRemoteChains {
 			registryMigrator, ok := adapter.(TokenPoolMigrator)
 			if !ok {
@@ -285,6 +296,11 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 				if err != nil {
 					return nil, nil, nil, fmt.Errorf("failed to resolve adapter for remote chain selector %d: %w", remoteSelector, err)
 				}
+				discoveredRemotes = append(discoveredRemotes, DiscoveredRemoteChain{
+					remoteSelector: remoteSelector,
+					remotePoolAddr: remotePoolAddr,
+					remoteAdapter:  remoteAdapter,
+				})
 				remoteTokenDecimals, err := remoteAdapter.DeriveTokenDecimals(e, remoteSelector, remotePoolRef, remoteTokenBytes)
 				if err != nil {
 					return nil, nil, nil, fmt.Errorf("failed to derive remote token decimals for remote chain selector %d: %w", remoteSelector, err)
@@ -392,6 +408,55 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 				}
 				batchOps = append(batchOps, feeBatchOps...)
 				reports = append(reports, feeReports...)
+			}
+		}
+
+		// Reverse-propagate the new pool address to every counterpart discovered by autoMigrateRemoteChains.
+		// Example: if pools A, B, and C form a fully connected web and we migrate B to B_new, then this step
+		// tells A and C to add B_new as an additional remote pool, so that web remains fully connected after
+		// the migration is performed. Without this, the forward direction (B_new → A) works, but the reverse
+		// (A → B_new) would fail because A's pool still only knows about B_old.
+		//
+		// This loop doesn't need to import rate limits, fee configs, or any other per-chain configs onto the
+		// counterpart pools (A, C). If a counterpart is itself migrated later then `autoMigrateRemoteChains`
+		// on that upgrade will discover B_new as the active pool on chain B and handle those imports at that
+		// time through the normal forward flow.
+		if len(discoveredRemotes) > 0 {
+			migratedTokenBytes, err := adapter.AddressRefToBytes(fullTokenRef)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("failed to convert token ref to bytes for reverse propagation on chain selector %d: %w", selector, err)
+			}
+			migratedPoolBytes, err := adapter.AddressRefToBytes(tokenPool)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("failed to convert new pool ref to bytes for reverse propagation on chain selector %d: %w", selector, err)
+			}
+			for _, ru := range discoveredRemotes {
+				reverseInput := ConfigureTokenForTransfersInput{
+					ExistingDataStore: e.DataStore,
+					TokenPoolAddress:  ru.remotePoolAddr,
+					ChainSelector:     ru.remoteSelector,
+					TokenRef:          fullTokenRef,
+					RemoteChains: map[uint64]RemoteChainConfig[[]byte, string]{
+						selector: {
+							RemoteToken: migratedTokenBytes,
+							RemotePool:  migratedPoolBytes,
+						},
+					},
+				}
+				reverseReport, err := cldf_ops.ExecuteSequence(e.OperationsBundle, ru.remoteAdapter.ConfigureTokenForTransfersSequence(), e.BlockChains, reverseInput)
+				if err != nil {
+					return nil, nil, nil, fmt.Errorf(
+						"failed to propagate new pool to counterpart chain selector %d for chain selector %d: %w",
+						ru.remoteSelector, selector, err,
+					)
+				}
+				batchOps = append(batchOps, reverseReport.Output.BatchOps...)
+				reports = append(reports, reverseReport.ExecutionReports...)
+				for _, r := range reverseReport.Output.Addresses {
+					if err := ds.Addresses().Add(r); err != nil {
+						return nil, nil, nil, fmt.Errorf("failed to add address %s to datastore: %w", r.Address, err)
+					}
+				}
 			}
 		}
 	}

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -175,7 +175,8 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 
 		type DiscoveredRemoteChain struct {
 			remoteSelector uint64
-			remotePoolAddr string
+			remoteTokenRef datastore.AddressRef
+			remotePoolRef  datastore.AddressRef
 			remoteAdapter  TokenAdapter
 		}
 
@@ -273,6 +274,10 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 				if err != nil {
 					return nil, nil, nil, fmt.Errorf("failed to get remote token for remote chain selector %d: %w", remoteSelector, err)
 				}
+				remoteTokenAddr, err := remoteNormalizer.BytesToString(remoteTokenBytes)
+				if err != nil {
+					return nil, nil, nil, fmt.Errorf("failed to normalize remote token address for remote chain selector %d: %w", remoteSelector, err)
+				}
 				remotePools, err := legacyPoolMigrator.GetRemotePools(e, selector, activePool, remoteSelector)
 				if err != nil {
 					return nil, nil, nil, fmt.Errorf("failed to get remote pools for remote chain selector %d: %w", remoteSelector, err)
@@ -288,17 +293,14 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 				if err != nil {
 					return nil, nil, nil, fmt.Errorf("failed to normalize remote pool address for remote chain selector %d: %w", remoteSelector, err)
 				}
-				remotePoolRef, err := ResolveTokenPoolRef(e, tokenRegistry, remoteSelector, datastore.AddressRef{Address: remotePoolAddr})
+				remoteAdapter, _, remotePoolRef, remoteTokenRef, err := ResolveAdapterAndRefs(e, tokenRegistry, remoteSelector, datastore.AddressRef{Address: remotePoolAddr}, datastore.AddressRef{Address: remoteTokenAddr})
 				if err != nil {
-					return nil, nil, nil, fmt.Errorf("failed to resolve token pool ref for remote chain selector %d: %w", remoteSelector, err)
-				}
-				remoteAdapter, _, err := ResolveAdapter(tokenRegistry, remoteSelector, remotePoolRef.Version)
-				if err != nil {
-					return nil, nil, nil, fmt.Errorf("failed to resolve adapter for remote chain selector %d: %w", remoteSelector, err)
+					return nil, nil, nil, fmt.Errorf("failed to resolve adapter and refs for remote chain selector %d: %w", remoteSelector, err)
 				}
 				discoveredRemotes = append(discoveredRemotes, DiscoveredRemoteChain{
 					remoteSelector: remoteSelector,
-					remotePoolAddr: remotePoolAddr,
+					remoteTokenRef: remoteTokenRef,
+					remotePoolRef:  remotePoolRef,
 					remoteAdapter:  remoteAdapter,
 				})
 				remoteTokenDecimals, err := remoteAdapter.DeriveTokenDecimals(e, remoteSelector, remotePoolRef, remoteTokenBytes)
@@ -433,9 +435,10 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 			for _, ru := range discoveredRemotes {
 				reverseInput := ConfigureTokenForTransfersInput{
 					ExistingDataStore: e.DataStore,
-					TokenPoolAddress:  ru.remotePoolAddr,
+					TokenPoolAddress:  ru.remotePoolRef.Address,
 					ChainSelector:     ru.remoteSelector,
-					TokenRef:          fullTokenRef,
+					TokenRef:          ru.remoteTokenRef,
+					PoolType:          ru.remotePoolRef.Type.String(),
 					RemoteChains: map[uint64]RemoteChainConfig[[]byte, string]{
 						selector: {
 							RemoteToken: migratedTokenBytes,

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -414,8 +414,8 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 		// Reverse-propagate the new pool address to every counterpart discovered by autoMigrateRemoteChains.
 		// Example: if pools A, B, and C form a fully connected web and we migrate B to B_new, then this step
 		// tells A and C to add B_new as an additional remote pool, so that web remains fully connected after
-		// the migration is performed. Without this, the forward direction (B_new → A) works, but the reverse
-		// (A → B_new) would fail because A's pool still only knows about B_old.
+		// the migration is performed. Without this, the forward direction (A → B_new) works, but the reverse
+		// (B_new → A) would fail because A's pool still only knows about B_old.
 		//
 		// This loop doesn't need to import rate limits, fee configs, or any other per-chain configs onto the
 		// counterpart pools (A, C). If a counterpart is itself migrated later then `autoMigrateRemoteChains`

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -280,7 +280,11 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 				}
 				var remotePoolBytes []byte
 				if counterpartCfg, alsoMigrating := cfg[remoteSelector]; alsoMigrating {
-					remotePoolBytes, err = adapter.AddressRefToBytes(counterpartCfg.TokenPoolRef)
+					fullRemotePoolRef, err := ResolveTokenPoolRef(e, tokenRegistry, remoteSelector, counterpartCfg.TokenPoolRef)
+					if err != nil {
+						return nil, nil, nil, fmt.Errorf("failed to resolve counterpart pool ref for remote chain selector %d: %w", remoteSelector, err)
+					}
+					remotePoolBytes, err = remoteNormalizer.StringToBytes(fullRemotePoolRef.Address)
 					if err != nil {
 						return nil, nil, nil, fmt.Errorf("failed to convert counterpart pool ref to bytes for chain selector %d: %w", remoteSelector, err)
 					}

--- a/deployment/tokens/product.go
+++ b/deployment/tokens/product.go
@@ -107,7 +107,9 @@ type RateLimitReaderAdapter interface {
 type TokenAdminRegistryReader interface {
 	// GetActivePool returns the pool currently registered for tokenRef in the TokenAdminRegistry
 	// as raw address bytes. Returns empty bytes (no error) when no pool is registered.
-	GetActivePool(e deployment.Environment, chainSelector uint64, tokenRef datastore.AddressRef) ([]byte, error)
+	// Overrides are optional registry refs to use instead of the datastore default;
+	// the first one that resolves from the datastore is used.
+	GetActivePool(e deployment.Environment, chainSelector uint64, tokenRef datastore.AddressRef, overrides ...datastore.AddressRef) ([]byte, error)
 	// GetTokenAdminRegistryRef resolves the TokenAdminRegistry ref for the given chain from the datastore.
 	GetTokenAdminRegistryRef(e deployment.Environment, chainSelector uint64) (datastore.AddressRef, error)
 }

--- a/deployment/tokens/product.go
+++ b/deployment/tokens/product.go
@@ -100,15 +100,24 @@ type RateLimitReaderAdapter interface {
 	) (OnchainRateLimits, error)
 }
 
+// TokenAdminRegistryReader is a versionless interface for reading the active pool from a chain's
+// TokenAdminRegistry (or equivalent). Implementations are registered per chain family via
+// TokenAdapterRegistry.RegisterTokenAdminRegistryReader and can be looked up by family regardless
+// of pool version.
+type TokenAdminRegistryReader interface {
+	// GetActivePool returns the pool currently registered for tokenRef in the TokenAdminRegistry
+	// as raw address bytes. Returns empty bytes (no error) when no pool is registered.
+	GetActivePool(e deployment.Environment, chainSelector uint64, tokenRef datastore.AddressRef) ([]byte, error)
+	// GetTokenAdminRegistryRef resolves the TokenAdminRegistry ref for the given chain from the datastore.
+	GetTokenAdminRegistryRef(e deployment.Environment, chainSelector uint64) (datastore.AddressRef, error)
+}
+
 // TokenPoolMigrator is an optional interface implemented by adapters that can read an existing pool's
 // cross-chain configuration on-chain. It powers AutoMigrateRemoteChains: during an upgrade, the remote
 // chains/tokens/pools the active pool is configured for are read back (as raw bytes) and carried forward
 // onto the new pool. All addresses are raw on-chain bytes so the interface stays chain-family-agnostic;
 // callers convert them per family via the AddressNormalizer registry when a string form is needed.
 type TokenPoolMigrator interface {
-	// GetActivePool returns the pool currently registered for the token (tokenRef) in the TokenAdminRegistry
-	// (regRef), as raw address bytes. Returns empty bytes (no error) when no pool is registered.
-	GetActivePool(e deployment.Environment, chainSelector uint64, regRef datastore.AddressRef, tokenRef datastore.AddressRef) ([]byte, error)
 	// GetSupportedChains returns the remote chain selectors the pool at poolAddr is configured for.
 	GetSupportedChains(e deployment.Environment, chainSelector uint64, poolAddr []byte) ([]uint64, error)
 	// GetRemoteToken returns the remote token (raw bytes) the pool at poolAddr uses for remoteSelector.
@@ -436,16 +445,19 @@ type SetTokenTransferFeeSequenceInput struct {
 
 // TokenAdapterRegistry maintains a registry of TokenAdapters.
 type TokenAdapterRegistry struct {
-	tokenRefResolverReg map[string]TokenRefResolver
-	tokenAdapterReg     map[tokenAdapterID]TokenAdapter
-	tokenRefResolverMu  sync.Mutex
-	tokenAdapterMu      sync.Mutex
+	tokenRefResolverReg         map[string]TokenRefResolver
+	tokenAdminRegistryReaderReg map[string]TokenAdminRegistryReader
+	tokenAdapterReg             map[tokenAdapterID]TokenAdapter
+	tokenRefResolverMu          sync.Mutex
+	tokenAdminRegistryReaderMu  sync.Mutex
+	tokenAdapterMu              sync.Mutex
 }
 
 func newTokenAdapterRegistry() *TokenAdapterRegistry {
 	return &TokenAdapterRegistry{
-		tokenRefResolverReg: make(map[string]TokenRefResolver),
-		tokenAdapterReg:     make(map[tokenAdapterID]TokenAdapter),
+		tokenRefResolverReg:         make(map[string]TokenRefResolver),
+		tokenAdminRegistryReaderReg: make(map[string]TokenAdminRegistryReader),
+		tokenAdapterReg:             make(map[tokenAdapterID]TokenAdapter),
 	}
 }
 
@@ -464,6 +476,23 @@ func (r *TokenAdapterRegistry) GetTokenRefResolver(chainFamily string) (TokenRef
 	defer r.tokenRefResolverMu.Unlock()
 	resolver, ok := r.tokenRefResolverReg[chainFamily]
 	return resolver, ok
+}
+
+// RegisterTokenAdminRegistryReader registers a versionless TAR reader for the given chain family.
+func (r *TokenAdapterRegistry) RegisterTokenAdminRegistryReader(family string, reader TokenAdminRegistryReader) {
+	r.tokenAdminRegistryReaderMu.Lock()
+	defer r.tokenAdminRegistryReaderMu.Unlock()
+	if _, exists := r.tokenAdminRegistryReaderReg[family]; !exists {
+		r.tokenAdminRegistryReaderReg[family] = reader
+	}
+}
+
+// GetTokenAdminRegistryReader retrieves a registered TokenAdminRegistryReader for the given chain family.
+func (r *TokenAdapterRegistry) GetTokenAdminRegistryReader(family string) (TokenAdminRegistryReader, bool) {
+	r.tokenAdminRegistryReaderMu.Lock()
+	defer r.tokenAdminRegistryReaderMu.Unlock()
+	reader, ok := r.tokenAdminRegistryReaderReg[family]
+	return reader, ok
 }
 
 // RegisterTokenAdapter allows chains to register their changeset logic.

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -363,8 +363,12 @@ func tokenExpansionApply() func(cldf.Environment, TokenExpansionInput) (cldf.Cha
 				// This runs BEFORE processTokenConfigForChain / UpdateAuthorities so the
 				// new pool is not registered in TAR yet, and we can read the legacy pool
 				// address directly from TAR.
+				var seedRegistryRef datastore.AddressRef
+				if tc := input.TokenTransferConfig; tc != nil {
+					seedRegistryRef = tc.RegistryRef
+				}
 				seedBatchOps, seedReports, err := buildSeedMigrationBatchOps(
-					e, tokenPoolRegistry, selector, *tokenPool, *tokenRef,
+					e, tokenPoolRegistry, selector, *tokenPool, *tokenRef, seedRegistryRef,
 					deployTokenPoolInput.TimelockAddress,
 					deployTokenPoolInput.LiquidityMigrationAmount,
 					deployTokenPoolInput.LiquidityMigrationBasisPoints,
@@ -632,6 +636,7 @@ func buildSeedMigrationBatchOps(
 	tokenPoolRegistry *TokenAdapterRegistry,
 	selector uint64,
 	tokenPool, tokenRef datastore.AddressRef,
+	registryRef datastore.AddressRef,
 	timelockAddr string,
 	amount *big.Int,
 	basisPoints *uint16,
@@ -658,7 +663,7 @@ func buildSeedMigrationBatchOps(
 		)
 	}
 
-	activePool, err := registryReader.GetActivePool(e, selector, fullTokenRef)
+	activePool, err := registryReader.GetActivePool(e, selector, fullTokenRef, registryRef)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get active pool for liquidity seed on chain selector %d: %w", selector, err)
 	}

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -363,12 +363,8 @@ func tokenExpansionApply() func(cldf.Environment, TokenExpansionInput) (cldf.Cha
 				// This runs BEFORE processTokenConfigForChain / UpdateAuthorities so the
 				// new pool is not registered in TAR yet, and we can read the legacy pool
 				// address directly from TAR.
-				var registryRef datastore.AddressRef
-				if tc := cfg.TokenExpansionInputPerChain[selector].TokenTransferConfig; tc != nil {
-					registryRef = tc.RegistryRef
-				}
 				seedBatchOps, seedReports, err := buildSeedMigrationBatchOps(
-					e, tokenPoolRegistry, selector, *tokenPool, *tokenRef, registryRef,
+					e, tokenPoolRegistry, selector, *tokenPool, *tokenRef,
 					deployTokenPoolInput.TimelockAddress,
 					deployTokenPoolInput.LiquidityMigrationAmount,
 					deployTokenPoolInput.LiquidityMigrationBasisPoints,
@@ -636,7 +632,6 @@ func buildSeedMigrationBatchOps(
 	tokenPoolRegistry *TokenAdapterRegistry,
 	selector uint64,
 	tokenPool, tokenRef datastore.AddressRef,
-	registryRef datastore.AddressRef,
 	timelockAddr string,
 	amount *big.Int,
 	basisPoints *uint16,
@@ -655,15 +650,15 @@ func buildSeedMigrationBatchOps(
 		return nil, nil, fmt.Errorf("adapter for chain selector %d does not support liquidity migration", selector)
 	}
 
-	registryMigrator, ok := tokenPoolAdapter.(TokenPoolMigrator)
+	registryReader, ok := tokenPoolRegistry.GetTokenAdminRegistryReader(family)
 	if !ok {
 		return nil, nil, fmt.Errorf(
-			"adapter for chain selector %d does not support reading active pool from registry, which is required for liquidity migration",
-			selector,
+			"no token admin registry reader for chain family %s, which is required for liquidity migration",
+			family,
 		)
 	}
 
-	activePool, err := registryMigrator.GetActivePool(e, selector, registryRef, fullTokenRef)
+	activePool, err := registryReader.GetActivePool(e, selector, fullTokenRef)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get active pool for liquidity seed on chain selector %d: %w", selector, err)
 	}

--- a/integration-tests/deployment/token_expansion_migration_test.go
+++ b/integration-tests/deployment/token_expansion_migration_test.go
@@ -548,6 +548,17 @@ func runAutoMigrateUpgrade(t *testing.T, oldPoolVersion *semver.Version, opts *a
 	cfgAfter, err := tarA.GetTokenConfig(&bind.CallOpts{Context: t.Context()}, s.tokAddrA)
 	require.NoError(t, err)
 	require.Equal(t, newPoolAddrA, cfgAfter.TokenPool, "TAR should be switched to the new v2.0 pool")
+
+	// Reverse propagation: the legacy pool on the remote chain (B_old) should now have the new pool (A_new)
+	// in its remote pool list for chain A. This is the counterpart direction of autoMigrateRemoteChains —
+	// handled by autoMigrateRemoteChains reverse propagation in processTokenConfigForChain.
+	chainB := e.BlockChains.EVMChains()[selB]
+	oldPoolB, err := tokenpoolV2_0_0.NewTokenPool(s.oldPoolAddrB, chainB.Client)
+	require.NoError(t, err)
+	gotRemotePoolsB, err := oldPoolB.GetRemotePools(&bind.CallOpts{Context: t.Context()}, selA)
+	require.NoError(t, err)
+	require.Contains(t, gotRemotePoolsB, common.LeftPadBytes(newPoolAddrA.Bytes(), 32),
+		"reverse propagation: legacy pool B should have new pool A in remote pools for chain A")
 }
 
 // TestTokenExpansionMigration_DeployWithSeed verifies that deploying a LockRelease pool with


### PR DESCRIPTION
# CCIP-12660: Reverse propagation for `autoMigrateRemoteChains`

## Problem

When migrating a token pool via `autoMigrateRemoteChains: true`, the forward direction is handled: the new pool (B_new) is configured with A and C as remote pools, enabling A → B_new and C → B_new. But the reverse direction is missed — A and C never learn about B_new's address. When B_new → A sends a message, A's `releaseOrMint` calls `isRemotePool` and fails because A only knows B_old. In a fully connected web (A↔B↔C), migrating B leaves the web broken in one direction.

Using `GetRemotePools()[0]` to find the counterpart pool is unsafe when the counterpart was already migrated — the list contains both stale and replacement pools, and calling `ConfigureTokenForTransfersSequence` on a stale pool triggers `RegisterToken.SetPool` which can switch TAR back to the stale pool.

## Design

### Reverse propagation

Added inside `processTokenConfigForChain`. During the autoMigrate discovery loop, each discovered counterpart (chain selector, adapter, full pool/token refs) is captured into a `discoveredRemotes` slice. After the forward configure and fee configs complete, iterates over the slice and calls `ConfigureTokenForTransfersSequence` on each counterpart's adapter. The sequence enters the already-supported branch, detects the new pool is missing, and emits a single `addRemotePool` write. TAR registration, rate limits, fee configs, and CCVs are all no-ops.

### Active pool resolution

Instead of `remotePools[0]`, the discovery loop queries the counterpart's TAR via `TokenAdminRegistryReader.GetActivePool` — a versionless interface registered per chain family. This replaces both the forward direction's pool address and the reverse direction's target selection.

The old `TokenPoolMigrator.GetActivePool` accepted an optional `RegistryRef` parameter for selecting a non-default TAR. The new `TokenAdminRegistryReader.GetActivePool` restores this via variadic `overrides ...datastore.AddressRef` — the first override that resolves from the datastore is used; when none are provided or none resolve, the default TAR is used. The forward call sites pass `token.RegistryRef` / the liquidity seed's `registryRef`; the reverse propagation passes nothing.

### Concurrent migration (batch)

When multiple pools are migrated in a single `TokenExpansion.Apply`, the discovery loop checks if the discovered remote is also in `cfg`. If so, it resolves the counterpart's pool ref via `ResolveTokenPoolRef` using the counterpart's chain registry, then converts via the `remoteNormalizer` — bypassing the chicken-and-egg problem where TAR still points at the legacy pool because activation hasn't happened yet, and avoiding cross-family conversion issues (the local adapter can't convert a Solana base58 address). Batch migration works: A_new discovers B_new directly, and the reverse propagation targets B_new instead of B_old.

### Why no new flag?

The reverse propagation is implicit in `autoMigrateRemoteChains: true`. No new input fields.

### Why no rate limit / fee config importing on the counterpart?

Rate limits and fee configs on A's pool for chain B govern traffic FROM A TO B. They already exist on A and remain correct after migration. If a counterpart is migrated later, `autoMigrateRemoteChains` handles imports via the normal forward flow.

## Interface changes

### `TokenAdminRegistryReader` (new, `product.go`)

Versionless interface for reading the active pool from a chain's TAR. Implementations registered per chain family on `TokenAdapterRegistry`. No pool version needed.

```go
type TokenAdminRegistryReader interface {
    GetActivePool(e deployment.Environment, chainSelector uint64, tokenRef datastore.AddressRef, overrides ...datastore.AddressRef) ([]byte, error)
    GetTokenAdminRegistryRef(e deployment.Environment, chainSelector uint64) (datastore.AddressRef, error)
}
```

### `TokenPoolMigrator` (modified, `product.go`)

`GetActivePool` and `GetTokenAdminRegistryRef` removed — now on `TokenAdminRegistryReader`. Retains `GetSupportedChains`, `GetRemoteToken`, `GetRemotePools`.

## Implementation

### `deployment/tokens/configure_tokens_for_transfers.go`

**Discovery loop**: For each auto-discovered counterpart, checks if `cfg[remoteSelector]` exists (concurrent migration). If yes, reads the new pool's ref directly. Otherwise queries TAR via `TokenAdminRegistryReader.GetActivePool`.

**Reverse propagation**: After forward configure + fee configs, calls `ConfigureTokenForTransfersSequence` on each counterpart's adapter with the migrated pool's bytes in `RemoteChains`. Batch ops and addresses appended to changeset output.

### `deployment/tokens/token_expansion.go`

Forward call sites use `tokenRegistry.GetTokenAdminRegistryReader(family).GetActivePool` instead of the old `TokenPoolMigrator.GetActivePool` path.

### `chains/evm/deployment/v1_0_0/adapters/`

`EVMTokenBase` registered as `TokenAdminRegistryReader` for EVM. `GetActivePool` resolves TAR from datastore and queries the TAR contract. `GetTokenAdminRegistryRef` resolves the TAR address.

### `chains/solana/deployment/v1_0_0/adapters/tar_reader.go`

`SolanaAdminRegistryReader` registered for Solana. `GetActivePool` reads the TAR PDA on-chain, reads the address lookup table, and returns the pool program at index 2 (per the SetPool layout at router.go:344-355 and ccip-common/src/v1.rs). `GetTokenAdminRegistryRef` resolves the Router address from the datastore.

### `integration-tests/deployment/token_expansion_migration_test.go`

Extended `runAutoMigrateUpgrade` with a reverse propagation assertion: after existing forward checks, asserts B_old's `GetRemotePools(selA)` contains A_new's address.
