### PR TITLE
CCIP-12654 - [TOOLING]: ERC20LockBox - applyAuthorizedCallerUpdates Support

### DIFF
--- a/chains/evm/deployment/v2_0_0/changesets/update_lockbox_authorized_callers.go
+++ b/chains/evm/deployment/v2_0_0/changesets/update_lockbox_authorized_callers.go
@@ -3,11 +3,9 @@ package changesets
 import (
 	"fmt"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
 	chain_selectors "github.com/smartcontractkit/chain-selectors"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
-	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf_deployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	mcms_types "github.com/smartcontractkit/mcms/types"
@@ -16,7 +14,6 @@ import (
 	lbops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/erc20_lock_box"
 	common_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils"
 	cs_changesets "github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
-	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 )
 
 // LockboxCallerUpdate is one lockbox's authorized-caller change. The chain it lives on comes
@@ -26,7 +23,9 @@ import (
 // side-effect of whichever sequence deployed the lockbox - the pool qualifier for a plain
 // lock-release pool, "<poolQualifier>-silo(<minRemoteSelector>)" per silo group, or
 // "remoteChainSelector(<selector>)" for siloed USDC - so they are not a stable addressing
-// scheme. Address is unambiguous, and verify confirms it really is a lockbox.
+// scheme. Address is unambiguous. A wrong address fails on-chain when the read or write
+// reverts, rather than being pre-checked against the datastore - datastore refs go missing
+// routinely, and blocking on one would force operators to hand-add refs just to proceed.
 type LockboxCallerUpdate struct {
 	Address common.Address   `json:"address"  yaml:"address"`
 	Appends []common.Address `json:"appends,omitempty"  yaml:"appends,omitempty"`
@@ -42,10 +41,9 @@ type ChainLockboxUpdate struct {
 }
 
 type UpdateLockboxAuthorizedCallersCfg struct {
-	// Version is cross-checked against the datastore ref for every Address, so a config
-	// written for one lockbox version cannot silently act on a newer one.
-	Version *semver.Version      `json:"version" yaml:"version"`
-	Input   []ChainLockboxUpdate `json:"input"   yaml:"input"`
+	// Version is not a field: this package is v2_0_0, so the target lockbox version is
+	// already pinned by the changeset the operator picked.
+	Input []ChainLockboxUpdate `json:"input" yaml:"input"`
 }
 
 var UpdateLockboxAuthorizedCallers = func(
@@ -64,9 +62,6 @@ func verifyUpdateLockboxAuthorizedCallers(
 	cfg := input.Cfg
 	if len(cfg.Input) == 0 {
 		return fmt.Errorf("at least one entry is required in input")
-	}
-	if cfg.Version == nil {
-		return fmt.Errorf("version is required so the target lockbox version can be cross-checked")
 	}
 
 	evmChains := e.BlockChains.EVMChains()
@@ -132,66 +127,7 @@ func verifyUpdateLockboxAuthorizedCallers(
 		}
 	}
 
-	// Every target is confirmed before any chain is touched, so a bad entry cannot leave
-	// earlier chains half-applied.
-	if err := checkLockboxRefs(e.DataStore, cfg); err != nil {
-		return err
-	}
-
-	// Validated against a populated copy so ValidUntil stays optional while a value the
-	// operator did supply is still rejected if it is unusable. The qualifier needs no
-	// default here: EVMMCMSReader.GetTimelockRef and GetMCMSRef already fall back to
-	// CLLQualifier when it is empty.
-	mcmsInput := input.MCMS
-	if err := mcmsInput.PopulateDefaults(); err != nil {
-		return fmt.Errorf("failed to populate MCMS defaults: %w", err)
-	}
-	if err := mcmsInput.Validate(); err != nil {
-		return fmt.Errorf("invalid MCMS input: %w", err)
-	}
-
 	return nil
-}
-
-// checkLockboxRefs confirms every Address resolves in the datastore to an ERC20LockBox at
-// the configured version on the chain it is nested under.
-func checkLockboxRefs(ds datastore.DataStore, cfg UpdateLockboxAuthorizedCallersCfg) error {
-	for _, chainUpdate := range cfg.Input {
-		sel := chainUpdate.Selector
-		for _, update := range chainUpdate.Lockboxes {
-			refs := ds.Addresses().Filter(datastore_utils.AddressRefToFilters(datastore.AddressRef{
-				ChainSelector: sel,
-				Address:       update.Address.Hex(),
-			})...)
-			if len(refs) != 1 {
-				return fmt.Errorf(
-					"expected exactly 1 datastore ref for address %s on chain %d, found %d",
-					update.Address, sel, len(refs))
-			}
-
-			ref := refs[0]
-			if ref.Type != datastore.ContractType(lbops.ContractType) {
-				return fmt.Errorf(
-					"address %s on chain %d is a %q, not an %s",
-					update.Address, sel, ref.Type, lbops.ContractType)
-			}
-			if ref.Version == nil || !ref.Version.Equal(cfg.Version) {
-				return fmt.Errorf(
-					"lockbox %s on chain %d is version %s, but config specifies %s",
-					update.Address, sel, versionString(ref.Version), cfg.Version)
-			}
-		}
-	}
-
-	return nil
-}
-
-func versionString(v *semver.Version) string {
-	if v == nil {
-		return "<nil>"
-	}
-
-	return v.String()
 }
 
 func applyUpdateLockboxAuthorizedCallers(
@@ -202,15 +138,6 @@ func applyUpdateLockboxAuthorizedCallers(
 		input cs_changesets.WithMCMS[UpdateLockboxAuthorizedCallersCfg],
 	) (cldf_deployment.ChangesetOutput, error) {
 		cfg := input.Cfg
-		if cfg.Version == nil {
-			return cldf_deployment.ChangesetOutput{}, fmt.Errorf("version is required")
-		}
-
-		// Re-checked here because Apply is callable without VerifyPreconditions, and every
-		// target must be known good before the first write goes out.
-		if err := checkLockboxRefs(e.DataStore, cfg); err != nil {
-			return cldf_deployment.ChangesetOutput{}, err
-		}
 
 		batchOps := make([]mcms_types.BatchOperation, 0, len(cfg.Input))
 		reports := make([]cldf_ops.Report[any, any], 0, len(cfg.Input))
@@ -231,17 +158,17 @@ func applyUpdateLockboxAuthorizedCallers(
 			for _, update := range chainUpdate.Lockboxes {
 				lockboxAddr := update.Address
 
-				// Read current authorized callers with a fresh bundle so idempotency
-				// reads are not served from a cached report.
-				readBundle := cldf_ops.NewBundle(
-					e.GetContext, e.Logger, cldf_ops.NewMemoryReporter())
+				// WithForceExecute so the idempotency read is never served from a cached
+				// report: a re-run after an out-of-band change has to see current state.
 				currentReport, err := cldf_ops.ExecuteOperation(
-					readBundle, lbops.GetAllAuthorizedCallers, chain,
+					e.OperationsBundle, lbops.GetAllAuthorizedCallers, chain,
 					contract.FunctionInput[struct{}]{
 						ChainSelector: chain.Selector,
 						Address:       lockboxAddr,
 						Args:          struct{}{},
-					})
+					},
+					cldf_ops.WithForceExecute[contract.FunctionInput[struct{}], evm.Chain](),
+				)
 				if err != nil {
 					return cldf_deployment.ChangesetOutput{}, fmt.Errorf(
 						"failed to read authorized callers on chain %d: %w", sel, err)
@@ -288,12 +215,11 @@ func applyUpdateLockboxAuthorizedCallers(
 							RemovedCallers: filteredRemoves,
 						},
 					},
-					// The shared bundle replays a cached report for an identical operation and
-					// input. The reads above dodge that with a fresh bundle; the write needs
-					// the same guarantee, or a re-apply after an out-of-band change would
-					// return the stale executed write and report success having done nothing.
-					// applyAuthorizedCallerUpdates is a set operation on-chain, so re-running
-					// it is harmless.
+					// Same reason as the read above: the shared bundle would replay a cached
+					// report for an identical operation and input, so a re-apply after an
+					// out-of-band change would return the stale executed write and report
+					// success having done nothing. applyAuthorizedCallerUpdates is a set
+					// operation on-chain, so re-running it is harmless.
 					cldf_ops.WithForceExecute[contract.FunctionInput[lbops.AuthorizedCallerArgs], evm.Chain](),
 				)
 				if err != nil {

--- a/chains/evm/deployment/v2_0_0/changesets/update_lockbox_authorized_callers.go
+++ b/chains/evm/deployment/v2_0_0/changesets/update_lockbox_authorized_callers.go
@@ -1,0 +1,299 @@
+package changesets
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/ethereum/go-ethereum/common"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf_deployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	mcms_types "github.com/smartcontractkit/mcms/types"
+
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
+	lbops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/erc20_lock_box"
+	common_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils"
+	cs_changesets "github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
+	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
+)
+
+// LockboxCallerUpdate is one chain's authorized-caller change for one lockbox.
+//
+// The lockbox is named by Address rather than by datastore qualifier. Qualifiers are a
+// side-effect of whichever sequence deployed the lockbox - the pool qualifier for a plain
+// lock-release pool, "<poolQualifier>-silo(<minRemoteSelector>)" per silo group, or
+// "remoteChainSelector(<selector>)" for siloed USDC - so they are not a stable addressing
+// scheme. Address is unambiguous, and verify confirms it really is a lockbox.
+type LockboxCallerUpdate struct {
+	Selector uint64           `json:"selector" yaml:"selector"`
+	Address  common.Address   `json:"address"  yaml:"address"`
+	Appends  []common.Address `json:"appends,omitempty"  yaml:"appends,omitempty"`
+	Removes  []common.Address `json:"removes,omitempty"  yaml:"removes,omitempty"`
+}
+
+type UpdateLockboxAuthorizedCallersCfg struct {
+	// Version is cross-checked against the datastore ref for every Address, so a config
+	// written for one lockbox version cannot silently act on a newer one.
+	Version *semver.Version       `json:"version" yaml:"version"`
+	Input   []LockboxCallerUpdate `json:"input"   yaml:"input"`
+}
+
+var UpdateLockboxAuthorizedCallers = func(
+	mcmsRegistry *cs_changesets.MCMSReaderRegistry,
+) cldf_deployment.ChangeSetV2[cs_changesets.WithMCMS[UpdateLockboxAuthorizedCallersCfg]] {
+	return cldf_deployment.CreateChangeSet(
+		applyUpdateLockboxAuthorizedCallers(mcmsRegistry),
+		verifyUpdateLockboxAuthorizedCallers,
+	)
+}
+
+func verifyUpdateLockboxAuthorizedCallers(
+	e cldf_deployment.Environment,
+	input cs_changesets.WithMCMS[UpdateLockboxAuthorizedCallersCfg],
+) error {
+	cfg := input.Cfg
+	if len(cfg.Input) == 0 {
+		return fmt.Errorf("at least one entry is required in input")
+	}
+	if cfg.Version == nil {
+		return fmt.Errorf("version is required so the target lockbox version can be cross-checked")
+	}
+
+	evmChains := e.BlockChains.EVMChains()
+	// Keyed on chain AND address, not chain alone: a chain legitimately holds several
+	// lockboxes (one per token, per silo group, or per remote chain), so several entries
+	// may share a selector. Only the same lockbox twice is a mistake.
+	type lockboxKey struct {
+		selector uint64
+		address  common.Address
+	}
+	seen := common_utils.NewSet[lockboxKey]()
+
+	for _, update := range cfg.Input {
+		sel := update.Selector
+		if _, err := chain_selectors.GetSelectorFamily(sel); err != nil {
+			return fmt.Errorf("invalid chain selector %d: %w", sel, err)
+		}
+		if _, ok := evmChains[sel]; !ok {
+			return fmt.Errorf("chain selector %d not found in environment EVM chains", sel)
+		}
+		if update.Address == (common.Address{}) {
+			return fmt.Errorf("zero lockbox address for chain %d", sel)
+		}
+		if seen.Add(lockboxKey{selector: sel, address: update.Address}) {
+			return fmt.Errorf(
+				"duplicate entry for lockbox %s on chain %d: merge them into a single entry",
+				update.Address, sel)
+		}
+
+		appends := common_utils.NewSet[common.Address]()
+		for _, addr := range update.Appends {
+			if addr == (common.Address{}) {
+				return fmt.Errorf("zero address in appends for chain %d", sel)
+			}
+			if appends.Add(addr) {
+				return fmt.Errorf("duplicate address %s in appends for chain %d", addr, sel)
+			}
+		}
+
+		removes := common_utils.NewSet[common.Address]()
+		for _, addr := range update.Removes {
+			if addr == (common.Address{}) {
+				return fmt.Errorf("zero address in removes for chain %d", sel)
+			}
+			if removes.Add(addr) {
+				return fmt.Errorf("duplicate address %s in removes for chain %d", addr, sel)
+			}
+			// An address in both lists never converges: the idempotency filter drops
+			// whichever side matches current on-chain state, so each apply flips it.
+			if appends.Has(addr) {
+				return fmt.Errorf(
+					"address %s is in both appends and removes for chain %d", addr, sel)
+			}
+		}
+	}
+
+	// Every target is confirmed before any chain is touched, so a bad entry cannot leave
+	// earlier chains half-applied.
+	if err := checkLockboxRefs(e.DataStore, cfg); err != nil {
+		return err
+	}
+
+	// Validated against a populated copy so ValidUntil stays optional while a value the
+	// operator did supply is still rejected if it is unusable. The qualifier needs no
+	// default here: EVMMCMSReader.GetTimelockRef and GetMCMSRef already fall back to
+	// CLLQualifier when it is empty.
+	mcmsInput := input.MCMS
+	if err := mcmsInput.PopulateDefaults(); err != nil {
+		return fmt.Errorf("failed to populate MCMS defaults: %w", err)
+	}
+	if err := mcmsInput.Validate(); err != nil {
+		return fmt.Errorf("invalid MCMS input: %w", err)
+	}
+
+	return nil
+}
+
+// checkLockboxRefs confirms every Address resolves in the datastore to an ERC20LockBox at
+// the configured version on the configured chain.
+func checkLockboxRefs(ds datastore.DataStore, cfg UpdateLockboxAuthorizedCallersCfg) error {
+	for _, update := range cfg.Input {
+		refs := ds.Addresses().Filter(datastore_utils.AddressRefToFilters(datastore.AddressRef{
+			ChainSelector: update.Selector,
+			Address:       update.Address.Hex(),
+		})...)
+		if len(refs) != 1 {
+			return fmt.Errorf(
+				"expected exactly 1 datastore ref for address %s on chain %d, found %d",
+				update.Address, update.Selector, len(refs))
+		}
+
+		ref := refs[0]
+		if ref.Type != datastore.ContractType(lbops.ContractType) {
+			return fmt.Errorf(
+				"address %s on chain %d is a %q, not an %s",
+				update.Address, update.Selector, ref.Type, lbops.ContractType)
+		}
+		if ref.Version == nil || !ref.Version.Equal(cfg.Version) {
+			return fmt.Errorf(
+				"lockbox %s on chain %d is version %s, but config specifies %s",
+				update.Address, update.Selector, versionString(ref.Version), cfg.Version)
+		}
+	}
+
+	return nil
+}
+
+func versionString(v *semver.Version) string {
+	if v == nil {
+		return "<nil>"
+	}
+
+	return v.String()
+}
+
+func applyUpdateLockboxAuthorizedCallers(
+	mcmsRegistry *cs_changesets.MCMSReaderRegistry,
+) func(cldf_deployment.Environment, cs_changesets.WithMCMS[UpdateLockboxAuthorizedCallersCfg]) (cldf_deployment.ChangesetOutput, error) {
+	return func(
+		e cldf_deployment.Environment,
+		input cs_changesets.WithMCMS[UpdateLockboxAuthorizedCallersCfg],
+	) (cldf_deployment.ChangesetOutput, error) {
+		cfg := input.Cfg
+		if cfg.Version == nil {
+			return cldf_deployment.ChangesetOutput{}, fmt.Errorf("version is required")
+		}
+
+		// Re-checked here because Apply is callable without VerifyPreconditions, and every
+		// target must be known good before the first write goes out.
+		if err := checkLockboxRefs(e.DataStore, cfg); err != nil {
+			return cldf_deployment.ChangesetOutput{}, err
+		}
+
+		batchOps := make([]mcms_types.BatchOperation, 0, len(cfg.Input))
+		reports := make([]cldf_ops.Report[any, any], 0, len(cfg.Input))
+		evmChains := e.BlockChains.EVMChains()
+
+		// Input order is the operator's order, so batch operation order - and therefore the
+		// MCMS proposal's merkle root - is reproducible for a given config.
+		for _, update := range cfg.Input {
+			sel := update.Selector
+			chain, ok := evmChains[sel]
+			if !ok {
+				return cldf_deployment.ChangesetOutput{}, fmt.Errorf(
+					"chain selector %d not found in environment EVM chains", sel)
+			}
+			lockboxAddr := update.Address
+
+			// Read current authorized callers with a fresh bundle so idempotency
+			// reads are not served from a cached report.
+			readBundle := cldf_ops.NewBundle(
+				e.GetContext, e.Logger, cldf_ops.NewMemoryReporter())
+			currentReport, err := cldf_ops.ExecuteOperation(
+				readBundle, lbops.GetAllAuthorizedCallers, chain,
+				contract.FunctionInput[struct{}]{
+					ChainSelector: chain.Selector,
+					Address:       lockboxAddr,
+					Args:          struct{}{},
+				})
+			if err != nil {
+				return cldf_deployment.ChangesetOutput{}, fmt.Errorf(
+					"failed to read authorized callers on chain %d: %w", sel, err)
+			}
+
+			currentSet := common_utils.NewSet[common.Address]()
+			for _, c := range currentReport.Output {
+				currentSet.Add(c)
+			}
+
+			filteredAppends := make([]common.Address, 0, len(update.Appends))
+			for _, a := range update.Appends {
+				if !currentSet.Has(a) {
+					filteredAppends = append(filteredAppends, a)
+				}
+			}
+
+			filteredRemoves := make([]common.Address, 0, len(update.Removes))
+			for _, r := range update.Removes {
+				if currentSet.Has(r) {
+					filteredRemoves = append(filteredRemoves, r)
+				}
+			}
+
+			if len(filteredAppends) == 0 && len(filteredRemoves) == 0 {
+				e.Logger.Infof(
+					"No-op: authorized caller updates already applied on lockbox %s on chain %d, skipping",
+					lockboxAddr, sel)
+
+				continue
+			}
+
+			e.Logger.Infof(
+				"Applying authorized caller updates on lockbox %s on chain %d: +%d -%d callers",
+				lockboxAddr, sel, len(filteredAppends), len(filteredRemoves))
+
+			report, err := cldf_ops.ExecuteOperation(
+				e.OperationsBundle, lbops.ApplyAuthorizedCallerUpdates, chain,
+				contract.FunctionInput[lbops.AuthorizedCallerArgs]{
+					ChainSelector: chain.Selector,
+					Address:       lockboxAddr,
+					Args: lbops.AuthorizedCallerArgs{
+						AddedCallers:   filteredAppends,
+						RemovedCallers: filteredRemoves,
+					},
+				},
+				// The shared bundle replays a cached report for an identical operation and
+				// input. The reads above dodge that with a fresh bundle; the write needs
+				// the same guarantee, or a re-apply after an out-of-band change would
+				// return the stale executed write and report success having done nothing.
+				// applyAuthorizedCallerUpdates is a set operation on-chain, so re-running
+				// it is harmless.
+				cldf_ops.WithForceExecute[contract.FunctionInput[lbops.AuthorizedCallerArgs], evm.Chain](),
+			)
+			if err != nil {
+				return cldf_deployment.ChangesetOutput{}, fmt.Errorf(
+					"failed to apply authorized caller updates on chain %d: %w", sel, err)
+			}
+
+			reports = append(reports, report.ToGenericReport())
+
+			batch, err := contract.NewBatchOperationFromWrites(
+				[]contract.WriteOutput{report.Output})
+			if err != nil {
+				return cldf_deployment.ChangesetOutput{}, fmt.Errorf(
+					"failed to create batch from writes on chain %d: %w", sel, err)
+			}
+			batchOps = append(batchOps, batch)
+		}
+
+		// SingleBatchOpPerChain, not BatchOps: a chain can have several lockboxes updated
+		// in one run, and MCMS expects all operations for a chain in one batch operation so
+		// they execute atomically rather than as separately-executable units.
+		return cs_changesets.NewOutputBuilder(e, mcmsRegistry).
+			WithReports(reports).
+			WithSingleBatchOpPerChain(batchOps).
+			Build(input.MCMS)
+	}
+}

--- a/chains/evm/deployment/v2_0_0/changesets/update_lockbox_authorized_callers.go
+++ b/chains/evm/deployment/v2_0_0/changesets/update_lockbox_authorized_callers.go
@@ -19,7 +19,8 @@ import (
 	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 )
 
-// LockboxCallerUpdate is one chain's authorized-caller change for one lockbox.
+// LockboxCallerUpdate is one lockbox's authorized-caller change. The chain it lives on comes
+// from the enclosing ChainLockboxUpdate.
 //
 // The lockbox is named by Address rather than by datastore qualifier. Qualifiers are a
 // side-effect of whichever sequence deployed the lockbox - the pool qualifier for a plain
@@ -27,17 +28,24 @@ import (
 // "remoteChainSelector(<selector>)" for siloed USDC - so they are not a stable addressing
 // scheme. Address is unambiguous, and verify confirms it really is a lockbox.
 type LockboxCallerUpdate struct {
-	Selector uint64           `json:"selector" yaml:"selector"`
-	Address  common.Address   `json:"address"  yaml:"address"`
-	Appends  []common.Address `json:"appends,omitempty"  yaml:"appends,omitempty"`
-	Removes  []common.Address `json:"removes,omitempty"  yaml:"removes,omitempty"`
+	Address common.Address   `json:"address"  yaml:"address"`
+	Appends []common.Address `json:"appends,omitempty"  yaml:"appends,omitempty"`
+	Removes []common.Address `json:"removes,omitempty"  yaml:"removes,omitempty"`
+}
+
+// ChainLockboxUpdate groups every lockbox update for one chain under that chain's selector.
+// A chain legitimately holds several lockboxes - one per token, per silo group, or per
+// remote chain - and nesting them keeps the selector written once per chain.
+type ChainLockboxUpdate struct {
+	Selector  uint64                `json:"selector"  yaml:"selector"`
+	Lockboxes []LockboxCallerUpdate `json:"lockboxes" yaml:"lockboxes"`
 }
 
 type UpdateLockboxAuthorizedCallersCfg struct {
 	// Version is cross-checked against the datastore ref for every Address, so a config
 	// written for one lockbox version cannot silently act on a newer one.
-	Version *semver.Version       `json:"version" yaml:"version"`
-	Input   []LockboxCallerUpdate `json:"input"   yaml:"input"`
+	Version *semver.Version      `json:"version" yaml:"version"`
+	Input   []ChainLockboxUpdate `json:"input"   yaml:"input"`
 }
 
 var UpdateLockboxAuthorizedCallers = func(
@@ -62,55 +70,64 @@ func verifyUpdateLockboxAuthorizedCallers(
 	}
 
 	evmChains := e.BlockChains.EVMChains()
-	// Keyed on chain AND address, not chain alone: a chain legitimately holds several
-	// lockboxes (one per token, per silo group, or per remote chain), so several entries
-	// may share a selector. Only the same lockbox twice is a mistake.
-	type lockboxKey struct {
-		selector uint64
-		address  common.Address
-	}
-	seen := common_utils.NewSet[lockboxKey]()
+	seenChains := common_utils.NewSet[uint64]()
 
-	for _, update := range cfg.Input {
-		sel := update.Selector
+	for _, chainUpdate := range cfg.Input {
+		sel := chainUpdate.Selector
 		if _, err := chain_selectors.GetSelectorFamily(sel); err != nil {
 			return fmt.Errorf("invalid chain selector %d: %w", sel, err)
 		}
 		if _, ok := evmChains[sel]; !ok {
 			return fmt.Errorf("chain selector %d not found in environment EVM chains", sel)
 		}
-		if update.Address == (common.Address{}) {
-			return fmt.Errorf("zero lockbox address for chain %d", sel)
-		}
-		if seen.Add(lockboxKey{selector: sel, address: update.Address}) {
+		// Each chain appears once and carries all of its lockboxes, so the nesting - and
+		// therefore the single batch operation built per chain in apply - is unambiguous.
+		if seenChains.Add(sel) {
 			return fmt.Errorf(
-				"duplicate entry for lockbox %s on chain %d: merge them into a single entry",
-				update.Address, sel)
+				"duplicate entry for chain %d: merge its lockboxes into a single entry", sel)
+		}
+		if len(chainUpdate.Lockboxes) == 0 {
+			return fmt.Errorf("no lockboxes listed for chain %d", sel)
 		}
 
-		appends := common_utils.NewSet[common.Address]()
-		for _, addr := range update.Appends {
-			if addr == (common.Address{}) {
-				return fmt.Errorf("zero address in appends for chain %d", sel)
-			}
-			if appends.Add(addr) {
-				return fmt.Errorf("duplicate address %s in appends for chain %d", addr, sel)
-			}
-		}
+		// Scoped to the chain: the same lockbox address twice on one chain is a mistake,
+		// but the same address on two chains is a coincidence, not an error.
+		seenLockboxes := common_utils.NewSet[common.Address]()
 
-		removes := common_utils.NewSet[common.Address]()
-		for _, addr := range update.Removes {
-			if addr == (common.Address{}) {
-				return fmt.Errorf("zero address in removes for chain %d", sel)
+		for _, update := range chainUpdate.Lockboxes {
+			if update.Address == (common.Address{}) {
+				return fmt.Errorf("zero lockbox address for chain %d", sel)
 			}
-			if removes.Add(addr) {
-				return fmt.Errorf("duplicate address %s in removes for chain %d", addr, sel)
-			}
-			// An address in both lists never converges: the idempotency filter drops
-			// whichever side matches current on-chain state, so each apply flips it.
-			if appends.Has(addr) {
+			if seenLockboxes.Add(update.Address) {
 				return fmt.Errorf(
-					"address %s is in both appends and removes for chain %d", addr, sel)
+					"duplicate entry for lockbox %s on chain %d: merge them into a single entry",
+					update.Address, sel)
+			}
+
+			appends := common_utils.NewSet[common.Address]()
+			for _, addr := range update.Appends {
+				if addr == (common.Address{}) {
+					return fmt.Errorf("zero address in appends for chain %d", sel)
+				}
+				if appends.Add(addr) {
+					return fmt.Errorf("duplicate address %s in appends for chain %d", addr, sel)
+				}
+			}
+
+			removes := common_utils.NewSet[common.Address]()
+			for _, addr := range update.Removes {
+				if addr == (common.Address{}) {
+					return fmt.Errorf("zero address in removes for chain %d", sel)
+				}
+				if removes.Add(addr) {
+					return fmt.Errorf("duplicate address %s in removes for chain %d", addr, sel)
+				}
+				// An address in both lists never converges: the idempotency filter drops
+				// whichever side matches current on-chain state, so each apply flips it.
+				if appends.Has(addr) {
+					return fmt.Errorf(
+						"address %s is in both appends and removes for chain %d", addr, sel)
+				}
 			}
 		}
 	}
@@ -137,29 +154,32 @@ func verifyUpdateLockboxAuthorizedCallers(
 }
 
 // checkLockboxRefs confirms every Address resolves in the datastore to an ERC20LockBox at
-// the configured version on the configured chain.
+// the configured version on the chain it is nested under.
 func checkLockboxRefs(ds datastore.DataStore, cfg UpdateLockboxAuthorizedCallersCfg) error {
-	for _, update := range cfg.Input {
-		refs := ds.Addresses().Filter(datastore_utils.AddressRefToFilters(datastore.AddressRef{
-			ChainSelector: update.Selector,
-			Address:       update.Address.Hex(),
-		})...)
-		if len(refs) != 1 {
-			return fmt.Errorf(
-				"expected exactly 1 datastore ref for address %s on chain %d, found %d",
-				update.Address, update.Selector, len(refs))
-		}
+	for _, chainUpdate := range cfg.Input {
+		sel := chainUpdate.Selector
+		for _, update := range chainUpdate.Lockboxes {
+			refs := ds.Addresses().Filter(datastore_utils.AddressRefToFilters(datastore.AddressRef{
+				ChainSelector: sel,
+				Address:       update.Address.Hex(),
+			})...)
+			if len(refs) != 1 {
+				return fmt.Errorf(
+					"expected exactly 1 datastore ref for address %s on chain %d, found %d",
+					update.Address, sel, len(refs))
+			}
 
-		ref := refs[0]
-		if ref.Type != datastore.ContractType(lbops.ContractType) {
-			return fmt.Errorf(
-				"address %s on chain %d is a %q, not an %s",
-				update.Address, update.Selector, ref.Type, lbops.ContractType)
-		}
-		if ref.Version == nil || !ref.Version.Equal(cfg.Version) {
-			return fmt.Errorf(
-				"lockbox %s on chain %d is version %s, but config specifies %s",
-				update.Address, update.Selector, versionString(ref.Version), cfg.Version)
+			ref := refs[0]
+			if ref.Type != datastore.ContractType(lbops.ContractType) {
+				return fmt.Errorf(
+					"address %s on chain %d is a %q, not an %s",
+					update.Address, sel, ref.Type, lbops.ContractType)
+			}
+			if ref.Version == nil || !ref.Version.Equal(cfg.Version) {
+				return fmt.Errorf(
+					"lockbox %s on chain %d is version %s, but config specifies %s",
+					update.Address, sel, versionString(ref.Version), cfg.Version)
+			}
 		}
 	}
 
@@ -198,89 +218,98 @@ func applyUpdateLockboxAuthorizedCallers(
 
 		// Input order is the operator's order, so batch operation order - and therefore the
 		// MCMS proposal's merkle root - is reproducible for a given config.
-		for _, update := range cfg.Input {
-			sel := update.Selector
+		for _, chainUpdate := range cfg.Input {
+			sel := chainUpdate.Selector
 			chain, ok := evmChains[sel]
 			if !ok {
 				return cldf_deployment.ChangesetOutput{}, fmt.Errorf(
 					"chain selector %d not found in environment EVM chains", sel)
 			}
-			lockboxAddr := update.Address
 
-			// Read current authorized callers with a fresh bundle so idempotency
-			// reads are not served from a cached report.
-			readBundle := cldf_ops.NewBundle(
-				e.GetContext, e.Logger, cldf_ops.NewMemoryReporter())
-			currentReport, err := cldf_ops.ExecuteOperation(
-				readBundle, lbops.GetAllAuthorizedCallers, chain,
-				contract.FunctionInput[struct{}]{
-					ChainSelector: chain.Selector,
-					Address:       lockboxAddr,
-					Args:          struct{}{},
-				})
-			if err != nil {
-				return cldf_deployment.ChangesetOutput{}, fmt.Errorf(
-					"failed to read authorized callers on chain %d: %w", sel, err)
-			}
+			writes := make([]contract.WriteOutput, 0, len(chainUpdate.Lockboxes))
 
-			currentSet := common_utils.NewSet[common.Address]()
-			for _, c := range currentReport.Output {
-				currentSet.Add(c)
-			}
+			for _, update := range chainUpdate.Lockboxes {
+				lockboxAddr := update.Address
 
-			filteredAppends := make([]common.Address, 0, len(update.Appends))
-			for _, a := range update.Appends {
-				if !currentSet.Has(a) {
-					filteredAppends = append(filteredAppends, a)
+				// Read current authorized callers with a fresh bundle so idempotency
+				// reads are not served from a cached report.
+				readBundle := cldf_ops.NewBundle(
+					e.GetContext, e.Logger, cldf_ops.NewMemoryReporter())
+				currentReport, err := cldf_ops.ExecuteOperation(
+					readBundle, lbops.GetAllAuthorizedCallers, chain,
+					contract.FunctionInput[struct{}]{
+						ChainSelector: chain.Selector,
+						Address:       lockboxAddr,
+						Args:          struct{}{},
+					})
+				if err != nil {
+					return cldf_deployment.ChangesetOutput{}, fmt.Errorf(
+						"failed to read authorized callers on chain %d: %w", sel, err)
 				}
-			}
 
-			filteredRemoves := make([]common.Address, 0, len(update.Removes))
-			for _, r := range update.Removes {
-				if currentSet.Has(r) {
-					filteredRemoves = append(filteredRemoves, r)
+				currentSet := common_utils.NewSet[common.Address]()
+				for _, c := range currentReport.Output {
+					currentSet.Add(c)
 				}
-			}
 
-			if len(filteredAppends) == 0 && len(filteredRemoves) == 0 {
+				filteredAppends := make([]common.Address, 0, len(update.Appends))
+				for _, a := range update.Appends {
+					if !currentSet.Has(a) {
+						filteredAppends = append(filteredAppends, a)
+					}
+				}
+
+				filteredRemoves := make([]common.Address, 0, len(update.Removes))
+				for _, r := range update.Removes {
+					if currentSet.Has(r) {
+						filteredRemoves = append(filteredRemoves, r)
+					}
+				}
+
+				if len(filteredAppends) == 0 && len(filteredRemoves) == 0 {
+					e.Logger.Infof(
+						"No-op: authorized caller updates already applied on lockbox %s on chain %d, skipping",
+						lockboxAddr, sel)
+
+					continue
+				}
+
 				e.Logger.Infof(
-					"No-op: authorized caller updates already applied on lockbox %s on chain %d, skipping",
-					lockboxAddr, sel)
+					"Applying authorized caller updates on lockbox %s on chain %d: +%d -%d callers",
+					lockboxAddr, sel, len(filteredAppends), len(filteredRemoves))
 
-				continue
-			}
-
-			e.Logger.Infof(
-				"Applying authorized caller updates on lockbox %s on chain %d: +%d -%d callers",
-				lockboxAddr, sel, len(filteredAppends), len(filteredRemoves))
-
-			report, err := cldf_ops.ExecuteOperation(
-				e.OperationsBundle, lbops.ApplyAuthorizedCallerUpdates, chain,
-				contract.FunctionInput[lbops.AuthorizedCallerArgs]{
-					ChainSelector: chain.Selector,
-					Address:       lockboxAddr,
-					Args: lbops.AuthorizedCallerArgs{
-						AddedCallers:   filteredAppends,
-						RemovedCallers: filteredRemoves,
+				report, err := cldf_ops.ExecuteOperation(
+					e.OperationsBundle, lbops.ApplyAuthorizedCallerUpdates, chain,
+					contract.FunctionInput[lbops.AuthorizedCallerArgs]{
+						ChainSelector: chain.Selector,
+						Address:       lockboxAddr,
+						Args: lbops.AuthorizedCallerArgs{
+							AddedCallers:   filteredAppends,
+							RemovedCallers: filteredRemoves,
+						},
 					},
-				},
-				// The shared bundle replays a cached report for an identical operation and
-				// input. The reads above dodge that with a fresh bundle; the write needs
-				// the same guarantee, or a re-apply after an out-of-band change would
-				// return the stale executed write and report success having done nothing.
-				// applyAuthorizedCallerUpdates is a set operation on-chain, so re-running
-				// it is harmless.
-				cldf_ops.WithForceExecute[contract.FunctionInput[lbops.AuthorizedCallerArgs], evm.Chain](),
-			)
-			if err != nil {
-				return cldf_deployment.ChangesetOutput{}, fmt.Errorf(
-					"failed to apply authorized caller updates on chain %d: %w", sel, err)
+					// The shared bundle replays a cached report for an identical operation and
+					// input. The reads above dodge that with a fresh bundle; the write needs
+					// the same guarantee, or a re-apply after an out-of-band change would
+					// return the stale executed write and report success having done nothing.
+					// applyAuthorizedCallerUpdates is a set operation on-chain, so re-running
+					// it is harmless.
+					cldf_ops.WithForceExecute[contract.FunctionInput[lbops.AuthorizedCallerArgs], evm.Chain](),
+				)
+				if err != nil {
+					return cldf_deployment.ChangesetOutput{}, fmt.Errorf(
+						"failed to apply authorized caller updates on chain %d: %w", sel, err)
+				}
+
+				reports = append(reports, report.ToGenericReport())
+				writes = append(writes, report.Output)
 			}
 
-			reports = append(reports, report.ToGenericReport())
-
-			batch, err := contract.NewBatchOperationFromWrites(
-				[]contract.WriteOutput{report.Output})
+			// One batch operation per chain, built from that chain's writes: MCMS executes a
+			// batch operation atomically, so a chain whose lockboxes are updated together
+			// cannot be left half-applied. NewBatchOperationFromWrites rejects writes that
+			// span chains, which is exactly why it is called once per chain here.
+			batch, err := contract.NewBatchOperationFromWrites(writes)
 			if err != nil {
 				return cldf_deployment.ChangesetOutput{}, fmt.Errorf(
 					"failed to create batch from writes on chain %d: %w", sel, err)
@@ -288,12 +317,13 @@ func applyUpdateLockboxAuthorizedCallers(
 			batchOps = append(batchOps, batch)
 		}
 
-		// SingleBatchOpPerChain, not BatchOps: a chain can have several lockboxes updated
-		// in one run, and MCMS expects all operations for a chain in one batch operation so
-		// they execute atomically rather than as separately-executable units.
+		// BatchOps, not SingleBatchOpPerChain: the per-chain merge is structural now, since
+		// batchOps already holds at most one batch operation per chain. Empty batches - a
+		// chain whose updates were all filtered as no-ops, or whose writes executed
+		// directly - are dropped by WithBatchOps.
 		return cs_changesets.NewOutputBuilder(e, mcmsRegistry).
 			WithReports(reports).
-			WithSingleBatchOpPerChain(batchOps).
+			WithBatchOps(batchOps).
 			Build(input.MCMS)
 	}
 }

--- a/chains/evm/deployment/v2_0_0/changesets/update_lockbox_authorized_callers_test.go
+++ b/chains/evm/deployment/v2_0_0/changesets/update_lockbox_authorized_callers_test.go
@@ -133,18 +133,20 @@ func mcmsConfig() mcms.Input {
 	return in
 }
 
-// lockboxCfg builds a single-entry config at the lockbox's real version.
+// lockboxCfg builds a single-chain, single-lockbox config at the lockbox's real version.
 func lockboxCfg(
 	lockboxAddr common.Address,
 	appends, removes []common.Address,
 ) changesets.UpdateLockboxAuthorizedCallersCfg {
 	return changesets.UpdateLockboxAuthorizedCallersCfg{
 		Version: lbops.Version,
-		Input: []changesets.LockboxCallerUpdate{{
+		Input: []changesets.ChainLockboxUpdate{{
 			Selector: lockboxTestChainSel,
-			Address:  lockboxAddr,
-			Appends:  appends,
-			Removes:  removes,
+			Lockboxes: []changesets.LockboxCallerUpdate{{
+				Address: lockboxAddr,
+				Appends: appends,
+				Removes: removes,
+			}},
 		}},
 	}
 }
@@ -343,27 +345,68 @@ func TestUpdateLockboxAuthorizedCallers_VerifyRequiresVersion(t *testing.T) {
 }
 
 // TestUpdateLockboxAuthorizedCallers_VerifyRejectsDuplicateLockbox covers what the old
-// map-keyed config made structurally impossible: the same lockbox listed twice.
+// map-keyed config made structurally impossible: the same lockbox listed twice under one
+// chain, which the nested shape still permits structurally.
 func TestUpdateLockboxAuthorizedCallers_VerifyRejectsDuplicateLockbox(t *testing.T) {
 	e, _, lockboxAddr := setupLockboxWithTimelock(t)
 	entry := changesets.LockboxCallerUpdate{
-		Selector: lockboxTestChainSel,
-		Address:  lockboxAddr,
-		Appends:  []common.Address{common.HexToAddress("0x0000000000000000000000000000000000000001")},
+		Address: lockboxAddr,
+		Appends: []common.Address{common.HexToAddress("0x0000000000000000000000000000000000000001")},
 	}
 
 	err := verifyLockbox(t, e, mcmsConfig(), changesets.UpdateLockboxAuthorizedCallersCfg{
 		Version: lbops.Version,
-		Input:   []changesets.LockboxCallerUpdate{entry, entry},
+		Input: []changesets.ChainLockboxUpdate{{
+			Selector:  lockboxTestChainSel,
+			Lockboxes: []changesets.LockboxCallerUpdate{entry, entry},
+		}},
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "duplicate entry for lockbox")
 }
 
+// TestUpdateLockboxAuthorizedCallers_VerifyRejectsDuplicateChain asserts one selector listed
+// twice is rejected. Nesting makes a chain's lockboxes its own list, so a repeated selector
+// would build two batch operations for that chain and its updates would stop being atomic.
+func TestUpdateLockboxAuthorizedCallers_VerifyRejectsDuplicateChain(t *testing.T) {
+	e, _, lockboxAddr := setupLockboxWithTimelock(t)
+	entry := changesets.ChainLockboxUpdate{
+		Selector: lockboxTestChainSel,
+		Lockboxes: []changesets.LockboxCallerUpdate{{
+			Address: lockboxAddr,
+			Appends: []common.Address{common.HexToAddress("0x0000000000000000000000000000000000000001")},
+		}},
+	}
+
+	err := verifyLockbox(t, e, mcmsConfig(), changesets.UpdateLockboxAuthorizedCallersCfg{
+		Version: lbops.Version,
+		Input:   []changesets.ChainLockboxUpdate{entry, entry},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate entry for chain")
+}
+
+// TestUpdateLockboxAuthorizedCallers_VerifyRejectsEmptyLockboxes asserts a chain entry with
+// an empty lockbox list is rejected. It is what a half-written config looks like, and
+// accepting it would silently do nothing for that chain.
+func TestUpdateLockboxAuthorizedCallers_VerifyRejectsEmptyLockboxes(t *testing.T) {
+	e, _, _ := setupLockboxWithTimelock(t)
+
+	err := verifyLockbox(t, e, mcmsConfig(), changesets.UpdateLockboxAuthorizedCallersCfg{
+		Version: lbops.Version,
+		Input: []changesets.ChainLockboxUpdate{{
+			Selector:  lockboxTestChainSel,
+			Lockboxes: nil,
+		}},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no lockboxes listed for chain")
+}
+
 // TestUpdateLockboxAuthorizedCallers_TwoLockboxesOneChain covers the layout that exists in
-// CCV prod_testnet, where ethereum-sepolia holds two lockboxes. Two entries sharing a
-// selector must be accepted, and their writes must be merged into a single batch operation
-// so the chain's updates execute atomically.
+// CCV prod_testnet, where ethereum-sepolia holds two lockboxes: one chain entry carrying two
+// lockboxes. Their writes must end up in a single batch operation so the chain's updates
+// execute atomically.
 func TestUpdateLockboxAuthorizedCallers_TwoLockboxesOneChain(t *testing.T) {
 	e, timelockAddr, firstLockbox := setupLockboxWithTimelock(t)
 
@@ -399,10 +442,13 @@ func TestUpdateLockboxAuthorizedCallers_TwoLockboxesOneChain(t *testing.T) {
 
 	cfg := changesets.UpdateLockboxAuthorizedCallersCfg{
 		Version: lbops.Version,
-		Input: []changesets.LockboxCallerUpdate{
-			{Selector: lockboxTestChainSel, Address: firstLockbox, Appends: []common.Address{callerA}},
-			{Selector: lockboxTestChainSel, Address: secondLockbox, Appends: []common.Address{callerB}},
-		},
+		Input: []changesets.ChainLockboxUpdate{{
+			Selector: lockboxTestChainSel,
+			Lockboxes: []changesets.LockboxCallerUpdate{
+				{Address: firstLockbox, Appends: []common.Address{callerA}},
+				{Address: secondLockbox, Appends: []common.Address{callerB}},
+			},
+		}},
 	}
 
 	require.NoError(t, verifyLockbox(t, e, mcmsConfig(), cfg), "two lockboxes on one chain must be allowed")
@@ -472,7 +518,7 @@ func TestUpdateLockboxAuthorizedCallers_VerifyNoInput(t *testing.T) {
 
 	err := verifyLockbox(t, e, mcmsConfig(), changesets.UpdateLockboxAuthorizedCallersCfg{
 		Version: lbops.Version,
-		Input:   []changesets.LockboxCallerUpdate{},
+		Input:   []changesets.ChainLockboxUpdate{},
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "at least one entry is required")
@@ -483,10 +529,12 @@ func TestUpdateLockboxAuthorizedCallers_VerifyInvalidChainSelector(t *testing.T)
 
 	err := verifyLockbox(t, e, mcmsConfig(), changesets.UpdateLockboxAuthorizedCallersCfg{
 		Version: lbops.Version,
-		Input: []changesets.LockboxCallerUpdate{{
+		Input: []changesets.ChainLockboxUpdate{{
 			Selector: 99999999,
-			Address:  lockboxAddr,
-			Appends:  []common.Address{common.HexToAddress("0x0000000000000000000000000000000000000001")},
+			Lockboxes: []changesets.LockboxCallerUpdate{{
+				Address: lockboxAddr,
+				Appends: []common.Address{common.HexToAddress("0x0000000000000000000000000000000000000001")},
+			}},
 		}},
 	})
 	require.Error(t, err)

--- a/chains/evm/deployment/v2_0_0/changesets/update_lockbox_authorized_callers_test.go
+++ b/chains/evm/deployment/v2_0_0/changesets/update_lockbox_authorized_callers_test.go
@@ -1,0 +1,544 @@
+package changesets_test
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf_deployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/changesets"
+	lbops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/erc20_lock_box"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/testsetup"
+	cs_changesets "github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
+
+	mcms_ops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/testhelpers"
+	common_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils"
+)
+
+const lockboxTestChainSel = uint64(5009297550715157269)
+
+// lockboxTestQualifier mirrors production, where every lockbox is deployed under a
+// qualifier. The changeset no longer addresses by qualifier, but the fixture keeps one so
+// the datastore refs look like the real thing.
+const lockboxTestQualifier = "USDC"
+
+// deployLockboxForTest deploys a lockbox, optionally under a qualifier. Pass nil for an
+// unqualified ref.
+func deployLockboxForTest(
+	t *testing.T,
+	e *cldf_deployment.Environment,
+	chainSelector uint64,
+	qualifier *string,
+) (datastore.AddressRef, common.Address) {
+	t.Helper()
+	chain := e.BlockChains.EVMChains()[chainSelector]
+
+	ref, err := contract.MaybeDeployContract(
+		e.OperationsBundle, lbops.Deploy, chain,
+		contract.DeployInput[lbops.ConstructorArgs]{
+			TypeAndVersion: cldf_deployment.NewTypeAndVersion(lbops.ContractType, *lbops.Version),
+			ChainSelector:  chainSelector,
+			Args:           lbops.ConstructorArgs{Token: chain.DeployerKey.From},
+			Qualifier:      qualifier,
+		}, nil)
+	require.NoError(t, err)
+
+	return ref, common.HexToAddress(ref.Address)
+}
+
+func readOnChainAuthorizedCallers(
+	t *testing.T,
+	e *cldf_deployment.Environment,
+	chainSelector uint64,
+	lockboxAddr common.Address,
+) []common.Address {
+	t.Helper()
+	chain := e.BlockChains.EVMChains()[chainSelector]
+	readBundle := testsetup.BundleWithFreshReporter(e.OperationsBundle)
+	report, err := cldf_ops.ExecuteOperation(
+		readBundle, lbops.GetAllAuthorizedCallers, chain,
+		contract.FunctionInput[struct{}]{
+			ChainSelector: chainSelector,
+			Address:       lockboxAddr,
+			Args:          struct{}{},
+		})
+	require.NoError(t, err)
+
+	return report.Output
+}
+
+// setupLockboxWithTimelock deploys a lockbox, deploys the MCMS instance, seals both
+// sets of refs into the DataStore, and transfers the lockbox to the timelock so that
+// applyAuthorizedCallerUpdates writes land in MCMS proposals instead of executing directly.
+func setupLockboxWithTimelock(
+	t *testing.T,
+	extraMCMSQualifiers ...string,
+) (*cldf_deployment.Environment, common.Address, common.Address) {
+	t.Helper()
+	e, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{lockboxTestChainSel}),
+	)
+	require.NoError(t, err)
+
+	chain := e.BlockChains.EVMChains()[lockboxTestChainSel]
+	b := e.OperationsBundle
+
+	qualifier := lockboxTestQualifier
+	ref, lockboxAddr := deployLockboxForTest(t, e, lockboxTestChainSel, &qualifier)
+
+	timelockAddr, mcmsAddrs := deployMCMSInstanceForTest(
+		t, b, chain, chain.DeployerKey.From, common_utils.CLLQualifier)
+
+	ds := datastore.NewMemoryDataStore()
+	require.NoError(t, ds.Addresses().Add(ref))
+	for _, addr := range mcmsAddrs {
+		require.NoError(t, ds.Addresses().Add(addr))
+	}
+	// Additional MCMS instances make an unqualified timelock lookup ambiguous, which is
+	// what production looks like - every chain carries CLLCCIP, RMNMCMS and UltraFastCurse.
+	for _, q := range extraMCMSQualifiers {
+		_, extraAddrs := deployMCMSInstanceForTest(t, b, chain, chain.DeployerKey.From, q)
+		for _, addr := range extraAddrs {
+			require.NoError(t, ds.Addresses().Add(addr))
+		}
+	}
+	e.DataStore = ds.Seal()
+
+	transferRampsToTimelockForTest(t, b, chain, e, []mcms_ops.OpTransferOwnershipInput{{
+		ChainSelector:   lockboxTestChainSel,
+		Address:         lockboxAddr,
+		ProposedOwner:   timelockAddr,
+		ContractType:    lbops.ContractType,
+		TimelockAddress: timelockAddr,
+	}})
+
+	return e, timelockAddr, lockboxAddr
+}
+
+// mcmsConfig is validMCMSInput with the CLL qualifier, which is the qualifier
+// setupLockboxWithTimelock deploys the MCMS instance under.
+func mcmsConfig() mcms.Input {
+	in := validMCMSInput()
+	in.Qualifier = common_utils.CLLQualifier
+
+	return in
+}
+
+// lockboxCfg builds a single-entry config at the lockbox's real version.
+func lockboxCfg(
+	lockboxAddr common.Address,
+	appends, removes []common.Address,
+) changesets.UpdateLockboxAuthorizedCallersCfg {
+	return changesets.UpdateLockboxAuthorizedCallersCfg{
+		Version: lbops.Version,
+		Input: []changesets.LockboxCallerUpdate{{
+			Selector: lockboxTestChainSel,
+			Address:  lockboxAddr,
+			Appends:  appends,
+			Removes:  removes,
+		}},
+	}
+}
+
+func applyLockbox(
+	t *testing.T,
+	e *cldf_deployment.Environment,
+	cfg changesets.UpdateLockboxAuthorizedCallersCfg,
+) (cldf_deployment.ChangesetOutput, error) {
+	t.Helper()
+
+	return changesets.UpdateLockboxAuthorizedCallers(cs_changesets.GetRegistry()).Apply(*e,
+		cs_changesets.WithMCMS[changesets.UpdateLockboxAuthorizedCallersCfg]{
+			MCMS: mcmsConfig(),
+			Cfg:  cfg,
+		})
+}
+
+func verifyLockbox(
+	t *testing.T,
+	e *cldf_deployment.Environment,
+	mcmsInput mcms.Input,
+	cfg changesets.UpdateLockboxAuthorizedCallersCfg,
+) error {
+	t.Helper()
+
+	return changesets.UpdateLockboxAuthorizedCallers(cs_changesets.GetRegistry()).VerifyPreconditions(*e,
+		cs_changesets.WithMCMS[changesets.UpdateLockboxAuthorizedCallersCfg]{
+			MCMS: mcmsInput,
+			Cfg:  cfg,
+		})
+}
+
+func TestUpdateLockboxAuthorizedCallers_AddAndRemove(t *testing.T) {
+	e, _, lockboxAddr := setupLockboxWithTimelock(t)
+
+	chain := e.BlockChains.EVMChains()[lockboxTestChainSel]
+	deployerKey := chain.DeployerKey.From
+	otherAddr := common.HexToAddress("0x0000000000000000000000000000000000000001")
+
+	out, err := applyLockbox(t, e, lockboxCfg(lockboxAddr,
+		[]common.Address{deployerKey, otherAddr}, nil))
+	require.NoError(t, err)
+	require.Len(t, out.MCMSTimelockProposals, 1)
+	testhelpers.ProcessTimelockProposals(t, *e, out.MCMSTimelockProposals, false)
+
+	callers := readOnChainAuthorizedCallers(t, e, lockboxTestChainSel, lockboxAddr)
+	require.ElementsMatch(t, []common.Address{deployerKey, otherAddr}, callers)
+
+	out, err = applyLockbox(t, e, lockboxCfg(lockboxAddr,
+		nil, []common.Address{deployerKey, otherAddr}))
+	require.NoError(t, err)
+	require.Len(t, out.MCMSTimelockProposals, 1)
+	testhelpers.ProcessTimelockProposals(t, *e, out.MCMSTimelockProposals, false)
+
+	require.Empty(t, readOnChainAuthorizedCallers(t, e, lockboxTestChainSel, lockboxAddr))
+}
+
+// TestUpdateLockboxAuthorizedCallers_IdempotentAdd asserts the second apply of an
+// already-applied add produces no proposal. The lockbox is timelock-owned, so dropping the
+// filter would re-propose the write and fail the final assertion.
+func TestUpdateLockboxAuthorizedCallers_IdempotentAdd(t *testing.T) {
+	e, _, lockboxAddr := setupLockboxWithTimelock(t)
+	caller := common.HexToAddress("0x0000000000000000000000000000000000000001")
+
+	out, err := applyLockbox(t, e, lockboxCfg(lockboxAddr, []common.Address{caller}, nil))
+	require.NoError(t, err)
+	require.Len(t, out.MCMSTimelockProposals, 1, "adding an absent caller must produce a proposal")
+	testhelpers.ProcessTimelockProposals(t, *e, out.MCMSTimelockProposals, false)
+
+	require.Equal(t, []common.Address{caller},
+		readOnChainAuthorizedCallers(t, e, lockboxTestChainSel, lockboxAddr))
+
+	out, err = applyLockbox(t, e, lockboxCfg(lockboxAddr, []common.Address{caller}, nil))
+	require.NoError(t, err)
+	require.Empty(t, out.MCMSTimelockProposals, "no-op add must produce no proposal")
+
+	require.Equal(t, []common.Address{caller},
+		readOnChainAuthorizedCallers(t, e, lockboxTestChainSel, lockboxAddr))
+}
+
+// TestUpdateLockboxAuthorizedCallers_IdempotentRemove asserts removing an absent caller
+// produces no proposal. On-chain the removal is a set no-op that does not revert, so only
+// timelock ownership makes the absence of a proposal meaningful.
+func TestUpdateLockboxAuthorizedCallers_IdempotentRemove(t *testing.T) {
+	e, _, lockboxAddr := setupLockboxWithTimelock(t)
+	absentAddr := common.HexToAddress("0x0000000000000000000000000000000000000001")
+
+	out, err := applyLockbox(t, e, lockboxCfg(lockboxAddr, nil, []common.Address{absentAddr}))
+	require.NoError(t, err)
+	require.Empty(t, out.MCMSTimelockProposals,
+		"removing an absent caller must produce no proposal")
+
+	require.Empty(t, readOnChainAuthorizedCallers(t, e, lockboxTestChainSel, lockboxAddr))
+}
+
+// TestUpdateLockboxAuthorizedCallers_IdempotentMixed asserts a config whose adds are all
+// present and whose removes are all absent produces no proposal.
+func TestUpdateLockboxAuthorizedCallers_IdempotentMixed(t *testing.T) {
+	e, _, lockboxAddr := setupLockboxWithTimelock(t)
+	present := common.HexToAddress("0x0000000000000000000000000000000000000001")
+	absent := common.HexToAddress("0x0000000000000000000000000000000000000002")
+
+	out, err := applyLockbox(t, e, lockboxCfg(lockboxAddr, []common.Address{present}, nil))
+	require.NoError(t, err)
+	require.Len(t, out.MCMSTimelockProposals, 1)
+	testhelpers.ProcessTimelockProposals(t, *e, out.MCMSTimelockProposals, false)
+
+	out, err = applyLockbox(t, e, lockboxCfg(lockboxAddr,
+		[]common.Address{present}, []common.Address{absent}))
+	require.NoError(t, err)
+	require.Empty(t, out.MCMSTimelockProposals, "fully filtered updates must produce no proposal")
+
+	require.Equal(t, []common.Address{present},
+		readOnChainAuthorizedCallers(t, e, lockboxTestChainSel, lockboxAddr))
+}
+
+// TestUpdateLockboxAuthorizedCallers_PartialFilter asserts that a config mixing an
+// already-applied add with a new one proposes only the new one.
+func TestUpdateLockboxAuthorizedCallers_PartialFilter(t *testing.T) {
+	e, _, lockboxAddr := setupLockboxWithTimelock(t)
+	first := common.HexToAddress("0x0000000000000000000000000000000000000001")
+	second := common.HexToAddress("0x0000000000000000000000000000000000000002")
+
+	out, err := applyLockbox(t, e, lockboxCfg(lockboxAddr, []common.Address{first}, nil))
+	require.NoError(t, err)
+	require.Len(t, out.MCMSTimelockProposals, 1)
+	testhelpers.ProcessTimelockProposals(t, *e, out.MCMSTimelockProposals, false)
+
+	out, err = applyLockbox(t, e, lockboxCfg(lockboxAddr,
+		[]common.Address{first, second}, nil))
+	require.NoError(t, err)
+	require.Len(t, out.MCMSTimelockProposals, 1, "the new caller must still be proposed")
+	testhelpers.ProcessTimelockProposals(t, *e, out.MCMSTimelockProposals, false)
+
+	require.ElementsMatch(t, []common.Address{first, second},
+		readOnChainAuthorizedCallers(t, e, lockboxTestChainSel, lockboxAddr))
+}
+
+// TestUpdateLockboxAuthorizedCallers_AddressNotInDataStore asserts an address absent from
+// the datastore is rejected rather than written to blindly.
+func TestUpdateLockboxAuthorizedCallers_AddressNotInDataStore(t *testing.T) {
+	e, _, _ := setupLockboxWithTimelock(t)
+	unknown := common.HexToAddress("0x00000000000000000000000000000000000000FF")
+
+	cfg := lockboxCfg(unknown,
+		[]common.Address{common.HexToAddress("0x0000000000000000000000000000000000000001")}, nil)
+
+	err := verifyLockbox(t, e, mcmsConfig(), cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expected exactly 1 datastore ref")
+
+	_, err = applyLockbox(t, e, cfg)
+	require.Error(t, err, "apply must reject it too, since it can run without verify")
+}
+
+// TestUpdateLockboxAuthorizedCallers_AddressIsNotALockbox asserts pointing at a real
+// datastore ref of the wrong contract type is rejected. The timelock is a convenient
+// non-lockbox ref that setupLockboxWithTimelock already seeds.
+func TestUpdateLockboxAuthorizedCallers_AddressIsNotALockbox(t *testing.T) {
+	e, timelockAddr, _ := setupLockboxWithTimelock(t)
+
+	cfg := lockboxCfg(timelockAddr,
+		[]common.Address{common.HexToAddress("0x0000000000000000000000000000000000000001")}, nil)
+
+	err := verifyLockbox(t, e, mcmsConfig(), cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not an ERC20LockBox")
+}
+
+// TestUpdateLockboxAuthorizedCallers_VersionMismatch asserts a config written for a
+// different lockbox version is rejected, so a future 2.0.1 lockbox is not acted on by a
+// config that meant 2.0.0.
+func TestUpdateLockboxAuthorizedCallers_VersionMismatch(t *testing.T) {
+	e, _, lockboxAddr := setupLockboxWithTimelock(t)
+
+	cfg := lockboxCfg(lockboxAddr,
+		[]common.Address{common.HexToAddress("0x0000000000000000000000000000000000000001")}, nil)
+	cfg.Version = semver.MustParse("2.0.1")
+
+	err := verifyLockbox(t, e, mcmsConfig(), cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "is version 2.0.0, but config specifies 2.0.1")
+}
+
+func TestUpdateLockboxAuthorizedCallers_VerifyRequiresVersion(t *testing.T) {
+	e, _, lockboxAddr := setupLockboxWithTimelock(t)
+
+	cfg := lockboxCfg(lockboxAddr,
+		[]common.Address{common.HexToAddress("0x0000000000000000000000000000000000000001")}, nil)
+	cfg.Version = nil
+
+	err := verifyLockbox(t, e, mcmsConfig(), cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "version is required")
+}
+
+// TestUpdateLockboxAuthorizedCallers_VerifyRejectsDuplicateLockbox covers what the old
+// map-keyed config made structurally impossible: the same lockbox listed twice.
+func TestUpdateLockboxAuthorizedCallers_VerifyRejectsDuplicateLockbox(t *testing.T) {
+	e, _, lockboxAddr := setupLockboxWithTimelock(t)
+	entry := changesets.LockboxCallerUpdate{
+		Selector: lockboxTestChainSel,
+		Address:  lockboxAddr,
+		Appends:  []common.Address{common.HexToAddress("0x0000000000000000000000000000000000000001")},
+	}
+
+	err := verifyLockbox(t, e, mcmsConfig(), changesets.UpdateLockboxAuthorizedCallersCfg{
+		Version: lbops.Version,
+		Input:   []changesets.LockboxCallerUpdate{entry, entry},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate entry for lockbox")
+}
+
+// TestUpdateLockboxAuthorizedCallers_TwoLockboxesOneChain covers the layout that exists in
+// CCV prod_testnet, where ethereum-sepolia holds two lockboxes. Two entries sharing a
+// selector must be accepted, and their writes must be merged into a single batch operation
+// so the chain's updates execute atomically.
+func TestUpdateLockboxAuthorizedCallers_TwoLockboxesOneChain(t *testing.T) {
+	e, timelockAddr, firstLockbox := setupLockboxWithTimelock(t)
+
+	// A second lockbox on the same chain, under its own qualifier, added to the datastore
+	// alongside the existing refs.
+	secondQualifier := "LINK"
+	secondRef, secondLockbox := deployLockboxForTest(t, e, lockboxTestChainSel, &secondQualifier)
+	require.NotEqual(t, firstLockbox, secondLockbox)
+
+	existing, err := e.DataStore.Addresses().Fetch()
+	require.NoError(t, err)
+	ds := datastore.NewMemoryDataStore()
+	for _, ref := range existing {
+		require.NoError(t, ds.Addresses().Add(ref))
+	}
+	require.NoError(t, ds.Addresses().Add(secondRef))
+	e.DataStore = ds.Seal()
+
+	// The second lockbox must also belong to the timelock, or its write executes inline
+	// with the deployer key and never reaches the batch.
+	transferRampsToTimelockForTest(t, e.OperationsBundle,
+		e.BlockChains.EVMChains()[lockboxTestChainSel], e,
+		[]mcms_ops.OpTransferOwnershipInput{{
+			ChainSelector:   lockboxTestChainSel,
+			Address:         secondLockbox,
+			ProposedOwner:   timelockAddr,
+			ContractType:    lbops.ContractType,
+			TimelockAddress: timelockAddr,
+		}})
+
+	callerA := common.HexToAddress("0x0000000000000000000000000000000000000001")
+	callerB := common.HexToAddress("0x0000000000000000000000000000000000000002")
+
+	cfg := changesets.UpdateLockboxAuthorizedCallersCfg{
+		Version: lbops.Version,
+		Input: []changesets.LockboxCallerUpdate{
+			{Selector: lockboxTestChainSel, Address: firstLockbox, Appends: []common.Address{callerA}},
+			{Selector: lockboxTestChainSel, Address: secondLockbox, Appends: []common.Address{callerB}},
+		},
+	}
+
+	require.NoError(t, verifyLockbox(t, e, mcmsConfig(), cfg), "two lockboxes on one chain must be allowed")
+
+	out, err := applyLockbox(t, e, cfg)
+	require.NoError(t, err)
+	require.Len(t, out.MCMSTimelockProposals, 1)
+
+	// One batch operation for the chain, carrying both lockbox calls.
+	ops := out.MCMSTimelockProposals[0].Operations
+	require.Len(t, ops, 1, "both lockbox writes must merge into one batch op for the chain")
+	require.Len(t, ops[0].Transactions, 2, "batch op must carry a transaction per lockbox")
+
+	targets := []common.Address{
+		common.HexToAddress(ops[0].Transactions[0].To),
+		common.HexToAddress(ops[0].Transactions[1].To),
+	}
+	require.ElementsMatch(t, []common.Address{firstLockbox, secondLockbox}, targets)
+
+	testhelpers.ProcessTimelockProposals(t, *e, out.MCMSTimelockProposals, false)
+	require.Equal(t, []common.Address{callerA},
+		readOnChainAuthorizedCallers(t, e, lockboxTestChainSel, firstLockbox))
+	require.Equal(t, []common.Address{callerB},
+		readOnChainAuthorizedCallers(t, e, lockboxTestChainSel, secondLockbox))
+}
+
+func TestUpdateLockboxAuthorizedCallers_VerifyRejectsAppendRemoveOverlap(t *testing.T) {
+	e, _, lockboxAddr := setupLockboxWithTimelock(t)
+	addr := common.HexToAddress("0x0000000000000000000000000000000000000001")
+
+	err := verifyLockbox(t, e, mcmsConfig(),
+		lockboxCfg(lockboxAddr, []common.Address{addr}, []common.Address{addr}))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "is in both appends and removes")
+}
+
+func TestUpdateLockboxAuthorizedCallers_VerifyRejectsDuplicates(t *testing.T) {
+	e, _, lockboxAddr := setupLockboxWithTimelock(t)
+	addr := common.HexToAddress("0x0000000000000000000000000000000000000001")
+
+	err := verifyLockbox(t, e, mcmsConfig(),
+		lockboxCfg(lockboxAddr, []common.Address{addr, addr}, nil))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate address")
+}
+
+func TestUpdateLockboxAuthorizedCallers_VerifyZeroLockboxAddress(t *testing.T) {
+	e, _, _ := setupLockboxWithTimelock(t)
+
+	err := verifyLockbox(t, e, mcmsConfig(), lockboxCfg(common.Address{},
+		[]common.Address{common.HexToAddress("0x0000000000000000000000000000000000000001")}, nil))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "zero lockbox address")
+}
+
+func TestUpdateLockboxAuthorizedCallers_VerifyZeroCallerAddress(t *testing.T) {
+	e, _, lockboxAddr := setupLockboxWithTimelock(t)
+
+	err := verifyLockbox(t, e, mcmsConfig(),
+		lockboxCfg(lockboxAddr, []common.Address{{}}, nil))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "zero address in appends")
+}
+
+func TestUpdateLockboxAuthorizedCallers_VerifyNoInput(t *testing.T) {
+	e, _, _ := setupLockboxWithTimelock(t)
+
+	err := verifyLockbox(t, e, mcmsConfig(), changesets.UpdateLockboxAuthorizedCallersCfg{
+		Version: lbops.Version,
+		Input:   []changesets.LockboxCallerUpdate{},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "at least one entry is required")
+}
+
+func TestUpdateLockboxAuthorizedCallers_VerifyInvalidChainSelector(t *testing.T) {
+	e, _, lockboxAddr := setupLockboxWithTimelock(t)
+
+	err := verifyLockbox(t, e, mcmsConfig(), changesets.UpdateLockboxAuthorizedCallersCfg{
+		Version: lbops.Version,
+		Input: []changesets.LockboxCallerUpdate{{
+			Selector: 99999999,
+			Address:  lockboxAddr,
+			Appends:  []common.Address{common.HexToAddress("0x0000000000000000000000000000000000000001")},
+		}},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid chain selector")
+}
+
+// TestUpdateLockboxAuthorizedCallers_VerifyMCMSDefaults asserts an empty MCMS block passes:
+// the qualifier defaults to CLLCCIP and ValidUntil is populated before validation, so
+// operators need not supply either.
+func TestUpdateLockboxAuthorizedCallers_VerifyMCMSDefaults(t *testing.T) {
+	e, _, lockboxAddr := setupLockboxWithTimelock(t)
+
+	err := verifyLockbox(t, e, mcms.Input{}, lockboxCfg(lockboxAddr,
+		[]common.Address{common.HexToAddress("0x0000000000000000000000000000000000000001")}, nil))
+	require.NoError(t, err)
+}
+
+// TestUpdateLockboxAuthorizedCallers_VerifyRejectsExpiredMCMS asserts a ValidUntil the
+// operator did supply is still rejected when it is already expired.
+func TestUpdateLockboxAuthorizedCallers_VerifyRejectsExpiredMCMS(t *testing.T) {
+	e, _, lockboxAddr := setupLockboxWithTimelock(t)
+
+	expired := mcmsConfig()
+	expired.ValidUntil = 1
+
+	err := verifyLockbox(t, e, expired, lockboxCfg(lockboxAddr,
+		[]common.Address{common.HexToAddress("0x0000000000000000000000000000000000000001")}, nil))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid MCMS input")
+}
+
+// TestUpdateLockboxAuthorizedCallers_OmittedQualifierResolvesCLLCCIP asserts an operator
+// can leave the MCMS qualifier unset and still get a working proposal against the CLLCCIP
+// timelock. The default comes from EVMMCMSReader.GetTimelockRef, not from this changeset;
+// this pins the end-to-end behaviour operators rely on. A second MCMS instance is seeded
+// under another qualifier so the datastore holds more than one timelock, as production does.
+func TestUpdateLockboxAuthorizedCallers_OmittedQualifierResolvesCLLCCIP(t *testing.T) {
+	e, _, lockboxAddr := setupLockboxWithTimelock(t, "RMNMCMS")
+	caller := common.HexToAddress("0x0000000000000000000000000000000000000001")
+
+	noQualifier := validMCMSInput()
+	require.Empty(t, noQualifier.Qualifier, "fixture must leave the qualifier unset")
+
+	out, err := changesets.UpdateLockboxAuthorizedCallers(cs_changesets.GetRegistry()).Apply(*e,
+		cs_changesets.WithMCMS[changesets.UpdateLockboxAuthorizedCallersCfg]{
+			MCMS: noQualifier,
+			Cfg:  lockboxCfg(lockboxAddr, []common.Address{caller}, nil),
+		})
+	require.NoError(t, err)
+	require.Len(t, out.MCMSTimelockProposals, 1)
+	testhelpers.ProcessTimelockProposals(t, *e, out.MCMSTimelockProposals, false)
+
+	require.Equal(t, []common.Address{caller},
+		readOnChainAuthorizedCallers(t, e, lockboxTestChainSel, lockboxAddr))
+}

--- a/chains/evm/deployment/v2_0_0/changesets/update_lockbox_authorized_callers_test.go
+++ b/chains/evm/deployment/v2_0_0/changesets/update_lockbox_authorized_callers_test.go
@@ -3,7 +3,6 @@ package changesets_test
 import (
 	"testing"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
@@ -139,7 +138,6 @@ func lockboxCfg(
 	appends, removes []common.Address,
 ) changesets.UpdateLockboxAuthorizedCallersCfg {
 	return changesets.UpdateLockboxAuthorizedCallersCfg{
-		Version: lbops.Version,
 		Input: []changesets.ChainLockboxUpdate{{
 			Selector: lockboxTestChainSel,
 			Lockboxes: []changesets.LockboxCallerUpdate{{
@@ -286,62 +284,48 @@ func TestUpdateLockboxAuthorizedCallers_PartialFilter(t *testing.T) {
 		readOnChainAuthorizedCallers(t, e, lockboxTestChainSel, lockboxAddr))
 }
 
-// TestUpdateLockboxAuthorizedCallers_AddressNotInDataStore asserts an address absent from
-// the datastore is rejected rather than written to blindly.
-func TestUpdateLockboxAuthorizedCallers_AddressNotInDataStore(t *testing.T) {
+// TestUpdateLockboxAuthorizedCallers_ForceExecutesWriteAfterOutOfBandChange pins the
+// WithForceExecute on the write. The shared operations bundle caches a report per
+// (operation, input), so a second apply with identical write args would otherwise replay the
+// first report - which was already executed - and report success having sent nothing.
+//
+// A deployer-owned lockbox is used deliberately: the write then executes inline, so whether
+// it really reached the chain is observable on-chain instead of parked in a proposal. The
+// changeset no longer reads the datastore, so this lockbox needs no ref.
+func TestUpdateLockboxAuthorizedCallers_ForceExecutesWriteAfterOutOfBandChange(t *testing.T) {
 	e, _, _ := setupLockboxWithTimelock(t)
-	unknown := common.HexToAddress("0x00000000000000000000000000000000000000FF")
+	caller := common.HexToAddress("0x0000000000000000000000000000000000000001")
 
-	cfg := lockboxCfg(unknown,
-		[]common.Address{common.HexToAddress("0x0000000000000000000000000000000000000001")}, nil)
+	deployerOwnedQualifier := "DEPLOYER_OWNED"
+	_, lockboxAddr := deployLockboxForTest(t, e, lockboxTestChainSel, &deployerOwnedQualifier)
 
-	err := verifyLockbox(t, e, mcmsConfig(), cfg)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "expected exactly 1 datastore ref")
+	cfg := lockboxCfg(lockboxAddr, []common.Address{caller}, nil)
 
+	out, err := applyLockbox(t, e, cfg)
+	require.NoError(t, err)
+	require.Empty(t, out.MCMSTimelockProposals, "a deployer-owned write executes inline")
+	require.Equal(t, []common.Address{caller},
+		readOnChainAuthorizedCallers(t, e, lockboxTestChainSel, lockboxAddr))
+
+	// Someone else changes the lockbox between runs.
+	chain := e.BlockChains.EVMChains()[lockboxTestChainSel]
+	_, err = cldf_ops.ExecuteOperation(
+		testsetup.BundleWithFreshReporter(e.OperationsBundle),
+		lbops.ApplyAuthorizedCallerUpdates, chain,
+		contract.FunctionInput[lbops.AuthorizedCallerArgs]{
+			ChainSelector: lockboxTestChainSel,
+			Address:       lockboxAddr,
+			Args:          lbops.AuthorizedCallerArgs{RemovedCallers: []common.Address{caller}},
+		})
+	require.NoError(t, err)
+	require.Empty(t, readOnChainAuthorizedCallers(t, e, lockboxTestChainSel, lockboxAddr))
+
+	// Identical config, so identical write args as the first apply.
 	_, err = applyLockbox(t, e, cfg)
-	require.Error(t, err, "apply must reject it too, since it can run without verify")
-}
-
-// TestUpdateLockboxAuthorizedCallers_AddressIsNotALockbox asserts pointing at a real
-// datastore ref of the wrong contract type is rejected. The timelock is a convenient
-// non-lockbox ref that setupLockboxWithTimelock already seeds.
-func TestUpdateLockboxAuthorizedCallers_AddressIsNotALockbox(t *testing.T) {
-	e, timelockAddr, _ := setupLockboxWithTimelock(t)
-
-	cfg := lockboxCfg(timelockAddr,
-		[]common.Address{common.HexToAddress("0x0000000000000000000000000000000000000001")}, nil)
-
-	err := verifyLockbox(t, e, mcmsConfig(), cfg)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "not an ERC20LockBox")
-}
-
-// TestUpdateLockboxAuthorizedCallers_VersionMismatch asserts a config written for a
-// different lockbox version is rejected, so a future 2.0.1 lockbox is not acted on by a
-// config that meant 2.0.0.
-func TestUpdateLockboxAuthorizedCallers_VersionMismatch(t *testing.T) {
-	e, _, lockboxAddr := setupLockboxWithTimelock(t)
-
-	cfg := lockboxCfg(lockboxAddr,
-		[]common.Address{common.HexToAddress("0x0000000000000000000000000000000000000001")}, nil)
-	cfg.Version = semver.MustParse("2.0.1")
-
-	err := verifyLockbox(t, e, mcmsConfig(), cfg)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "is version 2.0.0, but config specifies 2.0.1")
-}
-
-func TestUpdateLockboxAuthorizedCallers_VerifyRequiresVersion(t *testing.T) {
-	e, _, lockboxAddr := setupLockboxWithTimelock(t)
-
-	cfg := lockboxCfg(lockboxAddr,
-		[]common.Address{common.HexToAddress("0x0000000000000000000000000000000000000001")}, nil)
-	cfg.Version = nil
-
-	err := verifyLockbox(t, e, mcmsConfig(), cfg)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "version is required")
+	require.NoError(t, err)
+	require.Equal(t, []common.Address{caller},
+		readOnChainAuthorizedCallers(t, e, lockboxTestChainSel, lockboxAddr),
+		"the write must be re-executed, not replayed from the bundle cache")
 }
 
 // TestUpdateLockboxAuthorizedCallers_VerifyRejectsDuplicateLockbox covers what the old
@@ -355,7 +339,6 @@ func TestUpdateLockboxAuthorizedCallers_VerifyRejectsDuplicateLockbox(t *testing
 	}
 
 	err := verifyLockbox(t, e, mcmsConfig(), changesets.UpdateLockboxAuthorizedCallersCfg{
-		Version: lbops.Version,
 		Input: []changesets.ChainLockboxUpdate{{
 			Selector:  lockboxTestChainSel,
 			Lockboxes: []changesets.LockboxCallerUpdate{entry, entry},
@@ -379,8 +362,7 @@ func TestUpdateLockboxAuthorizedCallers_VerifyRejectsDuplicateChain(t *testing.T
 	}
 
 	err := verifyLockbox(t, e, mcmsConfig(), changesets.UpdateLockboxAuthorizedCallersCfg{
-		Version: lbops.Version,
-		Input:   []changesets.ChainLockboxUpdate{entry, entry},
+		Input: []changesets.ChainLockboxUpdate{entry, entry},
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "duplicate entry for chain")
@@ -393,7 +375,6 @@ func TestUpdateLockboxAuthorizedCallers_VerifyRejectsEmptyLockboxes(t *testing.T
 	e, _, _ := setupLockboxWithTimelock(t)
 
 	err := verifyLockbox(t, e, mcmsConfig(), changesets.UpdateLockboxAuthorizedCallersCfg{
-		Version: lbops.Version,
 		Input: []changesets.ChainLockboxUpdate{{
 			Selector:  lockboxTestChainSel,
 			Lockboxes: nil,
@@ -441,7 +422,6 @@ func TestUpdateLockboxAuthorizedCallers_TwoLockboxesOneChain(t *testing.T) {
 	callerB := common.HexToAddress("0x0000000000000000000000000000000000000002")
 
 	cfg := changesets.UpdateLockboxAuthorizedCallersCfg{
-		Version: lbops.Version,
 		Input: []changesets.ChainLockboxUpdate{{
 			Selector: lockboxTestChainSel,
 			Lockboxes: []changesets.LockboxCallerUpdate{
@@ -517,8 +497,7 @@ func TestUpdateLockboxAuthorizedCallers_VerifyNoInput(t *testing.T) {
 	e, _, _ := setupLockboxWithTimelock(t)
 
 	err := verifyLockbox(t, e, mcmsConfig(), changesets.UpdateLockboxAuthorizedCallersCfg{
-		Version: lbops.Version,
-		Input:   []changesets.ChainLockboxUpdate{},
+		Input: []changesets.ChainLockboxUpdate{},
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "at least one entry is required")
@@ -528,7 +507,6 @@ func TestUpdateLockboxAuthorizedCallers_VerifyInvalidChainSelector(t *testing.T)
 	e, _, lockboxAddr := setupLockboxWithTimelock(t)
 
 	err := verifyLockbox(t, e, mcmsConfig(), changesets.UpdateLockboxAuthorizedCallersCfg{
-		Version: lbops.Version,
 		Input: []changesets.ChainLockboxUpdate{{
 			Selector: 99999999,
 			Lockboxes: []changesets.LockboxCallerUpdate{{
@@ -539,31 +517,6 @@ func TestUpdateLockboxAuthorizedCallers_VerifyInvalidChainSelector(t *testing.T)
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid chain selector")
-}
-
-// TestUpdateLockboxAuthorizedCallers_VerifyMCMSDefaults asserts an empty MCMS block passes:
-// the qualifier defaults to CLLCCIP and ValidUntil is populated before validation, so
-// operators need not supply either.
-func TestUpdateLockboxAuthorizedCallers_VerifyMCMSDefaults(t *testing.T) {
-	e, _, lockboxAddr := setupLockboxWithTimelock(t)
-
-	err := verifyLockbox(t, e, mcms.Input{}, lockboxCfg(lockboxAddr,
-		[]common.Address{common.HexToAddress("0x0000000000000000000000000000000000000001")}, nil))
-	require.NoError(t, err)
-}
-
-// TestUpdateLockboxAuthorizedCallers_VerifyRejectsExpiredMCMS asserts a ValidUntil the
-// operator did supply is still rejected when it is already expired.
-func TestUpdateLockboxAuthorizedCallers_VerifyRejectsExpiredMCMS(t *testing.T) {
-	e, _, lockboxAddr := setupLockboxWithTimelock(t)
-
-	expired := mcmsConfig()
-	expired.ValidUntil = 1
-
-	err := verifyLockbox(t, e, expired, lockboxCfg(lockboxAddr,
-		[]common.Address{common.HexToAddress("0x0000000000000000000000000000000000000001")}, nil))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid MCMS input")
 }
 
 // TestUpdateLockboxAuthorizedCallers_OmittedQualifierResolvesCLLCCIP asserts an operator


### PR DESCRIPTION
### Add UpdateLockboxAuthorizedCallers changeset

**What this does**

Adds a changeset that changes who is allowed to call a lockbox (ERC20LockBox, v2.0.0) on one or more chains.

Each ERC20LockBox keeps a set of "authorized callers" — the addresses permitted to move funds in and out of it. This changeset lets an operator add to or remove from that set, producing an MCMS timelock proposal for governance to sign.

**Why we need it**

We're migrating token pools from 1.6 to 2.0. As part of that, each chain gets a new pool and a new lockbox, and the old pool's authorization on the lockbox needs to be cleared once liquidity has moved across. Nothing currently does that — the existing migration sequences only ever add authorized callers, never remove them.

**How you use it**

Lockboxes are nested under the chain they live on, because one chain legitimately holds several (one per token, per silo group, or per remote chain):

```yaml
environment: prod_testnet
domain: ccv
changesets:
  - update_lockbox_authorized_callers:
      chainOverrides: [16015286601757825753]
      payload:
        mcms:
          description: "Remove old pool from USDC lockbox"
        cfg:
          input:
            - selector: 16015286601757825753
              lockboxes:
                - address: "0x314c8F8D921E7fC15F81093b7D17af5E99cdaABB"
                  removes:
                    - "0xB36DFBa076E940f3d400b3cE262344ecc3879992"
                - address: "0xdADe19cC917a83555619816a7f1fc0e7CcE80a19"
                  appends:
                    - "0x591dF28e56e76f25bf343c86e029Fc18dd48E43A"
```

Several lockboxes and several chains can go in one run. The `mcms` block is optional — the timelock qualifier and expiry are filled in automatically.

**Notes**

- **Addressed by address, not qualifier.** Qualifiers are a side-effect of whichever sequence deployed the lockbox — the pool qualifier, `<poolQualifier>-silo(<minRemoteSelector>)`, or `remoteChainSelector(<selector>)` for siloed USDC — so they aren't a stable addressing scheme.
- **No `version` field.** This is the `v2_0_0` package, so the target version is already pinned by the changeset the operator picked.
- **Idempotent.** It reads the current on-chain caller set first and drops anything already in the desired state, so re-running is safe and won't produce a pointless proposal. Both the read and the write use `WithForceExecute`, so a re-run after an out-of-band change sees current state rather than a cached report.
- **Atomic per chain.** A chain's writes are collected and turned into a single MCMS batch operation, so several lockboxes on one chain execute together or not at all. `NewBatchOperationFromWrites` rejects writes spanning chains, which is why it's called once per chain.
- **Reproducible ordering.** Batch operations follow input order, so the proposal's merkle root is stable for a given config.
- **Rejects contradictory configs** before touching a chain: the same address in both `appends` and `removes` (which never converges — the contract removes before adding, while the idempotency filter drops whichever side matches current state), a repeated chain selector, the same lockbox twice within a chain, a chain entry with no lockboxes, per-list duplicates, and zero addresses.
- **No datastore pre-check.** A wrong address fails on-chain when the read or write reverts. Gating on a datastore ref would force operators to hand-add refs just to proceed, and a hand-added ref with an unnormalized address is a landmine for later runs.

**Testing**

- 17 unit tests against simulated chains: happy path, idempotency (add / remove / mixed / partial filter), two lockboxes on one chain merging into a single batch operation, MCMS qualifier defaulting end-to-end, and every validation rule.
- Every guard is mutation-checked — disabled in turn, confirming the specific test fails, then restored. That's how `ForceExecutesWriteAfterOutOfBandChange` came about: the write's `WithForceExecute` turned out to be pinned by nothing, so removing it left all tests green. All 13 guards now fail with their guard disabled.
- Exercised end to end as a dry run against CCV prod_testnet — three lockboxes across sepolia and fuji, covering add, remove, add+remove, two chains in one run, a fully idempotent no-op, and a partial filter, plus 14 configs that must be rejected. Proposals decoded to the expected `applyAuthorizedCallerUpdates((address[],address[]))` calls, with per-chain batching as described above. No transactions were executed. (Run before the review fixes in the latest commit, which removed the `version` field and the datastore pre-check; the behaviour exercised is unaffected by both.)
