### PR TITLE
Migration changeset fixes

### DIFF
--- a/chains/evm/deployment/v2_0_0/adapters/lanemigrator.go
+++ b/chains/evm/deployment/v2_0_0/adapters/lanemigrator.go
@@ -23,6 +23,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/rmn_proxy"
 	mcms_seq "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/sequences"
 	routerops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_2_0/operations/router"
+	onrampops_v150 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/operations/onramp"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_5_0/operations/token_admin_registry"
 	onrampops_v160 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/operations/onramp"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/committee_verifier"
@@ -133,14 +134,7 @@ func verifyAllContractsPresent(e deployment.Environment, chainSelector uint64, s
 		}
 	}
 	for _, ref := range singleRefContracts {
-		// OnRamp may have a legacy-qualified duplicate in the datastore after an
-		// upgrade; always resolve the canonical (empty-qualifier) ref.
-		var err error
-		if ref.Type == datastore.ContractType(onrampops.ContractType) {
-			_, err = datastore_utils.FindAndFormatCanonicalRef(e.DataStore, ref, chainSelector, evm_datastore_utils.ToEVMAddress)
-		} else {
-			_, err = datastore_utils.FindAndFormatRef(e.DataStore, ref, chainSelector, evm_datastore_utils.ToEVMAddress)
-		}
+		_, err := datastore_utils.FindAndFormatRef(e.DataStore, ref, chainSelector, evm_datastore_utils.ToEVMAddress)
 		if err != nil {
 			missing = append(missing, fmt.Sprintf("%s@%s", ref.Type, ref.Version))
 		}
@@ -185,11 +179,17 @@ func verifyExistingLaneVersion(e deployment.Environment, evmChain evm.Chain, cha
 			return fmt.Errorf("error fetching onRamp version for chain %d and remote chain %d: %w", chainSelector, remoteChainSelector, err)
 		}
 
-		if !onRampVersion.Equal(onrampops_v160.Version) {
+		if !onRampVersion.Equal(onrampops_v160.Version) && !onRampVersion.Equal(onrampops_v150.Version) {
 			return fmt.Errorf(
-				"precondition failed for chain %d and remote chain %d: expected onRamp version on Router to be %s, but got version %s. ",
-				chainSelector, remoteChainSelector, onrampops_v160.Version.String(), onRampVersion.String(),
+				"precondition failed for chain %d and remote chain %d: expected onRamp version on Router to be %s or %s, but got version %s. ",
+				chainSelector, remoteChainSelector, onrampops_v150.Version.String(), onrampops_v160.Version.String(), onRampVersion.String(),
 			)
+		}
+
+		// Only 1.6+ onRamps expose a FeeQuoter in their dynamic config; 1.5 onRamps
+		// use a PriceRegistry instead and share no fee quoter relationship to verify.
+		if !onRampVersion.Equal(onrampops_v160.Version) {
+			continue
 		}
 
 		// get the fee quoter from onRamp
@@ -290,9 +290,8 @@ func (r *LaneMigrator) UpdateVersionWithRouter() *cldf_ops.Sequence[deploy.RampU
 				}
 			}
 			tempDS := ds.Seal()
-			// fetch onRamp and offRamp from the existing addresses (canonical onRamp to
-			// ignore any legacy-qualified duplicate)
-			onRampAddr, err := datastore_utils.FindAndFormatCanonicalRef(
+			// fetch onRamp and offRamp from the existing addresses
+			onRampAddr, err := datastore_utils.FindAndFormatRef(
 				tempDS,
 				datastore.AddressRef{
 					ChainSelector: input.ChainSelector,

--- a/chains/evm/deployment/v2_0_0/adapters/lanemigrator.go
+++ b/chains/evm/deployment/v2_0_0/adapters/lanemigrator.go
@@ -133,7 +133,14 @@ func verifyAllContractsPresent(e deployment.Environment, chainSelector uint64, s
 		}
 	}
 	for _, ref := range singleRefContracts {
-		_, err := datastore_utils.FindAndFormatRef(e.DataStore, ref, chainSelector, evm_datastore_utils.ToEVMAddress)
+		// OnRamp may have a legacy-qualified duplicate in the datastore after an
+		// upgrade; always resolve the canonical (empty-qualifier) ref.
+		var err error
+		if ref.Type == datastore.ContractType(onrampops.ContractType) {
+			_, err = datastore_utils.FindAndFormatCanonicalRef(e.DataStore, ref, chainSelector, evm_datastore_utils.ToEVMAddress)
+		} else {
+			_, err = datastore_utils.FindAndFormatRef(e.DataStore, ref, chainSelector, evm_datastore_utils.ToEVMAddress)
+		}
 		if err != nil {
 			missing = append(missing, fmt.Sprintf("%s@%s", ref.Type, ref.Version))
 		}
@@ -283,8 +290,9 @@ func (r *LaneMigrator) UpdateVersionWithRouter() *cldf_ops.Sequence[deploy.RampU
 				}
 			}
 			tempDS := ds.Seal()
-			// fetch onRamp and offRamp from the existing addresses
-			onRampAddr, err := datastore_utils.FindAndFormatRef(
+			// fetch onRamp and offRamp from the existing addresses (canonical onRamp to
+			// ignore any legacy-qualified duplicate)
+			onRampAddr, err := datastore_utils.FindAndFormatCanonicalRef(
 				tempDS,
 				datastore.AddressRef{
 					ChainSelector: input.ChainSelector,

--- a/chains/evm/deployment/v2_0_0/adapters/lanemigrator.go
+++ b/chains/evm/deployment/v2_0_0/adapters/lanemigrator.go
@@ -181,7 +181,7 @@ func verifyExistingLaneVersion(e deployment.Environment, evmChain evm.Chain, cha
 
 		if !onRampVersion.Equal(onrampops_v160.Version) && !onRampVersion.Equal(onrampops_v150.Version) {
 			return fmt.Errorf(
-				"precondition failed for chain %d and remote chain %d: expected onRamp version on Router to be %s or %s, but got version %s. ",
+				"precondition failed for chain %d and remote chain %d: expected onRamp version on Router to be %s or %s, but got version %s.",
 				chainSelector, remoteChainSelector, onrampops_v150.Version.String(), onrampops_v160.Version.String(), onRampVersion.String(),
 			)
 		}

--- a/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2.go
+++ b/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2.go
@@ -504,16 +504,16 @@ func (d *laneDiscoverer) reverseDirectionCarriesExcludedToken(chainSel, remote u
 
 	resolver, ok := d.resolvers.GetLaneVersionResolver(remote)
 	if !ok {
-		d.env.Logger.Warnf("no lane version resolver for reverse chain %d; holding lane back", remote)
+		d.env.Logger.Warnf("no lane version resolver for reverse lane %d->%d; holding lane back", remote, chainSel)
 		return true, nil
 	}
 	if !resolver.IsSupportedChain(d.env, remote) {
-		d.env.Logger.Warnf("reverse chain %d is not supported by its lane version resolver; holding lane back", remote)
+		d.env.Logger.Warnf("reverse lane %d->%d is not supported by its lane version resolver; holding lane back", remote, chainSel)
 		return true, nil
 	}
 	laneVersions, _, err := resolver.DeriveLaneVersionsForChain(d.env, remote)
 	if err != nil {
-		d.env.Logger.Warnf("failed to derive lane versions for reverse chain %d: %v; holding lane back", remote, err)
+		d.env.Logger.Warnf("failed to derive lane versions for reverse lane %d->%d: %v; holding lane back", remote, chainSel, err)
 		return true, nil
 	}
 	version, connected := laneVersions[chainSel]

--- a/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2.go
+++ b/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/erc20"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 
@@ -370,6 +372,9 @@ func discoverLanesToMigrate(
 	symbolOf tokenSymbolLookup,
 	cfg MigrateChainLanesToV2Config,
 ) ([]v2changesets.CrossFamilyLanePair, error) {
+	if e.Logger == nil {
+		e.Logger = logger.Nop()
+	}
 	d := &laneDiscoverer{
 		env:             e,
 		resolvers:       resolvers,
@@ -433,6 +438,10 @@ func (d *laneDiscoverer) chainCandidates(chainSel uint64) ([]uint64, error) {
 	if !isEVMChain(chainSel) {
 		return nil, nil
 	}
+	if deprecatedChain(chainSel) {
+		d.env.Logger.Warnf("skipping deprecated chain %d", chainSel)
+		return nil, nil
+	}
 
 	resolver, ok := d.resolvers.GetLaneVersionResolver(chainSel)
 	if !ok {
@@ -446,15 +455,19 @@ func (d *laneDiscoverer) chainCandidates(chainSel uint64) ([]uint64, error) {
 		return nil, fmt.Errorf("failed to derive lane versions for chain %d: %w", chainSel, err)
 	}
 
-	// Keep only EVM remotes that are connected, not blocklisted, not already on 2.0, and whose
-	// source lane version we can migrate (i.e. has a registered config importer). Lanes with an
-	// unknown or unsupported version are skipped — we never migrate a lane without a resolver.
+	// Keep only EVM remotes that are connected, not blocklisted, not already on 2.0, not
+	// deprecated, and whose source lane version we can migrate (i.e. has a registered config
+	// importer). Lanes with an unknown or unsupported version are skipped — we never migrate a
+	// lane without a resolver.
 	candidateVersions := make(map[uint64]*semver.Version, len(laneVersions))
 	for remote, version := range laneVersions {
 		switch {
 		case isExcluded(d.excludedRemotes, remote):
 			continue
 		case !isEVMChain(remote):
+			continue
+		case deprecatedChain(remote):
+			d.env.Logger.Warnf("skipping deprecated remote chain %d on chain %d", remote, chainSel)
 			continue
 		case version != nil && version.Major() >= v2MajorVersion:
 			continue
@@ -481,6 +494,9 @@ func (d *laneDiscoverer) chainCandidates(chainSel uint64) ([]uint64, error) {
 
 // reverseDirectionCarriesExcludedToken checks the remote-to-local direction before a directional
 // candidate is promoted to a bidirectional lane. chainCandidates already checked chainSel-to-remote.
+// A reverse chain that cannot be resolved (dead RPC, or missing from the environment) is treated as
+// excluded — its lane is held back from this batch rather than migrating it unverified or aborting
+// discovery entirely.
 func (d *laneDiscoverer) reverseDirectionCarriesExcludedToken(chainSel, remote uint64) (bool, error) {
 	if len(d.excludedSymbols) == 0 {
 		return false, nil
@@ -488,14 +504,17 @@ func (d *laneDiscoverer) reverseDirectionCarriesExcludedToken(chainSel, remote u
 
 	resolver, ok := d.resolvers.GetLaneVersionResolver(remote)
 	if !ok {
-		return false, fmt.Errorf("no lane version resolver registered for reverse chain %d", remote)
+		d.env.Logger.Warnf("no lane version resolver for reverse chain %d; holding lane back", remote)
+		return true, nil
 	}
 	if !resolver.IsSupportedChain(d.env, remote) {
-		return false, fmt.Errorf("reverse chain %d is not supported by its lane version resolver", remote)
+		d.env.Logger.Warnf("reverse chain %d is not supported by its lane version resolver; holding lane back", remote)
+		return true, nil
 	}
 	laneVersions, _, err := resolver.DeriveLaneVersionsForChain(d.env, remote)
 	if err != nil {
-		return false, fmt.Errorf("failed to derive lane versions for reverse chain %d: %w", remote, err)
+		d.env.Logger.Warnf("failed to derive lane versions for reverse chain %d: %v; holding lane back", remote, err)
+		return true, nil
 	}
 	version, connected := laneVersions[chainSel]
 	if !connected {
@@ -684,6 +703,13 @@ func isExcluded(set map[uint64]struct{}, sel uint64) bool {
 func isEVMChain(sel uint64) bool {
 	family, err := chainsel.GetSelectorFamily(sel)
 	return err == nil && family == chainsel.FamilyEVM
+}
+
+// deprecatedChain reports whether the chain selector is marked deprecated in chain-selectors.
+// Unknown selectors are treated as not deprecated.
+func deprecatedChain(sel uint64) bool {
+	deprecated, err := chainsel.IsDeprecated(sel)
+	return err == nil && deprecated
 }
 
 // canonicalLaneKey returns an order-independent key for a bidirectional lane so that discovering

--- a/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2_internal_test.go
+++ b/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2_internal_test.go
@@ -30,6 +30,8 @@ type fakeLaneVersionResolver struct {
 	supported map[uint64]bool
 	lanes     map[uint64]map[uint64]*semver.Version
 	err       error
+	// errs returns a per-chain derivation error; checked before err.
+	errs map[uint64]error
 }
 
 func (f *fakeLaneVersionResolver) IsSupportedChain(_ cldf.Environment, sel uint64) bool {
@@ -37,6 +39,9 @@ func (f *fakeLaneVersionResolver) IsSupportedChain(_ cldf.Environment, sel uint6
 }
 
 func (f *fakeLaneVersionResolver) DeriveLaneVersionsForChain(_ cldf.Environment, sel uint64) (map[uint64]*semver.Version, []*semver.Version, error) {
+	if perChainErr, ok := f.errs[sel]; ok {
+		return nil, nil, perChainErr
+	}
 	if f.err != nil {
 		return nil, nil, f.err
 	}
@@ -336,6 +341,57 @@ func TestDiscoverLanesToMigrate_ErrorsWhenChainUnsupported(t *testing.T) {
 	assert.Contains(t, err.Error(), "not supported")
 }
 
+func TestDiscoverLanesToMigrate_SkipsDeprecatedRemotes(t *testing.T) {
+	chainA := chainsel.TEST_90000001.Selector
+	remoteLive := chainsel.TEST_90000002.Selector
+	remoteDeprecated := chainsel.CORN_MAINNET.Selector
+
+	require.True(t, deprecatedChain(remoteDeprecated))
+	require.False(t, deprecatedChain(remoteLive))
+
+	resolver := &fakeLaneVersionResolver{
+		supported: map[uint64]bool{chainA: true},
+		lanes: map[uint64]map[uint64]*semver.Version{
+			chainA: {
+				remoteLive:       semver.MustParse("1.6.0"),
+				remoteDeprecated: semver.MustParse("1.6.0"),
+			},
+		},
+	}
+
+	lanes, err := discoverLanesToMigrate(
+		cldf.Environment{},
+		registryWithResolver(t, resolver),
+		supportedFQRegistry(t),
+		nil,
+		MigrateChainLanesToV2Config{
+			MigrateChainLanesToV2Input: MigrateChainLanesToV2Input{ChainSelectors: []uint64{chainA}},
+		},
+	)
+	require.NoError(t, err)
+	require.Len(t, lanes, 1)
+	assert.Equal(t, remoteLive, lanes[0].ChainB)
+	for _, lane := range lanes {
+		assert.NotEqual(t, remoteDeprecated, lane.ChainB, "deprecated remote must not be migrated")
+	}
+}
+
+func TestDiscoverLanesToMigrate_SkipsDeprecatedLocalChain(t *testing.T) {
+	deprecated := chainsel.CORN_MAINNET.Selector
+
+	lanes, err := discoverLanesToMigrate(
+		cldf.Environment{},
+		adapters.NewDeployChainContractsRegistry(),
+		supportedFQRegistry(t),
+		nil,
+		MigrateChainLanesToV2Config{
+			MigrateChainLanesToV2Input: MigrateChainLanesToV2Input{ChainSelectors: []uint64{deprecated}},
+		},
+	)
+	require.NoError(t, err)
+	require.Empty(t, lanes)
+}
+
 func TestDiscoverLanesToMigrate_ExcludesNonEVMRemotes(t *testing.T) {
 	chainA := chainsel.TEST_90000001.Selector
 	remoteEVM := chainsel.TEST_90000002.Selector
@@ -461,6 +517,39 @@ func TestDiscoverLanesToMigrate_SkipsLaneWithExcludedTokenOnlyInReverseDirection
 		registryWithResolver(t, resolver),
 		fqRegistryWithImporter(t, version, importer),
 		symbolLookupFrom(map[common.Address]string{usdc: "USDC", other: "WETH"}),
+		MigrateChainLanesToV2Config{
+			MigrateChainLanesToV2Input: MigrateChainLanesToV2Input{
+				ChainSelectors:               []uint64{chainA},
+				ExcludeLanesWithTokenSymbols: []string{"USDC"},
+			},
+		},
+	)
+	require.NoError(t, err)
+	require.Empty(t, lanes)
+}
+
+func TestDiscoverLanesToMigrate_SkipsReverseCheckWhenResolverErrors(t *testing.T) {
+	chainA := chainsel.TEST_90000001.Selector
+	chainB := chainsel.TEST_90000002.Selector
+	version := semver.MustParse("1.6.0")
+
+	// chainA -> chainB is a valid candidate, but resolving chainB's own lanes (reverse direction)
+	// fails — e.g. chainB is deprecated with dead RPCs. Discovery must skip, not abort.
+	resolver := &fakeLaneVersionResolver{
+		supported: map[uint64]bool{chainA: true, chainB: true},
+		lanes: map[uint64]map[uint64]*semver.Version{
+			chainA: {chainB: version},
+		},
+		errs: map[uint64]error{
+			chainB: errors.New("EVM chain with selector 9043146809313071210 not found in environment"),
+		},
+	}
+
+	lanes, err := discoverLanesToMigrate(
+		cldf.Environment{},
+		registryWithResolver(t, resolver),
+		fqRegistryWithImporter(t, version, &fakeConfigImporter{tokensPerRemote: map[uint64][]common.Address{chainB: {}}}),
+		symbolLookupFrom(map[common.Address]string{}),
 		MigrateChainLanesToV2Config{
 			MigrateChainLanesToV2Input: MigrateChainLanesToV2Input{
 				ChainSelectors:               []uint64{chainA},

--- a/deployment/deploy/lanemigrator.go
+++ b/deployment/deploy/lanemigrator.go
@@ -129,8 +129,8 @@ func laneMigrateApply(migratorReg *LaneMigratorRegistry, mcmsRegistry *changeset
 			if err != nil {
 				return cldf.ChangesetOutput{}, err
 			}
-			// get the ramp address refs (canonical ref to ignore any legacy-qualified duplicate)
-			onRampRef, err := datastore_utils.FindAndFormatCanonicalRef(e.DataStore, datastore.AddressRef{
+			// get the ramp address refs
+			onRampRef, err := datastore_utils.FindAndFormatRef(e.DataStore, datastore.AddressRef{
 				ChainSelector: chainSel,
 				Type:          "OnRamp",
 				Version:       perChainConfig.RampVersion,

--- a/deployment/deploy/lanemigrator.go
+++ b/deployment/deploy/lanemigrator.go
@@ -129,8 +129,8 @@ func laneMigrateApply(migratorReg *LaneMigratorRegistry, mcmsRegistry *changeset
 			if err != nil {
 				return cldf.ChangesetOutput{}, err
 			}
-			// get the ramp address refs
-			onRampRef, err := datastore_utils.FindAndFormatRef(e.DataStore, datastore.AddressRef{
+			// get the ramp address refs (canonical ref to ignore any legacy-qualified duplicate)
+			onRampRef, err := datastore_utils.FindAndFormatCanonicalRef(e.DataStore, datastore.AddressRef{
 				ChainSelector: chainSel,
 				Type:          "OnRamp",
 				Version:       perChainConfig.RampVersion,


### PR DESCRIPTION
- Allow 1.5 to 2.0 migration (validation fixes)
- Exclude sunset chains from migrating lanes