### PR TITLE
SmokeTest - WaitForCCIPFilterRegistration guard on the smoke test setup

### DIFF
--- a/devenv/go.mod
+++ b/devenv/go.mod
@@ -61,6 +61,8 @@ require (
 	golang.org/x/sync v0.22.0
 )
 
+require github.com/lib/pq v1.12.3
+
 require (
 	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
@@ -285,7 +287,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
-	github.com/lib/pq v1.12.3 // indirect
 	github.com/logrusorgru/aurora v2.0.3+incompatible // indirect
 	github.com/lufia/plan9stats v0.0.0-20260216142805-b3301c5f2a88 // indirect
 	github.com/magiconair/properties v1.8.10 // indirect

--- a/devenv/tests/e2e/smoke_test.go
+++ b/devenv/tests/e2e/smoke_test.go
@@ -27,5 +27,6 @@ func TestE2ESmoke(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	tests.WaitForCCIPFilterRegistration(t, in.NodeSets[0].Out.CLNodes, selectors)
 	tests.RunSmokeTests(t, e, selectors)
 }

--- a/devenv/tests/filter_registration.go
+++ b/devenv/tests/filter_registration.go
@@ -1,0 +1,95 @@
+package tests
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-testing-framework/framework/components/clnode"
+)
+
+const (
+	filterRegistrationTimeout = 2 * time.Minute
+	filterRegistrationPoll    = time.Second
+)
+
+var tonCCIPFilterNames = []string{
+	"CCIPMessageSent",
+	"CommitReportAccepted",
+	"ExecutionStateChanged",
+}
+
+// WaitForCCIPFilterRegistration currently waits for TON filters only. Extend it
+// as other chain families need a pre-send registration gate.
+func WaitForCCIPFilterRegistration(t *testing.T, nodes []*clnode.Output, selectors []uint64) {
+	t.Helper()
+
+	tonSelectors := make([]uint64, 0)
+	for _, selector := range selectors {
+		family, err := chainsel.GetSelectorFamily(selector)
+		require.NoError(t, err)
+		if family == chainsel.FamilyTon {
+			tonSelectors = append(tonSelectors, selector)
+		}
+	}
+	if len(tonSelectors) > 0 {
+		waitForTONCCIPFilterRegistration(t, nodes, tonSelectors)
+	}
+}
+
+func waitForTONCCIPFilterRegistration(t *testing.T, nodes []*clnode.Output, selectors []uint64) {
+	t.Helper()
+	expectedFilters := len(selectors)
+
+	workerDBURLs := make([]string, 0, len(nodes))
+	for i, node := range nodes {
+		// Node 0 is the bootstrap node.
+		if i == 0 || node == nil || node.PostgreSQL == nil || node.PostgreSQL.Url == "" {
+			continue
+		}
+		workerDBURLs = append(workerDBURLs, node.PostgreSQL.Url)
+	}
+	require.NotEmpty(t, workerDBURLs, "TON CCIP filter gate requires at least one worker node database")
+
+	t.Logf("waiting for TON CCIP filter registration for %d chains on %d worker nodes", expectedFilters, len(workerDBURLs))
+	require.Eventually(t, func() bool {
+		for _, dbURL := range workerDBURLs {
+			registered, err := tonFiltersRegistered(t.Context(), dbURL, expectedFilters)
+			if err != nil || !registered {
+				return false
+			}
+		}
+		return true
+	}, filterRegistrationTimeout, filterRegistrationPoll,
+		"TON CCIP filters were not registered for every chain on every worker")
+}
+
+func tonFiltersRegistered(ctx context.Context, dbURL string, expectedFilters int) (bool, error) {
+	db, err := sql.Open("postgres", dbURL)
+	if err != nil {
+		return false, fmt.Errorf("open node database: %w", err)
+	}
+	defer db.Close()
+
+	for _, filterName := range tonCCIPFilterNames {
+		var filterCount int
+		err = db.QueryRowContext(ctx, `
+			SELECT COUNT(*)
+			FROM ton.log_poller_filters
+			WHERE name = $1 AND NOT is_deleted
+		`, filterName).Scan(&filterCount)
+		if err != nil {
+			return false, fmt.Errorf("query TON logpoller filter %s: %w", filterName, err)
+		}
+		if filterCount < expectedFilters {
+			return false, nil
+		}
+	}
+	return true, nil
+}


### PR DESCRIPTION
If you dispatch the devenv smoke test right after `ccip up` tests can fail due to the filters not being registered on the logpoller db yet. This happens because the filters are only registered when the plugin starts and the .

This PR adds a `WaitForCCIPFilterRegistration` check on the smoke test setup before dispatching the tests. Currently it only waits for the TON filters to be registered but it should be extended for other chains that find this issue.
