### PR TITLE
Skip TAR registration with a flag

### DIFF
--- a/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2.go
+++ b/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2.go
@@ -331,8 +331,17 @@ func newTestTokenPerChainConfig(e deployment.Environment, sel uint64, remotes ma
 			Decimals: testTokenDecimals,
 			Type:     deployment.ContractType(burn_mint_erc20_with_drip.ContractType),
 		}
-	} else if e.Logger != nil {
-		e.Logger.Infof("reusing existing %s token at %s on chain with selector %d", testTokenSymbol, existing[0].Address, sel)
+	} else {
+		// TESTTR is already recorded on this chain: the changeset that first touched it in this
+		// batch deployed it and emitted its TokenAdminRegistry registration + token admin
+		// handover ops. Those ops are pending in the same MCMS root — re-emitting them would
+		// revert AlreadyRegistered at execution time and, because MCMS ops must run in per-chain
+		// nonce order, block every later operation for this chain. Only the new lane's pool
+		// remote configuration still needs to run.
+		perChain.TokenTransferConfig.SkipTokenAdminRegistrySetup = true
+		if e.Logger != nil {
+			e.Logger.Infof("reusing existing %s token at %s on chain with selector %d; skipping already-emitted registry setup ops", testTokenSymbol, existing[0].Address, sel)
+		}
 	}
 	return perChain, nil
 }

--- a/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2_internal_test.go
+++ b/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2_internal_test.go
@@ -617,6 +617,67 @@ func TestBuildTestTokenExpansionInput_ReusesExistingToken(t *testing.T) {
 	assert.NotNil(t, in.TokenExpansionInputPerChain[chainB].DeployTokenInput, "chain without TESTTR must deploy a fresh token")
 }
 
+// TestBuildTestTokenExpansionInput_SharedChainDoesNotReemitRegistrySetup reproduces the
+// production failure from PR 18490 (12 of 35 chains affected): within one merged batch, two
+// migrate_chain_lanes_to_v2 changesets share a lane partner (chainShared here, e.g. sonic,
+// which lanes with bob, core, linea and mode). The first-touching changeset deploys TESTTR on
+// the shared chain and emits its TokenAdminRegistry registration (proposeAdministrator +
+// acceptAdminRole + setPool). The durable pipeline persists each changeset's output datastore,
+// so when the second changeset re-encounters the shared chain the token ref is already
+// recorded but the on-chain registry is still empty (nothing has executed yet). Re-emitting
+// the registration produced a second identical proposeAdministrator that reverts
+// AlreadyRegistered at execution time and — because MCMS ops must run in per-chain nonce
+// order — blocks every later operation for that chain in the root.
+func TestBuildTestTokenExpansionInput_SharedChainDoesNotReemitRegistrySetup(t *testing.T) {
+	chainFirst := chainsel.TEST_90000001.Selector  // first changeset's selected chain
+	chainSecond := chainsel.TEST_90000002.Selector // later changeset's selected chain
+	chainShared := chainsel.TEST_90000003.Selector // lane partner shared by both changesets
+
+	// Run 1: the first-touching changeset — both chains are fresh, so both get the full test
+	// token setup including the registry registration.
+	in1, err := buildTestTokenExpansionInput(cldf.Environment{}, MigrateChainLanesToV2Config{}, []v2changesets.CrossFamilyLanePair{
+		{ChainA: chainFirst, ChainB: chainShared},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, in1.TokenExpansionInputPerChain[chainShared].TokenTransferConfig)
+	assert.False(t, in1.TokenExpansionInputPerChain[chainShared].TokenTransferConfig.SkipTokenAdminRegistrySetup,
+		"the first-touching changeset must emit the registration ops")
+	assert.Contains(t, in1.TokenExpansionInputPerChain[chainShared].TokenTransferConfig.RemoteChains, chainFirst)
+
+	// The durable pipeline persists each changeset's output datastore, so by the time the second
+	// changeset runs, the shared chain's TESTTR token ref is already recorded.
+	ds := datastore.NewMemoryDataStore()
+	require.NoError(t, ds.Addresses().Add(datastore.AddressRef{
+		ChainSelector: chainShared,
+		Type:          datastore.ContractType(burn_mint_erc20_with_drip.ContractType),
+		Version:       burn_mint_erc20_with_drip.Version,
+		Qualifier:     testTokenSymbol,
+		Address:       "0x000000000000000000000000000000000000babe",
+	}))
+
+	// Run 2: the later changeset re-encounters the shared chain through its own lane.
+	in2, err := buildTestTokenExpansionInput(cldf.Environment{DataStore: ds.Seal()}, MigrateChainLanesToV2Config{}, []v2changesets.CrossFamilyLanePair{
+		{ChainA: chainSecond, ChainB: chainShared},
+	})
+	require.NoError(t, err)
+
+	// The re-encountering run must skip the registry setup for the shared chain (run 1's
+	// proposal already emitted it — a second identical proposeAdministrator reverts
+	// AlreadyRegistered at execution), while still wiring run 2's new lane remote into the
+	// shared chain's pool.
+	sharedCfg := in2.TokenExpansionInputPerChain[chainShared]
+	require.NotNil(t, sharedCfg.TokenTransferConfig)
+	assert.True(t, sharedCfg.TokenTransferConfig.SkipTokenAdminRegistrySetup,
+		"the re-encountering changeset must skip the already-emitted registry setup ops")
+	assert.Contains(t, sharedCfg.TokenTransferConfig.RemoteChains, chainSecond,
+		"run 2's new lane remote must still be configured on the shared chain's pool")
+
+	// The second changeset's own selected chain is fresh: it still gets the full setup,
+	// registration included.
+	assert.NotNil(t, in2.TokenExpansionInputPerChain[chainSecond].TokenTransferConfig)
+	assert.False(t, in2.TokenExpansionInputPerChain[chainSecond].TokenTransferConfig.SkipTokenAdminRegistrySetup)
+}
+
 func TestDiscoverLanesToMigrate_SkipsVersionWithoutConfigImporter(t *testing.T) {
 	chainA := chainsel.TEST_90000001.Selector
 	remote := chainsel.TEST_90000002.Selector

--- a/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_for_transfers.go
+++ b/chains/evm/deployment/v2_0_0/sequences/tokens/configure_token_for_transfers.go
@@ -135,18 +135,24 @@ var ConfigureTokenForTransfers = cldf_ops.NewSequence(
 		}
 		ops = append(ops, configureTokenPoolForRemoteChainsReport.Output.BatchOps...)
 
-		// Register the token with the token admin registry
-		registerTokenReport, err := cldf_ops.ExecuteSequence(b, v1_5_0.RegisterToken, evmChain, v1_5_0.RegisterTokenInput{
-			ChainSelector:             input.ChainSelector,
-			TokenAddress:              tokenAddress,
-			TokenPoolAddress:          registryTokenPoolAddress,
-			ExternalAdmin:             common.HexToAddress(input.ExternalAdmin),
-			TokenAdminRegistryAddress: registryAddress,
-		})
-		if err != nil {
-			return sequences.OnChainOutput{}, fmt.Errorf("failed to register token pool with address %s on %s: %w", input.TokenPoolAddress, evmChain, err)
+		// Register the token with the token admin registry. Skipped when an earlier changeset in
+		// the same MCMS batch already emitted the registration (SkipTokenAdminRegistrySetup): the
+		// on-chain gate inside RegisterToken cannot detect a pending but unexecuted registration,
+		// and a second identical proposeAdministrator would revert AlreadyRegistered at execution
+		// time, blocking every later op for this chain in the root.
+		if !input.SkipTokenAdminRegistrySetup {
+			registerTokenReport, err := cldf_ops.ExecuteSequence(b, v1_5_0.RegisterToken, evmChain, v1_5_0.RegisterTokenInput{
+				ChainSelector:             input.ChainSelector,
+				TokenAddress:              tokenAddress,
+				TokenPoolAddress:          registryTokenPoolAddress,
+				ExternalAdmin:             common.HexToAddress(input.ExternalAdmin),
+				TokenAdminRegistryAddress: registryAddress,
+			})
+			if err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("failed to register token pool with address %s on %s: %w", input.TokenPoolAddress, evmChain, err)
+			}
+			ops = append(ops, registerTokenReport.Output.BatchOps...)
 		}
-		ops = append(ops, registerTokenReport.Output.BatchOps...)
 
 		return sequences.OnChainOutput{
 			BatchOps: ops,

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -94,6 +94,14 @@ type TokenTransferConfig struct {
 	// implement that interface (e.g. USDCTokenPoolProxy) cause auto-migrate to fail; list remote chains
 	// explicitly in that case.
 	AutoMigrateRemoteChains bool `yaml:"autoMigrateRemoteChains" json:"autoMigrateRemoteChains"`
+	// SkipTokenAdminRegistrySetup suppresses the TokenAdminRegistry registration and the token
+	// admin role handover for this chain while still configuring the pool remote chains. Set it
+	// when the token's registry setup ops were already emitted by an earlier changeset in the
+	// same MCMS batch (the token is already recorded in the datastore but the registration has
+	// not executed yet): a second identical proposeAdministrator would revert with
+	// AlreadyRegistered at execution time and, because MCMS ops must run in per-chain nonce
+	// order, block every later operation for that chain.
+	SkipTokenAdminRegistrySetup bool `yaml:"skipTokenAdminRegistrySetup" json:"skipTokenAdminRegistrySetup"`
 }
 
 // ConfigureTokensForTransfersConfig is the configuration for the ConfigureTokensForTransfers changeset.
@@ -404,15 +412,16 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 		// Configure pool remotes (fee configs are excluded as they require
 		// special handling see comment below)
 		configureTokenReport, err := cldf_ops.ExecuteSequence(e.OperationsBundle, adapter.ConfigureTokenForTransfersSequence(), e.BlockChains, ConfigureTokenForTransfersInput{
-			ChainSelector:         selector,
-			TokenPoolAddress:      tokenPool.Address,
-			RemoteChains:          remoteChainsWithoutFeeConfigs,
-			ExternalAdmin:         token.ExternalAdmin,
-			RegistryAddress:       registryAddr,
-			TokenRef:              fullTokenRef,
-			PoolType:              tokenPool.Type.String(),
-			ExistingDataStore:     e.DataStore,
-			AllowedFinalityConfig: token.AllowedFinalityConfig,
+			ChainSelector:               selector,
+			TokenPoolAddress:            tokenPool.Address,
+			RemoteChains:                remoteChainsWithoutFeeConfigs,
+			ExternalAdmin:               token.ExternalAdmin,
+			RegistryAddress:             registryAddr,
+			TokenRef:                    fullTokenRef,
+			PoolType:                    tokenPool.Type.String(),
+			ExistingDataStore:           e.DataStore,
+			AllowedFinalityConfig:       token.AllowedFinalityConfig,
+			SkipTokenAdminRegistrySetup: token.SkipTokenAdminRegistrySetup,
 		})
 		if err != nil {
 			return batchOps, reports, nil, fmt.Errorf("failed to configure token pool on chain with selector %d: %w", selector, err)

--- a/deployment/tokens/product.go
+++ b/deployment/tokens/product.go
@@ -460,6 +460,11 @@ type ConfigureTokenForTransfersInput struct {
 	// to cover all chains the currently-registered pool supports. Set this when the pool being configured
 	// is not a direct replacement for the registered pool (e.g. CCTP-through-CCV alongside USDCTokenPoolProxy).
 	SkipActivePoolSupportedChainsCheck bool
+	// SkipTokenAdminRegistrySetup suppresses the TokenAdminRegistry registration (proposeAdministrator /
+	// acceptAdminRole / setPool). Set it when the registration ops were already emitted by an earlier
+	// changeset in the same MCMS batch: re-emitting them would revert AlreadyRegistered at execution
+	// time. The pool remote-chain configuration is unaffected by this flag.
+	SkipTokenAdminRegistrySetup bool
 	// Below are not provided by the user and populated programmatically.
 	// ExistingDataStore is the datastore containing existing deployment data.
 	ExistingDataStore datastore.DataStore


### PR DESCRIPTION
- `SkipTokenAdminRegistrySetup` suppresses the TokenAdminRegistry registration  (proposeAdministrator / acceptAdminRole / setPool). 
- Set it when the registration ops were already emitted by an earlier changeset in the same MCMS batch: re-emitting them would revert `AlreadyRegistered` at execution time. The pool remote-chain configuration is unaffected by this flag.
- For MigrateLanes if the Token exists in the datastore it assumes the Registration is already added in the proposal earlier or previous proposals & skips it