### PR TITLE
docs(runbooks): add chain-specific runbooks

### DIFF
--- a/devenv/dashboards/ccip-evm.json
+++ b/devenv/dashboards/ccip-evm.json
@@ -1,0 +1,923 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1101,
+      "panels": [],
+      "title": "READ - data source (RPC pool + log poller)",
+      "type": "row"
+    },
+    {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1102,
+      "options": {
+        "mode": "markdown",
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "Every panel maps to one stage of `docs/runbooks/evm.md`. Set `$chainID` to the EVM **destination (tx-sending) chain**; on a shared datasource set `$fEnv`/`$fProduct` (regex) to match only CCIP nodes (e.g. `env=staging, product=ccip`); leave `.*` to match all. Metrics: `evm_pool_rpc_node_*`, `evm_log_poller_last_processed_block` (read path); `gas_updater_*`, `tx_manager_*`, `txm_pending_*` (write path). **Grafana can't express the empty-result rule - a blank panel means \"re-read that runbook stage\", not \"assume healthy\".** The V2 `txm_*` family is deliberately absent here (not emitted by a CCIP EVM deploy - see the runbook cheat sheet)."
+      },
+      "title": "About this section (EVM)",
+      "type": "text",
+      "transparent": true
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "A0. failed climbing on one nodeName = that RPC; across all = pool/chain-wide (masquerades as reader read_outcome_error / fchain_read_errors).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 1103,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(evm_pool_rpc_node_calls_failed{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}[5m])) by (nodeName)",
+          "legendFormat": "failed {{nodeName}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(evm_pool_rpc_node_calls_total{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}[5m])) by (nodeName)",
+          "legendFormat": "total {{nodeName}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "A0 - RPC pool: calls failed vs total by node",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "A0 corroboration. Note success=\"true\" means *failed* (label inverted - see runbook).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 1104,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(rpc_call_latency_milliseconds_bucket{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\", success=\"true\"}[5m])))",
+          "legendFormat": "p95 failed",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "A0 (opt) - rpc_call_latency p95 (by failure)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "A1. Flat/stale = log-poller wedge => reader read_empty/chain_gap (false idle).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 1105,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "evm_log_poller_last_processed_block{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}",
+          "legendFormat": "{{chainID}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "A1 - log poller last processed block",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "id": 1106,
+      "panels": [],
+      "title": "WRITE - report transmission (gas + TXM)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "B0. connectivity>0 or base-fee missing/zero => TXM can't price sends (underpriced -> give-up).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 1107,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "gas_updater_current_base_fee{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}",
+          "legendFormat": "base fee",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(block_history_estimator_connectivity_failure_count{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}[15m])) by (mode)",
+          "legendFormat": "connectivity {{mode}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "B0 - fee layer: base fee + connectivity-failure",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "B1. confirmed==0 while broadcasted>0 = sent-but-not-landing => B2. Both>0 = healthy TXM.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 33
+      },
+      "id": 1108,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(tx_manager_num_broadcasted{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}[15m]))",
+          "legendFormat": "broadcasted",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(tx_manager_num_confirmed_transactions{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}[15m]))",
+          "legendFormat": "confirmed",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "B1 - broadcasts vs confirms",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "B2. queue->1 + oldest-age climbing + attempts rising = the \"one stuck thing\" blocking sends (nonce-gap analogue; no nonce metric in the live family).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 1109,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max(txm_pending_tx_queue_utilization{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"})",
+          "legendFormat": "queue util",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max(tx_manager_tx_oldest_non_terminal_age_seconds{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"})",
+          "legendFormat": "oldest nonterminal",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max(tx_manager_tx_attempt_count{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"})",
+          "legendFormat": "attempt count",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "B2 - TXM stuck gauges (queue / oldest age / attempts)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "B2. reverted climbing = included-but-failed.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 47
+      },
+      "id": 1110,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(tx_manager_num_tx_reverted{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}[15m]))",
+          "legendFormat": "reverted",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(tx_manager_num_confirmed_transactions{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}[15m]))",
+          "legendFormat": "confirmed",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "B2 (rev) - tx reverts vs confirms",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "ccip",
+    "evm",
+    "chain-family"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "VictoriaMetrics",
+          "value": "victoriametrics"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(multi_node_states{network=\"EVM\"}, env)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Platform ENV",
+        "multi": true,
+        "name": "fEnv",
+        "options": [],
+        "query": {
+          "query": "label_values(multi_node_states{network=\"EVM\"}, env)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(multi_node_states{network=\"EVM\"}, product)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Platform PRODUCT",
+        "multi": true,
+        "name": "fProduct",
+        "options": [],
+        "query": {
+          "query": "label_values(multi_node_states{network=\"EVM\"}, product)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(multi_node_states{network=\"EVM\", env=~\"$fEnv\", product=~\"$fProduct\"}, chainID)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Chain (chainID)",
+        "multi": true,
+        "name": "chainID",
+        "options": [],
+        "query": {
+          "query": "label_values(multi_node_states{network=\"EVM\", env=~\"$fEnv\", product=~\"$fProduct\"}, chainID)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "CCIP EVM chain family (chainlink-evm)",
+  "uid": "ccip-evm",
+  "version": 1,
+  "weekStart": ""
+}

--- a/devenv/dashboards/ccip-solana.json
+++ b/devenv/dashboards/ccip-solana.json
@@ -1,0 +1,1129 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1201,
+      "panels": [],
+      "title": "READ - data source (log poller + node pool)",
+      "type": "row"
+    },
+    {
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1202,
+      "options": {
+        "mode": "markdown",
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "Every panel maps to one stage of `docs/runbooks/solana.md`. Set `$chainID` to the Solana chain ID; on a shared datasource set `$fEnv`/`$fProduct` (regex) to isolate CCIP nodes - **required on the A0b node-pool panels**, which are general multinode metrics emitted by *every* chainlink node (without `env/product` you'll read non-CCIP nodes). Metrics: `solana_log_poller_*` (A0), `multi_node_states`/`pool_rpc_node_*` (A0b), `solana_bhe_compute_unit_price` (B0), `solana_txm_*` (B1/B2). **Grafana can't express the empty-result rule - blank = re-read the runbook stage, not \"healthy\".** On older CCIP builds the per-node `pool_rpc_node_*` \"why\" series may be entirely absent (framework version skew) - A0b's `multi_node_states` still works."
+      },
+      "title": "About this section (Solana)",
+      "type": "text",
+      "transparent": true
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "A0. Flat/stale = poller wedge => reader read_empty/chain_gap.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 4
+      },
+      "id": 1203,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "solana_log_poller_last_processed_slot{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}",
+          "legendFormat": "{{chainID}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "A0 - log poller last processed slot",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "A0. climbing = poller dropping ranges on retry exhaustion.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 11
+      },
+      "id": 1204,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(solana_log_poller_blocks_skipped{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}[15m]))",
+          "legendFormat": "blocks skipped",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "A0 (skip) - blocks skipped",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "A0b. ==0 = NO live node = the \"no nodes healthy\"/No live RPC nodes available signal. >0 = at least one reachable.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.001
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 1205,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(multi_node_states{network=\"solana\", env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\", state=\"Alive\"})",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "A0b - LIVE nodes (state=Alive)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "A0b. Alive vs Unreachable/OutOfSync/Syncing/Undialed over time. All drop together => shared RPC/LB path; staggered => per-node.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 1206,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(multi_node_states{network=\"solana\", env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}) by (state)",
+          "legendFormat": "{{state}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "A0b - node count by state",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "A0b why. Fires only at transition/failure moments (wide window). ABSENT is NOT healthy when state=Alive==0 - on older CCIP builds this whole series may be missing (version skew).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 1207,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(pool_rpc_node_num_transitions_to_unreachable{network=\"solana\", env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}[4h])) by (nodeName)",
+          "legendFormat": "to-unreachable {{nodeName}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(pool_rpc_node_polls_failed{network=\"solana\", env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}[4h])) by (nodeName)",
+          "legendFormat": "polls-failed {{nodeName}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(pool_rpc_node_verifies_failed{network=\"solana\", env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}[4h])) by (nodeName)",
+          "legendFormat": "verifies-failed {{nodeName}}",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "A0b (why) - transitions + poll/verify failures",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "A0b why. RAW gauge (do not rate()). Flat line = was alive then unreachable; no series = never got a head / not exported.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 1208,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "pool_rpc_node_highest_seen_block{network=\"solana\", env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}",
+          "legendFormat": "seen {{nodeName}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "pool_rpc_node_highest_finalized_block{network=\"solana\", env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}",
+          "legendFormat": "finalized {{nodeName}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "A0b (why) - highest seen/finalized block (raw)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
+      },
+      "id": 1209,
+      "panels": [],
+      "title": "WRITE - report transmission (fees + Txm)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "B0. Absent/stale = estimator not running. 0 on a quiet chain is normal; compare to recent history.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "id": 1210,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "solana_bhe_compute_unit_price{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}",
+          "legendFormat": "{{chainID}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "B0 - BHE compute unit price",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "B1. success/finalized>0 = Txm landing reports. Both 0 + pending climbing = nothing landing => B2.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "id": 1211,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(solana_txm_tx_success{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}[15m]))",
+          "legendFormat": "success",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(solana_txm_tx_finalized{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}[15m]))",
+          "legendFormat": "finalized",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max(solana_txm_tx_pending{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"})",
+          "legendFormat": "pending",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "B1 - Txm broadcast flow",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "B2. All absent = healthy. Reject/drop=>RPC/fee; sim_revert/revert=>report-state; sim_other=>unknown; dependency=>account dependency failed.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 51
+      },
+      "id": 1212,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.1.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(solana_txm_tx_error_reject{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}[15m]))",
+          "legendFormat": "reject",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(solana_txm_tx_error_drop{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}[15m]))",
+          "legendFormat": "drop",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(solana_txm_tx_error_sim_revert{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}[15m]))",
+          "legendFormat": "sim_revert",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(solana_txm_tx_error_sim_other{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}[15m]))",
+          "legendFormat": "sim_other",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(solana_txm_tx_error_revert{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}[15m]))",
+          "legendFormat": "revert",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(solana_txm_tx_error_dependency{env=~\"$fEnv\", product=~\"$fProduct\", chainID=~\"$chainID\"}[15m]))",
+          "legendFormat": "dependency",
+          "range": true,
+          "refId": "F"
+        }
+      ],
+      "title": "B2 - Txm failure taxonomy",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [
+    "ccip",
+    "solana",
+    "chain-family"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "VictoriaMetrics",
+          "value": "victoriametrics"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(multi_node_states{network=\"solana\"}, env)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Platform ENV",
+        "multi": true,
+        "name": "fEnv",
+        "options": [],
+        "query": {
+          "query": "label_values(multi_node_states{network=\"solana\"}, env)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(multi_node_states{network=\"solana\"}, product)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Platform PRODUCT",
+        "multi": true,
+        "name": "fProduct",
+        "options": [],
+        "query": {
+          "query": "label_values(multi_node_states{network=\"solana\"}, product)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(multi_node_states{network=\"solana\", env=~\"$fEnv\", product=~\"$fProduct\"}, chainID)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Chain (chainID)",
+        "multi": true,
+        "name": "chainID",
+        "options": [],
+        "query": {
+          "query": "label_values(multi_node_states{network=\"solana\", env=~\"$fEnv\", product=~\"$fProduct\"}, chainID)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "CCIP Solana chain family (chainlink-solana)",
+  "uid": "ccip-solana",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -11,6 +11,14 @@ apart.
 | [`uncommitted-message.md`](uncommitted-message.md) | reactive — you have a specific stuck message (source chain, dest chain, onramp seq num) and need to find where it's stuck |
 | [`commit-plugin-health.md`](commit-plugin-health.md) | proactive — no specific incident; is this commit plugin instance healthy right now |
 | [`chain-identifiers.md`](chain-identifiers.md) | reference, not a runbook — translating between chain ID / chain selector / chain name |
+| [`evm.md`](evm.md) | chain-family deep dive — your commit runbook hit a `data_source` or `report_transmission` failure on an **EVM** destination chain and handed off to a txm/infra owner; this is what to look at in the chainlink-evm layer (RPC pool, log poller, gas, TXM) |
+| [`solana.md`](solana.md) | chain-family deep dive — same, but for a **Solana** destination chain (log poller, block-history fee estimator, Txm) |
+
+The last two are not standalone: they're entered from `commit-plugin-health.md` / `uncommitted-message.md`
+when those hand off with `REPORT:...-txm-oncall` / `REPORT:...-infra-oncall` (chain-family-specific
+versions of the commit plugin's own covered paths), and they use the **chain-family** repos'
+metrics (chainlink-evm / chainlink-solana), not the `ccip_commit_*` / `ccip_reader_*` series the
+other docs query.
 
 Both currently cover the **commit plugin / merkle root processor** only, built from the metric
 coverage work in [`docs/metrics/commit-metrics.md`](../metrics/commit-metrics.md) and rendered

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -12,7 +12,7 @@ apart.
 | [`commit-plugin-health.md`](commit-plugin-health.md) | proactive — no specific incident; is this commit plugin instance healthy right now |
 | [`chain-identifiers.md`](chain-identifiers.md) | reference, not a runbook — translating between chain ID / chain selector / chain name |
 | [`evm.md`](evm.md) | chain-family deep dive — your commit runbook hit a `data_source` or `report_transmission` failure on an **EVM** destination chain and handed off to a txm/infra owner; this is what to look at in the chainlink-evm layer (RPC pool, log poller, gas, TXM) |
-| [`solana.md`](solana.md) | chain-family deep dive — same, but for a **Solana** destination chain (log poller, block-history fee estimator, Txm) |
+| [`solana.md`](solana.md) | chain-family deep dive — same, but for a **Solana** destination chain (multinode node pool / RPC health, log poller, block-history fee estimator, Txm) |
 
 The last two are not standalone: they're entered from `commit-plugin-health.md` / `uncommitted-message.md`
 when those hand off with `REPORT:...-txm-oncall` / `REPORT:...-infra-oncall` (chain-family-specific

--- a/docs/runbooks/commit-plugin-health.md
+++ b/docs/runbooks/commit-plugin-health.md
@@ -14,6 +14,8 @@ related:
   - docs/metrics/reader-metrics.md         # data-source (reader + config poller) metrics & gaps
   - devenv/dashboards/commit-plugin.json   # Grafana rendering of this runbook (Health section)
   - docs/runbooks/chain-identifiers.md     # translating chain ID / chain selector / chain name
+  - docs/runbooks/evm.md                   # chain-family deep dive when the dest chain is EVM (data_source/report_transmission)
+  - docs/runbooks/solana.md                # chain-family deep dive when the dest chain is Solana (data_source/report_transmission)
 status: living
 ---
 
@@ -498,6 +500,16 @@ rule below).
 `report_transmission_gave_up` is `CRIT`. `report_validation_rejected` is split by reason:
 `stale` alone is `INFO`, anything else present is `WARN`, and — being `always_emitted: false` —
 a fully empty result is `OK`, not `UNKNOWN`.
+
+**On a reverting/pre-send give-up, or any `data_source` finding, this checklist can't see too
+far "down" — it answers at the plugin layer.** If `report_transmission_gave_up` fires and
+`report_validation_rejected` doesn't explain it (nothing rejected locally, nothing landing), or if
+the `data_source` group fires at all, drop down into the **chain-family layer** the plugin reads
+and transmits through: [`evm.md`](evm.md) for an EVM `destChain` (RPC pool, log poller, gas, TXM)
+or [`solana.md`](solana.md) for a Solana `destChain` (log poller, block-history fee estimator,
+Txm). Those are the runbooks the `REPORT:chain-b-txm-oncall` / `chain-a-*/chain-b-*-infra-oncall`
+owners of this checklist's `CRIT`s would run next, and they use the chain-family repos' metrics
+rather than the `ccip_commit_*`/`ccip_reader_*` series here.
 
 ## Aggregation rule
 

--- a/docs/runbooks/commit-plugin-health.md
+++ b/docs/runbooks/commit-plugin-health.md
@@ -71,16 +71,6 @@ carries the source-side equivalent from `sourceChainAttrs()`:
 | `sourceChainName` | source chain name (this replaces the old `source_network_name`) |
 | `sourceChainSelector` | source CCIP chain selector, as a string |
 
-**The old labels are gone, not aliased.** `chainID`, `chain_id`, `chainFamily`, `chain_family`,
-`source_network_name`, and `dest_network_name` no longer appear on any Beholder-emitted series in
-this file — every query below now filters on `destChainID=~"$destChain"` and, where relevant,
-`sourceChainName=~"$sourceChains"`. If you have an old saved query or alert on this metric family,
-it now silently returns empty, not an error — re-check anything written before this rename before
-trusting a `UNKNOWN`/blank result from it. (The old names do still exist on a separate,
-`promauto`-only direct-scrape path for a handful of metrics in `commit/metrics/legacy_prom.go` —
-that path is unrelated to what this checklist queries and is flagged deprecated in-code; don't
-mix the two.)
-
 Since `destChainName`/`sourceChainName`/`destChainSelector`/`sourceChainSelector` are now
 first-class labels (not just something you compute via [`chain-identifiers.md`](chain-identifiers.md)),
 you can equally well filter `$destChain`/`$sourceChains` against whichever representation you were

--- a/docs/runbooks/evm.md
+++ b/docs/runbooks/evm.md
@@ -1,0 +1,460 @@
+---
+name: evm-chain-family
+description: Chain-family deep dive for an EVM chain feeding or receiving a CCIP commit plugin. Drills into the EVM chain-family library (chainlink-evm) layers -- RPC client pool, log poller, gas/fee estimators, and the transaction manager (TXM) -- that underpin the commit plugin's data-source (reader) and report-transmission paths. Enter this doc when the commit runbooks hand off with REPORT:chain-b-txm-oncall or REPORT:chain-infra-oncall, or when a data_source / report_transmission check in commit-plugin-health.md fires.
+trigger: "entered from docs/runbooks/commit-plugin-health.md (data_source or report_transmission group CRIT/WARN) or docs/runbooks/uncommitted-message.md (step2c, or Scenario 2-B 'transmitted, reverted/stuck on-chain'). Not triggered standalone."
+severity: page
+owner: chain-evm-oncall
+inputs:
+  chainID: {type: string, description: "the EVM chain ID of the chain under investigation. Crash-important: the commit runbooks filter on the commit plugin's destChainID label; the chainlink-evm metrics in THIS doc carry a bare chainID label (the EVM chain ID), so the value you substitute here is the same number you used for destChainID there, but it must be applied to a different label key -- see the label cheat sheet before running any query"}
+  entry: {type: string, description: "which commit-plugin symptom brought you here", default: "data_source"}
+  txHash: {type: string, required: false, description: "optional. If you have the specific stuck/reverted commit-report tx hash (from logs or an explorer), you can cross-reference it in stage B; otherwise run the checks blind and let them tell you what to look at"}
+related:
+  - docs/runbooks/commit-plugin-health.md # the health checklist this doc deep-dives for EVM dest chains
+  - docs/runbooks/uncommitted-message.md   # the triage doc this doc deep-dives for EVM dest chains
+  - docs/runbooks/solana.md                # the same deep-dive for the Solana chain family
+  - docs/runbooks/chain-identifiers.md     # translating chain ID / chain selector / chain name
+status: living
+---
+
+- [Runbook: EVM chain family (chainlink-evm)](#runbook-evm-chain-family-chainlink-evm)
+   * [For agents](#for-agents)
+      + [Label key cheat sheet -- the crash-important part](#label-key-cheat-sheet--the-crash-important-part)
+      + [The success label inversion on rpc_call_latency](#the-success-label-inversion-on-rpc_call_latency)
+      + [Which TXM metrics actually carry a chainID label (not all do)](#which-txm-metrics-actually-carry-a-chainid-label-not-all-do)
+      + [Empty result sets](#empty-result-sets)
+      + [Counter _total suffixing](#counter-total-suffixing)
+   * [Decision graph](#decision-graph)
+   * [Steps](#steps)
+      + [Stage A0 -- RPC client pool: are the nodes answering?](#stage-a0--rpc-client-pool-are-the-nodes-answering)
+      + [Stage A1 -- log poller: is it keeping up with the chain?](#stage-a1--log-poller-is-it-keeping-up-with-the-chain)
+      + [Stage B0 -- gas/fee layer: can it price and afford a send?](#stage-b0--gasfee-layer-can-it-price-and-afford-a-send)
+      + [Stage B1 -- TXM broadcast: are reports being sent at all?](#stage-b1--txm-broadcast-are-reports-being-sent-at-all)
+      + [Stage B2 -- TXM stuck: killed attempts, nonce gaps, lifecycle failures](#stage-b2--txm-stuck-killed-attempts-nonce-gaps-lifecycle-failures)
+   * [Metric reference](#metric-reference)
+   * [Output contract](#output-contract)
+
+# Runbook: EVM chain family (chainlink-evm)
+
+`commit-plugin-health.md` and `uncommitted-message.md` decide *whether* the commit plugin's
+destination chain is fine *as a plugin*. That decision bottoms out in `REPORT:chain-b-txm-oncall`
+(report transmission) and `REPORT:chain-infra-oncall` / the `data_source` group (reader feeding)
+-- but those handoffs deliberately don't tell the on-call **what to look at in the EVM layer**.
+This doc fills that gap: it's the runbook those `REPORT` outcomes and those two groups point to,
+using the metrics chainlink-evm itself emits (checked out at `../chainlink-evm`, one level above
+this repo's root) for its own critical components.
+
+Two layers matter to CCIP commit on an EVM destination chain, and they map 1:1 onto how the
+plugin got its data and how it gets its reports out:
+
+- **Read path (data source).** CCIP's reader reads on/offramp state and messages over RPC and
+  ingests on-chain events through the **log poller**. If either degrades, the commit plugin is
+  fed empty/partial/stale data and looks "fine but idle" -- exactly the 
+  [false idle](../runbooks/README.md#identifying-a-ccip-message) trap the reader-metrics gate in
+  `uncommitted-message.md` step2c is designed to catch. Stages **A0/A1**.
+- **Write path (report transmission).** Commit reports are submitted as normal transactions
+  through the **transaction manager (TXM)**, which must price them (gas estimators), broadcast
+  them, and shepherd them to inclusion. When `report_transmission_gave_up` fires in the commit
+  plugin, the root cause usually lives in one of: can't afford a send (fee layer), can't broadcast
+  (RPC), or the tx is stuck/reverting (nonce gap, max attempts, lifecycle failure). Stages
+  **B0/B1/B2**.
+
+Read A0 and A1 if your `entry` is `data_source`; read B0-B2 if it's `report_transmission`. The
+two halves are independent and you can enter directly at the relevant quarter.
+
+## For agents
+
+This is a reactive triage doc: walk the [decision graph](#decision-graph) mechanically, fill in
+`$chainID` (and `$entry`) from the inputs, evaluate each query's condition, and follow the output.
+Outcome vocabulary is the same three-way contract as `uncommitted-message.md`:
+`STOP` / `CONTINUE:<step>` / `REPORT:<owner>`. `REPORT` is a handover, never an action.
+
+### Label key cheat sheet -- the crash-important part
+
+The commit runbooks filter on the **commit plugin's** labels: `destChainID`, `sourceChainName`,
+etc. (from `destChainAttrs()`/`sourceChainAttrs()`). **The chainlink-evm metrics in this doc do
+not carry those.** They carry a bare `chainID` (the EVM chain ID), and in the older promauto
+downstream of the pool they carry `evmChainID`. There is no `destChainID` label anywhere in this
+doc. So the number you substitute for `$chainID` is the **same numeric EVM chain ID** you used for
+`destChainID` in the commit doc -- the key is just spelled differently. Do not try to swap in a
+chain selector, a chain name, or `destChainID` as a label key; every one of those silently returns
+empty here.
+
+| label key | appears on | meaning |
+|---|---|---|
+| `chainID` | all EVM beholder metrics | the EVM chain ID (== commit's `destChainID` value for the dest chain) |
+| `evmChainID` | the promauto pool counters (`evm_pool_rpc_node_calls_*`), gas-updater gauges (promauto side only) | same value, old promauto spelling. Only on the direct-scrape path, not the beholder path |
+| `nodeName` | `evm_pool_rpc_node_calls_*` | which RPC node -- use this to split a single bad RPC from the whole pool failing |
+| `rpcDomain` | `evm_pool_rpc_node_calls_*` (beholder), `rpc_call_latency` | the RPC endpoint/domain (sanitized) the call went to |
+| `callName` / `rpcCallName` | RPC metrics | which JSON-RPC method / logical call |
+| `address` | `txm_rpc_nonce` | the wallet address whose on-chain nonce is reported |
+| `stage` | `txm_transaction_lifecycle_failure_total` | where in the lifecycle the failure happened (`create`, `in_flight_subset`, `max_in_flight`, `broadcast`, `nonce_at`) |
+| `percentile` | the gas-updater gauges | which price percentile (`p25`, `p50`, ...) the gauge carries |
+| `mode` | `block_history_estimator_connectivity_failure_count` | `legacy` or `eip1559` |
+
+The pool metrics are effectively **dual-registered** (same name on promauto and beholder), which
+means the label set you see depends on which path your datasource consumes -- see
+[the note below](#counter-total-suffixing). On a beholder-fed Prometheus datasource expect
+`chainID,nodeName,rpcDomain,callName`; on a direct promauto scrape expect `evmChainID,nodeName`.
+Confirm against the metric browser before trusting an empty result.
+
+One metric in this doc is **not** part of the EVM pool's beholder trio and has to be reached via
+the chainlink-framework latency instrument -- **`rpc_call_latency`** (a histogram). It is the
+thinnest, most information-dense read-path signal (it exposes per-`callName` latency and success
+for *every* RPC call), so it earns the inversion warning below.
+
+### The success label inversion on rpc_call_latency
+
+`rpc_call_latency`'s `success` label is set from `strconv.FormatBool(err != nil)` in
+chainlink-framework's `RecordRequest`. That means **`success="true"` is the label attached to a
+failed call** (an error was present) and `success="false"` to a successful one. This is the
+opposite of intuition and of the metric's own `Help` text. If you write `{success="true"}` because
+you want "the successful calls," you get the failures. For latency-by-failure, author your queries
+against `success="true"` (err != nil) and `success="false"` (clean) -- and call out this inversion
+in any finding so the human doesn't re-derive it from the metric name. (The older
+`evm_pool_rpc_node_rpc_call_time` histogram shares the same `success` semantics on the promauto
+side.)
+
+### Which TXM metrics actually carry a chainID label (not all do)
+
+`pkg/txm/metrics.go` constructs a `metrics.Labeler` with `chainID` and carries it on the struct --
+but the beholder `.Add(...)`/`.Record(...)` calls for **most** of the `txm_*` instruments pass
+**no attributes** (`m.numBroadcastedTxs.Add(ctx, 1)`, etc.), so those beholder series get only the
+beholder client's inherited identity labels (`node_id`, `csa_public_key`), **no `chainID`**. Only
+**`txm_transaction_lifecycle_failure_total`** explicitly attaches `chainID` + `stage`. The
+consequences, and the escape hatches:
+
+- On a **beholder-fed** datasource, the counters `txm_num_broadcasted_transactions`,
+  `txm_num_confirmed_transactions`, `txm_num_nonce_gaps`, the gauge `txm_reached_max_attempts`,
+  the histogram `txm_time_until_tx_confirmed`, and the gauge `txm_rpc_nonce` **are not filterable
+  by `$chainID`**. Queries against them on a node hosting multiple chains will mix chains. Scope
+  them per `node_id`/`csa_public_key` instead, or use the **`txm_transaction_lifecycle_failure_total`**
+  (`chainID` + `stage`) as the chain-scoped backbone of stage B2.
+- The **promauto** dual-writes for all of these **do** carry `chainID` (and `txm_rpc_nonce` adds
+  `address`). If your datasource scrapes the node's prometheus endpoint directly, prefer the
+  pramaauto names for chain-scoped TXM questions.
+
+The queries in this doc are written to be correct on either path, but the label caveat is why stage
+B2 leans on `txm_transaction_lifecycle_failure_total` rather than assuming every TXM counter is
+chain-filterable.
+
+### Empty result sets
+
+No metric in this doc is an unconditional per-round heartbeat like the commit plugin's -- most are
+event counters that only get a time series after they fire, or gauges reported on their own
+ticker. The same two rules from `commit-plugin-health.md#empty-result-sets` apply:
+
+1. The **staleness/liveness gauges** -- `evm_log_poller_last_processed_block` (A1),
+   `txm_reached_max_attempts`, `txm_rpc_nonce` (B2) -- are reported continuously while the process
+   runs, so an **empty** result (no series at all) means the metric isn't reaching your datasource,
+   not "value zero." Report `UNKNOWN` there, don't grade it against thresholds.
+2. Everything else is an **event counter** (`evm_pool_rpc_node_calls_*`, `rpc_call_latency`
+   buckets, `block_history_estimator_connectivity_failure_count`, `txm_num_*`,
+   `txm_transaction_lifecycle_failure_total`): **empty == the event never happened == value 0.**
+   Grade normally. The one exception is the same as the commit docs: if a `UNKNOWN`-class gauge in
+   the same run is itself empty, don't trust counter-emptiness -- say so in `concerns`.
+
+`rpc_call_latency` and `txm_time_until_tx_confirmed` are histograms; if you only have their
+`_count`/`_bucket` forms on your datasource, derive `rate()`s and quantiles from those, treating an
+absent `_count` for a window as "no calls (or none clearing the first bucket) in that window."
+
+### Counter _total suffixing
+
+Same pipeline caveat as the commit runbooks: OTel counters that reach Prometheus via a
+prometheusremotewrite/OTel-collector exporter get a `_total` appended **unless the name already
+ends in `_total`**. Several EVM metrics are registered with `_total` already baked in
+(`evm_pool_rpc_node_calls_total`, `txm_transaction_lifecycle_failure_total`,
+`block_history_estimator_connectivity_failure_count` does *not*), so on such a datasource these
+names are *not* doubled -- but the fee/other counters also registered without `_total`
+(`gas_updater_set_gas_price` is a gauge; `txm_num_nonce_gaps` is a counter and would gain a
+`_total`). **Check one query against your datasource's metric browser before trusting the rest.**
+The doc lists the metric as registered; your pipeline may suffix it.
+
+## Decision graph
+
+```yaml
+# entry defaults to "data_source"; set to "report_transmission" when dropped from that path.
+steps:
+      # ---- READ PATH (data source) ----
+  - id: A0
+    check: rpc_node_pool_health
+    queries:
+      - 'sum(rate(evm_pool_rpc_node_calls_failed{chainID="$chainID"}[5m])) by (nodeName)'
+      - 'sum(rate(evm_pool_rpc_node_calls_total{chainID="$chainID"}[5m])) by (nodeName)'
+    condition: "any nodeName shows a failed/total ratio clearly above its peers, OR all nodeNames show failures"
+    if_true:
+      one_bad_node: {action: "REPORT:chain-evm-oncall", reason: "a single RPC node is failing calls that its peers aren't (nodeName differs) -- per-node RPC/infra issue, not the chain or the pool. The commit plugin auto-selects away from a failed node, so this usually self-heals, but a persistently failing primary stalls reads until failover. Hand off with the failing nodeName."}
+      all_nodes:     {action: "REPORT:chain-evm-oncall", reason: "every node in the pool is failing RPC calls for $chainID -- this is a chain-wide or pool-config outage, and it will surface upstream as reader read_outcome_error / ccip_commit_fchain_read_errors / onramp lag (uncommitted-message.md step2/step2c). Do not attribute it to the commit plugin."}
+    if_false: {action: "CONTINUE:A1", reason: "no node's failure ratio warrants a finding; move to log-poller catch-up"}
+    automatable: true
+
+  - id: A1
+    check: log_poller_catchup
+    query: 'evm_log_poller_last_processed_block{chainID="$chainID"}'
+    condition: "value stale (no sample in the last ~2 poll intervals) OR lagging the chain head by more than your environment's tolerance"
+    if_true: {action: "REPORT:chain-evm-oncall", reason: "the log poller for $chainID is stuck (no fresh samples) or far behind -- the reader's per-filter queries read logs through it, so a wedge here produces exactly the read_empty / MsgsBetweenSeqNums-empty / config_poller batch failures the commit runbooks attribute to 'data source'. Cross-check the reader metrics (ccip_reader_read_empty_total, ccip_reader_config_poll_failure_total reason=\"batch_fetch_failed\") to confirm they coincide with this log-poller stall before reporting."}
+    if_false: {action: "CONTINUE:$entry == \"report_transmission\" ? B0 : STOP", reason: "read path is healthy for $chainID. If you came in via data_source, stop here; if via report_transmission, continue to the write path."}
+    automatable: true
+
+  # ---- WRITE PATH (report transmission) ----
+  - id: B0
+    check: fee_layer_can_send
+    queries:
+      - 'sum(rate(block_history_estimator_connectivity_failure_count{chainID="$chainID"}[15m])) by (mode)'
+      - 'max(gas_updater_current_base_fee{chainID="$chainID"})'
+    condition: "connectivity_failure_count any mode > 0, OR base_fee gauge missing/zero when the chain is EIP-1559"
+    if_true: {action: "CONTINUE:B0_detail", reason: "gas estimation flagged a connectivity failure (bumps being suppressed) or has no base fee to price against -- TXM may refuse to bump or underprice"}
+    if_false: {action: "CONTINUE:B1", reason: "fee layer looks able to price sends; move to broadcast"}
+    automatable: true
+
+  - id: B0_detail
+    check: connectivity_failure_mode
+    query: 'sum(rate(block_history_estimator_connectivity_failure_count{chainID="$chainID"}[15m])) by (mode)'
+    condition: "any series > 0"
+    if_true: {action: "REPORT:chain-evm-oncall", reason: "gas bumps are being suppressed for $chainID due to a detected network propagation/connectivity issue (mode=legacy or mode=eip1559). This frequently pairs with report_transmission_gave_up: TXM keeps trying to bump but is blocked from re-pricing, so reports underprice and never land. Treat fee-layer connectivity as the root cause for the transmission give-up, not a secondary observation."}
+    if_false: {action: "REPORT:chain-evm-oncall", reason: "no connectivity-failure counter, but base fee is missing/zero on an EIP-1559 chain -- the estimator isn't obtaining a usable base fee, so TXM cannot price EIP-1559 sends correctly."}
+    automatable: true
+
+  - id: B1
+    check: txm_broadcast_flow
+    queries:
+      - 'sum(rate(txm_num_confirmed_transactions{chainID="$chainID"}[15m]))'
+      - 'sum(rate(txm_num_broadcasted_transactions{chainID="$chainID"}[15m]))'
+    condition: "confirmed == 0 AND broadcasted == 0 over the window"
+    note: "these two counters do NOT carry chainID on a beholder-only datasource (see the label cheat sheet) -- the {chainID=...} filter here works only if your datasource also has the promauto forms. If {chainID=...} returns empty on a datasource you believe is beholder-only, re-run WITHOUT chainID and split by node_id/csa_public_key instead; an empty-result treated as 'zero' here is exactly the trap the cheat sheet warns about."
+    if_true: {action: "CONTINUE:B2", reason: "nothing being broadcast at all -- the give-up is a 'no reports are even being sent' situation, dig into stuck/lifecycle markers"}
+    if_false:
+      confirmed_zero_broadcasted_positive: {action: "CONTINUE:B2", reason: "reports ARE being broadcast but NONE confirm in window -- a land/drop/revert problem, not a send problem"}
+      both_positive: {action: "STOP", reason: "TXN is broadcasting and confirming reports normally for $chainID. If report_transmission_gave_up still fires, it's almost certainly a per-report revert or a backlog-size / round-cadence issue, not the EVM node stack. Escalate with this evidence rather than assuming the EVM layer broken. (If you were handed a specific $txHash, sanity-check it on the explorer before stopping.)"}
+    automatable: true
+
+  - id: B2
+    check: txm_stuck_signals
+    query: 'sum by (stage) (rate(txm_transaction_lifecycle_failure_total{chainID="$chainID"}[15m]))'
+    condition: "any series > 0"
+    if_true: {action: "CONTINUE:B2_detail", reason: "transaction lifecycle failures present; stage names the phase"}
+    if_false: {action: "CONTINUE:B2_nonce", reason: "no lifecycle-failure counter; the stuck signal (give-up, zero confirms) must come from nonce or max-attempts instead"}
+    automatable: true
+
+  - id: B2_detail
+    check: lifecycle_failure_stage
+    query: 'sum by (stage) (rate(txm_transaction_lifecycle_failure_total{chainID="$chainID"}[15m]))'
+    condition: "report the dominant stage(s)"
+    if_true:
+      nonce_at:       {action: "REPORT:chain-evm-oncall", reason: "lifecycle failing at the nonce stage -- nonce tracking issue. Cross-check txm_rpc_nonce (per address) vs expected and the nonce gap counter (nonce_gap) below."}
+      max_in_flight:  {action: "REPORT:chain-evm-oncall", reason: "lifecycle failing at max_in_flight -- the TXM's max inflight budget is exhausted (slow finality or too many concurrent reports). Throttling, not an RPC failure."}
+      broadcast:      {action: "REPORT:chain-evm-oncall", reason: "lifecycle failing at broadcast -- the RPC rejected/dropped the send; corroborate with evm_pool_rpc_node_calls_failed at the same time."}
+      create:         {action: "REPORT:chain-evm-oncall", reason: "lifecycle failing at create -- the tx could not be constructed (e.g. missing wallet/crypto, keystore). Check infrastructure, not the chain."}
+      default:        {action: "REPORT:chain-evm-oncall", reason: "dominant/most relevant of the above, or a stage not named here -- report the exact stage string with the rate, don't guess."}
+    if_false: {action: "CONTINUE:B2_nonce", reason: "no strongly dominant stage; continue to the nonce/max-attempt check"}
+    automatable: true
+
+  - id: B2_nonce
+    check: nonce_gaps_and_max_attempts
+    queries:
+      - 'sum(rate(txm_num_nonce_gaps{chainID="$chainID"}[15m]))'
+      - 'max(txm_reached_max_attempts{chainID="$chainID"})'
+    condition: "nonce gaps rate > 0 OR reached_max_attempts == 1"
+    note: "same chainID caveat as B1 -- txm_num_nonce_gaps / txm_reached_max_attempts / txm_rpc_nonce lack chainID on beholder-only datasources. Prefer the chainID-bearing txm_transaction_lifecycle_failure_total from B2 when the datasource gives you no promauto forms; treat an empty {chainID=...} result here as 'cannot scope', not 'zero'."
+    if_true:
+      nonce_gaps:
+        action: "REPORT:chain-evm-oncall"
+        reason: "the TXM is filling nonce gaps for $chainID -- a stalled out-of-order tx is parking the sender's nonce and blocking subsequent reports (classic report_transmission_gave_up root cause). Cross-check txm_rpc_nonce per address to see the parked nonce."
+        followup_query: 'txm_rpc_nonce{chainID="$chainID"}'
+      max_attempts:
+        action: "REPORT:chain-evm-oncall"
+        reason: "reached_max_attempts == 1 -- the TXM gave up on a tx after exhausting its bump budget (combined with B0 if the bump was suppressed by a connectivity failure, or with B2's broadcast stage if the RPC dropped it). Any report behind that tx will report_transmission_gave_up until the wallet nonce recovers."
+    if_false: {action: "STOP", reason: "no nonce gaps and no max-attempt kill. Broadcasts were happening but nothing confirms and no stuck marker is firing -- this is most likely an RPC/indexing lag on the confirmation side (tx landed but isn't seen as finalized). Verify against the chain explorer / $txHash before escalating further."}
+    automatable: true
+```
+
+## Steps
+
+### Stage A0 -- RPC client pool: are the nodes answering?
+
+The commit reader's reads and the TXM's sends both go through the EVM pool's RPC clients. Group
+the pool counters by node to tell "one bad RPC" from "whole pool down":
+
+```promql
+sum(rate(evm_pool_rpc_node_calls_failed{chainID="$chainID"}[5m])) by (nodeName)
+sum(rate(evm_pool_rpc_node_calls_total{chainID="$chainID"}[5m])) by (nodeName)
+```
+
+Optionally corroborate at the wire level with the chain-client multicall latency histogram
+(`txm_multicall_duration_ms{success="false"}`, beholder-only) if your datasource has it, and with
+per-node latency (beholder histogram from chainlink-framework; `success="true"` means *failed* --
+see [the inversion](#the-success-label-inversion-on-rpc_call_latency)):
+
+```promql
+histogram_quantile(0.95, sum by (le) (rate(rpc_call_latency_bucket{chainID="$chainID", callName=~".*", success="true"}[5m])))
+```
+
+A single `nodeName` failing while peers pass → hand off that node (`chain-evm-oncall`). Every node
+failing → a pool/chain-wide outage that will masquerade as reader `read_outcome_error` /
+`fchain_read_errors` / onramp lag in the commit docs -- own it as a chain-family finding, not a
+plugin one.
+
+### Stage A1 -- log poller: is it keeping up with the chain?
+
+`ccip`'s reader ingests on-chain events (message sends, commits, config) through the EVM **log
+poller**. A log poller wedge is the single most common *silent* false-idle cause on an EVM dest
+chain: every per-filter log read returns empty, so the reader reports clean `read_empty` /
+`chain_gap` and the commit plugin sits idle looking healthy.
+
+The one gauge is `evm_log_poller_last_processed_block`:
+
+```promql
+evm_log_poller_last_processed_block{chainID="$chainID"}
+```
+
+Two failure shapes:
+- **No fresh samples** (stale for a couple of poll intervals): the poller goroutine itself is
+  wedged. This is the more dangerous one because `last_processed_block` parks at its last value
+  and looks "normal, just old."
+- **Lagging block head**: the poller is running but can't keep up (slow RPC, backlog of
+  reorg/dedupe work). Eventually bounded if the RPC catches up; unbounded if it doesn't.
+
+Either way report `chain-evm-oncall`, and corroborate with the reader's own signals
+(`ccip_reader_read_empty_total`, `ccip_reader_config_poll_failure_total{reason="batch_fetch_failed"}`)
+so the finding lands on the EVM layer rather than being re-attributed upstairs.
+
+### Stage B0 -- gas/fee layer: can it price and afford a send?
+
+Commit-report transactions must be priced. Two estimator families feed the TXM:
+- **block-history estimator** (EIP-1559 and legacy price percentiles via `gas_updater_*`
+  gauges, plus the connectivity-failure counter)
+- **fee-history estimator** (`base_fee_updater`, `gas_price_updater`,
+  `max_fee_per_gas_updater`, `max_priority_fee_per_gas_updater` gauges)
+
+The actionable signal is the **connectivity-failure counter** -- the estimator *detected* it
+couldn't trust the fee data and is refusing to bump, which starves transmission at the pricing
+layer:
+
+```promql
+sum(rate(block_history_estimator_connectivity_failure_count{chainID="$chainID"}[15m])) by (mode)
+```
+
+`mode` is `legacy` or `eip1559`. If it fires alongside `report_transmission_gave_up`, the bump
+was suppressed by the fee estimator's connectivity guard -- root cause at the fee layer, not a
+TXM logic bug. Also sanity-check `gas_updater_current_base_fee` exists and is nonzero
+on an EIP-1559 chain; a missing base fee means the estimator has nothing to price against.
+
+### Stage B1 -- TXM broadcast: are reports being sent at all?
+
+The two counters that divide "nothing is being sent" from "sent but not landing":
+
+```promql
+sum(rate(txm_num_confirmed_transactions{chainID="$chainID"}[15m]))
+sum(rate(txm_num_broadcasted_transactions{chainID="$chainID"}[15m]))
+```
+
+- Both `> 0` → the node stack is broadcasting **and confirming** reports normally. A persisted
+  `report_transmission_gave_up` together with a healthy TXM is a per-report revert or a
+  backlog/round-cadence issue, not the EVM stack. Stop here (verify the actual tx on-chain if you
+  have a `$txHash`).
+- Broadcasted `> 0`, confirmed `== 0` → reports go out but never land → **B2** (land/drop/revert /
+  nonce).
+- Both `== 0` → nothing is being sent at all → **B2** (stuck/never-created).
+
+`txm_time_until_tx_confirmed` (histogram) is the supporting latency signal; a healthy chain spends
+most of it near the chain's block time, and a value pinned at the histogram ceiling means confirms
+are being delayed, not that everything is fine.
+
+### Stage B2 -- TXM stuck: killed attempts, nonce gaps, lifecycle failures
+
+When broadcasts aren't confirming, name *why*. The chain-scoped backbone is the lifecycle-failure
+counter (the one TXM metric that reliably carries `chainID`):
+
+```promql
+sum by (stage) (rate(txm_transaction_lifecycle_failure_total{chainID="$chainID"}[15m]))
+```
+
+`stage` values: `create` (couldn't construct the tx -- keystore/wallet/infra),
+`in_flight_subset` / `max_in_flight` (concurrency budget exhausted -- throttling), `broadcast`
+(RPC rejected/dropped the send), `nonce_at` (nonce tracking broken). Pair each with the matching
+corroboration from the note on the decision-graph step.
+
+Then the classic stuck-nonce pair:
+
+```promql
+sum(rate(txm_num_nonce_gaps{chainID="$chainID"}[15m]))
+max(txm_reached_max_attempts{chainID="$chainID"})
+txm_rpc_nonce{chainID="$chainID"}   # per wallet address
+```
+
+A **nonce gap** (or `reached_max_attempts==1`) means one parked out-of-order tx is holding the
+sender's nonce, so every subsequent report (a) can't get its required nonce and (b) keeps bouncing
+off the RPC with a nonce-too-low/known-tx rejection. That is the archetypal
+`report_transmission_gave_up` + zero-confirms combination on EVM, and the fix lives in the EVM
+operation (find/nothing the stuck tx, recover the nonce), not in the commit plugin.
+
+If nothing in B2 fires at all but confirms are still zero, the remaining honest conclusion is an
+RPC confirmation/indexing lag rather than a TXM failure -- say so and verify against the explorer
+rather than inventing a stuck marker.
+
+## Metric reference
+
+`otel_type` governs `_total`/`_bucket` suffixing (see [the note](#counter-total-suffixing)).
+`dual` means promauto + beholder side-by-side; `beholder-only` means only the OTel/beholder path
+(chainlink-evm patterns mirror the commit-plugin ones in `uncommitted-message.md#metric-reference`).
+Many TXM beholder series carry **no `chainID` attribute** -- see
+[which TXM metrics carry chainID](#which-txm-metrics-actually-carry-a-chainid-label-not-all-do).
+
+| metric | otel_type | key labels | registration |
+|---|---|---|---|
+| `evm_pool_rpc_node_calls_total` | Counter | beholder: `chainID,nodeName,rpcDomain,callName`; promauto: `evmChainID,nodeName` | dual |
+| `evm_pool_rpc_node_calls_success` | Counter | same as above | dual |
+| `evm_pool_rpc_node_calls_failed` | Counter | same as above | dual |
+| `rpc_call_latency` | Histogram | `chainFamily,chainID,rpcDomain,isSendOnly,success,callName` (success inverted) | dual (chainlink-framework) |
+| `evm_log_poller_last_processed_block` | Gauge | `chainFamily,chainID` | dual |
+| `gas_updater_set_gas_price` | Gauge | `chainID,percentile` | dual |
+| `gas_updater_set_tip_cap` | Gauge | `chainID,percentile` | dual |
+| `gas_updater_all_gas_price_percentiles` | Gauge | `chainID,percentile` | dual |
+| `gas_updater_all_tip_cap_percentiles` | Gauge | `chainID,percentile` | dual |
+| `gas_updater_current_base_fee` | Gauge | `chainID` | dual |
+| `block_history_estimator_connectivity_failure_count` | Counter | `chainID,mode` (`legacy`\|`eip1559`) | dual |
+| `gas_price_updater` | Gauge | `chainID` | dual |
+| `base_fee_updater` | Gauge | `chainID` | dual |
+| `max_priority_fee_per_gas_updater` | Gauge | `chainID` | dual |
+| `max_fee_per_gas_updater` | Gauge | `chainID` | dual |
+| `txm_transaction_lifecycle_failure_total` | Counter | `chainID,stage` | both (chainID attached) |
+| `txm_num_broadcasted_transactions` | Counter | **no chainID on beholder**; promauto `chainID` | both |
+| `txm_num_confirmed_transactions` | Counter | **no chainID on beholder**; promauto `chainID` | both |
+| `txm_num_nonce_gaps` | Counter | **no chainID on beholder**; promauto `chainID` | both |
+| `txm_reached_max_attempts` | Gauge | **no chainID on beholder**; promauto `chainID` | both |
+| `txm_time_until_tx_confirmed` | Histogram | **no chainID on beholder**; promauto `chainID` | both |
+| `txm_rpc_nonce` | Gauge | **no chainID on beholder**; promauto `chainID,address` | both |
+| `txm_multicall_duration_ms` | Histogram | `chainID,method,blockTag,success,timedOut` | beholder-only |
+| `ofa_send_tx_status` / `ofa_send_tx_latency` | Counter / Histogram | `chainID,backend,status` | beholder-only (dual-broadcast/MEV only) |
+| `meta_endpoint_status_codes` / `meta_endpoint_latency` | Counter / Histogram | `chainID,feedAddress` | beholder-only (FastLane/Atlas only) |
+| `meta_bids_per_transaction` / `meta_errors` | Histogram / Counter | `chainID,feedAddress,errorType` | beholder-only (FastLane/Atlas only) |
+
+The `ofa_*` and `meta_*` families are only live on deployments that route sends through a
+dual-broadcast/MEV backend (Flashbots/Nova/FastLane Atlas); on a plain NOP commit deployment they
+will legitimately be absent. The commit-plugin's *own* `metrics` (the `ccip_commit_*` /
+`ccip_reader_*` series `commit-plugin-health.md` and `uncommitted-message.md` query) are **not**
+part of this doc -- this doc is the layer underneath, reached by their `REPORT:...-oncall`
+handoffs.
+
+## Output contract
+
+```yaml
+evm_finding:
+  chainID: string
+  entry: data_source | report_transmission
+  timestamp: string           # ISO8601
+  verdict: OK | ISSUE
+  steps_run:
+    - id: string              # A0 | A0_detail | A1 | B0 | B0_detail | B1 | B2 | B2_detail | B2_nonce
+      outcome: STOP | CONTINUE:<step> | REPORT:<owner>
+      value: string           # the raw number(s) that drove the outcome -- carry the gauges/counters as-is
+  findings:                   # one per REPORT; empty list if none
+    - owner: string           # chain-evm-oncall, or whoever stage named
+      summary: string
+      stage: string           # name the lifecycle stage / RPC node / queue that told you
+      evidence: string        # the exact query + result that produced it
+      commit_handoff: string  # which commit-runbook owner/check this replaces or justifies
+```
+
+Do not page, escalate, or take remediation -- your job ends by handing this report to the named
+owner. The commit runbook that dropped you here already decided *whether* there's a problem; this
+doc only locates *which EVM-layer component* owns it.

--- a/docs/runbooks/evm.md
+++ b/docs/runbooks/evm.md
@@ -55,8 +55,7 @@ plugin got its data and how it gets its reports out:
   through the **transaction manager (TXM)**, which must price them (gas estimators), broadcast
   them, and shepherd them to inclusion. When `report_transmission_gave_up` fires in the commit
   plugin, the root cause usually lives in one of: can't afford a send (fee layer), can't broadcast
-  (RPC), or the tx is stuck/reverting (nonce gap, max attempts, lifecycle failure). Stages
-  **B0/B1/B2**.
+  (RPC), or the tx is stuck/backing up the send queue. Stages **B0/B1/B2**.
 
 Read A0 and A1 if your `entry` is `data_source`; read B0-B2 if it's `report_transmission`. The
 two halves are independent and you can enter directly at the relevant quarter.
@@ -81,14 +80,13 @@ empty here.
 
 | label key | appears on | meaning |
 |---|---|---|
-| `chainID` | all EVM beholder metrics | the EVM chain ID (== commit's `destChainID` value for the dest chain) |
+| `chainID` | all EVM beholder metrics | the EVM chain ID (== commit's `destChainID` value for the dest chain). **Live gas/TXM metrics only exist on the destination/tx-sending chain** -- a query scoped to a chain the node doesn't send txs on returns empty, legitimately |
+| `chainFamily` | all EVM beholder metrics | `"EVM"` on the pool counters, `"evm"` on the log-poller and gas-updater gauges -- **case is not consistent**; don't regex against a single spelling |
 | `evmChainID` | the promauto pool counters (`evm_pool_rpc_node_calls_*`), gas-updater gauges (promauto side only) | same value, old promauto spelling. Only on the direct-scrape path, not the beholder path |
 | `nodeName` | `evm_pool_rpc_node_calls_*` | which RPC node -- use this to split a single bad RPC from the whole pool failing |
 | `rpcDomain` | `evm_pool_rpc_node_calls_*` (beholder), `rpc_call_latency` | the RPC endpoint/domain (sanitized) the call went to |
 | `callName` / `rpcCallName` | RPC metrics | which JSON-RPC method / logical call |
-| `address` | `txm_rpc_nonce` | the wallet address whose on-chain nonce is reported |
-| `stage` | `txm_transaction_lifecycle_failure_total` | where in the lifecycle the failure happened (`create`, `in_flight_subset`, `max_in_flight`, `broadcast`, `nonce_at`) |
-| `percentile` | the gas-updater gauges | which price percentile (`p25`, `p50`, ...) the gauge carries |
+| `percentile` | the gas-updater gauges | which price percentile, formatted as a **string like `"60%"`** (not `p25/p50`) |
 | `mode` | `block_history_estimator_connectivity_failure_count` | `legacy` or `eip1559` |
 
 The pool metrics are effectively **dual-registered** (same name on promauto and beholder), which
@@ -116,26 +114,22 @@ side.)
 
 ### Which TXM metrics actually carry a chainID label (not all do)
 
-`pkg/txm/metrics.go` constructs a `metrics.Labeler` with `chainID` and carries it on the struct --
-but the beholder `.Add(...)`/`.Record(...)` calls for **most** of the `txm_*` instruments pass
-**no attributes** (`m.numBroadcastedTxs.Add(ctx, 1)`, etc.), so those beholder series get only the
-beholder client's inherited identity labels (`node_id`, `csa_public_key`), **no `chainID`**. Only
-**`txm_transaction_lifecycle_failure_total`** explicitly attaches `chainID` + `stage`. The
-consequences, and the escape hatches:
+**What is actually live in a CCIP EVM deployment:** the counters `tx_manager_num_broadcasted_total`,
+`tx_manager_num_confirmed_transactions_total`, `tx_manager_num_successful_transactions_total`,
+`tx_manager_num_finalized_transactions_total`, the gauges `txm_pending_tx_queue_utilization`,
+`tx_manager_tx_oldest_non_terminal_age_seconds`, `tx_manager_tx_attempt_count`, and (on a revert)
+`tx_manager_num_tx_reverted_total`. **Every one of these carries a `chainID` label**, 
+so all write-path queries in this doc are chain-scoped reliably. They appear
+only on the **destination (tx-sending) chain** -- the same chain the commit plugin transmits on --
+so filter `$chainID` against that dest chain specifically.
 
-- On a **beholder-fed** datasource, the counters `txm_num_broadcasted_transactions`,
-  `txm_num_confirmed_transactions`, `txm_num_nonce_gaps`, the gauge `txm_reached_max_attempts`,
-  the histogram `txm_time_until_tx_confirmed`, and the gauge `txm_rpc_nonce` **are not filterable
-  by `$chainID`**. Queries against them on a node hosting multiple chains will mix chains. Scope
-  them per `node_id`/`csa_public_key` instead, or use the **`txm_transaction_lifecycle_failure_total`**
-  (`chainID` + `stage`) as the chain-scoped backbone of stage B2.
-- The **promauto** dual-writes for all of these **do** carry `chainID` (and `txm_rpc_nonce` adds
-  `address`). If your datasource scrapes the node's prometheus endpoint directly, prefer the
-  pramaauto names for chain-scoped TXM questions.
-
-The queries in this doc are written to be correct on either path, but the label caveat is why stage
-B2 leans on `txm_transaction_lifecycle_failure_total` rather than assuming every TXM counter is
-chain-filterable.
+Concretely, the live family maps onto the EVM V1 vocabulary:
+- no per-address nonce-gap counter → the "one stuck thing" read is `txm_pending_tx_queue_utilization`
+  climbing + `tx_manager_tx_oldest_non_terminal_age_seconds` climbing + `tx_manager_tx_attempt_count`
+  rising, *not* the V2 `txm_num_nonce_gaps`;
+- no lifecycle-failure stage breakdown → owe the *kind* of stuck (`max_in_flight` vs `broadcast`)
+  to logs/TXM config, not to a metric;
+- broadcast-vs-confirm gap is `tx_manager_num_broadcasted_total` vs `tx_manager_num_confirmed_transactions_total`.
 
 ### Empty result sets
 
@@ -143,31 +137,34 @@ No metric in this doc is an unconditional per-round heartbeat like the commit pl
 event counters that only get a time series after they fire, or gauges reported on their own
 ticker. The same two rules from `commit-plugin-health.md#empty-result-sets` apply:
 
-1. The **staleness/liveness gauges** -- `evm_log_poller_last_processed_block` (A1),
-   `txm_reached_max_attempts`, `txm_rpc_nonce` (B2) -- are reported continuously while the process
-   runs, so an **empty** result (no series at all) means the metric isn't reaching your datasource,
-   not "value zero." Report `UNKNOWN` there, don't grade it against thresholds.
-2. Everything else is an **event counter** (`evm_pool_rpc_node_calls_*`, `rpc_call_latency`
-   buckets, `block_history_estimator_connectivity_failure_count`, `txm_num_*`,
-   `txm_transaction_lifecycle_failure_total`): **empty == the event never happened == value 0.**
-   Grade normally. The one exception is the same as the commit docs: if a `UNKNOWN`-class gauge in
-   the same run is itself empty, don't trust counter-emptiness -- say so in `concerns`.
+1. The **continuous gauges** -- `evm_log_poller_last_processed_block`, `evm_pool_rpc_node_calls_*`
+   (counters, but accumulate rapidly), `gas_updater_current_base_fee`, and the txmgr gauges
+   `txm_pending_tx_queue_utilization`, `tx_manager_tx_oldest_non_terminal_age_seconds`,
+   `tx_manager_tx_attempt_count` -- are all emitted continuously while the process runs (the gauges)
+   or as fast-moving counters, so an **empty** result means the metric isn't reaching your
+   datasource (or you're looking at a chain the node isn't sending txs on -- the gas/TXM family only
+   exists on the destination/tx-sending chain), not "value zero." Report `UNKNOWN`, don't grade it.
+2. Everything else is an **event counter** fired only on occurrence
+   (`evm_pool_rpc_node_calls_failed`, `tx_manager_num_*_total`, `tx_manager_num_tx_reverted_total`,
+   `block_history_estimator_connectivity_failure_count`): **empty == the event never happened ==
+   value 0.** Grade normally. The one exception is the same as the commit docs: if a `UNKNOWN`-class
+   gauge in the same run is itself empty, don't trust counter-emptiness -- say so in `concerns`.
 
-`rpc_call_latency` and `txm_time_until_tx_confirmed` are histograms; if you only have their
-`_count`/`_bucket` forms on your datasource, derive `rate()`s and quantiles from those, treating an
-absent `_count` for a window as "no calls (or none clearing the first bucket) in that window."
+`rpc_call_latency_milliseconds` is a histogram; if you only have `_count`/`_bucket` forms on your
+datasource, derive `rate()`s and quantiles from those, treating an absent `_count` for a window as
+"no calls (or none clearing the first bucket) in that window."
 
 ### Counter _total suffixing
 
-Same pipeline caveat as the commit runbooks: OTel counters that reach Prometheus via a
-prometheusremotewrite/OTel-collector exporter get a `_total` appended **unless the name already
-ends in `_total`**. Several EVM metrics are registered with `_total` already baked in
-(`evm_pool_rpc_node_calls_total`, `txm_transaction_lifecycle_failure_total`,
-`block_history_estimator_connectivity_failure_count` does *not*), so on such a datasource these
-names are *not* doubled -- but the fee/other counters also registered without `_total`
-(`gas_updater_set_gas_price` is a gauge; `txm_num_nonce_gaps` is a counter and would gain a
-`_total`). **Check one query against your datasource's metric browser before trusting the rest.**
-The doc lists the metric as registered; your pipeline may suffix it.
+OTel counters that reach Prometheus via the otel-collector's
+`prometheusremotewrite` exporter get a `_total` appended **unless the name already ends in `_total`**.
+`evm_pool_rpc_node_calls_total` (already suffixed) stayed as-is, while `evm_pool_rpc_node_calls_success`
+became `evm_pool_rpc_node_calls_success_total` and `tx_manager_num_broadcasted` became
+`tx_manager_num_broadcasted_total`. Two unit-suffix gotchas also seen live: the framework `rpc_call_latency`
+histogram reaches Prometheus as **`rpc_call_latency_milliseconds_*`** (OTel appends the `ms` unit),
+and the `gas_updater_*` gauges carry `percentile="60%"`-style values, not `p25/p50`. **Check one
+query against your datasource's metric browser before trusting the rest.** The doc lists the metric
+as registered; your pipeline may suffix/rename it.
 
 ## Decision graph
 
@@ -217,11 +214,11 @@ steps:
   - id: B1
     check: txm_broadcast_flow
     queries:
-      - 'sum(rate(txm_num_confirmed_transactions{chainID="$chainID"}[15m]))'
-      - 'sum(rate(txm_num_broadcasted_transactions{chainID="$chainID"}[15m]))'
+      - 'sum(rate(tx_manager_num_confirmed_transactions{chainID="$chainID"}[15m]))'
+      - 'sum(rate(tx_manager_num_broadcasted{chainID="$chainID"}[15m]))'
     condition: "confirmed == 0 AND broadcasted == 0 over the window"
-    note: "these two counters do NOT carry chainID on a beholder-only datasource (see the label cheat sheet) -- the {chainID=...} filter here works only if your datasource also has the promauto forms. If {chainID=...} returns empty on a datasource you believe is beholder-only, re-run WITHOUT chainID and split by node_id/csa_public_key instead; an empty-result treated as 'zero' here is exactly the trap the cheat sheet warns about."
-    if_true: {action: "CONTINUE:B2", reason: "nothing being broadcast at all -- the give-up is a 'no reports are even being sent' situation, dig into stuck/lifecycle markers"}
+    note: "these are the framework/txmgr counters actually emitted by a CCIP EVM node (verified live -- the V2 txm_* variants are NOT emitted, see the cheat sheet). All carry chainID, so {chainID=...} is reliable here. Both are counters with a _total suffix on an OTel pipeline."
+    if_true: {action: "CONTINUE:B2", reason: "nothing being broadcast at all -- the give-up is a 'no reports are even being sent' situation, dig into the queue/stuck gauges"}
     if_false:
       confirmed_zero_broadcasted_positive: {action: "CONTINUE:B2", reason: "reports ARE being broadcast but NONE confirm in window -- a land/drop/revert problem, not a send problem"}
       both_positive: {action: "STOP", reason: "TXN is broadcasting and confirming reports normally for $chainID. If report_transmission_gave_up still fires, it's almost certainly a per-report revert or a backlog-size / round-cadence issue, not the EVM node stack. Escalate with this evidence rather than assuming the EVM layer broken. (If you were handed a specific $txHash, sanity-check it on the explorer before stopping.)"}
@@ -229,41 +226,14 @@ steps:
 
   - id: B2
     check: txm_stuck_signals
-    query: 'sum by (stage) (rate(txm_transaction_lifecycle_failure_total{chainID="$chainID"}[15m]))'
-    condition: "any series > 0"
-    if_true: {action: "CONTINUE:B2_detail", reason: "transaction lifecycle failures present; stage names the phase"}
-    if_false: {action: "CONTINUE:B2_nonce", reason: "no lifecycle-failure counter; the stuck signal (give-up, zero confirms) must come from nonce or max-attempts instead"}
-    automatable: true
-
-  - id: B2_detail
-    check: lifecycle_failure_stage
-    query: 'sum by (stage) (rate(txm_transaction_lifecycle_failure_total{chainID="$chainID"}[15m]))'
-    condition: "report the dominant stage(s)"
-    if_true:
-      nonce_at:       {action: "REPORT:chain-evm-oncall", reason: "lifecycle failing at the nonce stage -- nonce tracking issue. Cross-check txm_rpc_nonce (per address) vs expected and the nonce gap counter (nonce_gap) below."}
-      max_in_flight:  {action: "REPORT:chain-evm-oncall", reason: "lifecycle failing at max_in_flight -- the TXM's max inflight budget is exhausted (slow finality or too many concurrent reports). Throttling, not an RPC failure."}
-      broadcast:      {action: "REPORT:chain-evm-oncall", reason: "lifecycle failing at broadcast -- the RPC rejected/dropped the send; corroborate with evm_pool_rpc_node_calls_failed at the same time."}
-      create:         {action: "REPORT:chain-evm-oncall", reason: "lifecycle failing at create -- the tx could not be constructed (e.g. missing wallet/crypto, keystore). Check infrastructure, not the chain."}
-      default:        {action: "REPORT:chain-evm-oncall", reason: "dominant/most relevant of the above, or a stage not named here -- report the exact stage string with the rate, don't guess."}
-    if_false: {action: "CONTINUE:B2_nonce", reason: "no strongly dominant stage; continue to the nonce/max-attempt check"}
-    automatable: true
-
-  - id: B2_nonce
-    check: nonce_gaps_and_max_attempts
     queries:
-      - 'sum(rate(txm_num_nonce_gaps{chainID="$chainID"}[15m]))'
-      - 'max(txm_reached_max_attempts{chainID="$chainID"})'
-    condition: "nonce gaps rate > 0 OR reached_max_attempts == 1"
-    note: "same chainID caveat as B1 -- txm_num_nonce_gaps / txm_reached_max_attempts / txm_rpc_nonce lack chainID on beholder-only datasources. Prefer the chainID-bearing txm_transaction_lifecycle_failure_total from B2 when the datasource gives you no promauto forms; treat an empty {chainID=...} result here as 'cannot scope', not 'zero'."
-    if_true:
-      nonce_gaps:
-        action: "REPORT:chain-evm-oncall"
-        reason: "the TXM is filling nonce gaps for $chainID -- a stalled out-of-order tx is parking the sender's nonce and blocking subsequent reports (classic report_transmission_gave_up root cause). Cross-check txm_rpc_nonce per address to see the parked nonce."
-        followup_query: 'txm_rpc_nonce{chainID="$chainID"}'
-      max_attempts:
-        action: "REPORT:chain-evm-oncall"
-        reason: "reached_max_attempts == 1 -- the TXM gave up on a tx after exhausting its bump budget (combined with B0 if the bump was suppressed by a connectivity failure, or with B2's broadcast stage if the RPC dropped it). Any report behind that tx will report_transmission_gave_up until the wallet nonce recovers."
-    if_false: {action: "STOP", reason: "no nonce gaps and no max-attempt kill. Broadcasts were happening but nothing confirms and no stuck marker is firing -- this is most likely an RPC/indexing lag on the confirmation side (tx landed but isn't seen as finalized). Verify against the chain explorer / $txHash before escalating further."}
+      - 'max(txm_pending_tx_queue_utilization{chainID="$chainID"})'
+      - 'max(tx_manager_tx_oldest_non_terminal_age_seconds{chainID="$chainID"})'
+      - 'max(tx_manager_tx_attempt_count{chainID="$chainID"})'
+    condition: "queue_utilization rising toward 1, OR oldest_non_terminal_age climbing (well above normal block-time), OR attempt_count climbing"
+    note: "these three framework gauges (live on the dest chain) are the 'one stuck thing' read this deployment actually exposes -- there is no nonce-gap or lifecycle-stage metric in the live family (V2 txm_* is not emitted). Treat 'queue near full' + 'oldest non-terminal age climbing' + 'attempts rising' together as the stuck signature."
+    if_true: {action: "REPORT:chain-evm-oncall", reason: "the TXM queue is backing up / the oldest tx is aging / attempts are rising -- a stuck transaction is blocking the send path, which surfaces upstream as report_transmission_gave_up. Say which of the three gauges is the driver and its value. Pair with B0 if the fee layer is also suppressing bumps."}
+    if_false: {action: "STOP", reason: "no nonce/queue stuck signature and nothing aging. Broadcasts were happening but nothing confirms and no stuck marker is firing -- most likely an RPC/indexing lag on the confirmation side (tx landed but isn't seen as finalized). Verify against the chain explorer / $txHash before escalating."}
     automatable: true
 ```
 
@@ -279,13 +249,12 @@ sum(rate(evm_pool_rpc_node_calls_failed{chainID="$chainID"}[5m])) by (nodeName)
 sum(rate(evm_pool_rpc_node_calls_total{chainID="$chainID"}[5m])) by (nodeName)
 ```
 
-Optionally corroborate at the wire level with the chain-client multicall latency histogram
-(`txm_multicall_duration_ms{success="false"}`, beholder-only) if your datasource has it, and with
-per-node latency (beholder histogram from chainlink-framework; `success="true"` means *failed* --
+Corroborate at the wire level with per-node latency (the framework latency instrument; on an OTel
+pipeline it surfaces as `rpc_call_latency_milliseconds_*`, and `success="true"` means *failed* --
 see [the inversion](#the-success-label-inversion-on-rpc_call_latency)):
 
 ```promql
-histogram_quantile(0.95, sum by (le) (rate(rpc_call_latency_bucket{chainID="$chainID", callName=~".*", success="true"}[5m])))
+histogram_quantile(0.95, sum by (le) (rate(rpc_call_latency_milliseconds_bucket{chainID="$chainID", success="true"}[5m])))
 ```
 
 A single `nodeName` failing while peers pass → hand off that node (`chain-evm-oncall`). Every node
@@ -340,52 +309,54 @@ on an EIP-1559 chain; a missing base fee means the estimator has nothing to pric
 
 ### Stage B1 -- TXM broadcast: are reports being sent at all?
 
-The two counters that divide "nothing is being sent" from "sent but not landing":
+The two live counters that divide "nothing is being sent" from "sent but not landing":
 
 ```promql
-sum(rate(txm_num_confirmed_transactions{chainID="$chainID"}[15m]))
-sum(rate(txm_num_broadcasted_transactions{chainID="$chainID"}[15m]))
+sum(rate(tx_manager_num_confirmed_transactions{chainID="$chainID"}[15m]))
+sum(rate(tx_manager_num_broadcasted{chainID="$chainID"}[15m]))
 ```
 
 - Both `> 0` → the node stack is broadcasting **and confirming** reports normally. A persisted
   `report_transmission_gave_up` together with a healthy TXM is a per-report revert or a
   backlog/round-cadence issue, not the EVM stack. Stop here (verify the actual tx on-chain if you
   have a `$txHash`).
-- Broadcasted `> 0`, confirmed `== 0` → reports go out but never land → **B2** (land/drop/revert /
-  nonce).
+- Broadcasted `> 0`, confirmed `== 0` → reports go out but never land → **B2** (stuck/revert).
 - Both `== 0` → nothing is being sent at all → **B2** (stuck/never-created).
 
-`txm_time_until_tx_confirmed` (histogram) is the supporting latency signal; a healthy chain spends
-most of it near the chain's block time, and a value pinned at the histogram ceiling means confirms
-are being delayed, not that everything is fine.
+`tx_manager_num_finalized_transactions` / `tx_manager_num_successful_transactions` are the
+supporting confirmation counters (finalized = past finality horizon; successful = included and
+executed); a widening broadcast→confirmed↔finalized gap with confirms stuck at zero is the "sent
+but not landing" signature. (There is no `_time_until_confirmed` histogram in the live family --
+the V2 `txm_time_until_tx_confirmed` is not emitted -- so latency has to be inferred from how long
+the broadcast counter advances before the confirmed counter follows.)
 
-### Stage B2 -- TXM stuck: killed attempts, nonce gaps, lifecycle failures
+### Stage B2 -- TXM stuck: queue back-up, oldest-tx age, attempt count
 
-When broadcasts aren't confirming, name *why*. The chain-scoped backbone is the lifecycle-failure
-counter (the one TXM metric that reliably carries `chainID`):
-
-```promql
-sum by (stage) (rate(txm_transaction_lifecycle_failure_total{chainID="$chainID"}[15m]))
-```
-
-`stage` values: `create` (couldn't construct the tx -- keystore/wallet/infra),
-`in_flight_subset` / `max_in_flight` (concurrency budget exhausted -- throttling), `broadcast`
-(RPC rejected/dropped the send), `nonce_at` (nonce tracking broken). Pair each with the matching
-corroboration from the note on the decision-graph step.
-
-Then the classic stuck-nonce pair:
+When broadcasts aren't confirming, name *why* from the three framework gauges the deployment
+actually exposes -- there is **no** V2 lifecycle-stage or nonce-gap metric in the live family:
+`txm_pending_tx_queue_utilization` (queue fullness), `tx_manager_tx_oldest_non_terminal_age_seconds`
+(age of the oldest not-yet-terminal tx), and `tx_manager_tx_attempt_count` (how many attempts are
+stacked up, ~retries/bumps):
 
 ```promql
-sum(rate(txm_num_nonce_gaps{chainID="$chainID"}[15m]))
-max(txm_reached_max_attempts{chainID="$chainID"})
-txm_rpc_nonce{chainID="$chainID"}   # per wallet address
+max(txm_pending_tx_queue_utilization{chainID="$chainID"})
+max(tx_manager_tx_oldest_non_terminal_age_seconds{chainID="$chainID"})
+max(tx_manager_tx_attempt_count{chainID="$chainID"})
 ```
 
-A **nonce gap** (or `reached_max_attempts==1`) means one parked out-of-order tx is holding the
-sender's nonce, so every subsequent report (a) can't get its required nonce and (b) keeps bouncing
-off the RPC with a nonce-too-low/known-tx rejection. That is the archetypal
-`report_transmission_gave_up` + zero-confirms combination on EVM, and the fix lives in the EVM
-operation (find/nothing the stuck tx, recover the nonce), not in the commit plugin.
+The **stuck signature** is the combination: queue near `1.0` (or climbing), oldest-non-terminal-age
+far above a healthy block time (climbing → the stuck thing is old, not just momentarily delayed),
+and attempt-count climbing (the TXM keeps re-attempting/bumping the same txs). This is the EVM
+analogue of a `reached_max_attempts` / "parked nonce" outage -- one blocked transaction holds the
+send path open and the backlog up, so `report_transmission_gave_up` fires even while the reader is
+healthy. The fix lives in the EVM operation (identify the stuck tx, recover the sequence), not in
+the commit plugin. On a revert, additionally check `tx_manager_num_tx_reverted_total` rising.
+
+Cross-check the *kind* of backing-up from the log/tx-sender rather than a metric: in this family
+there is no `max_in_flight`-vs-`broadcast` stage breakdown like the unemitted V2
+`txm_transaction_lifecycle_failure_total` would give -- if you need to distinguish "throttling" from
+"RPC rejecting sends," pivot to the RPC pool (`evm_pool_rpc_node_calls_failed`) and the fee layer
+(B0) for the mechanism.
 
 If nothing in B2 fires at all but confirms are still zero, the remaining honest conclusion is an
 RPC confirmation/indexing lag rather than a TXM failure -- say so and verify against the explorer
@@ -399,41 +370,51 @@ rather than inventing a stuck marker.
 Many TXM beholder series carry **no `chainID` attribute** -- see
 [which TXM metrics carry chainID](#which-txm-metrics-actually-carry-a-chainid-label-not-all-do).
 
-| metric | otel_type | key labels | registration |
-|---|---|---|---|
-| `evm_pool_rpc_node_calls_total` | Counter | beholder: `chainID,nodeName,rpcDomain,callName`; promauto: `evmChainID,nodeName` | dual |
-| `evm_pool_rpc_node_calls_success` | Counter | same as above | dual |
-| `evm_pool_rpc_node_calls_failed` | Counter | same as above | dual |
-| `rpc_call_latency` | Histogram | `chainFamily,chainID,rpcDomain,isSendOnly,success,callName` (success inverted) | dual (chainlink-framework) |
-| `evm_log_poller_last_processed_block` | Gauge | `chainFamily,chainID` | dual |
-| `gas_updater_set_gas_price` | Gauge | `chainID,percentile` | dual |
-| `gas_updater_set_tip_cap` | Gauge | `chainID,percentile` | dual |
-| `gas_updater_all_gas_price_percentiles` | Gauge | `chainID,percentile` | dual |
-| `gas_updater_all_tip_cap_percentiles` | Gauge | `chainID,percentile` | dual |
-| `gas_updater_current_base_fee` | Gauge | `chainID` | dual |
-| `block_history_estimator_connectivity_failure_count` | Counter | `chainID,mode` (`legacy`\|`eip1559`) | dual |
-| `gas_price_updater` | Gauge | `chainID` | dual |
-| `base_fee_updater` | Gauge | `chainID` | dual |
-| `max_priority_fee_per_gas_updater` | Gauge | `chainID` | dual |
-| `max_fee_per_gas_updater` | Gauge | `chainID` | dual |
-| `txm_transaction_lifecycle_failure_total` | Counter | `chainID,stage` | both (chainID attached) |
-| `txm_num_broadcasted_transactions` | Counter | **no chainID on beholder**; promauto `chainID` | both |
-| `txm_num_confirmed_transactions` | Counter | **no chainID on beholder**; promauto `chainID` | both |
-| `txm_num_nonce_gaps` | Counter | **no chainID on beholder**; promauto `chainID` | both |
-| `txm_reached_max_attempts` | Gauge | **no chainID on beholder**; promauto `chainID` | both |
-| `txm_time_until_tx_confirmed` | Histogram | **no chainID on beholder**; promauto `chainID` | both |
-| `txm_rpc_nonce` | Gauge | **no chainID on beholder**; promauto `chainID,address` | both |
-| `txm_multicall_duration_ms` | Histogram | `chainID,method,blockTag,success,timedOut` | beholder-only |
-| `ofa_send_tx_status` / `ofa_send_tx_latency` | Counter / Histogram | `chainID,backend,status` | beholder-only (dual-broadcast/MEV only) |
-| `meta_endpoint_status_codes` / `meta_endpoint_latency` | Counter / Histogram | `chainID,feedAddress` | beholder-only (FastLane/Atlas only) |
-| `meta_bids_per_transaction` / `meta_errors` | Histogram / Counter | `chainID,feedAddress,errorType` | beholder-only (FastLane/Atlas only) |
+`otel_type` governs `_total`/`_bucket` suffixing; **status** reflects what was confirmed live (or
+absent) on a `ccip obs up --victoria` devel env while reports were transmitting:
 
-The `ofa_*` and `meta_*` families are only live on deployments that route sends through a
-dual-broadcast/MEV backend (Flashbots/Nova/FastLane Atlas); on a plain NOP commit deployment they
-will legitimately be absent. The commit-plugin's *own* `metrics` (the `ccip_commit_*` /
-`ccip_reader_*` series `commit-plugin-health.md` and `uncommitted-message.md` query) are **not**
-part of this doc -- this doc is the layer underneath, reached by their `REPORT:...-oncall`
-handoffs.
+| metric | otel_type | key labels | status in a CCIP EVM deploy |
+|---|---|---|---|
+| `evm_pool_rpc_node_calls_total` | Counter | `chainID,nodeName,rpcDomain,callName` (beholder) | **live** |
+| `evm_pool_rpc_node_calls_success` | Counter | same | **live** |
+| `evm_pool_rpc_node_calls_failed` | Counter | same | **live** (fires only on failure) |
+| `rpc_call_latency` | Histogram | `chainFamily,chainID,rpcDomain,isSendOnly,success,callName` (success inverted) | **live** -- surfaces as `rpc_call_latency_milliseconds_*` |
+| `evm_log_poller_last_processed_block` | Gauge | `chainFamily,chainID` | **live** |
+| `gas_updater_set_gas_price` | Gauge | `chainID,percentile` (e.g. `"60%"`) | **live** (dest/tx-sending chain) |
+| `gas_updater_all_gas_price_percentiles` | Gauge | `chainID,percentile` | **live** (dest chain) |
+| `gas_updater_current_base_fee` | Gauge | `chainID` | **live** (dest chain) |
+| `gas_updater_set_tip_cap` / `gas_updater_all_tip_cap_percentiles` | Gauge | `chainID,percentile` | conditional -- only EIP-1559; absent on a legacy chain |
+| `block_history_estimator_connectivity_failure_count` | Counter | `chainID,mode` | **live** (fires only on a detected connectivity failure) |
+| `gas_price_updater` / `base_fee_updater` / `max_priority_fee_per_gas_updater` / `max_fee_per_gas_updater` | Gauge | `chainID` | **not emitted** here -- these are the *fee-history* estimator, which the local block-history config does not run |
+| `txm_pending_tx_queue_utilization` | Gauge | `chainID` | **live** |
+| `tx_manager_tx_oldest_non_terminal_age_seconds` | Gauge | `chainID` | **live** |
+| `tx_manager_tx_attempt_count` | Gauge | `chainID` | **live** |
+| `tx_manager_num_broadcasted` | Counter | `chainID` | **live** (`_total` suffix) |
+| `tx_manager_num_confirmed_transactions` | Counter | `chainID` | **live** (`_total` suffix) |
+| `tx_manager_num_successful_transactions` | Counter | `chainID` | **live** (`_total` suffix) |
+| `tx_manager_num_finalized_transactions` | Counter | `chainID` | **live** (`_total` suffix) |
+| `tx_manager_num_tx_reverted` | Counter | `chainID` | **live** (fires only on a revert) |
+| `tx_manager_fwd_tx_count` | Counter | `chainID` | conditional (forwarding enabled) |
+| `tx_manager_num_gas_bumps` / `tx_manager_gas_bump_exceeds_limit` | Counter | `chainID` | conditional (fires only on a bump) |
+| `txm_num_broadcasted_transactions`, `txm_num_confirmed_transactions`, `txm_num_nonce_gaps`, `txm_reached_max_attempts`, `txm_time_until_tx_confirmed`, `txm_rpc_nonce`, `txm_transaction_lifecycle_failure_total` | V2 instruments | (V2 code would omit `chainID` on beholder) | **NOT emitted** -- V2 engine not the active transmit path; do not build on these |
+| `txm_multicall_duration_ms` | Histogram | `chainID,method,blockTag,success,timedOut` | **NOT emitted** here (V2 wrapper path) |
+| `ofa_send_tx_status` / `ofa_send_tx_latency` | Counter / Histogram | `chainID,backend,status` | MEV/dual-broadcast only |
+| `meta_endpoint_status_codes` / `meta_endpoint_latency` | Counter / Histogram | `chainID,feedAddress` | MEV/dual-broadcast only |
+| `meta_bids_per_transaction` / `meta_errors` | Histogram / Counter | `chainID,feedAddress,errorType` | MEV/dual-broadcast only |
+
+Read/interp notes for the table:
+
+- The **live** markers are empirical (local devel env, node 2.61.0, chains 1337/2337). A "heavy"
+  row absent on *your* datasource means it's the **not emitted** class, not a healthy zero -- check
+  the class before reporting.
+- **`gas_updater_*` and the whole TXM family exist only on the destination/tx-sending chain** --
+  a query scoped to a chain the node doesn't send txs on legitimately returns empty.
+- The `ofa_*`/`meta_*` families are only live on deployments that route sends through a
+  dual-broadcast/MEV backend (Flashbots/Nova/FastLane Atlas); on a plain NOP commit deployment they
+  will legitimately be absent.
+- The commit-plugin's *own* metrics (the `ccip_commit_*`/`ccip_reader_*` series
+  `commit-plugin-health.md` and `uncommitted-message.md` query) are **not** part of this doc --
+  this doc is the layer underneath, reached by their `REPORT:...-oncall` handoffs.
 
 ## Output contract
 

--- a/docs/runbooks/solana.md
+++ b/docs/runbooks/solana.md
@@ -1,6 +1,6 @@
 ---
 name: solana-chain-family
-description: Chain-family deep dive for a Solana chain feeding or receiving a CCIP commit plugin. Drills into the Solana chain-family library (chainlink-solana) layers -- log poller, block-history fee estimator, and the Solana transaction manager (Txm) -- that underpin the commit plugin's data-source (reader) and report-transmission paths. Enter this doc when the commit runbooks hand off with REPORT:...-txm-oncall / REPORT:...-infra-oncall, or when a data_source / report_transmission check in commit-plugin-health.md fires for a Solana chain.
+description: Chain-family deep dive for a Solana chain feeding or receiving a CCIP commit plugin. Drills into the Solana chain-family library (chainlink-solana) layers -- multinode node pool (RPC health), log poller, block-history fee estimator, and the Solana transaction manager (Txm) -- that underpin the commit plugin's data-source (reader) and report-transmission paths. Enter this doc when the commit runbooks hand off with REPORT:...-txm-oncall / REPORT:...-infra-oncall, or when a data_source / report_transmission check in commit-plugin-health.md fires for a Solana chain.
 trigger: "entered from docs/runbooks/commit-plugin-health.md (data_source or report_transmission group CRIT/WARN) or docs/runbooks/uncommitted-message.md (step2c, or Scenario 2 'report transmission stuck') when the destination chain is Solana. Not triggered standalone."
 severity: page
 owner: chain-solana-oncall
@@ -25,8 +25,9 @@ status: living
       + [Counter _total suffixing and the promauto-only read-path gap](#counter-total-suffixing-and-the-promauto-only-read-path-gap)
    * [Decision graph](#decision-graph)
    * [Steps](#steps)
-      + [Stage A0 -- log poller: keeping up with slots?](#stage-a0--log-poller-keeping-up-with-slots)
-      + [Stage B0 -- fee layer (block-history estimator): pricing sends?](#stage-b0--fee-layer-block-history-estimator-pricing-sends)
+       + [Stage A0 -- log poller: keeping up with slots?](#stage-a0--log-poller-keeping-up-with-slots)
+       + [Stage A0b -- node pool / RPC health (the "no nodes healthy" signal)](#stage-a0b--node-pool--rpc-health-the-no-nodes-healthy-signal)
+       + [Stage B0 -- fee layer (block-history estimator): pricing sends?](#stage-b0--fee-layer-block-history-estimator-pricing-sends)
       + [Stage B1 -- Txm broadcast: are reports landing at all?](#stage-b1--txm-broadcast-are-reports-landing-at-all)
       + [Stage B2 -- Txm failure taxonomy: which kind of non-landing?](#stage-b2--txm-failure-taxonomy-which-kind-of-non-landing)
    * [Metric reference](#metric-reference)
@@ -71,6 +72,9 @@ ID you already had.
 | label key | appears on | meaning |
 |---|---|---|
 | `chainID` | all metrics here | the Solana chain ID / cluster. Every beholder series also inherits `node_id` + `csa_public_key` from the beholder client for per-node splitting |
+| `network` | `multi_node_states`, `pool_rpc_node_*` (A0b) | the chain family, `"solana"` / `"EVM"` -- a dimension the other metrics don't carry. Filter `network="solana"` on every node-pool query alongside `chainID`, or you'll mix chains/families |
+| `state` | `multi_node_states` | the node FSM state, **PascalCase** (`Alive`, `Unreachable`, `OutOfSync`, `Syncing`, `InvalidChainID`, `Unusable`, ...) -- filter with the exact casing |
+| `nodeName` | `pool_rpc_node_*` (A0b) | which RPC node a poll/transition/verify/head belongs to -- use it to name the dead node(s) |
 | `# (outcome suffix)` | `solana_log_poller_txs_truncated_*`, `solana_log_poller_txs_log_parsing_error_*` | `_succeeded` vs `_reverted` -- whether the truncated/parse-failed tx ultimately succeeded or reverted on-chain |
 
 ### What Solana's TXM calls a failure -- and why the taxonomy matters
@@ -112,13 +116,15 @@ repeats per report until the underlying state or the fee budget changes. That is
 ### Empty result sets
 
 Same discipline as the other runbooks. The gauges that should be continuously present while the
-process runs are `solana_log_poller_last_processed_slot` (A0) and `solana_bhe_compute_unit_price`
+process runs are `solana_log_poller_last_processed_slot` (A0), `multi_node_states` (A0b -- reported
+for **every** state every report, zeros included, so an empty here is "multinode not on this
+node / not reaching the datasource," not "zero nodes"), and `solana_bhe_compute_unit_price`
 (B0): an **empty** result on those means the metric isn't reaching your datasource, not "zero" --
 report `UNKNOWN`. Every counter here (`solana_log_poller_blocks_skipped`,
-`solana_log_poller_txs_*`, all `solana_txm_*` error/success counters, `solana_txm_fee_bumps`) is
-an event counter: **empty == it never happened == 0**, grade normally. As ever, if a continuously-
-emitted gauge is itself empty in the same run, don't trust counter-emptiness to mean "confirmed
-clean."
+`solana_log_poller_txs_*`, all `solana_txm_*` error/success counters, `solana_txm_fee_bumps`, and
+the `pool_rpc_node_*` *failure/transition* counters) is an event counter: **empty == it never
+happened == 0**, grade normally. As ever, if a continuously-emitted gauge is itself empty in the
+same run, don't trust counter-emptiness to mean "confirmed clean."
 
 ### Counter _total suffixing and the promauto-only read-path gap
 
@@ -128,13 +134,16 @@ browser. (Among these, `solana_log_poller_blocks_skipped`, `solana_txm_tx_*`,
 `solana_txm_fee_bumps` will typically get a `_total` appended by an OTel→Prometheus exporter;
 `solana_log_poller_txs_truncated_*` etc. likewise.)
 
-**About the read-path RPC signal:** unlike EVM, chainlink-solana has **no beholder record for its
-RPC client calls** -- the per-node/client metrics (`solana_client_latency_ms`, deprecated; and the
-chainlink-framework `rpc_call_latency` promauto gauge) are **promauto-only**. They are still
-available on a direct-scrape datasource, so this doc can use them, but know that they will not
-appear on a strictly beholder-fed pipeline, and there is no `solana_pool_rpc_node_calls_*`
-beholder equivalent to EVM's. On a beholder-only datasource, leave the read-path RPC question to
-the commit-plugin reader metrics (`ccip_reader_read_outcome_error`) rather than this doc.
+**About the read-path RPC signal:** split it in two. **(1) Node *pool health*** is **beholder-emitted**
+(via chainlink-framework's `NewGenericMultiNodeMetrics`, wired by chainlink-solana): the
+`multi_node_states` gauge and the `pool_rpc_node_*` family (polls/transitions/verifies/highest-seen-block)
+all run through the OTel/beholder path and are the node-health signal this doc's Stage A0b uses. **(2)
+Per-call RPC latency** is **promauto-only** -- `solana_client_latency_ms` (deprecated) and the
+chainlink-framework `rpc_call_latency` promauto gauge are direct-scrape only and will not appear on
+a strictly beholder-fed pipeline. So: for "are there any live nodes," use Stage A0b (beholder); for
+per-call latency on a beholder-only datasource, fall back to the commit-plugin reader metrics
+(`ccip_reader_read_outcome_error`) rather than this doc. There is no `solana_pool_rpc_node_calls_*`
+beholder equivalent to EVM's.
 
 ## Decision graph
 
@@ -146,8 +155,20 @@ steps:
     query: 'solana_log_poller_last_processed_slot{chainID="$chainID"}'
     condition: "value stale (no fresh sample in the last couple of poll intervals) OR clearly lagging the current slot (cross-check on the explorer) OR blocks_skipped climbing"
     if_true:
-      stale_or_lag: {action: "REPORT:chain-solana-oncall", reason: "the Solana log poller for $chainID is stuck or behind -- every commit/reader log read routes through it, so a wedge here surfaces as clean reader read_empty / chain_gap (false idle) in the commit docs, or batch_fetch_failed in the config poller. Report as a Solana chain-family / infra finding, not a reader one. Corroborate blocks_skipped: solana_log_poller_blocks_skipped{chainID=\"$chainID\"}."}
-    if_false: {action: "CONTINUE:$entry == \"report_transmission\" ? B0 : STOP", reason: "log poller keeping up. Stop if you came in via data_source."}
+      stale_or_lag: {action: "CONTINUE:A0b", reason: "the Solana log poller for $chainID is stuck or behind -- but before reporting it as a log-poller issue, rule out the node pool: a log poller that can't reach any RPC wedges the same way. Continue to the node-pool health check to attribute it correctly (a genuinely wedged poller with healthy nodes is a different owner than 'no live nodes'). Corroborate blocks_skipped: solana_log_poller_blocks_skipped{chainID=\"$chainID\"}."}
+    if_false: {action: "CONTINUE:A0b", reason: "log poller keeping up -- still confirm the node pool is healthy before moving on"}
+    automatable: true
+
+  - id: A0b
+    check: solana_node_pool_health
+    queries:
+      - 'sum(multi_node_states{network="solana", chainID="$chainID", state="Alive"}) by (state)'
+      - 'sum(multi_node_states{network="solana", chainID="$chainID"}) by (state)'
+    condition: "state=\"Alive\" count == 0 (no node is reachable/healthy), OR some live nodes but more in a dead state (Unreachable/OutOfSync/Syncing/InvalidChainID/Unusable) than alive"
+    if_true:
+      no_nodes_alive: {action: "REPORT:chain-solana-oncall", reason: "the multinode node pool for $chainID has zero nodes in state=\"Alive\" -- this IS your 'no nodes healthy'/'No live RPC nodes available' (ErrNodeError). It explains every downstream signal (reader read_empty/read_outcome_error, config_poll batch_fetch_failed, log-poller stall, ccip_commit_fchain_read_errors, report_transmission_gave_up); do not re-attribute it to the plugin. Name the dead states by carrying the state breakdown, and which node(s), then check the transition/poll counters below for why."}
+      degraded: {action: "REPORT:chain-solana-oncall", reason: "some Solana nodes are down ($count alive of $total) -- degraded redundancy, not full outage. Carry the alive-total split and the dead state names. Worth checking the transition counters below for whether nodes are flapping."}
+    if_false: {action: "CONTINUE:$entry == \"report_transmission\" ? B0 : STOP", reason: "node pool has a live node and the read path is healthy. Stop if you came in via data_source; continue to the write path if report_transmission."}
     automatable: true
 
   # ---- WRITE PATH (report transmission) ----
@@ -233,6 +254,49 @@ count txs whose logs were truncated or failed to parse (split by whether the tx 
 messages even while the poller as a whole advances. If either climbs and you're investigating a
 specific message that "should have been seen," that is the first place to look.
 
+### Stage A0b -- node pool / RPC health (the no nodes healthy signal)
+
+The Solana client's RPC access is backed by a **multinode node pool** (chainlink-framework's
+`multi-node`, wired by chainlink-solana with `metrics.NewGenericMultiNodeMetrics`), and its health
+is the most fundamental read-path precondition: if the pool has no live node, *every* read, send,
+and log-poller poll fails. The metric that corresponds directly to the "no nodes healthy" /
+"`No live RPC nodes available`" condition is **`multi_node_states`** -- a gauge counting nodes in
+each FSM state, reported for **every state every report** (zeros included):
+
+```promql
+sum(multi_node_states{network="solana", chainID="$chainID"}) by (state)
+sum(multi_node_states{network="solana", chainID="$chainID", state="Alive"})   # the live-node headcount
+```
+
+`state` values are **PascalCase** (`Alive`, `Unreachable`, `OutOfSync`, `Syncing`, `InvalidChainID`,
+`Unusable`, `Undialed`, `Dialed`, `Closed`, `FinalizedBlockOutOfSync`, `FinalizedStateNotAvailable`)
+-- filter with the exact casing. When the pool goes "no nodes healthy," `state="Alive"` drops to `0`
+and one or more of the dead states rises. Because every state is reported, an **empty** result here
+means the metric isn't reaching your datasource (or multinode isn't on this node), **not** "zero
+nodes" -- handle it as `UNKNOWN`.
+
+To name *why* nodes left the alive set, the per-node `pool_rpc_node_*` family (same `network`/
+`chainID`/`nodeName` labels):
+
+```promql
+sum(rate(pool_rpc_node_num_transitions_to_unreachable{chainID="$chainID"}[15m])) by (nodeName)
+sum(rate(pool_rpc_node_num_transitions_to_out_of_sync{chainID="$chainID"}[15m])) by (nodeName)
+sum(rate(pool_rpc_node_polls_failed{chainID="$chainID"}[15m])) by (nodeName)        # health-poll failures
+sum(rate(pool_rpc_node_verifies_failed{chainID="$chainID"}[15m])) by (nodeName)    # chain-ID verify failures
+pool_rpc_node_highest_seen_block{chainID="$chainID"}                               # is a node advancing at all
+```
+
+`pool_rpc_node_highest_seen_block` is the "reachable ≠ actually progressing" check -- a node that's
+`Alive` but whose highest-seen-block is frozen is silently useless and worth calling out even with a
+nonzero live count. An absent `pool_rpc_node_*fault` counter is healthy (event counters, haven't
+fired).
+
+**This stage is a root cause for, and runs *before* you should report, the A0 log-poller finding and
+several upstream commit-doc signals**: a node pool with no live nodes produces exactly the
+reader `read_empty`/`read_outcome_error`, the `config_poll_failure reason="batch_fetch_failed"`,
+and the `report_transmission_gave_up` the commit runbooks surface -- attribution should land here,
+not on the plugin. If A0b is healthy, a genuine A0 stall is a log-poller problem (different owner).
+
 ### Stage B0 -- fee layer (block-history estimator): pricing sends?
 
 Solana transactions are priced by a **compute-unit-price** the block-history estimator derives
@@ -309,6 +373,23 @@ beholder) for the log-poller and Txm families; the read-path RPC metric is **pro
 | `solana_txm_fee_bumps` | Counter | `chainID` | dual |
 | `solana_client_latency_ms` | Gauge | `request,url` | promauto-only (deprecated) |
 | `rpc_call_latency` (Solana) | Histogram | `chainFamily,chainID,rpcUrl,isSendOnly,success,callName` | promauto-only via chainlink-framework |
+| `multi_node_states` | Gauge | `network,chainID,state` (PascalCase states) | dual (via chainlink-framework multinode; beholder-emitted) |
+| `pool_rpc_node_polls_total` | Counter | `network,chainID,nodeName` | dual |
+| `pool_rpc_node_polls_failed` / `pool_rpc_node_polls_success` | Counter | `network,chainID,nodeName` | dual (fires only on events) |
+| `pool_rpc_node_verifies_total` / `_verifies_failed` / `_verifies_success` | Counter | `network,chainID,nodeName` | dual |
+| `pool_rpc_node_highest_seen_block` / `pool_rpc_node_highest_finalized_block` | Gauge | `network,chainID,nodeName` | dual |
+| `pool_rpc_node_num_seen_blocks` | Counter | `network,chainID,nodeName` | dual |
+| `pool_rpc_node_num_transitions_to_alive` / `_to_unreachable` / `_to_out_of_sync` / `_to_syncing` / `_to_invalid_chain_id` / `_to_unusable` / `_to_in_sync` / `_to_finalized_state_not_available` | Counter | `network,chainID,nodeName` | dual (fires only on a transition) |
+| `pool_rpc_node_finalized_state_failed` | Counter | `network,chainID,nodeName` | dual (fires only on a failure) |
+| `multi_node_invariant_violations` | Counter | `network,chainID,invariant` | dual (fires only on a violation) |
+
+The `multi_node_states` / `pool_rpc_node_*` rows are the node-pool/RPC-health family for **Stage A0b**
+(chainlink-framework multinode, wired by chainlink-solana). They are **beholder-emitted** and shared
+by any chain family (the `network` label separates them). All are **dual** with promauto; note the
+promauto side of `multi_node_states` spells the ID label `chainId` while the beholder side spells it
+`chainID` -- check the metric browser for which your datasource shows. Their *failure/transition*
+counters are event-only (absent = healthy); `multi_node_states` and the `*_highest_*_block` gauges are
+continuous.
 
 (`--succeeded`/`--reverted` here are suffixes on the two log-poller tx-outcome counters, produced
 by chainlink-solana's `outcomeDependantMetric` helper.)
@@ -326,7 +407,7 @@ solana_finding:
   timestamp: string           # ISO8601
   verdict: OK | ISSUE
   steps_run:
-    - id: string              # A0 | B0 | B0_detail | B1 | B2
+    - id: string              # A0 | A0b | B0 | B0_detail | B1 | B2
       outcome: STOP | CONTINUE:<step> | REPORT:<owner>
       value: string           # the gauges/counter rates that drove the outcome, verbatim
   findings:                   # one per REPORT; empty list if none

--- a/docs/runbooks/solana.md
+++ b/docs/runbooks/solana.md
@@ -75,6 +75,7 @@ ID you already had.
 | `network` | `multi_node_states`, `pool_rpc_node_*` (A0b) | the chain family, `"solana"` / `"EVM"` -- a dimension the other metrics don't carry. Filter `network="solana"` on every node-pool query alongside `chainID`, or you'll mix chains/families |
 | `state` | `multi_node_states` | the node FSM state, **PascalCase** (`Alive`, `Unreachable`, `OutOfSync`, `Syncing`, `InvalidChainID`, `Unusable`, ...) -- filter with the exact casing |
 | `nodeName` | `pool_rpc_node_*` (A0b) | which RPC node a poll/transition/verify/head belongs to -- use it to name the dead node(s) |
+| `env` / `product` (and other platform resource attrs) | all beholder series, but required on `multi_node_states` / `pool_rpc_node_*` | platform-injected environment/product labels -- **on a shared datasource these are needed to isolate YOUR nodes from non-CCIP ones** (these general multinode metrics are emitted by every chainlink node). Add them to A0b queries if present in your datasource; the exact keys/spellings are platform-specific -- check the metric browser |
 | `# (outcome suffix)` | `solana_log_poller_txs_truncated_*`, `solana_log_poller_txs_log_parsing_error_*` | `_succeeded` vs `_reverted` -- whether the truncated/parse-failed tx ultimately succeeded or reverted on-chain |
 
 ### What Solana's TXM calls a failure -- and why the taxonomy matters
@@ -165,6 +166,7 @@ steps:
       - 'sum(multi_node_states{network="solana", chainID="$chainID", state="Alive"}) by (state)'
       - 'sum(multi_node_states{network="solana", chainID="$chainID"}) by (state)'
     condition: "state=\"Alive\" count == 0 (no node is reachable/healthy), OR some live nodes but more in a dead state (Unreachable/OutOfSync/Syncing/InvalidChainID/Unusable) than alive"
+    note: "these are general multinode metrics emitted by EVERY chainlink node on a shared datasource -- add your platform's env/product labels (e.g. env=\"staging\", product=\"ccip\") to the queries or you'll aggregate non-CCIP nodes into the count (see Stage A0b prose for exact keys). An empty result is 'multinode not on this node / wrong labels', NOT 'zero nodes'."
     if_true:
       no_nodes_alive: {action: "REPORT:chain-solana-oncall", reason: "the multinode node pool for $chainID has zero nodes in state=\"Alive\" -- this IS your 'no nodes healthy'/'No live RPC nodes available' (ErrNodeError). It explains every downstream signal (reader read_empty/read_outcome_error, config_poll batch_fetch_failed, log-poller stall, ccip_commit_fchain_read_errors, report_transmission_gave_up); do not re-attribute it to the plugin. Name the dead states by carrying the state breakdown, and which node(s), then check the transition/poll counters below for why."}
       degraded: {action: "REPORT:chain-solana-oncall", reason: "some Solana nodes are down ($count alive of $total) -- degraded redundancy, not full outage. Carry the alive-total split and the dead state names. Worth checking the transition counters below for whether nodes are flapping."}
@@ -279,17 +281,51 @@ To name *why* nodes left the alive set, the per-node `pool_rpc_node_*` family (s
 `chainID`/`nodeName` labels):
 
 ```promql
-sum(rate(pool_rpc_node_num_transitions_to_unreachable{chainID="$chainID"}[15m])) by (nodeName)
-sum(rate(pool_rpc_node_num_transitions_to_out_of_sync{chainID="$chainID"}[15m])) by (nodeName)
-sum(rate(pool_rpc_node_polls_failed{chainID="$chainID"}[15m])) by (nodeName)        # health-poll failures
-sum(rate(pool_rpc_node_verifies_failed{chainID="$chainID"}[15m])) by (nodeName)    # chain-ID verify failures
-pool_rpc_node_highest_seen_block{chainID="$chainID"}                               # is a node advancing at all
+sum(rate(pool_rpc_node_num_transitions_to_unreachable{chainID="$chainID"}[1h])) by (nodeName)
+sum(rate(pool_rpc_node_num_transitions_to_out_of_sync{chainID="$chainID"}[1h])) by (nodeName)
+sum(rate(pool_rpc_node_polls_failed{chainID="$chainID"}[1h])) by (nodeName)         # health-poll failures
+sum(rate(pool_rpc_node_verifies_failed{chainID="$chainID"}[1h])) by (nodeName)     # chain-ID verify failures (mostly at dial/verify time)
+pool_rpc_node_highest_seen_block{chainID="$chainID"}                               # raw value: is a node advancing at all
 ```
 
-`pool_rpc_node_highest_seen_block` is the "reachable ≠ actually progressing" check -- a node that's
-`Alive` but whose highest-seen-block is frozen is silently useless and worth calling out even with a
-nonzero live count. An absent `pool_rpc_node_*fault` counter is healthy (event counters, haven't
-fired).
+Reading these correctly matters -- each has a "quiet = healthy" and a "quiet = no signal recorded, not
+healthy" reading:
+
+- **The transition / poll-failure / verify-failure counters fire only on events**, and   two of the
+  triggers stop firing once a node is `Unreachable`: the per-node poll loop `return`s after
+  `declareUnreachable()` (`node_lifecycle.go:154-155`), so `polls_failed` climbs *during* the climb
+  to Unreachable then goes flat; `num_transitions_to_unreachable` fires **once per node at the
+  transition moment**. With a window that began after the outage, `rate(...)` is 0. **So absence here
+  is NOT evidence of health -- treat it as "no transition/poll telemetry recorded in this window,"**
+  especially when `state="Alive"` is 0 (use a `[1h]`+ window so it spans when the nodes actually
+  died). Verify the series even exist for your scope first (metric browser) before trusting an empty.
+- **`pool_rpc_node_highest_seen_block` / `pool_rpc_node_highest_finalized_block` are gauges --
+  query them RAW, never wrapped in `rate()`** (a frozen block number is a constant, so `rate()` of
+  it just reads 0). They are the "reachable ≠ actually progressing" check: a node that's `Alive` but
+  whose block height is flat is silently useless -- call it out even with a nonzero live count.
+  Read the value over time: **flat at a block number** = node was alive then went unreachable
+  (obvious stale gauge); **no series at all** = the node never got a head (unreachable-from-start)
+  or the metric isn't exported for that scope -- distinguish the two, since only the former points
+  at "was healthy then lost it."
+
+**Scope these queries to your environment and product -- they're general multinode metrics, not
+CCIP-specific.** `multi_node_states` / `pool_rpc_node_*` come from chainlink-framework's multinode
+pool, so **every** chainlink node in a shared datasource emits them (CCIP, non-CCIP, other products),
+and the same `chainID` appears on every node that serves that chain. On a shared deployment, a query
+narrowed only by `chainID` will aggregate across unrelated nodes. Beholder attaches platform
+resource attributes to every series (alongside the inherited `node_id`/`csa_public_key`), so add
+whatever environment/product/tenant labels your platform injects -- e.g.:
+
+```promql
+sum(multi_node_states{network="solana", chainID="$chainID", state="Alive", env="staging", product="ccip"})
+sum(rate(pool_rpc_node_polls_failed{chainID="$chainID", env="staging", product="ccip"}[15m])) by (nodeName)
+```
+
+If `env`/`product` aren't present on your datasource (e.g. a bare dev env), omit them; but if they
+exist and you drop them, expect false readings on a shared datasource. Pick the label *keys* your
+platform actually uses (here `env`, `product`) rather than assuming these spellings -- check the
+metric browser. This same inherited-resource-attribute scoping applies to the other CCIP-vs-non-CCIP
+ambiguous beholder series, but it bites hardest here because these metrics are the most general.
 
 **This stage is a root cause for, and runs *before* you should report, the A0 log-poller finding and
 several upstream commit-doc signals**: a node pool with no live nodes produces exactly the

--- a/docs/runbooks/solana.md
+++ b/docs/runbooks/solana.md
@@ -1,0 +1,342 @@
+---
+name: solana-chain-family
+description: Chain-family deep dive for a Solana chain feeding or receiving a CCIP commit plugin. Drills into the Solana chain-family library (chainlink-solana) layers -- log poller, block-history fee estimator, and the Solana transaction manager (Txm) -- that underpin the commit plugin's data-source (reader) and report-transmission paths. Enter this doc when the commit runbooks hand off with REPORT:...-txm-oncall / REPORT:...-infra-oncall, or when a data_source / report_transmission check in commit-plugin-health.md fires for a Solana chain.
+trigger: "entered from docs/runbooks/commit-plugin-health.md (data_source or report_transmission group CRIT/WARN) or docs/runbooks/uncommitted-message.md (step2c, or Scenario 2 'report transmission stuck') when the destination chain is Solana. Not triggered standalone."
+severity: page
+owner: chain-solana-oncall
+inputs:
+  chainID: {type: string, description: "the Solana chain ID (chain family / cluster identifier) of the chain under investigation. Like evm.md, the chainlink-solana metrics carry a bare chainID label -- same value you used for the commit plugin's destChainID where applicable, different label-key spelling"}
+  entry: {type: string, description: "which commit-plugin symptom brought you here", default: "data_source"}
+  txSignature: {type: string, required: false, description: "optional. A Solana transaction signature for the specific stuck/reverted commit-report tx, to cross-check on the explorer in stage B"}
+related:
+  - docs/runbooks/commit-plugin-health.md # the health checklist this doc deep-dives for Solana dest chains
+  - docs/runbooks/uncommitted-message.md   # the triage doc this doc deep-dives for Solana dest chains
+  - docs/runbooks/evm.md                   # the same deep-dive for the EVM chain family
+  - docs/runbooks/chain-identifiers.md     # translating chain ID / chain selector / chain name
+status: living
+---
+
+- [Runbook: Solana chain family (chainlink-solana)](#runbook-solana-chain-family-chainlinksolana)
+   * [For agents](#for-agents)
+      + [Label key cheat sheet](#label-key-cheat-sheet)
+      + [What Solana's TXM calls a failure -- and why the taxonomy matters](#what-solanas-txm-calls-a-failure--and-why-the-taxonomy-matters)
+      + [No on-chain per-address nonce, so no nonce-gap equivalent](#no-on-chain-per-address-nonce-so-no-nonce-gap-equivalent)
+      + [Empty result sets](#empty-result-sets)
+      + [Counter _total suffixing and the promauto-only read-path gap](#counter-total-suffixing-and-the-promauto-only-read-path-gap)
+   * [Decision graph](#decision-graph)
+   * [Steps](#steps)
+      + [Stage A0 -- log poller: keeping up with slots?](#stage-a0--log-poller-keeping-up-with-slots)
+      + [Stage B0 -- fee layer (block-history estimator): pricing sends?](#stage-b0--fee-layer-block-history-estimator-pricing-sends)
+      + [Stage B1 -- Txm broadcast: are reports landing at all?](#stage-b1--txm-broadcast-are-reports-landing-at-all)
+      + [Stage B2 -- Txm failure taxonomy: which kind of non-landing?](#stage-b2--txm-failure-taxonomy-which-kind-of-non-landing)
+   * [Metric reference](#metric-reference)
+   * [Output contract](#output-contract)
+
+# Runbook: Solana chain family (chainlink-solana)
+
+The CCIP commit plugin reaches Solana through chainlink-solana (checked out at
+`../chainlink-solana`, one level above this repo's root). Where EVM's
+transaction manager tracks discrete wallet nonces and gas price bumps, Solana's Txm operates in
+*priority-fee* (compute-unit-price) and *simulation* terms: a transaction either simulates cleanly
+and gets included, or it fails one of several distinct ways. Because of that, the metric story on
+Solana is a **taxonomy of why transactions don't land** plus a slot-based log poller -- and there
+is deliberately **no EVM-style nonce-gap concept** (see the note below).
+
+Two layers, matching the two commit-plugin paths exactly as `evm.md` does for EVM:
+
+- **Read path (data source).** The commit reader ingests CCIP events through the Solana **log
+  poller**, which tracks processed **slots** (Solana's equivalent of EVM block numbers). A slot
+  wedge or skip storm produces clean `read_empty` / `chain_gap` results upstream -- the classic
+  false-idle shape. Stage **A0**.
+- **Write path (report transmission).** Commit reports are submitted through the Solana **Txm**,
+  priced by the **block-history estimator** (compute-unit-price). That's the whole `B` half:
+  **B0** fee pricing, **B1** broadcast flow, **B2** the failure taxonomy.
+
+Read A0 for `data_source`, B0-B2 for `report_transmission`. The halves are independent.
+
+## For agents
+
+Reactive triage doc: walk the [decision graph](#decision-graph), substitute `$chainID` (and
+`$entry`), evaluate conditions, follow the output. Outcome vocabulary is the standard
+`STOP` / `CONTINUE:<step>` / `REPORT:<owner>`; `REPORT` is a handover, never a remediation.
+
+### Label key cheat sheet
+
+Every chainlink-solana metric in this doc carries a bare `chainID` label (from
+`metrics.Labeler().With("chainID", chainID)` in each package, exposed to beholder via
+`GetOtelAttributes()`). It is **not** the commit plugin's `destChainID`/`sourceChainName` family
+and there is no selector here. Same-number/different-key rule as `evm.md`: use the numeric chain
+ID you already had.
+
+| label key | appears on | meaning |
+|---|---|---|
+| `chainID` | all metrics here | the Solana chain ID / cluster. Every beholder series also inherits `node_id` + `csa_public_key` from the beholder client for per-node splitting |
+| `# (outcome suffix)` | `solana_log_poller_txs_truncated_*`, `solana_log_poller_txs_log_parsing_error_*` | `_succeeded` vs `_reverted` -- whether the truncated/parse-failed tx ultimately succeeded or reverted on-chain |
+
+### What Solana's TXM calls a failure -- and why the taxonomy matters
+
+EVM gives you a boolean stuck signal (`txm_reached_max_attempts`) and one lifecycle-failure
+counter. Solana instead gives you six purpose-built error counters that *subclass* the problem
+before you even look at a log header. Get these right or every drought looks like "the chain is
+down":
+
+- `solana_txm_tx_error_reject` — the **RPC rejected the transaction outright** (before broadcast).
+  This is almost always RPC/node-side, or a transaction that violates a validation rule (e.g. too
+  cheap a fee is a common real cause). Check RPC health / fee first, not the report.
+- `solana_txm_tx_error_drop` — timed out during confirmation; **most likely dropped** from the
+  chain (may still be included). Under-funding/compute-unit-price that's too low to get pulled in
+  is the archetypal cause → pair with `solana_bhe_compute_unit_price` and `solana_txm_fee_bumps`.
+- `solana_txm_tx_error_sim_revert` — **reverted during simulation** (never attempted). On a commit
+  report this usually points at a *state/account* condition the report hit at send-time, not the
+  transaction manager. Verify on-chain state before blaming either.
+- `solana_txm_tx_error_sim_other` — simulation failed with an **unrecognized error**. Same
+  treatment as sim_revert but explicitly "we don't know why." Say that you can't name it rather
+  than guessing; check logs.
+- `solana_txm_tx_error_revert` — **included but failed on-chain** (sometimes post-simulate
+  state change). The report landed in a block and reverted.
+- `solana_txm_tx_error_dependency` — failed because a **dependency transaction failed**.
+- `solana_txm_tx_error` — the umbrella sink for transactions that error-tested but didn't fall
+  into a named bucket.
+
+### No on-chain per-address nonce, so no nonce-gap equivalent
+
+`evm.md` leans on `txm_num_nonce_gaps` / `txm_rpc_nonce` because EVM serializes an account's
+transactions by nonce. Solana does not: a transaction identifies its instruction accounts and
+*blockhash/priority-fee* season, and there is no ordering nonce to park. Consequently there is **no
+`txm_num_nonce_gaps` or `txm_reached_max_attempts` here** -- do not go looking for them, and do not
+translate an EVM nonce diagnosis into a Solana one. The Solana "one stuck thing blocking the rest"
+equivalent is a **recurring `revert`/`sim_revert`/`dependency` on the same program/account**, which
+repeats per report until the underlying state or the fee budget changes. That is exactly what
+`report_transmission_gave_up` sees as a sustained drought.
+
+### Empty result sets
+
+Same discipline as the other runbooks. The gauges that should be continuously present while the
+process runs are `solana_log_poller_last_processed_slot` (A0) and `solana_bhe_compute_unit_price`
+(B0): an **empty** result on those means the metric isn't reaching your datasource, not "zero" --
+report `UNKNOWN`. Every counter here (`solana_log_poller_blocks_skipped`,
+`solana_log_poller_txs_*`, all `solana_txm_*` error/success counters, `solana_txm_fee_bumps`) is
+an event counter: **empty == it never happened == 0**, grade normally. As ever, if a continuously-
+emitted gauge is itself empty in the same run, don't trust counter-emptiness to mean "confirmed
+clean."
+
+### Counter _total suffixing and the promauto-only read-path gap
+
+Same pipeline rule as `evm.md`: OTel counters gain `_total` when converted to Prometheus unless the
+name already ends in it; the doc lists names as registered -- check your datasource's metric
+browser. (Among these, `solana_log_poller_blocks_skipped`, `solana_txm_tx_*`,
+`solana_txm_fee_bumps` will typically get a `_total` appended by an OTel→Prometheus exporter;
+`solana_log_poller_txs_truncated_*` etc. likewise.)
+
+**About the read-path RPC signal:** unlike EVM, chainlink-solana has **no beholder record for its
+RPC client calls** -- the per-node/client metrics (`solana_client_latency_ms`, deprecated; and the
+chainlink-framework `rpc_call_latency` promauto gauge) are **promauto-only**. They are still
+available on a direct-scrape datasource, so this doc can use them, but know that they will not
+appear on a strictly beholder-fed pipeline, and there is no `solana_pool_rpc_node_calls_*`
+beholder equivalent to EVM's. On a beholder-only datasource, leave the read-path RPC question to
+the commit-plugin reader metrics (`ccip_reader_read_outcome_error`) rather than this doc.
+
+## Decision graph
+
+```yaml
+steps:
+  # ---- READ PATH (data source) ----
+  - id: A0
+    check: log_poller_slot_catchup
+    query: 'solana_log_poller_last_processed_slot{chainID="$chainID"}'
+    condition: "value stale (no fresh sample in the last couple of poll intervals) OR clearly lagging the current slot (cross-check on the explorer) OR blocks_skipped climbing"
+    if_true:
+      stale_or_lag: {action: "REPORT:chain-solana-oncall", reason: "the Solana log poller for $chainID is stuck or behind -- every commit/reader log read routes through it, so a wedge here surfaces as clean reader read_empty / chain_gap (false idle) in the commit docs, or batch_fetch_failed in the config poller. Report as a Solana chain-family / infra finding, not a reader one. Corroborate blocks_skipped: solana_log_poller_blocks_skipped{chainID=\"$chainID\"}."}
+    if_false: {action: "CONTINUE:$entry == \"report_transmission\" ? B0 : STOP", reason: "log poller keeping up. Stop if you came in via data_source."}
+    automatable: true
+
+  # ---- WRITE PATH (report transmission) ----
+  - id: B0
+    check: fee_estimator_pricing
+    query: 'solana_bhe_compute_unit_price{chainID="$chainID"}'
+    condition: "value absent/stale (UNKNOWN) OR materially below historical floor for $chainID (compare against recent samples)"
+    if_true: {action: "CONTINUE:B0_detail", reason: "the block-history estimator is not producing a usable compute-unit-price -- underpriced txs get dropped/rejected and never land"}
+    if_false: {action: "CONTINUE:B1", reason: "BHE pricing normally; move to broadcast flow"}
+    automatable: true
+
+  - id: B0_detail
+    check: underpricing_signature
+    queries:
+      - 'sum(rate(solana_txm_tx_error_drop{chainID="$chainID"}[15m]))'
+      - 'sum(rate(solana_txm_tx_error_reject{chainID="$chainID"}[15m]))'
+      - 'sum(rate(solana_txm_fee_bumps{chainID="$chainID"}[15m]))'
+    condition: "drop OR reject climbing, combined with low/absent compute_unit_price"
+    if_true: {action: "REPORT:chain-solana-oncall", reason: "the fee/drop/reject signature points at costs: compute_unit_price is low/absent AND drop/reject are climbing. Underpriced Solana transactions are dropped by the cluster or rejected by RPCs, so every commit report struggles to land (report_transmission_gave_up) regardless of the reader being healthy. The fix is the block-history estimator (wider block window, higher default floor), an infra/ops decision, not a commit-plugin one."}
+    if_false: {action: "CONTINUE:B1", reason: "no concurrent drop/reject/fee-bump storm; treat the estimator note as a caveat, continue"}
+    automatable: true
+
+  - id: B1
+    check: txm_broadcast_flow
+    queries:
+      - 'sum(rate(solana_txm_tx_success{chainID="$chainID"}[15m]))'
+      - 'sum(rate(solana_txm_tx_finalized{chainID="$chainID"}[15m]))'
+      - 'max(solana_txm_tx_pending{chainID="$chainID"})'
+    condition: "success==0 AND finalized==0 over the window"
+    if_true: {action: "CONTINUE:B2", reason: "no reports confirming at all -- the give-up is a 'nothing lands' situation, classify why in B2"}
+    if_false:
+      pending_climbing_or_flat_high: {action: "CONTINUE:B2", reason: "txs are inflight but success/finalized are zero -- more are queued than landing; classify why"}
+      success_positive: {action: "STOP", reason: "Solana Txm is landing reports ($chainID). If report_transmission_gave_up still fires it's per-report (revert on a specific report) or a backlog/round-cadence issue, not the Solana node/Txm stack. If you have a $txSignature, sanity-check it on the explorer before stopping."}
+    automatable: true
+
+  - id: B2
+    check: txm_failure_taxonomy
+    queries:
+      - 'sum(rate(solana_txm_tx_error_reject{chainID="$chainID"}[15m]))'
+      - 'sum(rate(solana_txm_tx_error_revert{chainID="$chainID"}[15m]))'
+      - 'sum(rate(solana_txm_tx_error_sim_revert{chainID="$chainID"}[15m]))'
+      - 'sum(rate(solana_txm_tx_error_sim_other{chainID="$chainID"}[15m]))'
+      - 'sum(rate(solana_txm_tx_error_drop{chainID="$chainID"}[15m]))'
+      - 'sum(rate(solana_txm_tx_error_dependency{chainID="$chainID"}[15m]))'
+    condition: "classify the dominant nonzero class (report the counts)"
+    if_true:
+      reject_dominant:       {action: "REPORT:chain-solana-oncall", reason: "RPCs are rejecting the commit-report txs outright. Cross back to B0 (underpriced fees are a common real trigger) and check RPC/cluster health. Not a report-content bug."}
+      drop_dominant:         {action: "REPORT:chain-solana-oncall", reason: "commit txs are timing out during confirmation and being dropped. Pair with B0 fee pricing and solana_txm_fee_bumps. Likely cluster congestion or underpricing, not content."}
+      sim_revert_dominant:   {action: "REPORT:ccip-commit-oncall", reason: "commit reports are reverting at simulation (never attempted). This is usually a state/account condition the report hit at send-time -- e.g. the report references accounts/state that has already moved. Confirm on-chain state for $chainID before blaming the Txm; this can genuinely be a commit-report state issue."}
+      sim_other_dominant:    {action: "REPORT:ccip-commit-oncall", reason: "simulation failed with an unrecognized error. Do NOT translate this into a specific cause -- report the count and that the reason is unknown; pull node logs for the sim error text."}
+      revert_dominant:       {action: "REPORT:ccip-commit-oncall", reason: "commit reports are included in a block but revert on-chain. Confirm against $txSignature on the explorer; often a state/priority-fee interaction at execution."}
+      dependency_dominant:   {action: "REPORT:chain-solana-oncall", reason: "commit txs are failing because a dependency transaction failed. Naming the dependency requires the account list in the failing tx -- look to Txm logs / transaction detail."}
+      multiple:              {action: "REPORT:chain-solana-oncall", reason: "more than one class is firing; report each with its rate, order by impact, and note which likely share one root (e.g. drop+reject share the fee cause)."}
+    if_false: {action: "STOP", reason: "no tx in the window hit any named failure, yet nothing confirms and nothing is pending-ish -- the most honest reading is a confirmation/indexing lag on the RPC side (txs landed but aren't being observed as finalized). Verify on-chain via $txSignature / explorer before escalating further."}
+    automatable: true
+```
+
+## Steps
+
+### Stage A0 -- log poller: keeping up with slots?
+
+The commit reader ingests CCIP sends/commits through the Solana log poller, which tracks
+**processed slots**, not a chain head block. Two gauges:
+
+```promql
+solana_log_poller_last_processed_slot{chainID="$chainID"}
+```
+
+Continuous absence → the poller goroutine is wedged (parks at its last value). Clear lag behind
+the current slot, or `solana_log_poller_blocks_skipped` climbing, → it's running but can't keep
+up and is dropping ranges on retry exhaustion:
+
+```promql
+sum(rate(solana_log_poller_blocks_skipped{chainID="$chainID"}[15m]))
+```
+
+A wedged or skipping Solana log poller is the highest-probability *silent false idle* on a Solana
+dest chain: every per-filter log read comes back empty and clean, so the commit docs' reader gates
+fire `read_empty`/`chain_gap` and the plugin looks securely idle. Also worth a glance:
+`solana_log_poller_txs_truncated_*` and `solana_log_poller_txs_log_parsing_error_*` -- these
+count txs whose logs were truncated or failed to parse (split by whether the tx ultimately
+`_succeeded` or `_reverted`), and a parsing-error storm can drop *individually* *invisible*
+messages even while the poller as a whole advances. If either climbs and you're investigating a
+specific message that "should have been seen," that is the first place to look.
+
+### Stage B0 -- fee layer (block-history estimator): pricing sends?
+
+Solana transactions are priced by a **compute-unit-price** the block-history estimator derives
+from recent block fee data. If the estimator can't produce one (or produces one far below the
+cluster's actual floor), the Txm's broadcasts get dropped or rejected no matter how healthy the
+reader is:
+
+```promql
+solana_bhe_compute_unit_price{chainID="$chainID"}
+```
+
+Absent/stale = estimator not running (UNKNOWN, not zero). Abnormally low or gliding toward the
+default floor = it has no good recent data. Corroborate the "underpriced" diagnosis with:
+
+```promql
+sum(rate(solana_txm_tx_error_drop{chainID="$chainID"}[15m]))
+sum(rate(solana_txm_tx_error_reject{chainID="$chainID"}[15m]))
+sum(rate(solana_txm_fee_bumps{chainID="$chainID"}[15m]))
+```
+
+`fee_bumps` is the Txm re-raising the price to chase inclusion; a persistent bump storm with drops
+on top is a costs problem (estimator tuning / cluster congestion), a `chain-solana-oncall`
+decision, and it sits *underneath* the commit plugin's `report_transmission_gave_up`.
+
+### Stage B1 -- Txm broadcast: are reports landing at all?
+
+```promql
+sum(rate(solana_txm_tx_success{chainID="$chainID"}[15m]))
+sum(rate(solana_txm_tx_finalized{chainID="$chainID"}[15m]))
+max(solana_txm_tx_pending{chainID="$chainID"})
+```
+
+Solana separates **success** (included and executed) from **finalized** (committed past the
+finality horizon). A healthy node fronts them by roughly a block; both should be `> 0` whenever
+the plugin is transmitting. Both `== 0` with `pending` parked flat → nothing is landing → **B2**.
+`success`/`finalized` positive → the Txm is landing reports; a sustained commit-plugin
+`report_transmission_gave_up` on top of that is per-report or cadence, not the Solana stack.
+
+### Stage B2 -- Txm failure taxonomy: which kind of non-landing?
+
+Classify with the six error counters (queries in the decision graph). Read the taxonomy in
+[For agents](#what-solanas-txm-calls-a-failure--and-why-the-taxonomy-matters) -- the short version:
+`reject`/`drop` → RPC/costs (own as `chain-solana-oncall`, cross to B0); `sim_revert`/
+`sim_other`/`revert` → report/state-level, verify on-chain and own as `ccip-commit-oncall` when a
+real report-state interaction (be honest that sim_other is an unexplained reason); `dependency` →
+an account/program dependency failed, name it from the tx detail. If nothing fires but nothing
+lands either, conclude a confirmation/indexing lag and verify against the explorer rather than
+inventing a cause.
+
+## Metric reference
+
+`otel_type` governs `_total` suffixing (see the pipeline note). All carry `chainID`; beholder
+series also inherit `node_id` + `csa_public_key`. Registration is effectively **dual** (promauto +
+beholder) for the log-poller and Txm families; the read-path RPC metric is **promauto-only** (see
+[the gap note](#counter-total-suffixing-and-the-promauto-only-read-path-gap)).
+
+| metric | otel_type | key labels | registration |
+|---|---|---|---|
+| `solana_log_poller_last_processed_slot` | Gauge | `chainID` | dual |
+| `solana_log_poller_blocks_skipped` | Counter | `chainID` | dual |
+| `solana_log_poller_txs_truncated_succeeded` / `_reverted` | Counter | `chainID` | dual |
+| `solana_log_poller_txs_log_parsing_error_succeeded` / `_reverted` | Counter | `chainID` | dual |
+| `solana_bhe_compute_unit_price` | Gauge | `chainID` | dual |
+| `solana_txm_tx_success` | Counter | `chainID` | dual |
+| `solana_txm_tx_finalized` | Counter | `chainID` | dual |
+| `solana_txm_tx_pending` | Gauge | `chainID` | dual |
+| `solana_txm_tx_error` | Counter | `chainID` | dual |
+| `solana_txm_tx_error_reject` | Counter | `chainID` | dual |
+| `solana_txm_tx_error_revert` | Counter | `chainID` | dual |
+| `solana_txm_tx_error_drop` | Counter | `chainID` | dual |
+| `solana_txm_tx_error_sim_revert` | Counter | `chainID` | dual |
+| `solana_txm_tx_error_sim_other` | Counter | `chainID` | dual |
+| `solana_txm_tx_error_dependency` | Counter | `chainID` | dual |
+| `solana_txm_fee_bumps` | Counter | `chainID` | dual |
+| `solana_client_latency_ms` | Gauge | `request,url` | promauto-only (deprecated) |
+| `rpc_call_latency` (Solana) | Histogram | `chainFamily,chainID,rpcUrl,isSendOnly,success,callName` | promauto-only via chainlink-framework |
+
+(`--succeeded`/`--reverted` here are suffixes on the two log-poller tx-outcome counters, produced
+by chainlink-solana's `outcomeDependantMetric` helper.)
+
+The `ccip_commit_*` / `ccip_reader_*` series the commit runbooks actually query are **not** in this
+doc; the Solana layer is what sits underneath them and what this doc's `REPORT:...-oncall`
+outcomes hand you to investigate.
+
+## Output contract
+
+```yaml
+solana_finding:
+  chainID: string
+  entry: data_source | report_transmission
+  timestamp: string           # ISO8601
+  verdict: OK | ISSUE
+  steps_run:
+    - id: string              # A0 | B0 | B0_detail | B1 | B2
+      outcome: STOP | CONTINUE:<step> | REPORT:<owner>
+      value: string           # the gauges/counter rates that drove the outcome, verbatim
+  findings:                   # one per REPORT; empty list if none
+    - owner: string           # chain-solana-oncall | ccip-commit-oncall
+      summary: string
+      failure_class: string   # reject | drop | sim_revert | sim_other | revert | dependency | fee | log_poller
+      evidence: string        # exact query + result that produced it
+      commit_handoff: string  # which commit-runbook owner/check this replaces or justifies
+```
+
+Do not page, escalate, or remediate. Hand this report to the named owner; the commit runbook you
+dropped in from already established *whether* there's a problem, this doc only locates *which
+Solana-layer component* owns it.

--- a/docs/runbooks/uncommitted-message.md
+++ b/docs/runbooks/uncommitted-message.md
@@ -15,6 +15,8 @@ related:
   - docs/metrics/reader-metrics.md        # data-source (reader + config poller) metrics & gaps
   - devenv/dashboards/commit-plugin.json  # Grafana rendering of this runbook (Guided Debug section)
   - docs/runbooks/chain-identifiers.md    # translating chain ID / chain selector / chain name
+  - docs/runbooks/evm.md                  # chain-family deep dive when the dest chain is EVM (step2c / Scenario 2)
+  - docs/runbooks/solana.md               # chain-family deep dive when the dest chain is Solana (step2c / Scenario 2)
 status: living
 ---
 
@@ -347,6 +349,12 @@ destination-chain lanes sharing a source chain collide into one series per `(cha
 > (`ccip_reader_config_poll_failure_total`) here are rising, that's reader-layer/RPC-failure — not a
 > genuinely quiet lane — and the absent gauges are the symptom, not evidence of health.
 
+When this step fires for an EVM or Solana destination chain, the reader is almost always being fed
+from a degrading **chain-family** layer rather than misbehaving itself — drop into
+[`evm.md`](evm.md) (RPC pool + log poller) or [`solana.md`](solana.md) (log poller) to name which
+one. A wedged EVM log poller or Solana slot poller produces exactly this `read_empty`/`chain_gap`
+profile while the plugin itself looks fine.
+
 ### step3 — is the round producing outcomes at all?
 
 ```promql
@@ -439,7 +447,11 @@ sum(rate(ccip_commit_report_validation_rejected_total{destChainID=~"$destChain",
 
 **B — transmitted, reverted/stuck on-chain.** *(`automatable: false` — outside commit-plugin
 metrics.)* Check chain B's TXM/tx-sender dashboards for the assigned transmitter (nonce gap,
-underpriced gas, wallet balance, revert reason).
+underpriced gas, wallet balance, revert reason). **When chain B is EVM or Solana, run
+[`evm.md`](evm.md) / [`solana.md`](solana.md) to ground this in the chain-family layer's own
+metrics first** — the TXM/fee/log-poller queries there are automatable and will name the nonce
+gap, bump-suppression, drop/reject/revert class, or log-poller wedge that the bare dashboard
+look would have you hunt manually.
 
 **C — actually succeeded, read is lagging.** *(`automatable: false`.)*
 `ccip_commit_offramp_next_seq_num` is sourced from this plugin's own chain-B reader; if that's


### PR DESCRIPTION
* Add EVM and Solana runbooks that are referenced from the top-level health and uncommitted message runbooks.
* Add instructions on when to refer to these runbooks when following the top-level runbooks.
* Add grafana dashboard JSON files, [EVM](https://grafana.ops.prod.cldev.sh/d/ccip-evm/ccip-evm-chain-family-chainlink-evm?orgId=1&from=now-30m&to=now&timezone=utc&var-DS_PROMETHEUS=PEC841104E2358669&var-fEnv=staging&var-fProduct=ccip&var-chainID=$__all&refresh=5m) and [Solana](https://grafana.ops.prod.cldev.sh/d/ccip-solana/ccip-solana-chain-family-chainlink-solana?orgId=1&from=now-6h&to=now&timezone=utc&var-DS_PROMETHEUS=PEC841104E2358669&var-fEnv=production&var-fProduct=ccip&var-chainID=$__all&refresh=5m) have been added to Grafana already.