### PR TITLE
Add USDC proxy mechanism switch to lane migrator

### DIFF
--- a/chains/evm/deployment/v2_0_0/adapters/lanemigrator.go
+++ b/chains/evm/deployment/v2_0_0/adapters/lanemigrator.go
@@ -38,12 +38,21 @@ import (
 	fqops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/fee_quoter"
 	offrampops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/offramp"
 	onrampops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/onramp"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/usdc_token_pool_proxy"
 )
 
 const (
 	DefaultTxGasLimit       uint32 = 200_000
 	DefaultMaxDataBytes     uint32 = 32_000
 	DefaultTokenFeeUSDCents uint16 = 0
+
+	usdcLockOrBurnMechanismInvalid     uint8 = 0
+	usdcLockOrBurnMechanismCCTPV1      uint8 = 1
+	usdcLockOrBurnMechanismCCTPV2      uint8 = 2
+	usdcLockOrBurnMechanismLockRelease uint8 = 3
+	usdcLockOrBurnMechanismCCV         uint8 = 4
+
+	usdcMechanismCCTPV2WithCCV = "CCTP_V2_WITH_CCV"
 )
 
 type LaneMigrator struct{}
@@ -451,6 +460,11 @@ func (r *LaneMigrator) UpdateVersionWithRouter() *cldf_ops.Sequence[deploy.RampU
 				return sequences.OnChainOutput{}, fmt.Errorf("error applying destChainConfig update to fee quoter: %w", err)
 			}
 			writes = append(writes, fqDestChainUpdateRep.Output)
+			usdcProxyWrites, err := updateUSDCTokenPoolProxyMechanismsToCCTPV2WithCCV(b, c, tempDS, input.ChainSelector, input.RemoteChainSelectors)
+			if err != nil {
+				return sequences.OnChainOutput{}, err
+			}
+			writes = append(writes, usdcProxyWrites...)
 			batchOp, err := contract.NewBatchOperationFromWrites(writes)
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to create batch operation from writes: %w", err)
@@ -459,4 +473,93 @@ func (r *LaneMigrator) UpdateVersionWithRouter() *cldf_ops.Sequence[deploy.RampU
 				BatchOps: []mcms_types.BatchOperation{batchOp},
 			}, nil
 		})
+}
+
+// updateUSDCTokenPoolProxyMechanismsToCCTPV2WithCCV is a no-op for non-USDC
+// lanes, unset USDC lanes, lock-release lanes, and lanes already using CCV.
+func updateUSDCTokenPoolProxyMechanismsToCCTPV2WithCCV(
+	b cldf_ops.Bundle,
+	chain evm.Chain,
+	ds datastore.DataStore,
+	chainSelector uint64,
+	remoteChainSelectors []uint64,
+) ([]contract.WriteOutput, error) {
+	proxyRefs := ds.Addresses().Filter(
+		datastore.AddressRefByChainSelector(chainSelector),
+		datastore.AddressRefByType(datastore.ContractType(usdc_token_pool_proxy.ContractType)),
+		datastore.AddressRefByVersion(usdc_token_pool_proxy.Version),
+	)
+	switch len(proxyRefs) {
+	case 0:
+		return nil, nil
+	case 1:
+	default:
+		return nil, fmt.Errorf("expected at most one USDCTokenPoolProxy v%s on chain %d, found %d", usdc_token_pool_proxy.Version, chainSelector, len(proxyRefs))
+	}
+
+	proxyAddr, err := evm_datastore_utils.ToEVMAddress(proxyRefs[0])
+	if err != nil {
+		return nil, fmt.Errorf("error formatting USDCTokenPoolProxy address ref: %w", err)
+	}
+
+	toUpdateSelectors := make([]uint64, 0, len(remoteChainSelectors))
+	toUpdateMechanisms := make([]uint8, 0, len(remoteChainSelectors))
+	for _, remoteChainSelector := range remoteChainSelectors {
+		currentMechanismReport, err := cldf_ops.ExecuteOperation(b, usdc_token_pool_proxy.GetLockOrBurnMechanism, chain, contract.FunctionInput[uint64]{
+			ChainSelector: chainSelector,
+			Address:       proxyAddr,
+			Args:          remoteChainSelector,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get USDCTokenPoolProxy lock or burn mechanism for chain %d remote chain %d: %w", chainSelector, remoteChainSelector, err)
+		}
+
+		shouldUpdate, err := shouldUpdateUSDCLockOrBurnMechanismToCCTPV2WithCCV(currentMechanismReport.Output)
+		if err != nil {
+			return nil, fmt.Errorf("failed to evaluate USDCTokenPoolProxy lock or burn mechanism for chain %d remote chain %d: %w", chainSelector, remoteChainSelector, err)
+		}
+		if !shouldUpdate {
+			continue
+		}
+
+		toUpdateSelectors = append(toUpdateSelectors, remoteChainSelector)
+		toUpdateMechanisms = append(toUpdateMechanisms, usdcLockOrBurnMechanismCCV)
+	}
+	if len(toUpdateSelectors) == 0 {
+		return nil, nil
+	}
+	poolsReport, err := cldf_ops.ExecuteOperation(b, usdc_token_pool_proxy.GetPools, chain, contract.FunctionInput[struct{}]{
+		ChainSelector: chainSelector,
+		Address:       proxyAddr,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get USDCTokenPoolProxy pool addresses for chain %d: %w", chainSelector, err)
+	}
+	if poolsReport.Output.CctpV2PoolWithCCV == (common.Address{}) {
+		return nil, fmt.Errorf("cannot update USDCTokenPoolProxy lock or burn mechanisms to %s on chain %d: CCTP_V2_WITH_CCV pool is not set", usdcMechanismCCTPV2WithCCV, chainSelector)
+	}
+
+	report, err := cldf_ops.ExecuteOperation(b, usdc_token_pool_proxy.UpdateLockOrBurnMechanisms, chain, contract.FunctionInput[usdc_token_pool_proxy.UpdateLockOrBurnMechanismsArgs]{
+		ChainSelector: chainSelector,
+		Address:       proxyAddr,
+		Args: usdc_token_pool_proxy.UpdateLockOrBurnMechanismsArgs{
+			RemoteChainSelectors: toUpdateSelectors,
+			Mechanisms:           toUpdateMechanisms,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to update USDCTokenPoolProxy lock or burn mechanisms to %s: %w", usdcMechanismCCTPV2WithCCV, err)
+	}
+	return []contract.WriteOutput{report.Output}, nil
+}
+
+func shouldUpdateUSDCLockOrBurnMechanismToCCTPV2WithCCV(current uint8) (bool, error) {
+	switch current {
+	case usdcLockOrBurnMechanismCCTPV1, usdcLockOrBurnMechanismCCTPV2:
+		return true, nil
+	case usdcLockOrBurnMechanismInvalid, usdcLockOrBurnMechanismLockRelease, usdcLockOrBurnMechanismCCV:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected mechanism %d", current)
+	}
 }

--- a/chains/evm/deployment/v2_0_0/adapters/lanemigrator.go
+++ b/chains/evm/deployment/v2_0_0/adapters/lanemigrator.go
@@ -29,6 +29,7 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/committee_verifier"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/executor"
 	seq2_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences"
+	cctpseq "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences/cctp"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_1_0/operations/rmn"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/deploy"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
@@ -45,14 +46,6 @@ const (
 	DefaultTxGasLimit       uint32 = 200_000
 	DefaultMaxDataBytes     uint32 = 32_000
 	DefaultTokenFeeUSDCents uint16 = 0
-
-	usdcLockOrBurnMechanismInvalid     uint8 = 0
-	usdcLockOrBurnMechanismCCTPV1      uint8 = 1
-	usdcLockOrBurnMechanismCCTPV2      uint8 = 2
-	usdcLockOrBurnMechanismLockRelease uint8 = 3
-	usdcLockOrBurnMechanismCCV         uint8 = 4
-
-	usdcMechanismCCTPV2WithCCV = "CCTP_V2_WITH_CCV"
 )
 
 type LaneMigrator struct{}
@@ -523,7 +516,7 @@ func updateUSDCTokenPoolProxyMechanismsToCCTPV2WithCCV(
 		}
 
 		toUpdateSelectors = append(toUpdateSelectors, remoteChainSelector)
-		toUpdateMechanisms = append(toUpdateMechanisms, usdcLockOrBurnMechanismCCV)
+		toUpdateMechanisms = append(toUpdateMechanisms, cctpseq.LockOrBurnMechanismCCV)
 	}
 	if len(toUpdateSelectors) == 0 {
 		return nil, nil
@@ -536,7 +529,7 @@ func updateUSDCTokenPoolProxyMechanismsToCCTPV2WithCCV(
 		return nil, fmt.Errorf("failed to get USDCTokenPoolProxy pool addresses for chain %d: %w", chainSelector, err)
 	}
 	if poolsReport.Output.CctpV2PoolWithCCV == (common.Address{}) {
-		return nil, fmt.Errorf("cannot update USDCTokenPoolProxy lock or burn mechanisms to %s on chain %d: CCTP_V2_WITH_CCV pool is not set", usdcMechanismCCTPV2WithCCV, chainSelector)
+		return nil, fmt.Errorf("cannot update USDCTokenPoolProxy lock or burn mechanisms to %s on chain %d: CCTP_V2_WITH_CCV pool is not set", cctpseq.MechanismCCTPV2WithCCV, chainSelector)
 	}
 
 	report, err := cldf_ops.ExecuteOperation(b, usdc_token_pool_proxy.UpdateLockOrBurnMechanisms, chain, contract.FunctionInput[usdc_token_pool_proxy.UpdateLockOrBurnMechanismsArgs]{
@@ -548,16 +541,16 @@ func updateUSDCTokenPoolProxyMechanismsToCCTPV2WithCCV(
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to update USDCTokenPoolProxy lock or burn mechanisms to %s: %w", usdcMechanismCCTPV2WithCCV, err)
+		return nil, fmt.Errorf("failed to update USDCTokenPoolProxy lock or burn mechanisms to %s: %w", cctpseq.MechanismCCTPV2WithCCV, err)
 	}
 	return []contract.WriteOutput{report.Output}, nil
 }
 
 func shouldUpdateUSDCLockOrBurnMechanismToCCTPV2WithCCV(current uint8) (bool, error) {
 	switch current {
-	case usdcLockOrBurnMechanismCCTPV1, usdcLockOrBurnMechanismCCTPV2:
+	case cctpseq.LockOrBurnMechanismCCTPV1, cctpseq.LockOrBurnMechanismCCTPV2:
 		return true, nil
-	case usdcLockOrBurnMechanismInvalid, usdcLockOrBurnMechanismLockRelease, usdcLockOrBurnMechanismCCV:
+	case cctpseq.LockOrBurnMechanismInvalid, cctpseq.LockOrBurnMechanismLockRelease, cctpseq.LockOrBurnMechanismCCV:
 		return false, nil
 	default:
 		return false, fmt.Errorf("unexpected mechanism %d", current)

--- a/chains/evm/deployment/v2_0_0/adapters/lanemigrator_usdc_test.go
+++ b/chains/evm/deployment/v2_0_0/adapters/lanemigrator_usdc_test.go
@@ -1,0 +1,60 @@
+package adapters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldUpdateUSDCLockOrBurnMechanismToCCTPV2WithCCV(t *testing.T) {
+	tests := []struct {
+		name          string
+		current       uint8
+		wantUpdate    bool
+		wantErrSubstr string
+	}{
+		{
+			name:       "skips invalid mechanism",
+			current:    usdcLockOrBurnMechanismInvalid,
+			wantUpdate: false,
+		},
+		{
+			name:       "updates cctp v1",
+			current:    usdcLockOrBurnMechanismCCTPV1,
+			wantUpdate: true,
+		},
+		{
+			name:       "updates cctp v2",
+			current:    usdcLockOrBurnMechanismCCTPV2,
+			wantUpdate: true,
+		},
+		{
+			name:       "skips lock release",
+			current:    usdcLockOrBurnMechanismLockRelease,
+			wantUpdate: false,
+		},
+		{
+			name:       "skips ccv",
+			current:    usdcLockOrBurnMechanismCCV,
+			wantUpdate: false,
+		},
+		{
+			name:          "errors on unexpected mechanism",
+			current:       5,
+			wantErrSubstr: "unexpected mechanism 5",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := shouldUpdateUSDCLockOrBurnMechanismToCCTPV2WithCCV(test.current)
+			if test.wantErrSubstr != "" {
+				require.ErrorContains(t, err, test.wantErrSubstr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.wantUpdate, got)
+		})
+	}
+}

--- a/chains/evm/deployment/v2_0_0/adapters/lanemigrator_usdc_test.go
+++ b/chains/evm/deployment/v2_0_0/adapters/lanemigrator_usdc_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	cctpseq "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/sequences/cctp"
 )
 
 func TestShouldUpdateUSDCLockOrBurnMechanismToCCTPV2WithCCV(t *testing.T) {
@@ -15,27 +17,27 @@ func TestShouldUpdateUSDCLockOrBurnMechanismToCCTPV2WithCCV(t *testing.T) {
 	}{
 		{
 			name:       "skips invalid mechanism",
-			current:    usdcLockOrBurnMechanismInvalid,
+			current:    cctpseq.LockOrBurnMechanismInvalid,
 			wantUpdate: false,
 		},
 		{
 			name:       "updates cctp v1",
-			current:    usdcLockOrBurnMechanismCCTPV1,
+			current:    cctpseq.LockOrBurnMechanismCCTPV1,
 			wantUpdate: true,
 		},
 		{
 			name:       "updates cctp v2",
-			current:    usdcLockOrBurnMechanismCCTPV2,
+			current:    cctpseq.LockOrBurnMechanismCCTPV2,
 			wantUpdate: true,
 		},
 		{
 			name:       "skips lock release",
-			current:    usdcLockOrBurnMechanismLockRelease,
+			current:    cctpseq.LockOrBurnMechanismLockRelease,
 			wantUpdate: false,
 		},
 		{
 			name:       "skips ccv",
-			current:    usdcLockOrBurnMechanismCCV,
+			current:    cctpseq.LockOrBurnMechanismCCV,
 			wantUpdate: false,
 		},
 		{

--- a/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2.go
+++ b/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2.go
@@ -178,6 +178,10 @@ func MigrateChainLanesToV2(
 			return deployment.ChangesetOutput{}, err
 		}
 
+		// TODO: Wire the USDC CCTP_V2_WITH_CCV mechanism switch into this prod-router
+		// migration path once MigrateChainLanesToV2 supports the same targeted prod-lane
+		// workflow as LaneMigrateToNewVersionChangeset.
+
 		// Lane migrations to the TestRouter also get a TESTTR test token wired behind it.
 		if cfg.TestRouter == nil || !*cfg.TestRouter {
 			return laneOut, nil

--- a/chains/evm/deployment/v2_0_0/sequences/cctp/configure_cctp_chain_for_lanes.go
+++ b/chains/evm/deployment/v2_0_0/sequences/cctp/configure_cctp_chain_for_lanes.go
@@ -36,10 +36,16 @@ import (
 )
 
 const (
-	mechanismCCTPV1        = "CCTP_V1"
-	mechanismCCTPV2        = "CCTP_V2"
-	mechanismLockRelease   = "LOCK_RELEASE"
-	mechanismCCTPV2WithCCV = "CCTP_V2_WITH_CCV"
+	MechanismCCTPV1        = "CCTP_V1"
+	MechanismCCTPV2        = "CCTP_V2"
+	MechanismLockRelease   = "LOCK_RELEASE"
+	MechanismCCTPV2WithCCV = "CCTP_V2_WITH_CCV"
+
+	LockOrBurnMechanismInvalid     uint8 = 0
+	LockOrBurnMechanismCCTPV1      uint8 = 1
+	LockOrBurnMechanismCCTPV2      uint8 = 2
+	LockOrBurnMechanismLockRelease uint8 = 3
+	LockOrBurnMechanismCCV         uint8 = 4
 )
 
 var v162 = semver.MustParse("1.6.2")
@@ -73,7 +79,7 @@ var ConfigureCCTPChainForLanes = cldf_ops.NewSequence(
 		}
 		lockReleaseSelectors := make([]uint64, 0)
 		for sel, cfg := range input.RemoteChains {
-			if cfg.LockOrBurnMechanism == mechanismLockRelease {
+			if cfg.LockOrBurnMechanism == MechanismLockRelease {
 				lockReleaseSelectors = append(lockReleaseSelectors, sel)
 			}
 		}
@@ -237,7 +243,7 @@ var ConfigureCCTPChainForLanes = cldf_ops.NewSequence(
 		// Configure remote chains on CCTP V1 token pool (1.6.1 sequence).
 		cctpV1TokenPoolAddress := common.HexToAddress(refs.CCTPV1TokenPool.Address)
 		for remoteChainSelector, remoteChain := range input.RemoteChains {
-			if remoteChain.LockOrBurnMechanism != mechanismCCTPV1 {
+			if remoteChain.LockOrBurnMechanism != MechanismCCTPV1 {
 				continue
 			}
 			if refs.CCTPV1TokenPool.Address == "" {
@@ -267,7 +273,7 @@ var ConfigureCCTPChainForLanes = cldf_ops.NewSequence(
 		// would be wasted state.
 		cctpThroughCCVRemoteChainConfigs := make(map[uint64]tokens_core.RemoteChainConfig[[]byte, string])
 		for remoteChainSelector, remoteChainConfig := range remoteChainConfigs {
-			if input.RemoteChains[remoteChainSelector].LockOrBurnMechanism == mechanismLockRelease {
+			if input.RemoteChains[remoteChainSelector].LockOrBurnMechanism == MechanismLockRelease {
 				continue
 			}
 			if !isEVMRemote(remoteChainSelector) {
@@ -519,7 +525,7 @@ func buildRemoteChainConfigs(dep adapters.ConfigureCCTPChainForLanesDeps, input 
 func buildVerifierResolverOutboundArgs(input adapters.ConfigureCCTPChainForLanesInput, cctpVerifierAddress common.Address) []versioned_verifier_resolver.OutboundImplementationArgs {
 	out := make([]versioned_verifier_resolver.OutboundImplementationArgs, 0, len(input.RemoteChains))
 	for remoteChainSelector, remoteChain := range input.RemoteChains {
-		if remoteChain.LockOrBurnMechanism == mechanismLockRelease {
+		if remoteChain.LockOrBurnMechanism == MechanismLockRelease {
 			continue
 		}
 		if !isEVMRemote(remoteChainSelector) {
@@ -654,7 +660,7 @@ func buildCCTPV1PoolDomainUpdates(dep adapters.ConfigureCCTPChainForLanesDeps, i
 			// Non-canonical USDC chains do not support CCTP, so we don't need to perform any CCTP-specific operations.
 			continue
 		}
-		if remoteChain.LockOrBurnMechanism != mechanismCCTPV1 {
+		if remoteChain.LockOrBurnMechanism != MechanismCCTPV1 {
 			continue
 		}
 		allowedCallerOnDest, err := dep.RemoteChains[remoteChainSelector].CCTPV1AllowedCallerOnDest(dep.DataStore, dep.BlockChains, remoteChainSelector)
@@ -921,19 +927,19 @@ func applyCCTPV1PoolSetDomainsWrites(b cldf_ops.Bundle, chain evm.Chain, poolAdd
 
 func convertMechanismToUint8(mechanism string) (uint8, error) {
 	switch mechanism {
-	case mechanismCCTPV1:
-		return 1, nil
-	case mechanismCCTPV2:
-		return 2, nil
-	case mechanismLockRelease:
-		return 3, nil
-	case mechanismCCTPV2WithCCV:
-		return 4, nil
+	case MechanismCCTPV1:
+		return LockOrBurnMechanismCCTPV1, nil
+	case MechanismCCTPV2:
+		return LockOrBurnMechanismCCTPV2, nil
+	case MechanismLockRelease:
+		return LockOrBurnMechanismLockRelease, nil
+	case MechanismCCTPV2WithCCV:
+		return LockOrBurnMechanismCCV, nil
 	default:
-		return 0, fmt.Errorf("invalid mechanism, must be %s, %s, %s, or %s: %s", mechanismCCTPV1, mechanismCCTPV2, mechanismLockRelease, mechanismCCTPV2WithCCV, mechanism)
+		return 0, fmt.Errorf("invalid mechanism, must be %s, %s, %s, or %s: %s", MechanismCCTPV1, MechanismCCTPV2, MechanismLockRelease, MechanismCCTPV2WithCCV, mechanism)
 	}
 }
 
 func isV2Mechanism(mechanism string) bool {
-	return mechanism == mechanismCCTPV2 || mechanism == mechanismCCTPV2WithCCV
+	return mechanism == MechanismCCTPV2 || mechanism == MechanismCCTPV2WithCCV
 }


### PR DESCRIPTION
Adds USDCTokenPoolProxy handling to the EVM v2 LaneMigrateToNewVersionChangeset path.

- When migrating lanes to the prod router, the migrator now reads the current USDC lock/burn mechanism per remote chain and updates only `CCTP_V1` or `CCTP_V2` lanes to `CCTP_V2_WITH_CCV`. It skips unset, lock-release, and already-CCV lanes. 
- Also adds a TODO in `MigrateChainLanesToV2` for future prod-router support.

Changes
  - resolves USDCTokenPoolProxy from the datastore. No proxy ref means no-op.
  - Per remote lane, it reads `getLockOrBurnMechanism`
  - It updates only `CCTP_V1` or `CCTP_V2` to `CCTP_V2_WITH_CCV`
  - It skips `INVALID_MECHANISM`, `LOCK_RELEASE`, and already-CCV.
  - It preflights `getPools()` and errors if the `cctpV2PoolWithCCV` pool is not set before proposing/executing the update.
  - Add test
