### PR TITLE
Don't exclude LOCK_RELEASE-mechanism tokens from migrate_chain_lanes_to_v2 symbol exclusion

### DIFF
--- a/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2.go
+++ b/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2.go
@@ -14,10 +14,16 @@ import (
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/erc20"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
+	tokenadminregistry "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/latest/token_admin_registry"
+
+	tarref "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/operations/token_admin_registry"
+	usdctokenpoolproxy "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/usdc_token_pool_proxy"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/deploy"
 	changesetscore "github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
+	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/adapters"
 	v2changesets "github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/changesets"
@@ -27,8 +33,22 @@ import (
 // v2MajorVersion is the major version of a lane already on CCIP 2.0 (no migration needed).
 const v2MajorVersion = 2
 
+// lockOrBurnMechanismLockRelease is USDCTokenPoolProxy.LockOrBurnMechanism.LOCK_RELEASE (see the
+// Solidity enum backing getLockOrBurnMechanism/updateLockOrBurnMechanisms). A pool reporting this
+// mechanism for a given remote chain is not genuinely CCTP-backed for that lane, so a token whose
+// symbol matches an excluded name (e.g. "USDC") should NOT cause the lane to be excluded when its
+// pool reports LOCK_RELEASE for that remote.
+const lockOrBurnMechanismLockRelease uint8 = 3
+
 // tokenSymbolLookup resolves the ERC20 symbol of a token deployed on the given chain.
 type tokenSymbolLookup func(chainSel uint64, token common.Address) (string, error)
+
+// tokenPoolMechanismLookup resolves the on-chain lock/burn mechanism (USDCTokenPoolProxy enum,
+// e.g. CCTP_V1/CCTP_V2/LOCK_RELEASE/CCTP_V2_WITH_CCV) configured for token's pool on chainSel, for
+// the given remote chain selector. Returns an error if token's pool cannot be resolved or does not
+// implement USDCTokenPoolProxy (e.g. an LBTC/BTC.b pool) — callers should treat that as "unknown,
+// fall back to symbol-only matching" rather than a hard failure.
+type tokenPoolMechanismLookup func(chainSel uint64, token common.Address, remoteSel uint64) (uint8, error)
 
 // MigrateChainLanesToV2Input is the durable-pipeline payload for migrate_chain_lanes_to_v2.
 //
@@ -127,7 +147,7 @@ func MigrateChainLanesToV2(
 	}
 
 	apply := func(e deployment.Environment, cfg MigrateChainLanesToV2Config) (deployment.ChangesetOutput, error) {
-		lanes, err := discoverLanesToMigrate(e, deployChainContractsRegistry, fqRegistry, makeEVMSymbolLookup(e), cfg)
+		lanes, err := discoverLanesToMigrate(e, deployChainContractsRegistry, fqRegistry, makeEVMSymbolLookup(e), makeEVMMechanismLookup(e), cfg)
 		if err != nil {
 			return deployment.ChangesetOutput{}, err
 		}
@@ -171,6 +191,7 @@ type laneDiscoverer struct {
 	resolvers       *adapters.DeployChainContractsRegistry
 	fqRegistry      *deploy.FQAndRampUpdaterRegistry
 	symbolOf        tokenSymbolLookup
+	mechanismOf     tokenPoolMechanismLookup
 	excludedRemotes map[uint64]struct{}
 	excludedSymbols map[string]struct{}
 }
@@ -183,6 +204,7 @@ func discoverLanesToMigrate(
 	resolvers *adapters.DeployChainContractsRegistry,
 	fqRegistry *deploy.FQAndRampUpdaterRegistry,
 	symbolOf tokenSymbolLookup,
+	mechanismOf tokenPoolMechanismLookup,
 	cfg MigrateChainLanesToV2Config,
 ) ([]v2changesets.CrossFamilyLanePair, error) {
 	d := &laneDiscoverer{
@@ -190,6 +212,7 @@ func discoverLanesToMigrate(
 		resolvers:       resolvers,
 		fqRegistry:      fqRegistry,
 		symbolOf:        symbolOf,
+		mechanismOf:     mechanismOf,
 		excludedRemotes: newUint64Set(cfg.ExcludedRemoteChains),
 		excludedSymbols: canonicalSymbolSet(cfg.ExcludeLanesWithTokenSymbols),
 	}
@@ -368,10 +391,24 @@ func (d *laneDiscoverer) tokenExcludedRemotes(chainSel uint64, laneVersions map[
 			if err != nil {
 				return nil, fmt.Errorf("failed to read symbol for token %s on chain %d: %w", token.Hex(), chainSel, err)
 			}
-			if _, bad := d.excludedSymbols[strings.ToUpper(symbol)]; bad {
-				excluded[remote] = struct{}{}
-				break
+			if _, bad := d.excludedSymbols[strings.ToUpper(symbol)]; !bad {
+				continue
 			}
+
+			// The symbol matched an excluded name (e.g. "USDC"). Confirm via the pool's on-chain
+			// lock/burn mechanism before excluding: LOCK_RELEASE means this is not a genuine
+			// CCTP-backed token for this remote, so the lane should NOT be excluded on account of
+			// it. If the pool doesn't implement USDCTokenPoolProxy at all (mechErr != nil — e.g. an
+			// LBTC/BTC.b pool), fall back to the plain symbol match and exclude as before.
+			if d.mechanismOf != nil {
+				mechanism, mechErr := d.mechanismOf(chainSel, token, remote)
+				if mechErr == nil && mechanism == lockOrBurnMechanismLockRelease {
+					continue
+				}
+			}
+
+			excluded[remote] = struct{}{}
+			break
 		}
 	}
 	return excluded, nil
@@ -461,6 +498,70 @@ func readERC20Symbol(ctx context.Context, backend bind.ContractBackend, token co
 		return "", fmt.Errorf("failed to bind ERC20 at %s: %w", token.Hex(), err)
 	}
 	return erc20C.Symbol(&bind.CallOpts{Context: ctx})
+}
+
+// mechanismCacheKey identifies a (token, remote chain) pair on a specific local chain for
+// lock/burn-mechanism lookup caching.
+type mechanismCacheKey struct {
+	chainSel uint64
+	token    common.Address
+	remote   uint64
+}
+
+// makeEVMMechanismLookup returns a tokenPoolMechanismLookup that resolves token's pool address on
+// chainSel via TokenAdminRegistry.GetPool, then reads USDCTokenPoolProxy.GetLockOrBurnMechanism for
+// remoteSel on that pool. Errors (no TokenAdminRegistry ref, no pool, or the pool doesn't implement
+// USDCTokenPoolProxy) are returned to the caller, which treats them as "not a USDC proxy pool" and
+// falls back to symbol-only matching. Results are cached, and the returned closure is safe for
+// concurrent use (chains are discovered in parallel).
+func makeEVMMechanismLookup(e deployment.Environment) tokenPoolMechanismLookup {
+	var mu sync.Mutex
+	cache := make(map[mechanismCacheKey]uint8)
+	return func(chainSel uint64, token common.Address, remoteSel uint64) (uint8, error) {
+		key := mechanismCacheKey{chainSel: chainSel, token: token, remote: remoteSel}
+
+		mu.Lock()
+		mechanism, ok := cache[key]
+		mu.Unlock()
+		if ok {
+			return mechanism, nil
+		}
+
+		chain, ok := e.BlockChains.EVMChains()[chainSel]
+		if !ok {
+			return 0, fmt.Errorf("lock/burn mechanism lookup is only supported for EVM chains; chain %d is not an EVM chain", chainSel)
+		}
+
+		tarRef, err := datastore_utils.FindAndFormatRef(e.DataStore, datastore.AddressRef{
+			Type:    datastore.ContractType(tarref.ContractType),
+			Version: tarref.Version,
+		}, chainSel, datastore_utils.FullRef)
+		if err != nil {
+			return 0, fmt.Errorf("failed to find TokenAdminRegistry ref on chain %d: %w", chainSel, err)
+		}
+		tar, err := tokenadminregistry.NewTokenAdminRegistry(common.HexToAddress(tarRef.Address), chain.Client)
+		if err != nil {
+			return 0, fmt.Errorf("failed to bind TokenAdminRegistry at %s on chain %d: %w", tarRef.Address, chainSel, err)
+		}
+		poolAddr, err := tar.GetPool(&bind.CallOpts{Context: e.GetContext()}, token)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get pool for token %s on chain %d: %w", token.Hex(), chainSel, err)
+		}
+
+		proxy, err := usdctokenpoolproxy.NewUSDCTokenPoolProxyContract(poolAddr, chain.Client)
+		if err != nil {
+			return 0, fmt.Errorf("failed to bind USDCTokenPoolProxy at %s on chain %d: %w", poolAddr.Hex(), chainSel, err)
+		}
+		mechanism, err = proxy.GetLockOrBurnMechanism(&bind.CallOpts{Context: e.GetContext()}, remoteSel)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get lock/burn mechanism for token %s remote %d on chain %d: %w", token.Hex(), remoteSel, chainSel, err)
+		}
+
+		mu.Lock()
+		cache[key] = mechanism
+		mu.Unlock()
+		return mechanism, nil
+	}
 }
 
 // newUint64Set returns a set of the given selectors, or nil when empty.

--- a/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2_internal_test.go
+++ b/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2_internal_test.go
@@ -121,7 +121,7 @@ func TestDiscoverLanesToMigrate_SkipsAlreadyV2Lanes(t *testing.T) {
 		},
 	}
 
-	lanes, err := discoverLanesToMigrate(cldf.Environment{}, registryWithResolver(t, resolver), supportedFQRegistry(t), nil, MigrateChainLanesToV2Config{
+	lanes, err := discoverLanesToMigrate(cldf.Environment{}, registryWithResolver(t, resolver), supportedFQRegistry(t), nil, nil, MigrateChainLanesToV2Config{
 		MigrateChainLanesToV2Input: MigrateChainLanesToV2Input{ChainSelectors: []uint64{chainA}},
 	})
 	require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestDiscoverLanesToMigrate_SkipsUnsupportedVersionLane(t *testing.T) {
 		},
 	}
 
-	lanes, err := discoverLanesToMigrate(cldf.Environment{}, registryWithResolver(t, resolver), supportedFQRegistry(t), nil, MigrateChainLanesToV2Config{
+	lanes, err := discoverLanesToMigrate(cldf.Environment{}, registryWithResolver(t, resolver), supportedFQRegistry(t), nil, nil, MigrateChainLanesToV2Config{
 		MigrateChainLanesToV2Input: MigrateChainLanesToV2Input{ChainSelectors: []uint64{chainA}},
 	})
 	require.NoError(t, err)
@@ -168,7 +168,7 @@ func TestDiscoverLanesToMigrate_ExcludesBlocklistedRemotes(t *testing.T) {
 		},
 	}
 
-	lanes, err := discoverLanesToMigrate(cldf.Environment{}, registryWithResolver(t, resolver), supportedFQRegistry(t), nil, MigrateChainLanesToV2Config{
+	lanes, err := discoverLanesToMigrate(cldf.Environment{}, registryWithResolver(t, resolver), supportedFQRegistry(t), nil, nil, MigrateChainLanesToV2Config{
 		MigrateChainLanesToV2Input: MigrateChainLanesToV2Input{
 			ChainSelectors:       []uint64{chainA},
 			ExcludedRemoteChains: []uint64{remoteDrop},
@@ -196,7 +196,7 @@ func TestDiscoverLanesToMigrate_DedupsAcrossMultipleChains(t *testing.T) {
 		},
 	}
 
-	lanes, err := discoverLanesToMigrate(cldf.Environment{}, registryWithResolver(t, resolver), supportedFQRegistry(t), nil, MigrateChainLanesToV2Config{
+	lanes, err := discoverLanesToMigrate(cldf.Environment{}, registryWithResolver(t, resolver), supportedFQRegistry(t), nil, nil, MigrateChainLanesToV2Config{
 		MigrateChainLanesToV2Input: MigrateChainLanesToV2Input{ChainSelectors: []uint64{chainA, chainB, chainC}},
 	})
 	require.NoError(t, err)
@@ -246,7 +246,7 @@ func TestDiscoverLanesToMigrate_DedupsBidirectionalLane(t *testing.T) {
 		},
 	}
 
-	lanes, err := discoverLanesToMigrate(cldf.Environment{}, registryWithResolver(t, resolver), supportedFQRegistry(t), nil, MigrateChainLanesToV2Config{
+	lanes, err := discoverLanesToMigrate(cldf.Environment{}, registryWithResolver(t, resolver), supportedFQRegistry(t), nil, nil, MigrateChainLanesToV2Config{
 		MigrateChainLanesToV2Input: MigrateChainLanesToV2Input{ChainSelectors: []uint64{chainA, chainB}},
 	})
 	require.NoError(t, err)
@@ -265,7 +265,7 @@ func TestDiscoverLanesToMigrate_SkipsUnknownVersionLane(t *testing.T) {
 		},
 	}
 
-	lanes, err := discoverLanesToMigrate(cldf.Environment{}, registryWithResolver(t, resolver), supportedFQRegistry(t), nil, MigrateChainLanesToV2Config{
+	lanes, err := discoverLanesToMigrate(cldf.Environment{}, registryWithResolver(t, resolver), supportedFQRegistry(t), nil, nil, MigrateChainLanesToV2Config{
 		MigrateChainLanesToV2Input: MigrateChainLanesToV2Input{ChainSelectors: []uint64{chainA}},
 	})
 	require.NoError(t, err)
@@ -285,7 +285,7 @@ func TestDiscoverLanesToMigrate_SkipsAllWithoutFQRegistry(t *testing.T) {
 
 	// Without a fee-quoter/ramp updater registry we cannot confirm a version is supported, so nothing
 	// is migrated. (The hard requirement is enforced by the changeset's VerifyPreconditions.)
-	lanes, err := discoverLanesToMigrate(cldf.Environment{}, registryWithResolver(t, resolver), nil, nil, MigrateChainLanesToV2Config{
+	lanes, err := discoverLanesToMigrate(cldf.Environment{}, registryWithResolver(t, resolver), nil, nil, nil, MigrateChainLanesToV2Config{
 		MigrateChainLanesToV2Input: MigrateChainLanesToV2Input{ChainSelectors: []uint64{chainA}},
 	})
 	require.NoError(t, err)
@@ -296,7 +296,7 @@ func TestDiscoverLanesToMigrate_ErrorsWhenResolverMissing(t *testing.T) {
 	chainA := chainsel.TEST_90000001.Selector
 
 	// Empty registry: no resolver registered for any family.
-	_, err := discoverLanesToMigrate(cldf.Environment{}, adapters.NewDeployChainContractsRegistry(), supportedFQRegistry(t), nil, MigrateChainLanesToV2Config{
+	_, err := discoverLanesToMigrate(cldf.Environment{}, adapters.NewDeployChainContractsRegistry(), supportedFQRegistry(t), nil, nil, MigrateChainLanesToV2Config{
 		MigrateChainLanesToV2Input: MigrateChainLanesToV2Input{ChainSelectors: []uint64{chainA}},
 	})
 	require.Error(t, err)
@@ -311,7 +311,7 @@ func TestDiscoverLanesToMigrate_PropagatesResolverError(t *testing.T) {
 		err:       errors.New("rpc unavailable"),
 	}
 
-	_, err := discoverLanesToMigrate(cldf.Environment{}, registryWithResolver(t, resolver), supportedFQRegistry(t), nil, MigrateChainLanesToV2Config{
+	_, err := discoverLanesToMigrate(cldf.Environment{}, registryWithResolver(t, resolver), supportedFQRegistry(t), nil, nil, MigrateChainLanesToV2Config{
 		MigrateChainLanesToV2Input: MigrateChainLanesToV2Input{ChainSelectors: []uint64{chainA}},
 	})
 	require.Error(t, err)
@@ -325,7 +325,7 @@ func TestDiscoverLanesToMigrate_ErrorsWhenChainUnsupported(t *testing.T) {
 		supported: map[uint64]bool{chainA: false},
 	}
 
-	_, err := discoverLanesToMigrate(cldf.Environment{}, registryWithResolver(t, resolver), supportedFQRegistry(t), nil, MigrateChainLanesToV2Config{
+	_, err := discoverLanesToMigrate(cldf.Environment{}, registryWithResolver(t, resolver), supportedFQRegistry(t), nil, nil, MigrateChainLanesToV2Config{
 		MigrateChainLanesToV2Input: MigrateChainLanesToV2Input{ChainSelectors: []uint64{chainA}},
 	})
 	require.Error(t, err)
@@ -354,7 +354,7 @@ func TestDiscoverLanesToMigrate_ExcludesNonEVMRemotes(t *testing.T) {
 		},
 	}
 
-	lanes, err := discoverLanesToMigrate(cldf.Environment{}, registryWithResolver(t, resolver), supportedFQRegistry(t), nil, MigrateChainLanesToV2Config{
+	lanes, err := discoverLanesToMigrate(cldf.Environment{}, registryWithResolver(t, resolver), supportedFQRegistry(t), nil, nil, MigrateChainLanesToV2Config{
 		MigrateChainLanesToV2Input: MigrateChainLanesToV2Input{ChainSelectors: []uint64{chainA}},
 	})
 	require.NoError(t, err)
@@ -369,7 +369,7 @@ func TestDiscoverLanesToMigrate_SkipsNonEVMLocalChain(t *testing.T) {
 	solana := chainsel.SOLANA_DEVNET.Selector
 
 	// No resolver needed: non-EVM local chains are skipped before any resolver lookup.
-	lanes, err := discoverLanesToMigrate(cldf.Environment{}, adapters.NewDeployChainContractsRegistry(), supportedFQRegistry(t), nil, MigrateChainLanesToV2Config{
+	lanes, err := discoverLanesToMigrate(cldf.Environment{}, adapters.NewDeployChainContractsRegistry(), supportedFQRegistry(t), nil, nil, MigrateChainLanesToV2Config{
 		MigrateChainLanesToV2Input: MigrateChainLanesToV2Input{ChainSelectors: []uint64{solana}},
 	})
 	require.NoError(t, err)
@@ -418,11 +418,132 @@ func TestDiscoverLanesToMigrate_SkipsLanesWithExcludedTokenSymbol(t *testing.T) 
 		registryWithResolver(t, resolver),
 		fqRegistryWithImporter(t, version, importer),
 		symbolOf,
+		nil,
 		MigrateChainLanesToV2Config{
 			MigrateChainLanesToV2Input: MigrateChainLanesToV2Input{
 				ChainSelectors: []uint64{chainA},
 				// Lowercase to confirm case-insensitive matching against on-chain "USDC".
 				ExcludeLanesWithTokenSymbols: []string{"usdc"},
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, lanes, 1)
+	assert.Equal(t, remotePlain, lanes[0].ChainB)
+}
+
+// mechanismLookupFrom builds a fake tokenPoolMechanismLookup from a token-address -> mechanism map.
+// Tokens not present in the map report an error, simulating a pool that doesn't implement
+// USDCTokenPoolProxy (e.g. an LBTC/BTC.b pool).
+func mechanismLookupFrom(mechanisms map[common.Address]uint8) tokenPoolMechanismLookup {
+	return func(_ uint64, token common.Address, _ uint64) (uint8, error) {
+		mechanism, ok := mechanisms[token]
+		if !ok {
+			return 0, errors.New("not a USDCTokenPoolProxy pool")
+		}
+		return mechanism, nil
+	}
+}
+
+func TestDiscoverLanesToMigrate_DoesNotExcludeLockReleaseUSDCLikeToken(t *testing.T) {
+	chainA := chainsel.TEST_90000001.Selector
+	remoteWithUSDC := chainsel.TEST_90000002.Selector
+	remotePlain := chainsel.TEST_90000003.Selector
+
+	version := semver.MustParse("1.6.0")
+	usdc := common.HexToAddress("0x000000000000000000000000000000000000abcd")
+	other := common.HexToAddress("0x0000000000000000000000000000000000001234")
+
+	resolver := &fakeLaneVersionResolver{
+		supported: map[uint64]bool{chainA: true, remoteWithUSDC: true, remotePlain: true},
+		lanes: map[uint64]map[uint64]*semver.Version{
+			chainA: {
+				remoteWithUSDC: version,
+				remotePlain:    version,
+			},
+			remoteWithUSDC: {chainA: version},
+			remotePlain:    {chainA: version},
+		},
+	}
+	importer := &fakeConfigImporter{
+		tokensPerRemote: map[uint64][]common.Address{
+			remoteWithUSDC: {other, usdc},
+			remotePlain:    {other},
+		},
+	}
+	symbolOf := symbolLookupFrom(map[common.Address]string{
+		usdc:  "USDC",
+		other: "WETH",
+	})
+	// The pool backing "usdc" reports LOCK_RELEASE for this remote, so it is not genuinely
+	// CCTP-backed and must NOT cause the lane to be excluded despite the symbol match.
+	mechanismOf := mechanismLookupFrom(map[common.Address]uint8{
+		usdc: lockOrBurnMechanismLockRelease,
+	})
+
+	lanes, err := discoverLanesToMigrate(
+		cldf.Environment{},
+		registryWithResolver(t, resolver),
+		fqRegistryWithImporter(t, version, importer),
+		symbolOf,
+		mechanismOf,
+		MigrateChainLanesToV2Config{
+			MigrateChainLanesToV2Input: MigrateChainLanesToV2Input{
+				ChainSelectors:               []uint64{chainA},
+				ExcludeLanesWithTokenSymbols: []string{"USDC"},
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, lanes, 2, "LOCK_RELEASE mechanism means this is not real USDC, so neither lane should be excluded")
+	gotRemotes := map[uint64]struct{}{lanes[0].ChainB: {}, lanes[1].ChainB: {}}
+	assert.Contains(t, gotRemotes, remoteWithUSDC)
+	assert.Contains(t, gotRemotes, remotePlain)
+}
+
+func TestDiscoverLanesToMigrate_ExcludesWhenMechanismLookupFailsFallsBackToSymbol(t *testing.T) {
+	chainA := chainsel.TEST_90000001.Selector
+	remoteWithUSDC := chainsel.TEST_90000002.Selector
+	remotePlain := chainsel.TEST_90000003.Selector
+
+	version := semver.MustParse("1.6.0")
+	usdc := common.HexToAddress("0x000000000000000000000000000000000000abcd")
+	other := common.HexToAddress("0x0000000000000000000000000000000000001234")
+
+	resolver := &fakeLaneVersionResolver{
+		supported: map[uint64]bool{chainA: true, remotePlain: true},
+		lanes: map[uint64]map[uint64]*semver.Version{
+			chainA: {
+				remoteWithUSDC: version,
+				remotePlain:    version,
+			},
+			remotePlain: {chainA: version},
+		},
+	}
+	importer := &fakeConfigImporter{
+		tokensPerRemote: map[uint64][]common.Address{
+			remoteWithUSDC: {other, usdc},
+			remotePlain:    {other},
+		},
+	}
+	symbolOf := symbolLookupFrom(map[common.Address]string{
+		usdc:  "USDC",
+		other: "WETH",
+	})
+	// mechanismLookupFrom(nil) errors for every token (not a USDCTokenPoolProxy pool), so the plain
+	// symbol match must still exclude the lane.
+	mechanismOf := mechanismLookupFrom(nil)
+
+	lanes, err := discoverLanesToMigrate(
+		cldf.Environment{},
+		registryWithResolver(t, resolver),
+		fqRegistryWithImporter(t, version, importer),
+		symbolOf,
+		mechanismOf,
+		MigrateChainLanesToV2Config{
+			MigrateChainLanesToV2Input: MigrateChainLanesToV2Input{
+				ChainSelectors:               []uint64{chainA},
+				ExcludeLanesWithTokenSymbols: []string{"USDC"},
 			},
 		},
 	)
@@ -457,6 +578,7 @@ func TestDiscoverLanesToMigrate_SkipsLaneWithExcludedTokenOnlyInReverseDirection
 		registryWithResolver(t, resolver),
 		fqRegistryWithImporter(t, version, importer),
 		symbolLookupFrom(map[common.Address]string{usdc: "USDC", other: "WETH"}),
+		nil,
 		MigrateChainLanesToV2Config{
 			MigrateChainLanesToV2Input: MigrateChainLanesToV2Input{
 				ChainSelectors:               []uint64{chainA},
@@ -484,6 +606,7 @@ func TestDiscoverLanesToMigrate_SkipsVersionWithoutConfigImporter(t *testing.T) 
 		registryWithResolver(t, resolver),
 		fqRegistryWithImporter(t, semver.MustParse("1.5.0"), &fakeConfigImporter{}),
 		symbolLookupFrom(nil),
+		nil,
 		MigrateChainLanesToV2Config{
 			MigrateChainLanesToV2Input: MigrateChainLanesToV2Input{ChainSelectors: []uint64{chainA}},
 		},


### PR DESCRIPTION
## Summary
- `excludeLanesWithTokenSymbols` (e.g. `[USDC, LBTC, BTC.b]`) previously excluded a lane purely on a case-insensitive ERC20 `symbol()` match, which could incorrectly hold back a lane whose "USDC"-symbol token is not actually a genuine CCTP-backed pool.
- For every token whose symbol matches an excluded name, the resolver now also reads the pool's on-chain lock/burn mechanism via `TokenAdminRegistry.GetPool` + `USDCTokenPoolProxy.GetLockOrBurnMechanism`. If the mechanism is `LOCK_RELEASE`, the token is not treated as genuine USDC and the lane is not excluded on its account.
- If the mechanism lookup errors (pool doesn't implement `USDCTokenPoolProxy`, e.g. an LBTC/BTC.b pool) or returns any other mechanism (`CCTP_V1`/`CCTP_V2`/`CCTP_V2_WITH_CCV`), behavior falls back to the previous plain symbol-match exclusion.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./deployment/v2_0_0/changesets/...`
- [x] `go test ./deployment/v2_0_0/changesets/...` — 17/17 pass, including 2 new tests covering the LOCK_RELEASE bypass and the mechanism-lookup-failure fallback
- [x] Independent review pass confirmed enum value, control flow, and fallback behavior against the Solidity `LockOrBurnMechanism` enum

🤖 Generated with [Claude Code](https://claude.com/claude-code)