### PR TITLE
fix: batched reverse-propagation for v2 pool migrations

### DIFF
--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -140,8 +140,16 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 	reports := make([]cldf_ops.Report[any, any], 0)
 	ds := datastore.NewMemoryDataStore()
 
+	// If autoMigrateRemoteChains is enabled for any chain then we need to take a snapshot of
+	// the currently active pools for reverse propagation purposes. We *SHOULDN'T* do this in
+	// the loop below because the active pool may be updated in the same batch and we need to
+	// know the pre-batch state.
+	activePoolsSnapshot, err := snapshotActivePools(e, tokenRegistry, cfg)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to snapshot active pools for auto-migrate: %w", err)
+	}
+
 	// Process chains in deterministic (sorted) selector order (Go map iteration is randomized)
-	var err error
 	for _, selector := range slices.Sorted(maps.Keys(cfg)) {
 		token := cfg[selector]
 
@@ -191,10 +199,12 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 		}
 
 		type DiscoveredRemoteChain struct {
-			remoteSelector uint64
-			remoteTokenRef datastore.AddressRef
-			remotePoolRef  datastore.AddressRef
-			remoteAdapter  TokenAdapter
+			remoteNormalizer deploy.AddressNormalizer
+			remoteSelector   uint64
+			remoteTokenRef   datastore.AddressRef
+			remotePoolRef    datastore.AddressRef
+			remoteAdapter    TokenAdapter
+			remoteFamily     string
 		}
 
 		// When AutoMigrateRemoteChains = true, we read the legacy pool's remote chains and import them into
@@ -244,17 +254,10 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 						if err != nil {
 							return nil, nil, nil, fmt.Errorf("failed to resolve adapter for active pool on chain selector %d: %w", selector, err)
 						}
-						// Auto-migration is only meaningful for a genuine V2 upgrade, so require the configured
-						// target pool to be v2.0.0+ - keying this on the target's version (rather than on which
-						// interfaces the active-pool adapter happens to implement) keeps the gate robust across
-						// chain families including adapters which implement TokenPoolMigrator while their chain
-						// is still not on V2. The active-pool adapter must also implement the TokenPoolMigrator
-						// interface for the discovery body to run; if either condition fails, auto-migrate is a
-						// no-op for that chain.
 						if tokenPool.Version != nil && tokenPool.Version.GreaterThanEqual(utils.Version_2_0_0) {
-							// For a genuine V2 target, discovery needs the active adapter to implement the migrator.
-							// If it doesn't then we fall back to the remotes listed explicitly in the input (this is
-							// the documented workaround e.g. `USDCTokenPoolProxy`)
+							// If TokenPoolMigrator is not implemented, then we intentionally won't treat this as
+							// a hard fail. Some pools (e.g. USDCTokenPoolProxy) cannot implement this interface,
+							// so operators should be allowed to manually list the remotes to workaround this.
 							if legacyPoolMigrator, ok = legacyAdapter.(TokenPoolMigrator); ok {
 								if legacyRateLimitReader, ok = legacyAdapter.(RateLimitReaderAdapter); !ok {
 									return nil, nil, nil, fmt.Errorf(
@@ -338,10 +341,12 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 					return nil, nil, nil, fmt.Errorf("failed to get remote pools for remote chain selector %d: %w", remoteSelector, err)
 				}
 				discoveredRemotes = append(discoveredRemotes, DiscoveredRemoteChain{
-					remoteSelector: remoteSelector,
-					remoteTokenRef: remoteTokenRef,
-					remotePoolRef:  remotePoolRef,
-					remoteAdapter:  remoteAdapter,
+					remoteNormalizer: remoteNormalizer,
+					remoteSelector:   remoteSelector,
+					remoteTokenRef:   remoteTokenRef,
+					remotePoolRef:    remotePoolRef,
+					remoteAdapter:    remoteAdapter,
+					remoteFamily:     remoteFamily,
 				})
 				remoteTokenDecimals, err := remoteAdapter.DeriveTokenDecimals(e, remoteSelector, remotePoolRef, remoteTokenBytes)
 				if err != nil {
@@ -474,26 +479,25 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 				return nil, nil, nil, fmt.Errorf("failed to convert new pool ref to bytes for reverse propagation on chain selector %d: %w", selector, err)
 			}
 			for _, ru := range discoveredRemotes {
-				// After a pool migrates reverse-propagation tells every peer it was connected to about the new
-				// pool, keeping the web reachable in both directions. We skip one case: a same-batch peer that
-				// is itself being REPLACED — its new pool isn't live yet, so configuring it now would activate
-				// it too early and break that peer's own migration. Its own forward config wires it instead.
-				//
-				// A peer is being replaced exactly when its configured TARGET pool is V2 (>= 2.0.0): such a
-				// peer is skipped. Any peer with a pre-V2 target is not being replaced and must still learn
-				// about the new pool. Example: in one batch say we migrate A and C to A2/C2 while B remains
-				// on its v1 pool. Processing A tells B about A2 but leaves C alone (C is getting C2 in this
-				// same batch); processing C tells B about C2 and leaves A alone. So B learns both A2 and C2,
-				// C2 pairs with A2 via C's own forward config, A2 pairse with C2 via A's own forward config,
-				// and the web stays fully connected.
-				//
-				// Deciding by the target version (not by which interfaces the peer's adapter implements) stays
-				// correct even if a non-V2 family later adds a migrator.
+				// After a pool is migrated, we need to tell every connected chain about the new pool so that the
+				// web stays reachable in both directions. One edge case to consider - suppose we have a web with
+				// pools A1, B1, C1, where A1 + B1 are being migrated to A2 and B2. When A2's reverse propagation
+				// runs, it should *skip* B2 otherwise it would prematurely activate it and breaks B's migration.
+				// Instead we let B2's own forward propagation handle this case. One nuance to keep in mind: it's
+				// also possible that we could have a web like A1, B2, C1 where B2 is already migrated. If we are
+				// migrating A1 to A2, then A2's reverse propagation should *not skip* B2 since it's already live
+				// and we want to tell it about A2. To differentiate between these two cases, we compare the pool
+				// that the counterpart chain is currently using (from the pre-batch snapshot) with the pool that
+				// it is being migrated to in this changeset. If they differ, or it has no current pool then it's
+				// getting a new pool and we leave it alone. If they are the same, then it keeps its current pool
+				// and should be told about the new pool.
 				if _, alsoMigrating := cfg[ru.remoteSelector]; alsoMigrating {
-					if ru.remotePoolRef.Version == nil {
-						return nil, nil, nil, fmt.Errorf("remote pool version is required for reverse propagation to counterpart chain selector %d for chain selector %d", ru.remoteSelector, selector)
+					targetBytes, err := ru.remoteNormalizer.StringToBytes(ru.remotePoolRef.Address)
+					if err != nil {
+						return nil, nil, nil, fmt.Errorf("failed to convert remote pool ref to bytes for chain selector %d: %w", ru.remoteSelector, err)
 					}
-					if ru.remotePoolRef.Version.GreaterThanEqual(utils.Version_2_0_0) {
+					activeBytes := activePoolsSnapshot[ru.remoteSelector]
+					if len(activeBytes) == 0 || !bytes.Equal(activeBytes, targetBytes) {
 						continue
 					}
 				}
@@ -538,6 +542,44 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 	}
 
 	return batchOps, reports, ds, nil
+}
+
+// snapshotActivePools reads each chain's active pool from its TokenAdminRegistry. This must run before
+// any peer is forward-configured (see the call site)
+func snapshotActivePools(e cldf.Environment, tokenRegistry *TokenAdapterRegistry, cfg map[uint64]TokenTransferConfig) (map[uint64][]byte, error) {
+	var needsSnapshot bool
+	for _, tc := range cfg {
+		if tc.AutoMigrateRemoteChains {
+			needsSnapshot = true
+			break
+		}
+	}
+	if !needsSnapshot {
+		return nil, nil
+	}
+
+	snapshot := make(map[uint64][]byte, len(cfg))
+	for selector, tc := range cfg {
+		family, err := chain_selectors.GetSelectorFamily(selector)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get chain family for selector %d: %w", selector, err)
+		}
+		reader, ok := tokenRegistry.GetTokenAdminRegistryReader(family)
+		if !ok {
+			return nil, fmt.Errorf("no token admin registry reader for chain family %s", family)
+		}
+		_, _, _, fullTokenRef, err := ResolveAdapterAndRefs(e, tokenRegistry, selector, tc.TokenPoolRef, tc.TokenRef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve token for pre-batch snapshot of chain selector %d: %w", selector, err)
+		}
+		activePool, err := reader.GetActivePool(e, selector, fullTokenRef, tc.RegistryRef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read pre-batch active pool for chain selector %d: %w", selector, err)
+		}
+		snapshot[selector] = activePool
+	}
+
+	return snapshot, nil
 }
 
 func applyTokenTransferFeeConfig(

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -465,15 +465,23 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 				return nil, nil, nil, fmt.Errorf("failed to convert new pool ref to bytes for reverse propagation on chain selector %d: %w", selector, err)
 			}
 			for _, ru := range discoveredRemotes {
-				// NOTE: we skip reverse-propagation into a counterpart being migrated in this same batch:
+				// NOTE: for a counterpart being *REPLACED* in the same batch we skip reverse-propagation:
 				// running the full `ConfigureTokenForTransfers()` sequence on its not-yet-live pool would
 				// activate it `setPool()` prematurely so its own subsequent migration pass sees itself as
 				// "already the target pool", and skips auto-migration entirely (losing its legacy remotes
 				// and reverse-propagation). Wiring between same-batch peers is handled by each pool's own
 				// forward config; reverse-propagation only needs to reach every NON-migrating counterpart
 				// (already-active v2 or v1 pools) to keep them reachable.
+				//
+				// "Being replaced" is decided by capability, not by batch membership alone: a peer present
+				// in cfg but whose adapter has no TokenPoolMigrator is NOT being replaced, so it is safe —
+				// and necessary — to reverse-propagate into it so it stays reachable from this migration's
+				// new pool. Only a same-batch peer that is actually on V2 (i.e. its adapter implements the
+				// TokenPoolMigrator interface) is skipped.
 				if _, alsoMigrating := cfg[ru.remoteSelector]; alsoMigrating {
-					continue
+					if _, hasMigrator := ru.remoteAdapter.(TokenPoolMigrator); hasMigrator {
+						continue
+					}
 				}
 				reverseInput := ConfigureTokenForTransfersInput{
 					// Reverse propagation only *ADDS* this migration's new pool as an additional remote to an

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -252,6 +252,9 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 						// interface for the discovery body to run; if either condition fails, auto-migrate is a
 						// no-op for that chain.
 						if tokenPool.Version != nil && tokenPool.Version.GreaterThanEqual(utils.Version_2_0_0) {
+							// For a genuine V2 target, discovery needs the active adapter to implement the migrator.
+							// If it doesn't then we fall back to the remotes listed explicitly in the input (this is
+							// the documented workaround e.g. `USDCTokenPoolProxy`)
 							if legacyPoolMigrator, ok = legacyAdapter.(TokenPoolMigrator); ok {
 								if legacyRateLimitReader, ok = legacyAdapter.(RateLimitReaderAdapter); !ok {
 									return nil, nil, nil, fmt.Errorf(

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -49,14 +49,14 @@ type TokenTransferConfig struct {
 	// automatically with (token, pool, decimals, rate limits, and MigrationMetadata). Legacy lane fees are read
 	// from the fee quoter (v1.6+) or onramp (v1.5) and merged with any user-provided tokenTransferFeeConfig on each
 	// remote (set YAML fields win; unset fields are imported). Resolved connectivity, rate limits, and migration
-	// metadata are passed to ConfigureTokenForTransfersSequence for on-chain apply. Migration relies on the
-	// legacy (pre-V2 active pool) adapter implementing the TokenPoolMigrator interface; when it does, discovery
-	// also requires the RateLimitReaderAdapter interface. See (4) for when the migrator is absent. This knob has
-	// no effect if any of the following are true:
+	// metadata are passed to ConfigureTokenForTransfersSequence for on-chain apply. Forward migration runs only
+	// for a genuine V2 upgrade (configured target pool is v2.0.0+) and requires the legacy (pre-V2 active pool)
+	// adapter to implement the TokenPoolMigrator interface; discovery also requires the RateLimitReaderAdapter
+	// interface. This knob has no effect if any of the following are true:
 	//  (1) There is no active pool in TAR for the token
 	//  (2) The active pool in TAR is already the target pool (extend mode)
 	//  (3) The active pool in TAR is already v2.0.0 or higher
-	//  (4) The active pool's chain family is not on V2, so its adapter has no token pool migrator - the knob is a no-op for that chain since there is no V2 pool to migrate to
+	//  (4) The configured target pool is not v2.0.0+ (i.e. there is no V2 pool to migrate to), so the knob is a no-op for that chain regardless of its adapter's interfaces
 	//
 	// When discovery is skipped, the changeset logs at info level and does not error. Remote chains,
 	// connectivity, and fees are taken only from explicit RemoteChains YAML (same as autoMigrateRemoteChains: false).
@@ -85,8 +85,10 @@ type TokenTransferConfig struct {
 	//  - Forward propagation: A_new's RemoteChains are populated with all remotes discovered from the
 	//    active pool (A's legacy remotes B and C), so A_new is configured to reach B and C.
 	//  - Reverse propagation: B and C are each told to add A_new as an additional remote pool, so the
-	//    web stays reachable from B/C back to A_new. Same-batch peers being migrated in this changeset
-	//    are skipped for reverse propagation; forward config wires them instead.
+	//    web stays reachable from B/C back to A_new. Same-batch peers that are being REPLACED in this
+	//    changeset (their target pool differs from their active pool) are skipped for reverse
+	//    propagation; forward config wires them instead. Same-batch peers that are not being replaced
+	//    (e.g. non-V2 chains like Solana) are still reverse-propagated into so the web stays connected.
 	//
 	// Limitation: discovery calls getSupportedChains on the TAR-registered active pool. Pools that do not
 	// implement that interface (e.g. USDCTokenPoolProxy) cause auto-migrate to fail; list remote chains
@@ -242,35 +244,39 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 						if err != nil {
 							return nil, nil, nil, fmt.Errorf("failed to resolve adapter for active pool on chain selector %d: %w", selector, err)
 						}
-						// Capability-based gate: only families whose legacy adapter implements the
-						// TokenPoolMigrator interface can be the source of an auto-migration (e.g.
-						// EVM on V2). A family that is not on V2 intentionally has no migrator, so
-						// treat auto-migrate as a no-op for that chain instead of hard failing the
-						// changeset.
-						legacyPoolMigrator, ok = legacyAdapter.(TokenPoolMigrator)
-						if !ok {
-							e.Logger.Infof("adapter for active pool version %s on chain selector %d does not support token pool migration, skipping auto-migration of remote chains", activePoolRef.Version, selector)
-						} else {
-							legacyRateLimitReader, ok = legacyAdapter.(RateLimitReaderAdapter)
-							if !ok {
-								return nil, nil, nil, fmt.Errorf(
-									"adapter for active pool version %s on chain selector %d does not implement RateLimitReaderAdapter",
-									activePoolRef.Version, selector,
-								)
-							}
-							tokenBytes, err := legacyAdapter.AddressRefToBytes(fullTokenRef)
-							if err != nil {
-								return nil, nil, nil, fmt.Errorf("failed to convert token ref to bytes on chain selector %d: %w", selector, err)
-							}
-							localDecimals, err = legacyAdapter.DeriveTokenDecimals(e, selector, activePoolRef, tokenBytes)
-							if err != nil {
-								return nil, nil, nil, fmt.Errorf("failed to derive local token decimals on chain selector %d: %w", selector, err)
-							}
-							if supported, err := legacyPoolMigrator.GetSupportedChains(e, selector, activePool); err != nil {
-								return nil, nil, nil, fmt.Errorf("failed to get supported remote chains for token pool on chain selector %d: %w", selector, err)
+						// Auto-migration is only meaningful for a genuine V2 upgrade, so require the configured
+						// target pool to be v2.0.0+ - keying this on the target's version (rather than on which
+						// interfaces the active-pool adapter happens to implement) keeps the gate robust across
+						// chain families including adapters which implement TokenPoolMigrator while their chain
+						// is still not on V2. The active-pool adapter must also implement the TokenPoolMigrator
+						// interface for the discovery body to run; if either condition fails, auto-migrate is a
+						// no-op for that chain.
+						if tokenPool.Version != nil && tokenPool.Version.GreaterThanEqual(utils.Version_2_0_0) {
+							if legacyPoolMigrator, ok = legacyAdapter.(TokenPoolMigrator); ok {
+								if legacyRateLimitReader, ok = legacyAdapter.(RateLimitReaderAdapter); !ok {
+									return nil, nil, nil, fmt.Errorf(
+										"adapter for active pool version %s on chain selector %d does not implement RateLimitReaderAdapter",
+										activePoolRef.Version, selector,
+									)
+								}
+								tokenBytes, err := legacyAdapter.AddressRefToBytes(fullTokenRef)
+								if err != nil {
+									return nil, nil, nil, fmt.Errorf("failed to convert token ref to bytes on chain selector %d: %w", selector, err)
+								}
+								localDecimals, err = legacyAdapter.DeriveTokenDecimals(e, selector, activePoolRef, tokenBytes)
+								if err != nil {
+									return nil, nil, nil, fmt.Errorf("failed to derive local token decimals on chain selector %d: %w", selector, err)
+								}
+								if supported, err := legacyPoolMigrator.GetSupportedChains(e, selector, activePool); err != nil {
+									return nil, nil, nil, fmt.Errorf("failed to get supported remote chains for token pool on chain selector %d: %w", selector, err)
+								} else {
+									allRemoteSelectors = supported
+								}
 							} else {
-								allRemoteSelectors = supported
+								e.Logger.Infof("adapter for active pool version %s on chain selector %d does not support token pool migration, skipping auto-migration of remote chains", activePoolRef.Version, selector)
 							}
+						} else {
+							e.Logger.Infof("Active pool version %s on chain selector %d has no v2.0.0+ migration target, skipping auto-migration of remote chains", activePoolRef.Version, selector)
 						}
 					} else {
 						e.Logger.Infof("Active pool on chain selector %d is already v2.0.0 or higher, skipping auto-migration of remote chains", selector)
@@ -465,21 +471,23 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 				return nil, nil, nil, fmt.Errorf("failed to convert new pool ref to bytes for reverse propagation on chain selector %d: %w", selector, err)
 			}
 			for _, ru := range discoveredRemotes {
-				// NOTE: for a counterpart being *REPLACED* in the same batch we skip reverse-propagation:
-				// running the full `ConfigureTokenForTransfers()` sequence on its not-yet-live pool would
-				// activate it `setPool()` prematurely so its own subsequent migration pass sees itself as
-				// "already the target pool", and skips auto-migration entirely (losing its legacy remotes
-				// and reverse-propagation). Wiring between same-batch peers is handled by each pool's own
-				// forward config; reverse-propagation only needs to reach every NON-migrating counterpart
-				// (already-active v2 or v1 pools) to keep them reachable.
+				// After a pool migrates reverse-propagation tells every peer it was connected to about the new
+				// pool, keeping the web reachable in both directions. We skip one case: a same-batch peer that
+				// is itself being REPLACED — its new pool isn't live yet, so configuring it now would activate
+				// it too early and break that peer's own migration. Its own forward config wires it instead.
 				//
-				// "Being replaced" is decided by capability, not by batch membership alone: a peer present
-				// in cfg but whose adapter has no TokenPoolMigrator is NOT being replaced, so it is safe —
-				// and necessary — to reverse-propagate into it so it stays reachable from this migration's
-				// new pool. Only a same-batch peer that is actually on V2 (i.e. its adapter implements the
-				// TokenPoolMigrator interface) is skipped.
+				// A peer is being replaced exactly when its configured TARGET pool is V2 (>= 2.0.0): such a
+				// peer is skipped. Any peer with a pre-V2 target is not being replaced and must still learn
+				// about the new pool. Example: in one batch say we migrate A and C to A2/C2 while B remains
+				// on its v1 pool. Processing A tells B about A2 but leaves C alone (C is getting C2 in this
+				// same batch); processing C tells B about C2 and leaves A alone. So B learns both A2 and C2,
+				// C2 pairs with A2 via C's own forward config, A2 pairse with C2 via A's own forward config,
+				// and the web stays fully connected.
+				//
+				// Deciding by the target version (not by which interfaces the peer's adapter implements) stays
+				// correct even if a non-V2 family later adds a migrator.
 				if _, alsoMigrating := cfg[ru.remoteSelector]; alsoMigrating {
-					if _, hasMigrator := ru.remoteAdapter.(TokenPoolMigrator); hasMigrator {
+					if ru.remotePoolRef.Version != nil && ru.remotePoolRef.Version.GreaterThanEqual(utils.Version_2_0_0) {
 						continue
 					}
 				}

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -487,7 +487,10 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 				// Deciding by the target version (not by which interfaces the peer's adapter implements) stays
 				// correct even if a non-V2 family later adds a migrator.
 				if _, alsoMigrating := cfg[ru.remoteSelector]; alsoMigrating {
-					if ru.remotePoolRef.Version != nil && ru.remotePoolRef.Version.GreaterThanEqual(utils.Version_2_0_0) {
+					if ru.remotePoolRef.Version == nil {
+						return nil, nil, nil, fmt.Errorf("remote pool version is required for reverse propagation to counterpart chain selector %d for chain selector %d", ru.remoteSelector, selector)
+					}
+					if ru.remotePoolRef.Version.GreaterThanEqual(utils.Version_2_0_0) {
 						continue
 					}
 				}

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -488,10 +488,10 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 					PoolType:                           ru.remotePoolRef.Type.String(),
 					RemoteChains: map[uint64]RemoteChainConfig[[]byte, string]{
 						selector: {
-							// Pad to match on-chain storage format (32-byte left-padded for EVM).
-							// The token comparison in ConfigureTokenPoolForRemoteChain (line 234)
-							// compares against on-chain bytes without padding, so a 20-byte input
-							// would mismatch and trigger a remove+re-add instead of addRemotePool
+							// Pad to match on-chain storage format (32-byte left-padded). The address
+							// comparisons in `ConfigureTokenPoolForRemoteChain()` compare against on-
+							// chain bytes without padding, so a 20-byte input would mismatch and fire
+							// a remove+re-add instead of addRemotePool
 							RemoteToken: common.LeftPadBytes(migratedTokenBytes, 32),
 							RemotePool:  common.LeftPadBytes(migratedPoolBytes, 32),
 						},

--- a/deployment/tokens/configure_tokens_for_transfers_test.go
+++ b/deployment/tokens/configure_tokens_for_transfers_test.go
@@ -1176,11 +1176,11 @@ func (transfersTest_IdentityNormalizer) StringToBytes(address string) ([]byte, e
 	return []byte(address), nil
 }
 
-// TestAutoMigrate_NonMigratableSourceSkips exercises the case where a chain sets
-// AutoMigrateRemoteChains=true but its legacy adapter does not implement TokenPoolMigrator (e.g.
-// Solana, which is not on V2). This must be treated as a no-op that skips auto-migration discovery
-// for that chain rather than a hard error. The active pool is registered and differs from the target
-// pool and is pre-V2, so the code genuinely reaches the migrator capability check.
+// TestAutoMigrate_NonMigratableSourceSkips exercises the case where a chain sets AutoMigrateRemoteChains=true
+// for a source whose configured target pool is not v2.0.0+ and whose adapter does not implement TokenPoolMigrator.
+// This must be treated as a no-op that skips auto-migration discovery for that chain rather than a hard error. The
+// active pool is registered and differs from the target pool and is pre-V2, so the code genuinely reaches the
+// migration gate.
 func TestAutoMigrate_NonMigratableSourceSkips(t *testing.T) {
 	const sel = 5009297550715157269
 	const (
@@ -1241,4 +1241,87 @@ func TestAutoMigrate_NonMigratableSourceSkips(t *testing.T) {
 	changeset := tokens.ConfigureTokensForTransfers(tokenRegistry, changesets.GetRegistry())
 	_, err = changeset.Apply(env, cfg)
 	require.NoError(t, err)
+}
+
+// transfersTest_MigratingMockTokenAdapter is transfersTest_MockTokenAdapter extended to implement
+// TokenPoolMigrator, so it can model a source whose adapter HAS a migrator while the chain is still
+// not on V2 (e.g. Solana after #2273). getSupportedChainsCalls records whether forward discovery ran.
+type transfersTest_MigratingMockTokenAdapter struct {
+	*transfersTest_MockTokenAdapter
+	getSupportedChainsCalls int
+}
+
+func (ma *transfersTest_MigratingMockTokenAdapter) GetSupportedChains(_ deployment.Environment, _ uint64, _ []byte) ([]uint64, error) {
+	ma.getSupportedChainsCalls++
+	return []uint64{5009297550715157269}, nil
+}
+
+func (ma *transfersTest_MigratingMockTokenAdapter) GetRemoteToken(_ deployment.Environment, _ uint64, _ []byte, _ uint64) ([]byte, error) {
+	return []byte("mocked-remote-token-address"), nil
+}
+
+func (ma *transfersTest_MigratingMockTokenAdapter) GetRemotePools(_ deployment.Environment, _ uint64, _ []byte, _ uint64) ([][]byte, error) {
+	return [][]byte{[]byte("mocked-remote-pool")}, nil
+}
+
+// TestAutoMigrate_V2TargetRequired exercises the case where a source's adapter DOES implement
+// TokenPoolMigrator but its configured target pool is not v2.0.0+ (a non-V2 family that has grown a
+// migrator). Auto-migration must still be a no-op — forward discovery must not run — because there is
+// no V2 pool to migrate to.
+func TestAutoMigrate_V2TargetRequired(t *testing.T) {
+	const sel = 5009297550715157269
+	const (
+		targetPoolAddr = "target-pool"
+		activePoolAddr = "legacy-active-pool"
+	)
+
+	tokenRegistry := tokens.GetTokenAdapterRegistry()
+	// Distinct version (1.5.1) so Register records THIS instance and we can observe discovery calls. The test is
+	// self-contained (registers the resolver + evm identity normalizer + MCMS reader) so it passes standalone.
+	mockAdapter := &transfersTest_MigratingMockTokenAdapter{transfersTest_MockTokenAdapter: &transfersTest_MockTokenAdapter{}}
+	tokenRegistry.RegisterTokenAdapter("evm", semver.MustParse("1.5.1"), mockAdapter)
+	tokenRegistry.RegisterTokenRefResolver("evm", mockAdapter)
+	tokenRegistry.RegisterTokenAdminRegistryReader("evm", &transfersTest_MockTokenAdminRegistryReader{activePool: []byte(activePoolAddr)})
+	deploy.GetAddressNormalizerRegistry().RegisterAddressNormalizer(chain_selectors.FamilyEVM, transfersTest_IdentityNormalizer{})
+	changesets.GetRegistry().RegisterMCMSReader("evm", &MockReader{})
+
+	legacyVersion := semver.MustParse("1.5.1")
+	ds := datastore.NewMemoryDataStore()
+	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
+		ChainSelector: sel, Address: targetPoolAddr, Type: "TokenPool", Version: legacyVersion, Qualifier: "default",
+	}))
+	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
+		ChainSelector: sel, Address: activePoolAddr, Type: "TokenPool", Version: legacyVersion, Qualifier: "legacy-active",
+	}))
+	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
+		ChainSelector: sel, Address: "registry", Type: "Registry", Version: legacyVersion,
+	}))
+
+	lggr, err := logger.New()
+	require.NoError(t, err)
+	bundle := cldf_ops.NewBundle(func() context.Context { return context.Background() }, lggr, cldf_ops.NewMemoryReporter())
+	env := deployment.Environment{OperationsBundle: bundle, Logger: lggr, DataStore: ds.Seal()}
+
+	cfg := tokens.ConfigureTokensForTransfersConfig{
+		Tokens: []tokens.TokenTransferConfig{
+			{
+				AutoMigrateRemoteChains: true,
+				ChainSelector:           sel,
+				TokenPoolRef: datastore.AddressRef{
+					Type: "TokenPool", Version: legacyVersion, ChainSelector: sel, Qualifier: "default",
+				},
+				RegistryRef: datastore.AddressRef{
+					Type: "Registry", Version: legacyVersion, ChainSelector: sel,
+				},
+			},
+		},
+		MCMS: basicMCMSInput,
+	}
+
+	changeset := tokens.ConfigureTokensForTransfers(tokenRegistry, changesets.GetRegistry())
+	_, err = changeset.Apply(env, cfg)
+	require.NoError(t, err)
+	// Even though this adapter implements TokenPoolMigrator, forward discovery must NOT run: the target is
+	// pre-V2, so auto-migration is a no-op (there is no V2 pool to migrate to).
+	require.Zero(t, mockAdapter.getSupportedChainsCalls, "discovery should not run without a v2.0.0+ migration target")
 }

--- a/integration-tests/deployment/token_expansion_scenarios_test.go
+++ b/integration-tests/deployment/token_expansion_scenarios_test.go
@@ -1485,60 +1485,90 @@ func TestTokenExpansionScenariosSolana(t *testing.T) {
 	})
 
 	// Scenario6 exercises AutoMigrateRemoteChains end-to-end across chain families: a legacy EVM pool connected
-	// to a Solana remote is upgraded to v2.0 with an empty RemoteChains map; the changeset must discover the
-	// Solana remote (token, pool, decimals, rate limits, and legacy lane fees) and carry it forward onto the new pool.
-	t.Run("Scenario6_AutoMigrateDiscoversSolanaRemote", func(t *testing.T) {
-		const evmTokenSymbol = "S6_EVM_TOK"
-		const solTokenSymbol = "S6_SOL_TOK"
-		const evmPoolQual = "S6_EVM_POOL"
-		const newEvmPoolQual = "S6_NEW_EVM_POOL"
+	// to a Solana remote is upgraded to v2.0 with an empty RemoteChains map; the changeset must discover the Solana
+	// remote (token, pool, decimals, rate limits, and legacy lane fees) and carry it forward onto the new pool.
+	// Scenario6 exercises batched cross-family auto-migration of a fully-connected 3-chain web: evm1 (TEST_90000001)
+	// and evm2 (TEST_90000002) both upgrade their legacy v1.5.1 pools to v2.0, while Solana (not on V2) stays on its
+	// v1.6.0 pool but is present in the same batch. The batched reverse-propagation must reach the non-replaced Solana
+	// peer (adding both new EVM pools as remotes) while skipping reverse-propagation into the being-replaced EVM peers
+	// (wired by their own forward configs).
+	t.Run("Scenario6_AutoMigrateBatchedWebReversePropagatesToSolana", func(t *testing.T) {
+		evm1ChainSel := evmChainSel
+		evm2ChainSel := newChainSel
+		const (
+			evm1TokenSymbol = "S6_EVM1_TOK"
+			evm2TokenSymbol = "S6_EVM2_TOK"
+			solTokenSymbol  = "S6_SOL_TOK"
+			evm1PoolQual    = "S6_EVM1_POOL"
+			evm1NewPoolQual = "S6_NEW_EVM1_POOL"
+			evm2PoolQual    = "S6_EVM2_POOL"
+			evm2NewPoolQual = "S6_NEW_EVM2_POOL"
+		)
 		evmDecimals := uint8(18)
 		svmDecimals := uint8(9)
 		maxSupply := uint64(1e6)
 		preMint := uint64(1e5)
 		defaultRL := tokensapi.RateLimiterConfigFloatInput{Capacity: 100, Rate: 10, IsEnabled: true}
 
-		// v2.0 pool deployment requires v2.0 core on the EVM chain (migration-test order).
+		// v2.0 pool deployment requires v2.0 core on both EVM chains (migration-test order).
 		v2CoreDS := datastore.NewMemoryDataStore()
-		DeployChainContractsV2_0_0(t, env, v2CoreDS, evmChainSel)
+		DeployChainContractsV2_0_0(t, env, v2CoreDS, evm1ChainSel)
+		DeployChainContractsV2_0_0(t, env, v2CoreDS, evm2ChainSel)
 		MergeAddresses(t, env, v2CoreDS)
 
-		// Wire CCIP lanes between EVM and Solana. Required for legacy fee import during auto-migrate
-		// (ResolveFeeAdapter / FeeQuoter reads on EVM -> Solana).
+		// Wire the full triangle of CCIP lanes (evm1<->sol, evm2<->sol, evm1<->evm2). Required for legacy fee
+		// import during auto-migrate (ResolveFeeAdapter / FeeQuoter reads on each source chain).
 		env.OperationsBundle = testsetupV2_0_0.BundleWithFreshReporter(env.OperationsBundle)
 		laneConnectOut, err := lanes.ConnectChains(lanes.GetLaneAdapterRegistry(), changesets.GetRegistry()).Apply(*env, lanes.ConnectChainsConfig{
 			MCMS: NewDefaultInputForMCMS("Scenario 6 lanes"),
 			Lanes: []lanes.LaneConfig{
-				{
-					Version: v1_6_0_scenarios,
-					ChainA:  lanes.ChainDefinition{Selector: solChainSel},
-					ChainB:  lanes.ChainDefinition{Selector: evmChainSel},
-				},
+				{Version: v1_6_0_scenarios, ChainA: lanes.ChainDefinition{Selector: solChainSel}, ChainB: lanes.ChainDefinition{Selector: evm1ChainSel}},
+				{Version: v1_6_0_scenarios, ChainA: lanes.ChainDefinition{Selector: solChainSel}, ChainB: lanes.ChainDefinition{Selector: evm2ChainSel}},
+				{Version: v1_6_0_scenarios, ChainA: lanes.ChainDefinition{Selector: evm1ChainSel}, ChainB: lanes.ChainDefinition{Selector: evm2ChainSel}},
 			},
 		})
 		require.NoError(t, err)
 		MergeAddresses(t, env, laneConnectOut.DataStore)
 		testhelpers.ProcessTimelockProposals(t, *env, laneConnectOut.MCMSTimelockProposals, false)
 
-		// Deploy a legacy EVM v1.5.1 BurnMint pool connected to a Solana v1.6.0 LockRelease pool, registered in
-		// each chain's TokenAdminRegistry.
+		// Deploy legacy EVM v1.5.1 BurnMint pools on both EVM chains connected to a Solana v1.6.0 LockRelease
+		// pool, each registered in its chain's TokenAdminRegistry. The web is fully connected so every active
+		// pool already lists all other web members.
 		connectOut, err := tokensapi.TokenExpansion().Apply(*env, tokensapi.TokenExpansionInput{
 			ChainAdapterVersion: v1_6_0_scenarios,
 			MCMS:                NewDefaultInputForMCMS("Scenario 6 connect"),
 			TokenExpansionInputPerChain: map[uint64]tokensapi.TokenExpansionInputPerChain{
-				evmChainSel: {
+				evm1ChainSel: {
 					TokenPoolVersion: v1_5_1_scenarios,
 					DeployTokenInput: &tokensapi.DeployTokenInput{
-						Name: "Scenario6 EVM Token", Symbol: evmTokenSymbol, Decimals: evmDecimals,
+						Name: "Scenario6 EVM1 Token", Symbol: evm1TokenSymbol, Decimals: evmDecimals,
 						Type: bnmERC20ops.ContractType, Supply: &maxSupply, PreMint: &preMint,
 					},
 					DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
-						TokenPoolQualifier: evmPoolQual,
+						TokenPoolQualifier: evm1PoolQual,
 						PoolType:           cciputils.BurnMintTokenPool.String(),
 					},
 					TokenTransferConfig: &tokensapi.TokenTransferConfig{
 						RemoteChains: map[uint64]tokensapi.RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
-							solChainSel: {OutboundRateLimiterConfig: &defaultRL},
+							solChainSel:  {OutboundRateLimiterConfig: &defaultRL},
+							evm2ChainSel: {OutboundRateLimiterConfig: &defaultRL},
+						},
+					},
+				},
+				evm2ChainSel: {
+					TokenPoolVersion: v1_5_1_scenarios,
+					DeployTokenInput: &tokensapi.DeployTokenInput{
+						Name: "Scenario6 EVM2 Token", Symbol: evm2TokenSymbol, Decimals: evmDecimals,
+						Type: bnmERC20ops.ContractType, Supply: &maxSupply, PreMint: &preMint,
+					},
+					DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
+						TokenPoolQualifier: evm2PoolQual,
+						PoolType:           cciputils.BurnMintTokenPool.String(),
+					},
+					TokenTransferConfig: &tokensapi.TokenTransferConfig{
+						RemoteChains: map[uint64]tokensapi.RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
+							solChainSel:  {OutboundRateLimiterConfig: &defaultRL},
+							evm1ChainSel: {OutboundRateLimiterConfig: &defaultRL},
 						},
 					},
 				},
@@ -1558,7 +1588,8 @@ func TestTokenExpansionScenariosSolana(t *testing.T) {
 					},
 					TokenTransferConfig: &tokensapi.TokenTransferConfig{
 						RemoteChains: map[uint64]tokensapi.RemoteChainConfig[*datastore.AddressRef, datastore.AddressRef]{
-							evmChainSel: {OutboundRateLimiterConfig: &defaultRL},
+							evm1ChainSel: {OutboundRateLimiterConfig: &defaultRL},
+							evm2ChainSel: {OutboundRateLimiterConfig: &defaultRL},
 						},
 					},
 				},
@@ -1569,37 +1600,66 @@ func TestTokenExpansionScenariosSolana(t *testing.T) {
 		testhelpers.ProcessTimelockProposals(t, *env, connectOut.MCMSTimelockProposals, false)
 
 		// Validate that the token and pool addresses were saved to the datastore.
-		evmTokAddr := assertTokenExists(t, env, evmChainSel, evmTokenSymbol, "Scenario6 EVM Token", evmDecimals)
-		oldPoolAddr, err := evmAdapter.FindLatestAddressRef(env.DataStore, datastore.AddressRef{
-			ChainSelector: evmChainSel,
-			Qualifier:     evmPoolQual,
+		evm1TokAddr := assertTokenExists(t, env, evm1ChainSel, evm1TokenSymbol, "Scenario6 EVM1 Token", evmDecimals)
+		evm2TokAddr := assertTokenExists(t, env, evm2ChainSel, evm2TokenSymbol, "Scenario6 EVM2 Token", evmDecimals)
+		oldPool1Addr, err := evmAdapter.FindLatestAddressRef(env.DataStore, datastore.AddressRef{
+			ChainSelector: evm1ChainSel,
+			Qualifier:     evm1PoolQual,
+			Type:          datastore.ContractType(cciputils.BurnMintTokenPool),
+		})
+		require.NoError(t, err)
+		oldPool2Addr, err := evmAdapter.FindLatestAddressRef(env.DataStore, datastore.AddressRef{
+			ChainSelector: evm2ChainSel,
+			Qualifier:     evm2PoolQual,
 			Type:          datastore.ContractType(cciputils.BurnMintTokenPool),
 		})
 		require.NoError(t, err)
 
-		// Validate that the old pool has the expected Solana remote token and pool before the upgrade.
-		oldPool, err := bnmpool.NewBurnMintTokenPool(oldPoolAddr, evmChain.Client)
+		evm1Ch, ok := env.BlockChains.EVMChains()[evm1ChainSel]
+		require.True(t, ok)
+		evm2Ch, ok := env.BlockChains.EVMChains()[evm2ChainSel]
+		require.True(t, ok)
+
+		// Validate that both old pools have the expected remote token and pool for their lane partners before
+		// the upgrade (the pre-batch "fully connected" web).
+		oldPool1, err := bnmpool.NewBurnMintTokenPool(oldPool1Addr, evm1Ch.Client)
 		require.NoError(t, err)
-		oldRemoteToken, err := oldPool.GetRemoteToken(&bind.CallOpts{Context: t.Context()}, solChainSel)
+		oldRemoteToken, err := oldPool1.GetRemoteToken(&bind.CallOpts{Context: t.Context()}, solChainSel)
 		require.NoError(t, err)
 		require.NotEmpty(t, oldRemoteToken)
-		oldRemotePools, err := oldPool.GetRemotePools(&bind.CallOpts{Context: t.Context()}, solChainSel)
+		oldRemotePools, err := oldPool1.GetRemotePools(&bind.CallOpts{Context: t.Context()}, solChainSel)
 		require.NoError(t, err)
 		require.NotEmpty(t, oldRemotePools)
+		oldPool2, err := bnmpool.NewBurnMintTokenPool(oldPool2Addr, evm2Ch.Client)
+		require.NoError(t, err)
+		oldPool1Supported, err := oldPool1.GetSupportedChains(&bind.CallOpts{Context: t.Context()})
+		require.NoError(t, err)
+		require.Contains(t, oldPool1Supported, evm2ChainSel, "pre-batch evm1 should know evm2")
+		oldPool2Supported, err := oldPool2.GetSupportedChains(&bind.CallOpts{Context: t.Context()})
+		require.NoError(t, err)
+		require.Contains(t, oldPool2Supported, evm1ChainSel, "pre-batch evm2 should know evm1")
 
-		// Seed legacy lane fees for EVM → Solana before upgrade (auto-migrate imports from FeeQuoter).
+		// Resolve the Solana token + pool program so we can assert reverse-propagation on-chain.
+		solPoolRefs := env.DataStore.Addresses().Filter(datastore.AddressRefByChainSelector(solChainSel), datastore.AddressRefByType(datastore.ContractType(cciputils.LockReleaseTokenPool)))
+		require.Len(t, solPoolRefs, 1, "Solana LockRelease token pool program should exist in env.DataStore")
+		solMintRefs := env.DataStore.Addresses().Filter(datastore.AddressRefByChainSelector(solChainSel), datastore.AddressRefByQualifier(solTokenSymbol))
+		require.Len(t, solMintRefs, 1, "Solana token should exist in env.DataStore")
+		solPoolProgID := solana.MustPublicKeyFromBase58(solPoolRefs[0].Address)
+		solMint := solana.MustPublicKeyFromBase58(solMintRefs[0].Address)
+
+		// Seed legacy lane fees for EVM1 → Solana before upgrade (auto-migrate imports from FeeQuoter).
 		env.OperationsBundle = testsetupV2_0_0.BundleWithFreshReporter(env.OperationsBundle)
 		feeSeedOut, err := fees.SetTokenTransferFee().Apply(*env, fees.SetTokenTransferFeeInput{
 			MCMS: NewDefaultInputForMCMS("Scenario 6 seed fees"),
 			Args: []fees.TokenTransferFeeForSrc{
 				{
-					Selector: evmChainSel,
+					Selector: evm1ChainSel,
 					Settings: []fees.TokenTransferFeeForDst{
 						{
 							Selector: solChainSel,
 							Settings: []fees.TokenTransferFee{
 								{
-									Address: evmTokAddr.Hex(),
+									Address: evm1TokAddr.Hex(),
 									FeeArgs: fees.UnresolvedTokenTransferFeeArgs{
 										DestBytesOverhead: cciputils.NewOptional(uint32(150_000)),
 										DestGasOverhead:   cciputils.NewOptional(uint32(50_000)),
@@ -1617,30 +1677,57 @@ func TestTokenExpansionScenariosSolana(t *testing.T) {
 		testhelpers.ProcessTimelockProposals(t, *env, feeSeedOut.MCMSTimelockProposals, false)
 
 		// Ensure the fee config was set
-		feeAdapter, fqRef, err := fees.ResolveFeeAdapter(env.OperationsBundle, env.BlockChains, env.DataStore, evmChainSel, solChainSel)
+		feeAdapter, fqRef, err := fees.ResolveFeeAdapter(env.OperationsBundle, env.BlockChains, env.DataStore, evm1ChainSel, solChainSel)
 		require.NoError(t, err)
-		legacyFee, err := feeAdapter.GetOnchainTokenTransferFeeConfig(env.OperationsBundle, env.BlockChains, fqRef, evmChainSel, solChainSel, evmTokAddr.Hex())
+		legacyFee, err := feeAdapter.GetOnchainTokenTransferFeeConfig(env.OperationsBundle, env.BlockChains, fqRef, evm1ChainSel, solChainSel, evm1TokAddr.Hex())
 		require.NoError(t, err)
 		require.Equal(t, uint32(150_000), legacyFee.DestBytesOverhead)
 		require.Equal(t, uint32(50_000), legacyFee.DestGasOverhead)
 		require.Equal(t, uint32(17), legacyFee.MinFeeUSDCents)
 		require.True(t, legacyFee.IsEnabled)
 
-		// Upgrade to v2.0 with AutoMigrateRemoteChains and no RemoteChains — Solana must be discovered.
+		// Upgrade both EVM pools to v2.0 in a single batch, with Solana present but NOT being migrated (it
+		// stays on v1.6.0). The v2 entries carry no explicit RemoteChains: AutoMigrateRemoteChains replays the
+		// active pool's actual remotes (re-entering all pre-existing web lanes by hand is error-prone), and each
+		// EVM pool will reach its same-batch EVM peer (via target-pool resolution) and Solana (via discovery),
+		// while Solana learns the two new EVM pools via reverse-propagation.
 		env.OperationsBundle = testsetupV2_0_0.BundleWithFreshReporter(env.OperationsBundle)
 		upgradeOut, err := tokensapi.TokenExpansion().Apply(*env, tokensapi.TokenExpansionInput{
 			ChainAdapterVersion: cciputils.Version_2_0_0,
 			MCMS:                NewDefaultInputForMCMS("Scenario 6 upgrade"),
 			TokenExpansionInputPerChain: map[uint64]tokensapi.TokenExpansionInputPerChain{
-				evmChainSel: {
+				evm1ChainSel: {
 					TokenPoolVersion: cciputils.Version_2_0_0,
 					DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
-						TokenPoolQualifier: newEvmPoolQual,
+						TokenPoolQualifier: evm1NewPoolQual,
 						PoolType:           cciputils.BurnMintTokenPool.String(),
-						TokenRef:           &datastore.AddressRef{Address: evmTokAddr.Hex()},
+						TokenRef:           &datastore.AddressRef{Address: evm1TokAddr.Hex()},
 					},
 					TokenTransferConfig: &tokensapi.TokenTransferConfig{
 						AutoMigrateRemoteChains: true,
+					},
+				},
+				evm2ChainSel: {
+					TokenPoolVersion: cciputils.Version_2_0_0,
+					DeployTokenPoolInput: &tokensapi.DeployTokenPoolInput{
+						TokenPoolQualifier: evm2NewPoolQual,
+						PoolType:           cciputils.BurnMintTokenPool.String(),
+						TokenRef:           &datastore.AddressRef{Address: evm2TokAddr.Hex()},
+					},
+					TokenTransferConfig: &tokensapi.TokenTransferConfig{
+						AutoMigrateRemoteChains: true,
+					},
+				},
+				solChainSel: {
+					// Solana is not on V2 so it is not migrated; it is present in the batch so its entry is
+					// processed, but AutoMigrateRemoteChains is a no-op for it (no TokenPoolMigrator). No explicit
+					// remote chains: the pre-batch web already wired it to both EVM chains, and it learns the two
+					// new EVM pools via reverse-propagation instead.
+					TokenPoolVersion: v1_6_0_scenarios,
+					TokenTransferConfig: &tokensapi.TokenTransferConfig{
+						AutoMigrateRemoteChains: true,
+						TokenPoolRef:            datastore.AddressRef{Address: solPoolRefs[0].Address},
+						TokenRef:                datastore.AddressRef{Address: solMint.String()},
 					},
 				},
 			},
@@ -1649,34 +1736,46 @@ func TestTokenExpansionScenariosSolana(t *testing.T) {
 		MergeAddresses(t, env, upgradeOut.DataStore)
 		testhelpers.ProcessTimelockProposals(t, *env, upgradeOut.MCMSTimelockProposals, false)
 
-		// Validate that the new pool was saved to the datastore
-		newPoolRef := datastore.AddressRef{
-			ChainSelector: evmChainSel,
-			Type:          datastore.ContractType(cciputils.BurnMintTokenPool),
-			Version:       cciputils.Version_2_0_0,
-			Qualifier:     newEvmPoolQual,
-		}
-		newPoolAddr, err := datastore_utils.FindAndFormatRef(env.DataStore, newPoolRef, evmChainSel, evm_datastore_utils.ToEVMAddress)
+		// Resolve the newly migrated EVM pools from the datastore.
+		newPool1Ref := datastore.AddressRef{ChainSelector: evm1ChainSel, Type: datastore.ContractType(cciputils.BurnMintTokenPool), Version: cciputils.Version_2_0_0, Qualifier: evm1NewPoolQual}
+		newPool2Ref := datastore.AddressRef{ChainSelector: evm2ChainSel, Type: datastore.ContractType(cciputils.BurnMintTokenPool), Version: cciputils.Version_2_0_0, Qualifier: evm2NewPoolQual}
+		newPool1Addr, err := datastore_utils.FindAndFormatRef(env.DataStore, newPool1Ref, evm1ChainSel, evm_datastore_utils.ToEVMAddress)
 		require.NoError(t, err)
-		require.NotEqual(t, oldPoolAddr, newPoolAddr, "new pool must be a distinct contract from the old pool")
+		require.NotEqual(t, oldPool1Addr, newPool1Addr, "evm1 new pool must be a distinct contract from the old pool")
+		newPool2Addr, err := datastore_utils.FindAndFormatRef(env.DataStore, newPool2Ref, evm2ChainSel, evm_datastore_utils.ToEVMAddress)
+		require.NoError(t, err)
+		require.NotEqual(t, oldPool2Addr, newPool2Addr, "evm2 new pool must be a distinct contract from the old pool")
 
-		// Validate that the new v2.0 pool has the same Solana remote token and pool carried forward, and that
-		// Solana is in the supported chains list even though we did not explicitly configure it on the v2.0
-		// side (AutoMigrateRemoteChains should have discovered and carried it forward).
-		newPool, err := tokenpoolV2_0_0.NewTokenPool(newPoolAddr, evmChain.Client)
+		// Forward: evm1_new must carry forward the Solana remote and know evm2_new (same-batch replaced peer
+		// wired via its target pool ref).
+		newPool1, err := tokenpoolV2_0_0.NewTokenPool(newPool1Addr, evm1Ch.Client)
 		require.NoError(t, err)
-		newSupported, err := newPool.GetSupportedChains(&bind.CallOpts{Context: t.Context()})
+		new1Supported, err := newPool1.GetSupportedChains(&bind.CallOpts{Context: t.Context()})
 		require.NoError(t, err)
-		require.Contains(t, newSupported, solChainSel, "auto-migrated pool should support Solana without it being listed")
-		gotRemoteToken, err := newPool.GetRemoteToken(&bind.CallOpts{Context: t.Context()}, solChainSel)
+		require.Contains(t, new1Supported, solChainSel, "auto-migrated evm1 pool should support Solana")
+		require.Contains(t, new1Supported, evm2ChainSel, "auto-migrated evm1 pool should support evm2")
+		gotRemoteToken, err := newPool1.GetRemoteToken(&bind.CallOpts{Context: t.Context()}, solChainSel)
 		require.NoError(t, err)
-		require.True(t, bytes.Equal(oldRemoteToken, gotRemoteToken), "remote Solana token should be carried forward")
-		gotRemotePools, err := newPool.GetRemotePools(&bind.CallOpts{Context: t.Context()}, solChainSel)
+		require.True(t, bytes.Equal(oldRemoteToken, gotRemoteToken), "remote Solana token should be carried forward onto evm1_new")
+		gotRemotePools, err := newPool1.GetRemotePools(&bind.CallOpts{Context: t.Context()}, solChainSel)
 		require.NoError(t, err)
-		require.Contains(t, gotRemotePools, oldRemotePools[0], "remote Solana pool should be carried forward")
+		require.Contains(t, gotRemotePools, oldRemotePools[0], "remote Solana pool should be carried forward onto evm1_new")
+		evm2RemotePools, err := newPool1.GetRemotePools(&bind.CallOpts{Context: t.Context()}, evm2ChainSel)
+		require.NoError(t, err)
+		require.Contains(t, evm2RemotePools, common.LeftPadBytes(newPool2Addr.Bytes(), 32), "evm1_new should know evm2_new")
 
-		// Legacy lane fees should be imported from FeeQuoter onto the new v2.0 pool for EVM -> Solana.
-		// expectedFee mirrors discovery merge; apply merges again but Populate sets all fields so values are unchanged.
+		// Forward: evm2_new must know Solana and evm1_new.
+		newPool2, err := tokenpoolV2_0_0.NewTokenPool(newPool2Addr, evm2Ch.Client)
+		require.NoError(t, err)
+		new2Supported, err := newPool2.GetSupportedChains(&bind.CallOpts{Context: t.Context()})
+		require.NoError(t, err)
+		require.Contains(t, new2Supported, solChainSel, "auto-migrated evm2 pool should support Solana")
+		require.Contains(t, new2Supported, evm1ChainSel, "auto-migrated evm2 pool should support evm1")
+		evm1RemotePools, err := newPool2.GetRemotePools(&bind.CallOpts{Context: t.Context()}, evm1ChainSel)
+		require.NoError(t, err)
+		require.Contains(t, evm1RemotePools, common.LeftPadBytes(newPool1Addr.Bytes(), 32), "evm2_new should know evm1_new")
+
+		// Legacy lane fees should be imported from FeeQuoter onto evm1_new for EVM1 -> Solana.
 		expectedFee := tokensapi.PartialTokenTransferFeeConfig{}.MergeWith(tokensapi.TokenTransferFeeConfig{
 			DestGasOverhead:               legacyFee.DestGasOverhead,
 			DestBytesOverhead:             legacyFee.DestBytesOverhead,
@@ -1686,7 +1785,7 @@ func TestTokenExpansionScenariosSolana(t *testing.T) {
 			CustomFinalityTransferFeeBps:  0,
 			IsEnabled:                     legacyFee.IsEnabled,
 		})
-		gotFee, err := newPool.GetTokenTransferFeeConfig(&bind.CallOpts{Context: t.Context()}, common.Address{}, solChainSel, finality.RawWaitForFinality, []byte{})
+		gotFee, err := newPool1.GetTokenTransferFeeConfig(&bind.CallOpts{Context: t.Context()}, common.Address{}, solChainSel, finality.RawWaitForFinality, []byte{})
 		require.NoError(t, err)
 		require.Equal(t, expectedFee.DefaultFinalityFeeUSDCents, gotFee.FinalityFeeUSDCents, "finality fee USD cents")
 		require.Equal(t, expectedFee.DestGasOverhead, gotFee.DestGasOverhead, "dest gas overhead")
@@ -1699,7 +1798,7 @@ func TestTokenExpansionScenariosSolana(t *testing.T) {
 		// Outbound is exact in local (18) decimals. Inbound is imported from the v1.5.1 active pool (stored in
 		// remote 9-decimal units) and rebased to local decimals; allow float ULP like the EVM-only migration test.
 		const rlTolerance = int64(1e9)
-		rl, err := newPool.GetCurrentRateLimiterState(&bind.CallOpts{Context: t.Context()}, solChainSel, false)
+		rl, err := newPool1.GetCurrentRateLimiterState(&bind.CallOpts{Context: t.Context()}, solChainSel, false)
 		require.NoError(t, err)
 		require.True(t, rl.OutboundRateLimiterState.IsEnabled, "outbound rate limit should be enabled")
 		RequireBigIntsEqual(t, tokensapi.ScaleFloatToBigInt(defaultRL.Capacity, int(evmDecimals), 0), rl.OutboundRateLimiterState.Capacity, "outbound capacity")
@@ -1713,14 +1812,45 @@ func TestTokenExpansionScenariosSolana(t *testing.T) {
 		RequireBigIntsApprox(t, expInboundCap, rl.InboundRateLimiterState.Capacity, rlTolerance, "inbound capacity")
 		RequireBigIntsApprox(t, expInboundRate, rl.InboundRateLimiterState.Rate, rlTolerance, "inbound rate")
 
-		// Ensure that the active pool in the TAR is switched to the new v2.0 pool
-		tarAddr, err := evmAdapter.GetTokenAdminRegistryAddress(env.DataStore, evmChainSel)
+		// Ensure that the active pool in the TAR on both EVM chains is switched to the new v2.0 pools.
+		tar1Addr, err := evmAdapter.GetTokenAdminRegistryAddress(env.DataStore, evm1ChainSel)
 		require.NoError(t, err)
-		tar, err := tarbindings.NewTokenAdminRegistry(tarAddr, evmChain.Client)
+		tar1, err := tarbindings.NewTokenAdminRegistry(tar1Addr, evm1Ch.Client)
 		require.NoError(t, err)
-		cfgAfter, err := tar.GetTokenConfig(&bind.CallOpts{Context: t.Context()}, evmTokAddr)
+		cfg1After, err := tar1.GetTokenConfig(&bind.CallOpts{Context: t.Context()}, evm1TokAddr)
 		require.NoError(t, err)
-		require.Equal(t, newPoolAddr, cfgAfter.TokenPool, "TAR should be switched to the new v2.0 pool")
+		require.Equal(t, newPool1Addr, cfg1After.TokenPool, "evm1 TAR should be switched to evm1_new")
+		tar2Addr, err := evmAdapter.GetTokenAdminRegistryAddress(env.DataStore, evm2ChainSel)
+		require.NoError(t, err)
+		tar2, err := tarbindings.NewTokenAdminRegistry(tar2Addr, evm2Ch.Client)
+		require.NoError(t, err)
+		cfg2After, err := tar2.GetTokenConfig(&bind.CallOpts{Context: t.Context()}, evm2TokAddr)
+		require.NoError(t, err)
+		require.Equal(t, newPool2Addr, cfg2After.TokenPool, "evm2 TAR should be switched to evm2_new")
+
+		// Solana is a same-batch peer listed in cfg but it is NOT being replaced (not on V2, so its
+		// adapter has no TokenPoolMigrator). Reverse-propagation must therefore still reach it, adding
+		// both new EVM pools to its remote list even though it is not migrated.
+		for _, tc := range []struct {
+			remoteSel uint64
+			newPool   common.Address
+		}{
+			{evm1ChainSel, newPool1Addr},
+			{evm2ChainSel, newPool2Addr},
+		} {
+			pda, _, err := tokens.TokenPoolChainConfigPDA(tc.remoteSel, solMint, solPoolProgID)
+			require.NoError(t, err)
+			var chainCfg lockrelease_token_pool.ChainConfig
+			require.NoError(t, solChain.GetAccountDataBorshInto(t.Context(), pda, &chainCfg))
+			found := false
+			for _, poolAddr := range chainCfg.Base.Remote.PoolAddresses {
+				if bytes.Equal(tc.newPool.Bytes(), poolAddr.Address[len(poolAddr.Address)-len(tc.newPool.Bytes()):]) {
+					found = true
+					break
+				}
+			}
+			require.True(t, found, "Solana v1 pool should be reverse-propagated to know new pool on chain %d", tc.remoteSel)
+		}
 	})
 }
 


### PR DESCRIPTION
# Version-based batch migration with a pre-batch reverse-propagation snapshot

## Background

`AutoMigrateRemoteChains` carries a pre-V2 pool's cross-chain configuration forward onto a V2 replacement and, via reverse-propagation, keeps the rest of the web connected: after a pool migrates, every peer is told to add the new pool to its remote list so connectivity works in both directions.

In a batched migration the reverse-propagation step must skip a peer that is itself being **replaced** that batch — its brand-new pool isn't live yet, and configuring it would prematurely activate it and break that peer's own migration. But it must still reach a peer that is merely listed in the batch while reusing its existing pool, otherwise that peer is silently left one-directional (it never learns the new pools) even though the migration reports success.

## The core problem: ordering

Deciding "is this peer being replaced?" by reading its on-chain TAR-active pool *during the build* is unreliable. A peer's TAR-active flips to its new pool the moment that peer is forward-configured inside the loop, so a source processed later reads an already-moved value and misclassifies a being-replaced peer as "reuse" — reverse-propagating into a not-yet-live pool. The failure is order-dependent and can be reproduced empirically.

The fix takes a **pre-batch snapshot** of every same-batch peer's active pool at the very start of the changeset build, before anything is forward-configured (this runs only when at least one chain in the batch uses auto-migration, so non-migrating batches are untouched). Because no peer's active has moved yet, every snapshot is the pre-batch value regardless of processing order, so the being-replaced decision becomes order-independent.

## The discriminator

A same-batch peer is treated as being replaced (reverse-propagation into it is skipped) when its configured target pool differs from its pre-batch active pool, or when it has no pre-batch active pool at all. A peer whose target matches its pre-batch active pool is being reused and is reverse-propagated into. Deciding this from pool state rather than from any adapter interface keeps the logic correct across families and across a non-V2 family later gaining a token-pool migrator.

The snapshot triages its inputs: a peer with no active pool (a brand-new token) has nothing to migrate from and is a safe skip; a token that cannot be resolved at all is treated as a hard error, since reaching that point means an inconsistency rather than a legitimate absence of state; a read failure on the active pool is likewise surfaced as an error rather than guessed at.

## Interaction with the source gate

The source (forward) side runs auto-migration only for a genuine V2 upgrade — the configured target pool is 2.0.0+ — and requires the active adapter to implement the migrator for the discovery body to run; otherwise it is a no-op. This is keyed on the target's version rather than on interfaces, and documents the workaround for pools whose adapter cannot auto-discover (for example a token-pool proxy that relies on explicitly listed remote chains).

The forward and reverse gates stay consistent across every peer shape: a V2-migrating peer gets forward-wired and reverse-propagation into it is skipped; a non-V2 peer reusing its pool is reverse-propagated into; a pre-V2 pool swap is left to explicit configuration on both sides. Because the reverse side no longer depends on the target's version, it also handles the two-batch workflow (deploy a pool in an earlier batch, activate it in a later one), where the pool already exists on-chain and only becomes active now.
