### PR TITLE
Chunk lane migration to stay under per tx gascap

### DIFF
--- a/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2.go
+++ b/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2.go
@@ -77,6 +77,11 @@ type MigrateChainLanesToV2Input struct {
 	// TestRouter migrates the lanes onto the TestRouter instead of the production Router, and
 	// configures a TESTTR test token behind the TestRouter on every migrated chain.
 	TestRouter *bool `json:"testRouter,omitempty" yaml:"testRouter,omitempty"`
+	// MaxLanesPerChunk caps how many lanes are configured per underlying apply, bounding each
+	// chain's per-timelock-batch gas below restrictive per-tx caps (e.g. Linea's 2^24). Each
+	// chunk emits its own MCMS proposal, so multi-chunk runs require merge-proposals: true and
+	// an explicit mcms.validUntil in the pipeline input. 0 (default) keeps a single chunk.
+	MaxLanesPerChunk int `json:"maxLanesPerChunk,omitempty" yaml:"maxLanesPerChunk,omitempty"`
 }
 
 // MigrateChainLanesToV2Config is the full changeset config: the durable-pipeline payload plus the
@@ -159,21 +164,7 @@ func MigrateChainLanesToV2(
 		e.Logger.Infow("migrate_chain_lanes_to_v2: migrating lanes to CCIP 2.0",
 			"count", len(lanes), "lanes", laneDescriptions)
 
-		resolvedCfg := v2changesets.ConfigureChainsForLanesFromTopologyConfig{
-			Topology: cfg.Topology,
-			BuildLanesCrossFamilyConfig: v2changesets.BuildLanesCrossFamilyConfig{
-				Lanes:      lanes,
-				MCMS:       cfg.MCMS,
-				TestRouter: cfg.TestRouter,
-				// A migration's whole purpose is to swap each lane's pre-2.0 OnRamp for the CCIP 2.0
-				// OnRamp on the (prod) router, so it must be allowed to overwrite the existing mapping.
-				AllowOnrampOverride: true,
-			},
-		}
-		if err := underlying.VerifyPreconditions(e, resolvedCfg); err != nil {
-			return deployment.ChangesetOutput{}, fmt.Errorf("resolved lane config failed preconditions: %w", err)
-		}
-		laneOut, err := underlying.Apply(e, resolvedCfg)
+		laneOut, err := applyLanesInChunks(e, underlying, cfg, lanes)
 		if err != nil {
 			return deployment.ChangesetOutput{}, err
 		}
@@ -199,24 +190,69 @@ func MigrateChainLanesToV2(
 		if err != nil {
 			return deployment.ChangesetOutput{}, err
 		}
-		return mergeTestTokenOutput(e, laneOut, tokenOut)
+		return mergeOutputs(e, laneOut, tokenOut)
 	}
 
 	return deployment.CreateChangeSet(apply, validate)
 }
 
-func mergeTestTokenOutput(e deployment.Environment, laneOut, tokenOut deployment.ChangesetOutput) (deployment.ChangesetOutput, error) {
-	merged := laneOut
-	if err := deployment.MergeChangesetOutput(e, &merged, tokenOut); err != nil {
-		return deployment.ChangesetOutput{}, fmt.Errorf("failed to merge test token output: %w", err)
+// applyLanesInChunks runs the underlying lane changeset once per chunk of at most
+// cfg.MaxLanesPerChunk lanes (a single chunk when unset) and merges the outputs. Each chunk
+// yields its own proposal; the pipeline's merge-proposals step folds them into one.
+func applyLanesInChunks(
+	e deployment.Environment,
+	underlying deployment.ChangeSetV2[v2changesets.ConfigureChainsForLanesFromTopologyConfig],
+	cfg MigrateChainLanesToV2Config,
+	lanes []v2changesets.CrossFamilyLanePair,
+) (deployment.ChangesetOutput, error) {
+	chunkSize := cfg.MaxLanesPerChunk
+	if chunkSize <= 0 {
+		chunkSize = len(lanes)
+	}
+	var out deployment.ChangesetOutput
+	for start := 0; start < len(lanes); start += chunkSize {
+		resolvedCfg := v2changesets.ConfigureChainsForLanesFromTopologyConfig{
+			Topology: cfg.Topology,
+			BuildLanesCrossFamilyConfig: v2changesets.BuildLanesCrossFamilyConfig{
+				Lanes:      lanes[start:min(start+chunkSize, len(lanes))],
+				MCMS:       cfg.MCMS,
+				TestRouter: cfg.TestRouter,
+				// A migration's whole purpose is to swap each lane's pre-2.0 OnRamp for the CCIP 2.0
+				// OnRamp on the (prod) router, so it must be allowed to overwrite the existing mapping.
+				AllowOnrampOverride: true,
+			},
+		}
+		if err := underlying.VerifyPreconditions(e, resolvedCfg); err != nil {
+			return deployment.ChangesetOutput{}, fmt.Errorf("resolved lane config failed preconditions: %w", err)
+		}
+		chunkOut, err := underlying.Apply(e, resolvedCfg)
+		if err != nil {
+			return deployment.ChangesetOutput{}, err
+		}
+		if start == 0 {
+			out = chunkOut
+			continue
+		}
+		out, err = mergeOutputs(e, out, chunkOut)
+		if err != nil {
+			return deployment.ChangesetOutput{}, err
+		}
+	}
+	return out, nil
+}
+
+func mergeOutputs(e deployment.Environment, base, extra deployment.ChangesetOutput) (deployment.ChangesetOutput, error) {
+	merged := base
+	if err := deployment.MergeChangesetOutput(e, &merged, extra); err != nil {
+		return deployment.ChangesetOutput{}, fmt.Errorf("failed to merge changeset output: %w", err)
 	}
 	// MergeChangesetOutput does not carry the DataStore.
 	switch {
 	case merged.DataStore == nil:
-		merged.DataStore = tokenOut.DataStore
-	case tokenOut.DataStore != nil:
-		if err := merged.DataStore.Merge(tokenOut.DataStore.Seal()); err != nil {
-			return deployment.ChangesetOutput{}, fmt.Errorf("failed to merge test token datastore: %w", err)
+		merged.DataStore = extra.DataStore
+	case extra.DataStore != nil:
+		if err := merged.DataStore.Merge(extra.DataStore.Seal()); err != nil {
+			return deployment.ChangesetOutput{}, fmt.Errorf("failed to merge datastore: %w", err)
 		}
 	}
 	return merged, nil

--- a/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2_internal_test.go
+++ b/chains/evm/deployment/v2_0_0/changesets/migrate_chain_lanes_to_v2_internal_test.go
@@ -2,13 +2,18 @@ package changesets
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/ethereum/go-ethereum/common"
 	chainsel "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/mcms"
+	mcms_types "github.com/smartcontractkit/mcms/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
@@ -676,6 +681,74 @@ func TestBuildTestTokenExpansionInput_SharedChainDoesNotReemitRegistrySetup(t *t
 	// registration included.
 	assert.NotNil(t, in2.TokenExpansionInputPerChain[chainSecond].TokenTransferConfig)
 	assert.False(t, in2.TokenExpansionInputPerChain[chainSecond].TokenTransferConfig.SkipTokenAdminRegistrySetup)
+}
+
+// TestApplyLanesInChunks_ChunkedOutputMatchesUnchunked proves chunking changes only the
+// packaging, not the work: the chunked run must apply the identical config and lane list
+// (behavioral), and its proposals' concatenated operations must be identical to the single
+// unchunked proposal's (structural) — so after merge-proposals the executed transactions are
+// unchanged.
+func TestApplyLanesInChunks_ChunkedOutputMatchesUnchunked(t *testing.T) {
+	chainA := chainsel.TEST_90000001.Selector
+	chainB := chainsel.TEST_90000002.Selector
+	chainC := chainsel.TEST_90000003.Selector
+	lanes := []v2changesets.CrossFamilyLanePair{
+		{ChainA: chainA, ChainB: chainB},
+		{ChainA: chainA, ChainB: chainC},
+		{ChainA: chainB, ChainB: chainC},
+	}
+
+	// Stub underlying changeset: one proposal per Apply whose batch ops encode the exact lanes
+	// given, so output equality proves no lane is dropped, reordered, or duplicated.
+	var gotConfigs []v2changesets.ConfigureChainsForLanesFromTopologyConfig
+	stub := cldf.CreateChangeSet(
+		func(_ cldf.Environment, cfg v2changesets.ConfigureChainsForLanesFromTopologyConfig) (cldf.ChangesetOutput, error) {
+			gotConfigs = append(gotConfigs, cfg)
+			ops := make([]mcms_types.BatchOperation, 0, len(cfg.Lanes))
+			for _, lane := range cfg.Lanes {
+				ops = append(ops, mcms_types.BatchOperation{
+					ChainSelector: mcms_types.ChainSelector(lane.ChainA),
+					Transactions:  []mcms_types.Transaction{{Data: fmt.Appendf(nil, "%d->%d", lane.ChainA, lane.ChainB)}},
+				})
+			}
+			return cldf.ChangesetOutput{MCMSTimelockProposals: []mcms.TimelockProposal{{Operations: ops}}}, nil
+		},
+		func(cldf.Environment, v2changesets.ConfigureChainsForLanesFromTopologyConfig) error { return nil },
+	)
+
+	env := cldf.Environment{Logger: logger.Nop()}
+	topology := &offchain.EnvironmentTopology{}
+	baseCfg := MigrateChainLanesToV2Config{Topology: topology}
+
+	unchunked, err := applyLanesInChunks(env, stub, baseCfg, lanes)
+	require.NoError(t, err)
+	require.Len(t, gotConfigs, 1)
+	require.Len(t, unchunked.MCMSTimelockProposals, 1)
+
+	gotConfigs = nil
+	chunkedCfg := baseCfg
+	chunkedCfg.MaxLanesPerChunk = 2
+	chunked, err := applyLanesInChunks(env, stub, chunkedCfg, lanes)
+	require.NoError(t, err)
+	require.Len(t, gotConfigs, 2, "3 lanes at 2 per chunk -> 2 applies")
+
+	// Behavioral: chunks carry the identical config apart from the lane subset, and the subsets
+	// reassemble the original lane list exactly.
+	var appliedLanes []v2changesets.CrossFamilyLanePair
+	for _, cfg := range gotConfigs {
+		assert.Same(t, topology, cfg.Topology)
+		assert.True(t, cfg.AllowOnrampOverride)
+		appliedLanes = append(appliedLanes, cfg.Lanes...)
+	}
+	assert.Equal(t, lanes, appliedLanes)
+
+	// Structural: chunked proposals' operations, concatenated, equal the unchunked proposal's.
+	require.Len(t, chunked.MCMSTimelockProposals, 2)
+	var chunkedOps []mcms_types.BatchOperation
+	for _, p := range chunked.MCMSTimelockProposals {
+		chunkedOps = append(chunkedOps, p.Operations...)
+	}
+	assert.Equal(t, unchunked.MCMSTimelockProposals[0].Operations, chunkedOps)
 }
 
 func TestDiscoverLanesToMigrate_SkipsVersionWithoutConfigImporter(t *testing.T) {


### PR DESCRIPTION
1. `migrate_chain_lanes_to_v2` sent all of a chain's lanes to the underlying changeset in one
   call, producing a single timelock batch. Linea's 17-lane batch needed ~22.5M gas vs Linea's
   16,777,216 cap, so it was unexecutable (proposal #18490).
2. Added opt-in `maxLanesPerChunk`: applies the underlying lane changeset once per chunk of N
   lanes. Default `0` = single chunk, so existing inputs are unchanged.
3. Each chunk emits its own proposal, so multi-chunk runs need `merge-proposals: true` and an
   explicit `mcms.validUntil` (noted on the field).
4. Verified on a real Linea run (`maxLanesPerChunk: 5`): largest batch 33,120 B → 10,784 B
   (~7M gas), all write sets and entry counts match the unchunked baseline, proposals are
   merge-compatible, token expansion emitted once.