### PR TITLE
fix: v2 token pool migration detection

### DIFF
--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -47,14 +47,16 @@ type TokenTransferConfig struct {
 	// AutoMigrateRemoteChains is only applicable when migrating a pre-V2 pool to V2. When true, the changeset
 	// fetches the currently active pool from TAR, queries its supported remote chains, and populates RemoteChains
 	// automatically with (token, pool, decimals, rate limits, and MigrationMetadata). Legacy lane fees are read
-	// from the fee quoter or onramp (v1.5.x) and merged with any user-provided tokenTransferFeeConfig on each
+	// from the fee quoter (v1.6+) or onramp (v1.5) and merged with any user-provided tokenTransferFeeConfig on each
 	// remote (set YAML fields win; unset fields are imported). Resolved connectivity, rate limits, and migration
-	// metadata are passed to ConfigureTokenForTransfersSequence for on-chain apply.
-	// Requires an adapter implementing the TokenPoolMigrator and RateLimitReaderAdapter interfaces. This knob has no effect if any of the
-	// following are true:
+	// metadata are passed to ConfigureTokenForTransfersSequence for on-chain apply. Migration relies on the
+	// legacy (pre-V2 active pool) adapter implementing the TokenPoolMigrator interface; when it does, discovery
+	// also requires the RateLimitReaderAdapter interface. See (4) for when the migrator is absent. This knob has
+	// no effect if any of the following are true:
 	//  (1) There is no active pool in TAR for the token
 	//  (2) The active pool in TAR is already the target pool (extend mode)
 	//  (3) The active pool in TAR is already v2.0.0 or higher
+	//  (4) The active pool's chain family is not on V2, so its adapter has no token pool migrator - the knob is a no-op for that chain since there is no V2 pool to migrate to
 	//
 	// When discovery is skipped, the changeset logs at info level and does not error. Remote chains,
 	// connectivity, and fees are taken only from explicit RemoteChains YAML (same as autoMigrateRemoteChains: false).
@@ -77,6 +79,14 @@ type TokenTransferConfig struct {
 	// Fee discovery requires connected CCIP lanes (OnRamp/FeeQuoter resolvable per remote). Discovery failures
 	// abort the entire changeset. If legacy lane fees are disabled and YAML omits tokenTransferFeeConfig,
 	// no fee transactions are emitted on the new v2 pool.
+	//
+	// Connectivity is propagated in both directions across the existing web of pools. Given a fully connected
+	// web A, B, C and migrating A to A_new:
+	//  - Forward propagation: A_new's RemoteChains are populated with all remotes discovered from the
+	//    active pool (A's legacy remotes B and C), so A_new is configured to reach B and C.
+	//  - Reverse propagation: B and C are each told to add A_new as an additional remote pool, so the
+	//    web stays reachable from B/C back to A_new. Same-batch peers being migrated in this changeset
+	//    are skipped for reverse propagation; forward config wires them instead.
 	//
 	// Limitation: discovery calls getSupportedChains on the TAR-registered active pool. Pools that do not
 	// implement that interface (e.g. USDCTokenPoolProxy) cause auto-migrate to fail; list remote chains
@@ -232,32 +242,35 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 						if err != nil {
 							return nil, nil, nil, fmt.Errorf("failed to resolve adapter for active pool on chain selector %d: %w", selector, err)
 						}
-						legacyRateLimitReader, ok = legacyAdapter.(RateLimitReaderAdapter)
-						if !ok {
-							return nil, nil, nil, fmt.Errorf(
-								"adapter for active pool version %s on chain selector %d does not implement RateLimitReaderAdapter",
-								activePoolRef.Version, selector,
-							)
-						}
+						// Capability-based gate: only families whose legacy adapter implements the
+						// TokenPoolMigrator interface can be the source of an auto-migration (e.g.
+						// EVM on V2). A family that is not on V2 intentionally has no migrator, so
+						// treat auto-migrate as a no-op for that chain instead of hard failing the
+						// changeset.
 						legacyPoolMigrator, ok = legacyAdapter.(TokenPoolMigrator)
 						if !ok {
-							return nil, nil, nil, fmt.Errorf(
-								"adapter for active pool version %s on chain selector %d does not support token pool migration",
-								activePoolRef.Version, selector,
-							)
-						}
-						tokenBytes, err := legacyAdapter.AddressRefToBytes(fullTokenRef)
-						if err != nil {
-							return nil, nil, nil, fmt.Errorf("failed to convert token ref to bytes on chain selector %d: %w", selector, err)
-						}
-						localDecimals, err = legacyAdapter.DeriveTokenDecimals(e, selector, activePoolRef, tokenBytes)
-						if err != nil {
-							return nil, nil, nil, fmt.Errorf("failed to derive local token decimals on chain selector %d: %w", selector, err)
-						}
-						if supported, err := legacyPoolMigrator.GetSupportedChains(e, selector, activePool); err != nil {
-							return nil, nil, nil, fmt.Errorf("failed to get supported remote chains for token pool on chain selector %d: %w", selector, err)
+							e.Logger.Infof("adapter for active pool version %s on chain selector %d does not support token pool migration, skipping auto-migration of remote chains", activePoolRef.Version, selector)
 						} else {
-							allRemoteSelectors = supported
+							legacyRateLimitReader, ok = legacyAdapter.(RateLimitReaderAdapter)
+							if !ok {
+								return nil, nil, nil, fmt.Errorf(
+									"adapter for active pool version %s on chain selector %d does not implement RateLimitReaderAdapter",
+									activePoolRef.Version, selector,
+								)
+							}
+							tokenBytes, err := legacyAdapter.AddressRefToBytes(fullTokenRef)
+							if err != nil {
+								return nil, nil, nil, fmt.Errorf("failed to convert token ref to bytes on chain selector %d: %w", selector, err)
+							}
+							localDecimals, err = legacyAdapter.DeriveTokenDecimals(e, selector, activePoolRef, tokenBytes)
+							if err != nil {
+								return nil, nil, nil, fmt.Errorf("failed to derive local token decimals on chain selector %d: %w", selector, err)
+							}
+							if supported, err := legacyPoolMigrator.GetSupportedChains(e, selector, activePool); err != nil {
+								return nil, nil, nil, fmt.Errorf("failed to get supported remote chains for token pool on chain selector %d: %w", selector, err)
+							} else {
+								allRemoteSelectors = supported
+							}
 						}
 					} else {
 						e.Logger.Infof("Active pool on chain selector %d is already v2.0.0 or higher, skipping auto-migration of remote chains", selector)

--- a/deployment/tokens/configure_tokens_for_transfers_test.go
+++ b/deployment/tokens/configure_tokens_for_transfers_test.go
@@ -14,6 +14,7 @@ import (
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	mcms_types "github.com/smartcontractkit/mcms/types"
 
+	"github.com/smartcontractkit/chainlink-ccip/deployment/deploy"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
@@ -156,6 +157,13 @@ func (ma *transfersTest_MockTokenAdapter) DeriveTokenAddress(e deployment.Enviro
 
 func (ma *transfersTest_MockTokenAdapter) DeriveTokenDecimals(e deployment.Environment, chainSelector uint64, poolRef datastore.AddressRef, token []byte) (uint8, error) {
 	return 18, nil
+}
+
+// GetOnchainRateLimits makes transfersTest_MockTokenAdapter implement RateLimitReaderAdapter while
+// deliberately NOT implementing TokenPoolMigrator. This mirrors the shape of a real non-V2 adapter
+// (e.g. Solana): it can read rate limits but has no pool migrator.
+func (ma *transfersTest_MockTokenAdapter) GetOnchainRateLimits(_ cldf_ops.Bundle, _ cldf_chain.BlockChains, _ datastore.DataStore, _ uint64, _ datastore.AddressRef, _ datastore.AddressRef, _ uint64, _ bool) (tokens.OnchainRateLimits, error) {
+	return tokens.OnchainRateLimits{}, nil
 }
 
 func (ma *transfersTest_MockTokenAdapter) DeriveTokenPoolCounterpart(e deployment.Environment, chainSelector uint64, tokenPool []byte, token []byte) ([]byte, error) {
@@ -1136,4 +1144,101 @@ func TestLegacyRateLimitsForAutoMigrate(t *testing.T) {
 			require.Equal(t, 0, tt.wantInbound.Rate.Cmp(got.Inbound.Rate))
 		})
 	}
+}
+
+type transfersTest_MockTokenAdminRegistryReader struct {
+	activePool []byte
+}
+
+func (r *transfersTest_MockTokenAdminRegistryReader) GetActivePool(_ deployment.Environment, _ uint64, _ datastore.AddressRef, _ ...datastore.AddressRef) ([]byte, error) {
+	return r.activePool, nil
+}
+
+func (r *transfersTest_MockTokenAdminRegistryReader) GetTokenAdminRegistryRef(_ deployment.Environment, chainSelector uint64) (datastore.AddressRef, error) {
+	return datastore.AddressRef{ChainSelector: chainSelector}, nil
+}
+
+// transfersTest_IdentityNormalizer passes addresses through unchanged. It is registered for the
+// EVM family only in tests that need to reach the auto-migrate discovery path (which requires an
+// address normalizer). It is safe for sibling tests, which use non-hexaddresses that would trip a
+// real EVM normalizer.
+type transfersTest_IdentityNormalizer struct{}
+
+func (transfersTest_IdentityNormalizer) NormalizeAddress(address string) (string, error) {
+	return address, nil
+}
+
+func (transfersTest_IdentityNormalizer) BytesToString(address []byte) (string, error) {
+	return string(address), nil
+}
+
+func (transfersTest_IdentityNormalizer) StringToBytes(address string) ([]byte, error) {
+	return []byte(address), nil
+}
+
+// TestAutoMigrate_NonMigratableSourceSkips exercises the case where a chain sets
+// AutoMigrateRemoteChains=true but its legacy adapter does not implement TokenPoolMigrator (e.g.
+// Solana, which is not on V2). This must be treated as a no-op that skips auto-migration discovery
+// for that chain rather than a hard error. The active pool is registered and differs from the target
+// pool and is pre-V2, so the code genuinely reaches the migrator capability check.
+func TestAutoMigrate_NonMigratableSourceSkips(t *testing.T) {
+	const sel = 5009297550715157269
+	const (
+		targetPoolAddr = "target-pool"
+		activePoolAddr = "legacy-active-pool"
+	)
+
+	// Register mocks idempotently on the singleton registries. The "evm" normalizer is an identity
+	// normalizer so test addresses flow through unchanged.
+	tokenRegistry := tokens.GetTokenAdapterRegistry()
+
+	// Use a distinct pre-V2 version (1.5.0) so this test resolves its OWN adapter instance and is
+	// isolated from the shared mock that TestConfigureTokensForTransfers_Apply mutates (it sets
+	// error fields without clearing them, and RegisterTokenAdapter is a no-op once registered).
+	mockAdapter := &transfersTest_MockTokenAdapter{}
+	tokenRegistry.RegisterTokenAdapter("evm", semver.MustParse("1.5.0"), mockAdapter)
+	tokenRegistry.RegisterTokenRefResolver("evm", mockAdapter)
+	tokenRegistry.RegisterTokenAdminRegistryReader("evm", &transfersTest_MockTokenAdminRegistryReader{activePool: []byte(activePoolAddr)})
+	deploy.GetAddressNormalizerRegistry().RegisterAddressNormalizer(chain_selectors.FamilyEVM, transfersTest_IdentityNormalizer{})
+	changesets.GetRegistry().RegisterMCMSReader("evm", &MockReader{})
+
+	legacyVersion := semver.MustParse("1.5.0")
+	ds := datastore.NewMemoryDataStore()
+	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
+		ChainSelector: sel, Address: targetPoolAddr, Type: "TokenPool", Version: legacyVersion, Qualifier: "default",
+	}))
+	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
+		ChainSelector: sel, Address: activePoolAddr, Type: "TokenPool", Version: legacyVersion, Qualifier: "legacy-active",
+	}))
+	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
+		ChainSelector: sel, Address: "registry", Type: "Registry", Version: legacyVersion,
+	}))
+
+	lggr, err := logger.New()
+	require.NoError(t, err)
+	bundle := cldf_ops.NewBundle(func() context.Context { return context.Background() }, lggr, cldf_ops.NewMemoryReporter())
+	env := deployment.Environment{OperationsBundle: bundle, Logger: lggr, DataStore: ds.Seal()}
+
+	cfg := tokens.ConfigureTokensForTransfersConfig{
+		Tokens: []tokens.TokenTransferConfig{
+			{
+				AutoMigrateRemoteChains: true,
+				ChainSelector:           sel,
+				TokenPoolRef: datastore.AddressRef{
+					Type: "TokenPool", Version: legacyVersion, ChainSelector: sel, Qualifier: "default",
+				},
+				RegistryRef: datastore.AddressRef{
+					Type: "Registry", Version: legacyVersion, ChainSelector: sel,
+				},
+			},
+		},
+		MCMS: basicMCMSInput,
+	}
+
+	// Regression: a pre-V2 source whose adapter has no TokenPoolMigrator must not error. Auto-migrate
+	// discovery and reverse-propagation are skipped for the non-migratable source (no batch ops are
+	// fabricated for it), and the changeset otherwise completes normally.
+	changeset := tokens.ConfigureTokensForTransfers(tokenRegistry, changesets.GetRegistry())
+	_, err = changeset.Apply(env, cfg)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
# AutoMigrateRemoteChains: gracefully skip non-migratable pool sources

## Background

`AutoMigrateRemoteChains` lets a token-pool expansion upgrade carry an existing pre-V2 pool's cross-chain configuration forward onto its V2 replacement. It reads the currently-registered active pool from the TokenAdminRegistry, discovers the remotes it is wired to, and re-applies that connectivity (plus rate limits, fees, and migration metadata) so the new pool replaces the old one without manual reconfiguration.

CCIP V2 is not homogeneous across chain families. Today EVM pools have a V2 target; Solana pools do not (there is no Solana V2 pool to migrate to). Solana can participate in a migration web as a counterpart, but a Solana pool can never be the migrating source.

## The problem

The auto-migrate discovery path treated "the active pool's adapter has no token pool migrator" as a hard changeset failure. A single non-migratable source chain (for instance, a Solana pool with `AutoMigrateRemoteChains: true`) aborted the entire operation, even though migration of that pool is simply not applicable — there is no V2 destination for it.

## What this change does

The core intent is to make a non-migratable source a no-op for that chain instead of a fatal error, and to do so without introducing chain-family knowledge into chain-agnostic code.

The migration capability is expressed as a Go interface: `TokenPoolMigrator`. A chain family that can be migrated implements it; one that cannot does not. This makes the interface assertion itself the natural, extensible signal of "this family is on V2", rather than an `if family == solana` hardcode in the generic orchestrator.

Key behavioral changes:

- **The migrator becomes the gate.** Discovery first asks whether the active pool's adapter implements `TokenPoolMigrator`. If not, auto-migration for that chain is skipped and the code proceeds to configure the pool normally with only the explicitly-listed remote chains — exactly as if `AutoMigrateRemoteChains` had been false. The skip is logged at info level, matching the other "no effect" branches (already v2, already the target pool).
- **Rate-limit reading is only required once migration is actually possible.** The `RateLimitReaderAdapter` requirement now applies only on the migrator-supported path, so an adapter that can read rate limits but has no migrator is not incorrectly rejected up front. EVM, which implements both, is unaffected.
- When migration *is* supported, the pre-existing discovery flow (remote token/pool resolution, rate-limit import, fee import, and reverse propagation back to legacy counterparts) runs unchanged.

The guarded variables are scoped such that a skipped source simply leaves the discovered-remotes set empty, so no discovery or reverse-propagation effects are emitted for it, and no downstream code observes nil migrator/rate-limit readers.

## Design notes

- **Capability over family.** The fix uses interface satisfaction as the source of truth for migratability. This keeps the orchestrator family-agnostic and automatically covers any future non-V2 family, not just Solana.
- **Skip, not warn.** Skipping logs at info rather than warning. The reference behavior for auto-migrate is that the knob "has no effect" under documented conditions, and a non-migratable source is treated as one of those conditions rather than a misconfiguration.
- **Docs track the new semantics.** The field comment now enumerates the non-migratable case as a distinct no-op condition and clarifies that the rate-limit-reader requirement is conditional on migration actually being possible.
