### PR TITLE
fix: token expansion partial migration CLD bugs

### DIFF
--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chain.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chain.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"slices"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
@@ -437,18 +438,57 @@ func maybeUpdateRateLimiters(
 	}
 
 	if len(args) > 0 {
-		setInboundRateLimiterReport, err := cldf_ops.ExecuteOperation(b, token_pool.SetRateLimitConfig, chain, evm_contract.FunctionInput[[]token_pool.RateLimitConfigArgs]{
-			ChainSelector: chainSelector,
-			Address:       tokenPoolAddress,
-			Args:          args,
-		})
+		setInboundRateLimiterReport, err := setRateLimiterConfigWithLaneVisibilityRetry(b, chain, chainSelector, tokenPoolAddress, args)
 		if err != nil {
-			return nil, fmt.Errorf("failed to set rate limiters config: %w", err)
+			return nil, err
 		}
-		return &setInboundRateLimiterReport.Output, nil
+		return setInboundRateLimiterReport, nil
 	}
 
 	return nil, nil
+}
+
+// setRateLimiterConfigWithLaneVisibilityRetry executes SetRateLimitConfig with a short block-scale
+// backoff. When the lane is being added in the same sequence (this pool just went through the
+// not-supported add-lane path), the applyChainUpdates tx that created the lane may not yet be
+// visible to the RPC node's estimate view when SetRateLimitConfig is prepared, producing a spurious
+// NonExistentChain revert. Retrying over base-block intervals lets the lane-add propagate before the
+// next prepare attempt. This mirrors the framework's OnlyOwner visibility retry ("newly deployed
+// contract / modified state may not be immediately visible to the RPC node").
+func setRateLimiterConfigWithLaneVisibilityRetry(
+	b cldf_ops.Bundle,
+	chain evm.Chain,
+	chainSelector uint64,
+	tokenPoolAddress common.Address,
+	args []token_pool.RateLimitConfigArgs,
+) (*evm_contract.WriteOutput, error) {
+	type rlIn = evm_contract.FunctionInput[[]token_pool.RateLimitConfigArgs]
+
+	retryDelay := 2 * time.Second
+	retryCfg := cldf_ops.RetryConfig[rlIn, evm.Chain]{
+		Enabled: true,
+		Policy:  cldf_ops.RetryPolicy{MaxAttempts: 4},
+		InputHook: func(attempt uint, _ error, in rlIn, _ evm.Chain) rlIn {
+			time.Sleep(time.Duration(attempt+1) * retryDelay)
+			return in
+		},
+	}
+
+	setInboundRateLimiterReport, err := cldf_ops.ExecuteOperation(
+		b,
+		token_pool.SetRateLimitConfig,
+		chain,
+		evm_contract.FunctionInput[[]token_pool.RateLimitConfigArgs]{
+			ChainSelector: chainSelector,
+			Address:       tokenPoolAddress,
+			Args:          args,
+		},
+		cldf_ops.WithRetryConfig(retryCfg),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set rate limiters config: %w", err)
+	}
+	return &setInboundRateLimiterReport.Output, nil
 }
 
 // rateLimiterConfigsEqual returns true if the current rate limiter config on-chain matches the desired config.

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chain.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chain.go
@@ -438,9 +438,9 @@ func maybeUpdateRateLimiters(
 	}
 
 	if len(args) > 0 {
-		setInboundRateLimiterReport, err := setRateLimiterConfigWithLaneVisibilityRetry(b, chain, chainSelector, tokenPoolAddress, args)
+		setInboundRateLimiterReport, err := setRateLimiterConfigWithLaneVisibilityRetry(b, chain, tokenPoolAddress, args)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to set rate limiter config: %w", err)
 		}
 		return setInboundRateLimiterReport, nil
 	}
@@ -449,46 +449,55 @@ func maybeUpdateRateLimiters(
 }
 
 // setRateLimiterConfigWithLaneVisibilityRetry executes SetRateLimitConfig with a short block-scale
-// backoff. When the lane is being added in the same sequence (this pool just went through the
-// not-supported add-lane path), the applyChainUpdates tx that created the lane may not yet be
-// visible to the RPC node's estimate view when SetRateLimitConfig is prepared, producing a spurious
-// NonExistentChain revert. Retrying over base-block intervals lets the lane-add propagate before the
-// next prepare attempt. This mirrors the framework's OnlyOwner visibility retry ("newly deployed
-// contract / modified state may not be immediately visible to the RPC node").
+// backoff. When the lane is being added in the same sequence (this pool just went through the not-
+// supported add-lane path) the `applyChainUpdates` tx that created the lane may not yet be visible
+// to the RPC node's estimate view when SetRateLimitConfig is prepared, which produces a misleading
+// NonExistentChain revert. Retrying over base-block intervals lets the change propagate before the
+// next prepare attempt.
 func setRateLimiterConfigWithLaneVisibilityRetry(
 	b cldf_ops.Bundle,
 	chain evm.Chain,
-	chainSelector uint64,
 	tokenPoolAddress common.Address,
 	args []token_pool.RateLimitConfigArgs,
 ) (*evm_contract.WriteOutput, error) {
-	type rlIn = evm_contract.FunctionInput[[]token_pool.RateLimitConfigArgs]
+	type RateLimitArgs = evm_contract.FunctionInput[[]token_pool.RateLimitConfigArgs]
 
-	retryDelay := 2 * time.Second
-	retryCfg := cldf_ops.RetryConfig[rlIn, evm.Chain]{
+	retryBuffer := 2 * time.Second
+	retryPolicy := cldf_ops.RetryPolicy{MaxAttempts: 5}
+	retryConfig := cldf_ops.RetryConfig[RateLimitArgs, evm.Chain]{
 		Enabled: true,
-		Policy:  cldf_ops.RetryPolicy{MaxAttempts: 4},
-		InputHook: func(attempt uint, _ error, in rlIn, _ evm.Chain) rlIn {
-			time.Sleep(time.Duration(attempt+1) * retryDelay)
+		Policy:  retryPolicy,
+		InputHook: func(attempt uint, _ error, in RateLimitArgs, _ evm.Chain) RateLimitArgs {
+			b.Logger.Infof(
+				"Retrying SetRateLimitConfig for chain %d, attempt %d/%d, waiting %s before next attempt",
+				chain.Selector, attempt+1, retryPolicy.MaxAttempts, retryBuffer,
+			)
+
+			// We avoid time.Sleep since it doesn't respect context cancellation. Instead, we either wait
+			// for the entire backoff duration or for the context to be cancelled, whichever comes first.
+			select {
+			case <-time.After(time.Duration(attempt+1) * retryBuffer):
+			case <-b.GetContext().Done():
+			}
+
 			return in
 		},
 	}
 
-	setInboundRateLimiterReport, err := cldf_ops.ExecuteOperation(
-		b,
-		token_pool.SetRateLimitConfig,
-		chain,
+	setRateLimitReport, err := cldf_ops.ExecuteOperation(
+		b, token_pool.SetRateLimitConfig, chain,
 		evm_contract.FunctionInput[[]token_pool.RateLimitConfigArgs]{
-			ChainSelector: chainSelector,
+			ChainSelector: chain.Selector,
 			Address:       tokenPoolAddress,
 			Args:          args,
 		},
-		cldf_ops.WithRetryConfig(retryCfg),
+		cldf_ops.WithRetryConfig(retryConfig),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set rate limiters config: %w", err)
 	}
-	return &setInboundRateLimiterReport.Output, nil
+
+	return &setRateLimitReport.Output, nil
 }
 
 // rateLimiterConfigsEqual returns true if the current rate limiter config on-chain matches the desired config.

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chain.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chain.go
@@ -129,7 +129,7 @@ var ConfigureTokenPoolForRemoteChain = cldf_ops.NewSequence(
 						RemoteChainSelector: input.RemoteChainSelector,
 						FastFinality:        false,
 					},
-				})
+				}, cldf_ops.WithForceExecute[evm_contract.FunctionInput[token_pool.GetCurrentRateLimiterStateArgs], evm.Chain]())
 				if err != nil {
 					return sequences.OnChainOutput{}, fmt.Errorf("failed to get default rate limiter state for remote chain %d: %w", input.RemoteChainSelector, err)
 				}
@@ -228,7 +228,7 @@ var ConfigureTokenPoolForRemoteChain = cldf_ops.NewSequence(
 				ChainSelector: input.ChainSelector,
 				Address:       input.TokenPoolAddress,
 				Args:          input.RemoteChainSelector,
-			})
+			}, cldf_ops.WithForceExecute[evm_contract.FunctionInput[uint64], evm.Chain]())
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to get remote token: %w", err)
 			}
@@ -259,7 +259,7 @@ var ConfigureTokenPoolForRemoteChain = cldf_ops.NewSequence(
 					ChainSelector: input.ChainSelector,
 					Address:       input.TokenPoolAddress,
 					Args:          input.RemoteChainSelector,
-				})
+				}, cldf_ops.WithForceExecute[evm_contract.FunctionInput[uint64], evm.Chain]())
 				if err != nil {
 					return sequences.OnChainOutput{}, fmt.Errorf("failed to get remote pools: %w", err)
 				}
@@ -409,7 +409,7 @@ func maybeUpdateRateLimiters(
 				RemoteChainSelector: remoteChainSelector,
 				FastFinality:        desiredRL.FastFinality,
 			},
-		})
+		}, cldf_ops.WithForceExecute[evm_contract.FunctionInput[token_pool.GetCurrentRateLimiterStateArgs], evm.Chain]())
 		if err != nil {
 			return nil, fmt.Errorf("failed to get rate limiter state: %w", err)
 		}
@@ -467,17 +467,19 @@ func setRateLimiterConfigWithLaneVisibilityRetry(
 	retryConfig := cldf_ops.RetryConfig[RateLimitArgs, evm.Chain]{
 		Enabled: true,
 		Policy:  retryPolicy,
-		InputHook: func(attempt uint, _ error, in RateLimitArgs, _ evm.Chain) RateLimitArgs {
+		InputHook: func(attempt uint, err error, in RateLimitArgs, _ evm.Chain) RateLimitArgs {
+			wait := time.Duration(attempt+1) * retryBuffer
+
 			b.Logger.Infof(
-				"Retrying SetRateLimitConfig for chain %d, attempt %d/%d, waiting %s before next attempt",
-				chain.Selector, attempt+1, retryPolicy.MaxAttempts, retryBuffer,
+				"Retrying SetRateLimitConfig for chain %d, attempt %d/%d, waiting %s, err: %v",
+				chain.Selector, attempt+1, retryPolicy.MaxAttempts, wait, err,
 			)
 
 			// We avoid time.Sleep since it doesn't respect context cancellation. Instead, we either wait
 			// for the entire backoff duration or for the context to be cancelled, whichever comes first.
 			select {
-			case <-time.After(time.Duration(attempt+1) * retryBuffer):
 			case <-b.GetContext().Done():
+			case <-time.After(wait):
 			}
 
 			return in

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_pool_for_remote_chains.go
@@ -115,11 +115,10 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 			}
 		}
 
-		ops := make([]mcms_types.BatchOperation, 0)
 		supportedChainsReport, err := cldf_ops.ExecuteOperation(b, token_pool.GetSupportedChains, chain, evm_contract.FunctionInput[struct{}]{
 			ChainSelector: input.ChainSelector,
 			Address:       input.TokenPoolAddress,
-		})
+		}, cldf_ops.WithForceExecute[evm_contract.FunctionInput[struct{}], evm.Chain]())
 		if err != nil {
 			return sequences.OnChainOutput{}, fmt.Errorf("failed to get supported chains from pool: %w", err)
 		}
@@ -127,6 +126,8 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 		for _, s := range supportedChainsReport.Output {
 			supportedSet[s] = struct{}{}
 		}
+
+		ops := make([]mcms_types.BatchOperation, 0)
 		for remoteChainSelector, remoteChainConfig := range input.RemoteChains {
 			_, alreadySupported := supportedSet[remoteChainSelector]
 			report, err := cldf_ops.ExecuteSequence(b, ConfigureTokenPoolForRemoteChain, chain, ConfigureTokenPoolForRemoteChainInput{
@@ -144,6 +145,7 @@ var ConfigureTokenPoolForRemoteChains = cldf_ops.NewSequence(
 			}
 			ops = append(ops, report.Output.BatchOps...)
 		}
+
 		return sequences.OnChainOutput{BatchOps: ops}, nil
 	},
 )

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -514,12 +514,16 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 					PoolType:                           ru.remotePoolRef.Type.String(),
 					RemoteChains: map[uint64]RemoteChainConfig[[]byte, string]{
 						selector: {
-							// Pad to match on-chain storage format (32-byte left-padded). The address
-							// comparisons in `ConfigureTokenPoolForRemoteChain()` compare against on-
-							// chain bytes without padding, so a 20-byte input would mismatch and fire
-							// a remove+re-add instead of addRemotePool
+							// The remote TOKEN is left-padded to 32 bytes to match the forward-path convention (see
+							// convertRemoteChainConfig). However, The remote POOL is intentionally NOT padded here.
+							// Each counterpart adapter normalizes the RemotePool to its own expected on-chain form.
+							// For example, the EVM code left-pads pool addresses to 32-bytes for `addRemotePool( )`
+							// whereas Solana passes raw 20-byte EVM addresses to `AppendRemotePoolAddresses( )`. As
+							// a result, it'd be incorrect to pad the pool here since it would leak *32-byte-padded*
+							// addresses into Solana's append and break EVM > Solana transfers with an error such as
+							// `InvalidSourcePoolAddress`.
 							RemoteToken: common.LeftPadBytes(migratedTokenBytes, 32),
-							RemotePool:  common.LeftPadBytes(migratedPoolBytes, 32),
+							RemotePool:  migratedPoolBytes,
 						},
 					},
 				}

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -327,7 +327,7 @@ func tokenExpansionApply() func(cldf.Environment, TokenExpansionInput) (cldf.Cha
 				}
 				normalizedTokenRef, err := ccipdeploy.TryNormalizeAddressRef(selector, newTokenRef)
 				if err != nil {
-					return cldf.ChangesetOutput{}, fmt.Errorf("failed to normalize token ref %s for chain selector %d: %w", datastore_utils.SprintRef(*tokenRef), selector, err)
+					return cldf.ChangesetOutput{}, fmt.Errorf("failed to normalize token ref %s for chain selector %d: %w", datastore_utils.SprintRef(newTokenRef), selector, err)
 				}
 				tokenRef = &normalizedTokenRef
 

--- a/deployment/tokens/token_expansion.go
+++ b/deployment/tokens/token_expansion.go
@@ -316,14 +316,21 @@ func tokenExpansionApply() func(cldf.Environment, TokenExpansionInput) (cldf.Cha
 			}
 
 			if input.DeployTokenPoolInput != nil {
-				newTokenRef, err := datastore_utils.MergeRefs(
-					tokenRef,
-					input.DeployTokenPoolInput.TokenRef,
-				)
+				// Ensure the token ref is normalized so that datastore address comparisons
+				// work correctly. If we don't normalize the token ref here, then this will
+				// lead to misconfigurations (e.g. the token won't be found in the DS and a
+				// chain implementation may treat that as an error or skip an important set
+				// up step like granting burn/mint roles to the pool).
+				newTokenRef, err := datastore_utils.MergeRefs(tokenRef, input.DeployTokenPoolInput.TokenRef)
 				if err != nil {
 					return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge token refs for chain selector %d: %w", selector, err)
 				}
-				tokenRef = &newTokenRef
+				normalizedTokenRef, err := ccipdeploy.TryNormalizeAddressRef(selector, newTokenRef)
+				if err != nil {
+					return cldf.ChangesetOutput{}, fmt.Errorf("failed to normalize token ref %s for chain selector %d: %w", datastore_utils.SprintRef(*tokenRef), selector, err)
+				}
+				tokenRef = &normalizedTokenRef
+
 				// deploy token pool
 				tmpDatastore = datastore.NewMemoryDataStore()
 				deployTokenPoolInput := *input.DeployTokenPoolInput


### PR DESCRIPTION
# Context

Hardening fixes to the EVM token-expansion path
(`deployment/tokens/token_expansion.go` and
`chains/evm/deployment/v2_0_0/sequences/tokens/…`) that surfaced while activating migrated v2 pools.

## 1. The burn/mint pool-role grant was silently skipped due to an un-normalized token ref

**Problem.** When a pool is deployed, the adapter's inherited grant step
(`EVMPoolAdapter.TidyTokenPoolRoles` → `GrantPoolRoles`) grants a burn/mint pool its token-side
mint/burn role. That can only happen if the token's implementation (and thus its role-grant strategy)
is resolved. The deploy path passed the token ref through **unchanged**, and the datastore lookup that
recovers the ref's type matches the address with an **exact, case-sensitive** comparison against the
stored EIP-55 checksum form. A token ref supplied in lowercase (as in the durable-pipeline input for
the base TEST token) therefore failed the lookup (0 matches), leaving the token's type unresolved.
The grant step then **silently skipped** the role grant, and the freshly-deployed burn/mint pool was
left without its mint/burn role — which is only discovered later, when mint-on-destination
(`releaseOrMint`) reverts with an `AccessControl` error.

**This change.** The deploy path now **canonicalizes the token ref address** via the chain-family
address normalizer (which, for EVM, produces the EIP-55 checksum form) before handing the ref to the
adapter, so the datastore lookup matches regardless of the casing of the input address. With the type
resolved, the inherited pool-role grant runs and the pool receives its mint/burn role.

Design choices:

- **Normalize at the source.** Done once in `deployment/tokens` (the deploy loop) where the ref is
  built, reusing the existing per-family `AddressNormalizer` — no change to the shared/framework
  datastore filter or to per-version adapters.
- **Localized.** Addresses are canonicalized for EVM by applying the EIP-55 checksum; other access
  to token/pool refs via the existing resolution helpers already normalizes, so the fix closes the one
  path that did not.
- **Required-role semantics.** A burn/mint pool cannot function without the token-side role; ensuring
  the ref resolves so the grant runs (rather than silently skipping) is the correct behavior.

Note: the grant mechanism itself is inherited and intact; the defect was the ref being resolved in
the wrong casing, not the grant logic.

## 2. Add-lane configure is resilient to RPC view-lag and idempotent on re-runs

**Problem.** Activating a pool that adds lanes and configures rate limits in one sequence hit two
failure modes on re-runs after partial application: a spurious `NonExistentChain` on the rate-limit
write (the lane-add not yet visible to the RPC's estimate view — a timing/visibility race), and
non-idempotent state-changing reads (report replay causing redundant/incorrect writes).

**Changes.** The decision-bearing reads (`getSupportedChains`, `getRemoteToken`, `getRemotePools`,
`getCurrentRateLimiterState` at both call sites) are forced fresh, and `SetRateLimitConfig` is wrapped
in a bounded, block-scale, context-cancellation-aware retry with per-attempt logging. Fresh reads make
add-vs-skip and emit-vs-skip decisions reflect current on-chain state; the retry bridges the intrinsic
timing window of a write for a lane being added in the same sequence (e.g. fast-finality buckets).

## 3. Reverse-propagation no longer left-pads the remote pool address

**Problem.** During `autoMigrateRemoteChains` reverse-propagation, the migrated pool/token bytes are
handed to each counterpart adapter via the change set's `RemoteChains`. Both were being left-padded to
32 bytes (`LeftPadBytes(…, 32)`). The **token** padding matches the established forward
path convention, but the **pool** padding is the responsibility of each counterpart adapter and is
misleading when left-padded at this layer:
- EVM counterpart adapters already left-pad the `RemotePool` themselves (they maintain their own
  32-byte abi on-chain bytes across all versions), so padding here was redundant for EVM.
- A **Solana** counterpart `AppendRemotePoolAddresses` stores the bytes verbatim and later does a
  byte-exact `contains` against the message's **20-byte** `sourcePoolAddress`. Padding the pool to 32
  caused Solana to register a 32-byte-padded pool, so every EVM→Solana send reverted
  `InvalidSourcePoolAddress` even though the append reported success.

**This change.** The reverse-prop `RemoteChains` now passes the **raw source-family pool bytes**
(EVM: 20-byte) and keeps only the **token** left-padded. Each counterpart adapter is responsible for
normalizing the `RemotePool` to its own on-chain form (the EVM adapters already do), so Solana
receives the 20-byte address it compares against.

Design choices:

- **Asymmetric on purpose — and documented:** the remote **token** stays 32-byte padded (forward-path
  convention); the remote **pool** is left unpadded because adapters normalize it. This asymmetry is
  the actual contract and is called out in the code so it isn't "fixed" the wrong way later.
- **Family normalization belongs at the family edge.** The top-level `deployment/tokens` code stays
  chain-agnostic; it does not assert a pool byte width. Each counterpart adapter encodes the pool for
  its own chain — the same pluggable boundary that already exists for `addRemotePool` /
  `AppendRemotePoolAddresses`.
- **Minimal, targeted.** One line, plus the explanatory comment; EVM behavior is unchanged (the EVM
  adapters re-pad), and Solana EVM→Solana transfers resume.

## Intended behavior change

- A burn/mint pool deployed via token expansion always receives its mint/burn role (no silent skip
  from a case-mismatched ref), so it can mint on the destination.
- The v2 add-lane path is resilient to RPC view-lag and idempotent across repeated or partial
  activations.
- `autoMigrateRemoteChains` reverse-propagation no longer corrupts the remote pool address: token
  stays 32-byte padded, pool is passed unpadded and normalized per counterpart, so EVM→Solana
  transfers won't revert `InvalidSourcePoolAddress` from a padded remote pool.
