### PR TITLE
CCIP-12911: Adding changeset, seq and ops for withdrawFeeTokens method

### DIFF
--- a/chains/evm/deployment/operations_gen_config.yaml
+++ b/chains/evm/deployment/operations_gen_config.yaml
@@ -216,6 +216,8 @@ contracts:
         access: public
       - name: setDynamicConfig
         access: owner
+      - name: withdrawFeeTokens
+        access: public
 
   - contract_name: OffRamp
     package_name: offramp

--- a/chains/evm/deployment/utils/feetokens.go
+++ b/chains/evm/deployment/utils/feetokens.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/smartcontractkit/chainlink-ccip/deployment/fees"
+)
+
+// EVMFeeTokenAddresses converts the family-agnostic fee token withdrawal list into the address
+// slice that EVM's withdrawFeeTokens(address[]) expects.
+//
+// The on-chain call always sweeps the contract's entire balance of each token, so a caller-supplied
+// Amount cannot be honoured. Rather than withdraw more than was asked for, this rejects any entry
+// carrying an amount.
+func EVMFeeTokenAddresses(feeTokens []fees.FeeTokenWithdrawal, chainSelector uint64) ([]common.Address, error) {
+	if len(feeTokens) == 0 {
+		return nil, fmt.Errorf("no fee tokens specified for chain %d", chainSelector)
+	}
+
+	addrs := make([]common.Address, 0, len(feeTokens))
+	for i, tok := range feeTokens {
+		if !common.IsHexAddress(tok.Token) {
+			return nil, fmt.Errorf("invalid fee token address %q at feeTokens[%d] on chain %d", tok.Token, i, chainSelector)
+		}
+		if tok.Amount != nil {
+			return nil, fmt.Errorf(
+				"partial withdrawals are not supported on EVM: fee token %s at feeTokens[%d] on chain %d specifies an amount, "+
+					"but withdrawFeeTokens always sweeps the full balance; omit the amount to proceed",
+				tok.Token, i, chainSelector)
+		}
+		addrs = append(addrs, common.HexToAddress(tok.Token))
+	}
+
+	return addrs, nil
+}

--- a/chains/evm/deployment/utils/feetokens_test.go
+++ b/chains/evm/deployment/utils/feetokens_test.go
@@ -1,0 +1,65 @@
+package utils_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	evm_utils "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/fees"
+)
+
+const testChainSelector = uint64(909606746561742123)
+
+func TestEVMFeeTokenAddresses(t *testing.T) {
+	linkAddr := "0x779877A7B0D9E8603169DdbD7836e478b4624789"
+	wethAddr := "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+
+	t.Run("converts multiple tokens preserving order", func(t *testing.T) {
+		got, err := evm_utils.EVMFeeTokenAddresses([]fees.FeeTokenWithdrawal{
+			{Token: linkAddr},
+			{Token: wethAddr},
+		}, testChainSelector)
+		require.NoError(t, err)
+		require.Equal(t, []common.Address{
+			common.HexToAddress(linkAddr),
+			common.HexToAddress(wethAddr),
+		}, got)
+	})
+
+	t.Run("accepts non-checksummed addresses", func(t *testing.T) {
+		got, err := evm_utils.EVMFeeTokenAddresses([]fees.FeeTokenWithdrawal{
+			{Token: "0x779877a7b0d9e8603169ddbd7836e478b4624789"},
+		}, testChainSelector)
+		require.NoError(t, err)
+		require.Equal(t, []common.Address{common.HexToAddress(linkAddr)}, got)
+	})
+
+	t.Run("rejects an empty token list", func(t *testing.T) {
+		_, err := evm_utils.EVMFeeTokenAddresses(nil, testChainSelector)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "no fee tokens specified")
+	})
+
+	t.Run("rejects a malformed address", func(t *testing.T) {
+		_, err := evm_utils.EVMFeeTokenAddresses([]fees.FeeTokenWithdrawal{
+			{Token: linkAddr},
+			{Token: "not-an-address"},
+		}, testChainSelector)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid fee token address")
+		require.Contains(t, err.Error(), "feeTokens[1]")
+	})
+
+	// withdrawFeeTokens always sweeps the full balance, so honouring an amount is impossible.
+	// Silently withdrawing everything would move more than the operator asked for.
+	t.Run("rejects a per-token amount", func(t *testing.T) {
+		_, err := evm_utils.EVMFeeTokenAddresses([]fees.FeeTokenWithdrawal{
+			{Token: linkAddr, Amount: big.NewInt(100)},
+		}, testChainSelector)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "partial withdrawals are not supported on EVM")
+	})
+}

--- a/chains/evm/deployment/v1_6_0/adapters/fee_aggregator.go
+++ b/chains/evm/deployment/v1_6_0/adapters/fee_aggregator.go
@@ -174,6 +174,25 @@ func (a *FeeAggregatorAdapter) WithdrawFeeTokens(e cldf.Environment) *operations
 			}
 			onRampAddr := common.HexToAddress(onRampRef.Address)
 
+			// Check the OnRamp we are about to sweep rather than the default one: input.Contracts
+			// may name a different OnRamp, and its fee aggregator can differ. Withdrawing while it
+			// is unset reverts on-chain with ZeroAddressNotAllowed, which is harder to act on.
+			cfgReport, err := operations.ExecuteOperation(
+				b, onrampops.GetDynamicConfig, evmChain,
+				contract.FunctionInput[struct{}]{
+					ChainSelector: evmChain.Selector,
+					Address:       onRampAddr,
+				},
+			)
+			if err != nil {
+				return result, fmt.Errorf("failed to read OnRamp dynamic config at %s on chain %d: %w",
+					onRampAddr.Hex(), input.ChainSelector, err)
+			}
+			if cfgReport.Output.FeeAggregator == (common.Address{}) {
+				return result, fmt.Errorf("fee aggregator is not set on OnRamp at %s (chain %d); set it before withdrawing fee tokens",
+					onRampAddr.Hex(), input.ChainSelector)
+			}
+
 			// withdrawFeeTokens takes the whole token list in one call, so a chain with many fee
 			// tokens still costs a single transaction.
 			writeReport, err := operations.ExecuteOperation(

--- a/chains/evm/deployment/v1_6_0/adapters/fee_aggregator.go
+++ b/chains/evm/deployment/v1_6_0/adapters/fee_aggregator.go
@@ -11,9 +11,10 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
-	evmseq "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/sequences"
-	onrampops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/operations/onramp"
+	evm_utils "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
+	onrampops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/operations/onramp"
+	evmseq "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/sequences"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/fees"
 	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
@@ -74,18 +75,18 @@ func (a *FeeAggregatorAdapter) GetFeeAggregator(e cldf.Environment, chainSelecto
 	return dynamicCfg.FeeAggregator.Hex(), nil
 }
 
-func (a *FeeAggregatorAdapter) resolveOnRampRef(e cldf.Environment, input fees.FeeAggregatorForChain) (datastore.AddressRef, error) {
-	if len(input.Contracts) > 0 {
-		if len(input.Contracts) != 1 {
-			return datastore.AddressRef{}, fmt.Errorf("EVM 1.6 adapter supports exactly one contract ref, got %d", len(input.Contracts))
+func (a *FeeAggregatorAdapter) resolveOnRampRef(e cldf.Environment, chainSelector uint64, contracts []datastore.AddressRef) (datastore.AddressRef, error) {
+	if len(contracts) > 0 {
+		if len(contracts) != 1 {
+			return datastore.AddressRef{}, fmt.Errorf("EVM 1.6 adapter supports exactly one contract ref, got %d", len(contracts))
 		}
-		ref := input.Contracts[0]
+		ref := contracts[0]
 		if ref.Type != datastore.ContractType(onrampops.ContractType) {
 			return datastore.AddressRef{}, fmt.Errorf("EVM 1.6 adapter only supports contract type %q, got %q", onrampops.ContractType, ref.Type)
 		}
-		return datastore_utils.FindAndFormatRef(e.DataStore, ref, input.ChainSelector, datastore_utils.FullRef)
+		return datastore_utils.FindAndFormatRef(e.DataStore, ref, chainSelector, datastore_utils.FullRef)
 	}
-	return a.getOnRampRef(e, input.ChainSelector)
+	return a.getOnRampRef(e, chainSelector)
 }
 
 func (a *FeeAggregatorAdapter) SetFeeAggregator(e cldf.Environment) *operations.Sequence[fees.FeeAggregatorForChain, sequences.OnChainOutput, cldf_chain.BlockChains] {
@@ -106,7 +107,7 @@ func (a *FeeAggregatorAdapter) SetFeeAggregator(e cldf.Environment) *operations.
 			}
 			newFeeAggregator := common.HexToAddress(input.FeeAggregator)
 
-			onRampRef, err := a.resolveOnRampRef(e, input)
+			onRampRef, err := a.resolveOnRampRef(e, input.ChainSelector, input.Contracts)
 			if err != nil {
 				return result, err
 			}
@@ -136,6 +137,56 @@ func (a *FeeAggregatorAdapter) SetFeeAggregator(e cldf.Environment) *operations.
 			)
 			if err != nil {
 				return result, fmt.Errorf("failed to set OnRamp dynamic config on chain %d: %w", input.ChainSelector, err)
+			}
+
+			batch, err := contract.NewBatchOperationFromWrites([]contract.WriteOutput{writeReport.Output})
+			if err != nil {
+				return result, fmt.Errorf("failed to create batch operation from writes for chain %d: %w", input.ChainSelector, err)
+			}
+			result.BatchOps = append(result.BatchOps, batch)
+
+			return result, nil
+		},
+	)
+}
+
+func (a *FeeAggregatorAdapter) WithdrawFeeTokens(e cldf.Environment) *operations.Sequence[fees.WithdrawFeeTokensForChain, sequences.OnChainOutput, cldf_chain.BlockChains] {
+	return operations.NewSequence(
+		"WithdrawFeeTokens",
+		semver.MustParse("1.6.0"),
+		"Withdraws accumulated fee token balances to the fee aggregator on the CCIP 1.6.0 OnRamp",
+		func(b operations.Bundle, chains cldf_chain.BlockChains, input fees.WithdrawFeeTokensForChain) (sequences.OnChainOutput, error) {
+			var result sequences.OnChainOutput
+
+			evmChain, ok := chains.EVMChains()[input.ChainSelector]
+			if !ok {
+				return result, fmt.Errorf("EVM chain with selector %d not defined", input.ChainSelector)
+			}
+
+			feeTokens, err := evm_utils.EVMFeeTokenAddresses(input.FeeTokens, input.ChainSelector)
+			if err != nil {
+				return result, err
+			}
+
+			onRampRef, err := a.resolveOnRampRef(e, input.ChainSelector, input.Contracts)
+			if err != nil {
+				return result, err
+			}
+			onRampAddr := common.HexToAddress(onRampRef.Address)
+
+			// withdrawFeeTokens takes the whole token list in one call, so a chain with many fee
+			// tokens still costs a single transaction.
+			writeReport, err := operations.ExecuteOperation(
+				b, onrampops.WithdrawFeeTokens, evmChain,
+				contract.FunctionInput[[]common.Address]{
+					ChainSelector: evmChain.Selector,
+					Address:       onRampAddr,
+					Args:          feeTokens,
+				},
+			)
+			if err != nil {
+				return result, fmt.Errorf("failed to withdraw fee tokens from OnRamp at %s on chain %d: %w",
+					onRampAddr.Hex(), input.ChainSelector, err)
 			}
 
 			batch, err := contract.NewBatchOperationFromWrites([]contract.WriteOutput{writeReport.Output})

--- a/chains/evm/deployment/v1_6_0/operations/onramp/onramp.go
+++ b/chains/evm/deployment/v1_6_0/operations/onramp/onramp.go
@@ -120,6 +120,10 @@ func (c *OnRampContract) SetDynamicConfig(opts *bind.TransactOpts, args DynamicC
 	return c.contract.Transact(opts, "setDynamicConfig", args)
 }
 
+func (c *OnRampContract) WithdrawFeeTokens(opts *bind.TransactOpts, args []common.Address) (*types.Transaction, error) {
+	return c.contract.Transact(opts, "withdrawFeeTokens", args)
+}
+
 type AllowlistConfigArgs struct {
 	DestChainSelector         uint64
 	AllowlistEnabled          bool
@@ -276,5 +280,23 @@ var SetDynamicConfig = contract.NewWrite(contract.WriteParams[DynamicConfig, *On
 		args DynamicConfig,
 	) (*types.Transaction, error) {
 		return c.SetDynamicConfig(opts, args)
+	},
+})
+
+var WithdrawFeeTokens = contract.NewWrite(contract.WriteParams[[]common.Address, *OnRampContract]{
+	Name:            "onramp:withdraw-fee-tokens",
+	Version:         Version,
+	Description:     "Calls withdrawFeeTokens on the contract",
+	ContractType:    ContractType,
+	ContractABI:     OnRampABI,
+	NewContract:     NewOnRampContract,
+	IsAllowedCaller: contract.AllCallersAllowed[*OnRampContract, []common.Address],
+	Validate:        func([]common.Address) error { return nil },
+	CallContract: func(
+		c *OnRampContract,
+		opts *bind.TransactOpts,
+		args []common.Address,
+	) (*types.Transaction, error) {
+		return c.WithdrawFeeTokens(opts, args)
 	},
 })

--- a/chains/evm/deployment/v2_0_0/adapters/fee_aggregator.go
+++ b/chains/evm/deployment/v2_0_0/adapters/fee_aggregator.go
@@ -288,6 +288,10 @@ func (a *FeeAggregatorAdapter) WithdrawFeeTokens(e cldf.Environment) *operations
 				return result, err
 			}
 
+			if err := verifyFeeAggregatorsAreSet(e, input.ChainSelector, refs); err != nil {
+				return result, err
+			}
+
 			for _, ref := range refs {
 				writes, err := withdrawFeeTokensOnContract(b, evmChain, ref, feeTokens)
 				if err != nil {
@@ -307,6 +311,77 @@ func (a *FeeAggregatorAdapter) WithdrawFeeTokens(e cldf.Environment) *operations
 			return result, nil
 		},
 	)
+}
+
+// feeAggregatorOnContract reads the fee aggregator currently configured on a single 2.0 contract.
+// Each type stores it differently: Proxy exposes it directly, OnRamp and Executor keep it in their
+// dynamic config.
+func feeAggregatorOnContract(e cldf.Environment, chain cldf_evm.Chain, ref datastore.AddressRef) (common.Address, error) {
+	addr := common.HexToAddress(ref.Address)
+	opts := &bind.CallOpts{Context: e.GetContext()}
+
+	switch ref.Type {
+	case datastore.ContractType(proxyops.ContractType):
+		proxy, err := proxyops.NewProxyContract(addr, chain.Client)
+		if err != nil {
+			return common.Address{}, fmt.Errorf("failed to instantiate Proxy at %s: %w", addr.Hex(), err)
+		}
+		feeAgg, err := proxy.GetFeeAggregator(opts)
+		if err != nil {
+			return common.Address{}, fmt.Errorf("failed to read fee aggregator from Proxy at %s: %w", addr.Hex(), err)
+		}
+		return feeAgg, nil
+
+	case datastore.ContractType(onrampops.ContractType):
+		onRamp, err := onrampops.NewOnRampContract(addr, chain.Client)
+		if err != nil {
+			return common.Address{}, fmt.Errorf("failed to instantiate OnRamp at %s: %w", addr.Hex(), err)
+		}
+		dynamicCfg, err := onRamp.GetDynamicConfig(opts)
+		if err != nil {
+			return common.Address{}, fmt.Errorf("failed to read OnRamp dynamic config at %s: %w", addr.Hex(), err)
+		}
+		return dynamicCfg.FeeAggregator, nil
+
+	case datastore.ContractType(executorops.ContractType):
+		executor, err := executorops.NewExecutorContract(addr, chain.Client)
+		if err != nil {
+			return common.Address{}, fmt.Errorf("failed to instantiate Executor at %s: %w", addr.Hex(), err)
+		}
+		dynamicCfg, err := executor.GetDynamicConfig(opts)
+		if err != nil {
+			return common.Address{}, fmt.Errorf("failed to read Executor dynamic config at %s: %w", addr.Hex(), err)
+		}
+		return dynamicCfg.FeeAggregator, nil
+
+	default:
+		// Kept in step with withdrawFeeTokensOnContract: a type we cannot sweep is also a type
+		// whose fee aggregator we have no accessor for.
+		return common.Address{}, fmt.Errorf("no fee aggregator accessor for contract type %q", ref.Type)
+	}
+}
+
+// verifyFeeAggregatorsAreSet fails the withdrawal before any transaction is built if a target
+// contract has no fee aggregator. Withdrawing to the zero address reverts on-chain with
+// ZeroAddressNotAllowed, which is far harder to act on than this message.
+func verifyFeeAggregatorsAreSet(e cldf.Environment, chainSelector uint64, refs []datastore.AddressRef) error {
+	chain, ok := e.BlockChains.EVMChains()[chainSelector]
+	if !ok {
+		return fmt.Errorf("EVM chain with selector %d not defined", chainSelector)
+	}
+
+	for _, ref := range refs {
+		feeAgg, err := feeAggregatorOnContract(e, chain, ref)
+		if err != nil {
+			return fmt.Errorf("chain %d: %w", chainSelector, err)
+		}
+		if feeAgg == (common.Address{}) {
+			return fmt.Errorf("fee aggregator is not set on %s at %s (chain %d); set it before withdrawing fee tokens",
+				ref.Type, ref.Address, chainSelector)
+		}
+	}
+
+	return nil
 }
 
 func withdrawFeeTokensOnContract(

--- a/chains/evm/deployment/v2_0_0/adapters/fee_aggregator.go
+++ b/chains/evm/deployment/v2_0_0/adapters/fee_aggregator.go
@@ -12,11 +12,12 @@ import (
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
+	evm_utils "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils"
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
 	executorops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/executor"
 	onrampops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/onramp"
 	proxyops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/proxy"
 	usdcproxyops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/usdc_token_pool_proxy"
-	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/utils/operations/contract"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/fees"
 	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
@@ -89,7 +90,7 @@ func (a *FeeAggregatorAdapter) SetFeeAggregator(e cldf.Environment) *operations.
 			}
 			newFeeAggregator := common.HexToAddress(input.FeeAggregator)
 
-			refs, err := a.resolveRefs(e, input)
+			refs, err := a.resolveRefs(e, input.ChainSelector, input.Contracts)
 			if err != nil {
 				return result, err
 			}
@@ -115,34 +116,34 @@ func (a *FeeAggregatorAdapter) SetFeeAggregator(e cldf.Environment) *operations.
 	)
 }
 
-func (a *FeeAggregatorAdapter) resolveRefs(e cldf.Environment, input fees.FeeAggregatorForChain) ([]datastore.AddressRef, error) {
-	if len(input.Contracts) == 0 {
+func (a *FeeAggregatorAdapter) resolveRefs(e cldf.Environment, chainSelector uint64, contracts []datastore.AddressRef) ([]datastore.AddressRef, error) {
+	if len(contracts) == 0 {
 		ref, err := datastore_utils.FindAndFormatRef(
 			e.DataStore,
 			datastore.AddressRef{Type: datastore.ContractType(proxyops.ContractType), Version: proxyops.Version},
-			input.ChainSelector,
+			chainSelector,
 			datastore_utils.FullRef,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("failed to find default Proxy ref for chain %d: %w", input.ChainSelector, err)
+			return nil, fmt.Errorf("failed to find default Proxy ref for chain %d: %w", chainSelector, err)
 		}
 		return []datastore.AddressRef{ref}, nil
 	}
 
-	resolved := make([]datastore.AddressRef, 0, len(input.Contracts))
-	for _, c := range input.Contracts {
+	resolved := make([]datastore.AddressRef, 0, len(contracts))
+	for _, c := range contracts {
 		if !supportedContractTypes[c.Type] {
-			return nil, fmt.Errorf("unsupported contract type %q for fee aggregator on chain %d", c.Type, input.ChainSelector)
+			return nil, fmt.Errorf("unsupported contract type %q on chain %d", c.Type, chainSelector)
 		}
 		ref, err := datastore_utils.FindAndFormatRef(
 			e.DataStore,
 			c,
-			input.ChainSelector,
+			chainSelector,
 			datastore_utils.FullRef,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve ref for %s (version=%v, qualifier=%q) on chain %d: %w",
-				c.Type, c.Version, c.Qualifier, input.ChainSelector, err)
+				c.Type, c.Version, c.Qualifier, chainSelector, err)
 		}
 		resolved = append(resolved, ref)
 	}
@@ -262,4 +263,94 @@ func setFeeAggregatorViaExecutorDynamicConfig(
 		return nil, fmt.Errorf("failed to write Executor DynamicConfig: %w", err)
 	}
 	return []contract.WriteOutput{writeReport.Output}, nil
+}
+
+func (a *FeeAggregatorAdapter) WithdrawFeeTokens(e cldf.Environment) *operations.Sequence[fees.WithdrawFeeTokensForChain, sequences.OnChainOutput, cldf_chain.BlockChains] {
+	return operations.NewSequence(
+		"WithdrawFeeTokens",
+		semver.MustParse("2.0.0"),
+		"Withdraws accumulated fee token balances to the fee aggregator on CCIP 2.0.0 contracts",
+		func(b operations.Bundle, chains cldf_chain.BlockChains, input fees.WithdrawFeeTokensForChain) (sequences.OnChainOutput, error) {
+			var result sequences.OnChainOutput
+
+			evmChain, ok := chains.EVMChains()[input.ChainSelector]
+			if !ok {
+				return result, fmt.Errorf("EVM chain with selector %d not defined", input.ChainSelector)
+			}
+
+			feeTokens, err := evm_utils.EVMFeeTokenAddresses(input.FeeTokens, input.ChainSelector)
+			if err != nil {
+				return result, err
+			}
+
+			refs, err := a.resolveRefs(e, input.ChainSelector, input.Contracts)
+			if err != nil {
+				return result, err
+			}
+
+			for _, ref := range refs {
+				writes, err := withdrawFeeTokensOnContract(b, evmChain, ref, feeTokens)
+				if err != nil {
+					return result, fmt.Errorf("failed to withdraw fee tokens on %s (%s) on chain %d: %w",
+						ref.Type, ref.Address, input.ChainSelector, err)
+				}
+				if len(writes) > 0 {
+					batch, err := contract.NewBatchOperationFromWrites(writes)
+					if err != nil {
+						return result, fmt.Errorf("failed to create batch operation for %s on chain %d: %w",
+							ref.Type, input.ChainSelector, err)
+					}
+					result.BatchOps = append(result.BatchOps, batch)
+				}
+			}
+
+			return result, nil
+		},
+	)
+}
+
+func withdrawFeeTokensOnContract(
+	b operations.Bundle,
+	chain cldf_evm.Chain,
+	ref datastore.AddressRef,
+	feeTokens []common.Address,
+) ([]contract.WriteOutput, error) {
+	addr := common.HexToAddress(ref.Address)
+
+	switch ref.Type {
+	case datastore.ContractType(proxyops.ContractType):
+		return withdrawFeeTokensDirect(b, chain, addr, proxyops.WithdrawFeeTokens, feeTokens)
+
+	case datastore.ContractType(onrampops.ContractType):
+		return withdrawFeeTokensDirect(b, chain, addr, onrampops.WithdrawFeeTokens, feeTokens)
+
+	case datastore.ContractType(executorops.ContractType):
+		return withdrawFeeTokensDirect(b, chain, addr, executorops.WithdrawFeeTokens, feeTokens)
+
+	default:
+		// USDCTokenPoolProxy is a supported fee aggregator target but has no generated
+		// withdrawFeeTokens operation, so it cannot be swept through this changeset.
+		return nil, fmt.Errorf("no withdrawFeeTokens handler for contract type %q", ref.Type)
+	}
+}
+
+func withdrawFeeTokensDirect(
+	b operations.Bundle,
+	chain cldf_evm.Chain,
+	addr common.Address,
+	op *operations.Operation[contract.FunctionInput[[]common.Address], contract.WriteOutput, cldf_evm.Chain],
+	feeTokens []common.Address,
+) ([]contract.WriteOutput, error) {
+	report, err := operations.ExecuteOperation(
+		b, op, chain,
+		contract.FunctionInput[[]common.Address]{
+			ChainSelector: chain.Selector,
+			Address:       addr,
+			Args:          feeTokens,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return []contract.WriteOutput{report.Output}, nil
 }

--- a/chains/solana/deployment/v1_6_0/adapters/fee_aggregator.go
+++ b/chains/solana/deployment/v1_6_0/adapters/fee_aggregator.go
@@ -1,17 +1,19 @@
 package adapters
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/rpc"
+	"github.com/smartcontractkit/mcms/types"
+
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
 	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
-	"github.com/smartcontractkit/mcms/types"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/utils"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_6_0/operations/router"
@@ -154,11 +156,11 @@ func resolveTokenProgram(e cldf.Environment, chain cldf_solana.Chain, mint solan
 	resp, err := chain.Client.GetAccountInfoWithOpts(e.GetContext(), mint, &rpc.GetAccountInfoOpts{
 		Commitment: cldf_solana.SolDefaultCommitment,
 	})
+	if errors.Is(err, rpc.ErrNotFound) {
+		return solana.PublicKey{}, fmt.Errorf("mint %s not found on chain %d", mint, chain.Selector)
+	}
 	if err != nil {
 		return solana.PublicKey{}, fmt.Errorf("failed to get account info for mint %s: %w", mint, err)
-	}
-	if resp == nil || resp.Value == nil {
-		return solana.PublicKey{}, fmt.Errorf("mint %s not found on chain %d", mint, chain.Selector)
 	}
 
 	owner := resp.Value.Owner
@@ -166,6 +168,47 @@ func resolveTokenProgram(e cldf.Environment, chain cldf_solana.Chain, mint solan
 		return solana.PublicKey{}, fmt.Errorf("mint %s is owned by %s, which is not a supported token program: %w", mint, owner, err)
 	}
 	return owner, nil
+}
+
+// ensureFeeAggregatorATA makes sure the fee aggregator holds a token account for the mint, since
+// the router will not create the recipient itself.
+//
+// Creating an ATA is permissionless, so this runs immediately with the deployer key instead of
+// joining the MCMS proposal: the account is in place by the time the withdrawal executes, and the
+// proposal stays limited to the privileged instruction.
+func ensureFeeAggregatorATA(
+	e cldf.Environment,
+	chain cldf_solana.Chain,
+	tokenProgram, mint, feeAggregator, recipient solana.PublicKey,
+) error {
+	_, err := chain.Client.GetAccountInfoWithOpts(e.GetContext(), recipient, &rpc.GetAccountInfoOpts{
+		Commitment: cldf_solana.SolDefaultCommitment,
+	})
+	switch {
+	case err == nil:
+		return nil
+	case !errors.Is(err, rpc.ErrNotFound):
+		return fmt.Errorf("failed to check fee aggregator ATA %s for mint %s on chain %d: %w",
+			recipient, mint, chain.Selector, err)
+	}
+
+	createIx, created, err := tokens.CreateAssociatedTokenAccount(
+		tokenProgram, mint, feeAggregator, chain.DeployerKey.PublicKey())
+	if err != nil {
+		return fmt.Errorf("failed to build ATA creation for fee aggregator %s and mint %s on chain %d: %w",
+			feeAggregator, mint, chain.Selector, err)
+	}
+	// Guards against the derivation here drifting from the one used to build the instruction.
+	if created != recipient {
+		return fmt.Errorf("derived fee aggregator ATA %s does not match expected %s for mint %s on chain %d",
+			created, recipient, mint, chain.Selector)
+	}
+	if err := chain.Confirm([]solana.Instruction{createIx}); err != nil {
+		return fmt.Errorf("failed to create fee aggregator ATA %s for mint %s on chain %d: %w",
+			recipient, mint, chain.Selector, err)
+	}
+
+	return nil
 }
 
 // withdrawAmountFor translates the family-agnostic amount into the (transferAll, desiredAmount)
@@ -184,7 +227,7 @@ func (a *FeeAggregatorAdapter) WithdrawFeeTokens(e cldf.Environment) *operations
 	return operations.NewSequence(
 		"WithdrawFeeTokens",
 		semver.MustParse("1.6.0"),
-		"Withdraws accumulated fee token balances to the fee aggregator on the Solana 1.6.0 Router",
+		"Withdraws accumulated fee token balances to the fee aggregator on the Solana Router",
 		func(b operations.Bundle, chains cldf_chain.BlockChains, input fees.WithdrawFeeTokensForChain) (sequences.OnChainOutput, error) {
 			solChain, ok := chains.SolanaChains()[input.ChainSelector]
 			if !ok {
@@ -247,19 +290,9 @@ func (a *FeeAggregatorAdapter) WithdrawFeeTokens(e cldf.Environment) *operations
 					return sequences.OnChainOutput{}, fmt.Errorf("failed to derive fee aggregator ATA for mint %s on chain %d: %w", mint, input.ChainSelector, err)
 				}
 
-				// The router rejects a missing recipient account with an opaque constraint error,
-				// so fail here with something an operator can act on.
-				recipientInfo, err := solChain.Client.GetAccountInfoWithOpts(e.GetContext(), recipient, &rpc.GetAccountInfoOpts{
-					Commitment: cldf_solana.SolDefaultCommitment,
-				})
-				if err != nil {
-					return sequences.OnChainOutput{}, fmt.Errorf("failed to check fee aggregator ATA %s for mint %s on chain %d: %w",
-						recipient, mint, input.ChainSelector, err)
-				}
-				if recipientInfo == nil || recipientInfo.Value == nil {
-					return sequences.OnChainOutput{}, fmt.Errorf(
-						"fee aggregator ATA %s for mint %s does not exist on chain %d; create it for fee aggregator %s before withdrawing",
-						recipient, mint, input.ChainSelector, feeAggregator)
+				// The router rejects a missing recipient account, so make sure it exists first.
+				if err := ensureFeeAggregatorATA(e, solChain, tokenProgram, mint, feeAggregator, recipient); err != nil {
+					return sequences.OnChainOutput{}, err
 				}
 
 				transferAll, desiredAmount, err := withdrawAmountFor(tok)

--- a/chains/solana/deployment/v1_6_0/adapters/fee_aggregator.go
+++ b/chains/solana/deployment/v1_6_0/adapters/fee_aggregator.go
@@ -5,16 +5,20 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
 	cldf_chain "github.com/smartcontractkit/chainlink-deployments-framework/chain"
+	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 	"github.com/smartcontractkit/mcms/types"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/utils"
-	solseq "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_6_0/sequences"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_6_0/operations/router"
+	solseq "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_6_0/sequences"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/gobindings/v0_1_1/ccip_router"
 	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/fees"
 	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/sequences"
@@ -57,28 +61,28 @@ func (a *FeeAggregatorAdapter) GetFeeAggregator(e cldf.Environment, chainSelecto
 	return cfg.FeeAggregator.String(), nil
 }
 
-func (a *FeeAggregatorAdapter) resolveRouterPubkey(e cldf.Environment, input fees.FeeAggregatorForChain) (solana.PublicKey, error) {
-	if len(input.Contracts) > 0 {
-		if len(input.Contracts) != 1 {
-			return solana.PublicKey{}, fmt.Errorf("Solana 1.6 adapter supports exactly one contract ref, got %d", len(input.Contracts))
+func (a *FeeAggregatorAdapter) resolveRouterPubkey(e cldf.Environment, chainSelector uint64, contracts []datastore.AddressRef) (solana.PublicKey, error) {
+	if len(contracts) > 0 {
+		if len(contracts) != 1 {
+			return solana.PublicKey{}, fmt.Errorf("Solana 1.6 adapter supports exactly one contract ref, got %d", len(contracts))
 		}
-		ref := input.Contracts[0]
+		ref := contracts[0]
 		if string(ref.Type) != router.ContractType.String() {
 			return solana.PublicKey{}, fmt.Errorf("Solana 1.6 adapter only supports contract type %q, got %q", router.ContractType, ref.Type)
 		}
-		resolved, err := datastore_utils.FindAndFormatRef(e.DataStore, ref, input.ChainSelector, datastore_utils.FullRef)
+		resolved, err := datastore_utils.FindAndFormatRef(e.DataStore, ref, chainSelector, datastore_utils.FullRef)
 		if err != nil {
-			return solana.PublicKey{}, fmt.Errorf("failed to resolve Router ref on chain %d: %w", input.ChainSelector, err)
+			return solana.PublicKey{}, fmt.Errorf("failed to resolve Router ref on chain %d: %w", chainSelector, err)
 		}
 		routerPubkey, err := solana.PublicKeyFromBase58(resolved.Address)
 		if err != nil {
-			return solana.PublicKey{}, fmt.Errorf("failed to parse resolved Router address %q on chain %d: %w", resolved.Address, input.ChainSelector, err)
+			return solana.PublicKey{}, fmt.Errorf("failed to parse resolved Router address %q on chain %d: %w", resolved.Address, chainSelector, err)
 		}
 		return routerPubkey, nil
 	}
-	routerAddr, err := a.sol.GetRouterAddress(e.DataStore, input.ChainSelector)
+	routerAddr, err := a.sol.GetRouterAddress(e.DataStore, chainSelector)
 	if err != nil {
-		return solana.PublicKey{}, fmt.Errorf("failed to get Router address for chain selector %d: %w", input.ChainSelector, err)
+		return solana.PublicKey{}, fmt.Errorf("failed to get Router address for chain selector %d: %w", chainSelector, err)
 	}
 	return solana.PublicKeyFromBytes(routerAddr), nil
 }
@@ -99,7 +103,7 @@ func (a *FeeAggregatorAdapter) SetFeeAggregator(e cldf.Environment) *operations.
 				return sequences.OnChainOutput{}, fmt.Errorf("invalid fee aggregator base58 address %q: %w", input.FeeAggregator, err)
 			}
 
-			routerPubkey, err := a.resolveRouterPubkey(e, input)
+			routerPubkey, err := a.resolveRouterPubkey(e, input.ChainSelector, input.Contracts)
 			if err != nil {
 				return sequences.OnChainOutput{}, err
 			}
@@ -137,6 +141,165 @@ func (a *FeeAggregatorAdapter) SetFeeAggregator(e cldf.Environment) *operations.
 
 			if err := solChain.Confirm([]solana.Instruction{ixn}); err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to confirm UpdateFeeAggregator instruction: %w", err)
+			}
+
+			return sequences.OnChainOutput{}, nil
+		},
+	)
+}
+
+// resolveTokenProgram determines which SPL token program owns a mint. Fee tokens may be either
+// classic SPL or Token-2022, and the withdraw instruction has to be handed the matching program.
+func resolveTokenProgram(e cldf.Environment, chain cldf_solana.Chain, mint solana.PublicKey) (solana.PublicKey, error) {
+	resp, err := chain.Client.GetAccountInfoWithOpts(e.GetContext(), mint, &rpc.GetAccountInfoOpts{
+		Commitment: cldf_solana.SolDefaultCommitment,
+	})
+	if err != nil {
+		return solana.PublicKey{}, fmt.Errorf("failed to get account info for mint %s: %w", mint, err)
+	}
+	if resp == nil || resp.Value == nil {
+		return solana.PublicKey{}, fmt.Errorf("mint %s not found on chain %d", mint, chain.Selector)
+	}
+
+	owner := resp.Value.Owner
+	if _, err := utils.GetTokenProgramType(owner); err != nil {
+		return solana.PublicKey{}, fmt.Errorf("mint %s is owned by %s, which is not a supported token program: %w", mint, owner, err)
+	}
+	return owner, nil
+}
+
+// withdrawAmountFor translates the family-agnostic amount into the (transferAll, desiredAmount)
+// pair the router instruction expects. A nil amount withdraws the whole accumulated balance.
+func withdrawAmountFor(tok fees.FeeTokenWithdrawal) (transferAll bool, desiredAmount uint64, err error) {
+	if tok.Amount == nil {
+		return true, 0, nil
+	}
+	if !tok.Amount.IsUint64() {
+		return false, 0, fmt.Errorf("amount %s for fee token %s does not fit in uint64", tok.Amount, tok.Token)
+	}
+	return false, tok.Amount.Uint64(), nil
+}
+
+func (a *FeeAggregatorAdapter) WithdrawFeeTokens(e cldf.Environment) *operations.Sequence[fees.WithdrawFeeTokensForChain, sequences.OnChainOutput, cldf_chain.BlockChains] {
+	return operations.NewSequence(
+		"WithdrawFeeTokens",
+		semver.MustParse("1.6.0"),
+		"Withdraws accumulated fee token balances to the fee aggregator on the Solana 1.6.0 Router",
+		func(b operations.Bundle, chains cldf_chain.BlockChains, input fees.WithdrawFeeTokensForChain) (sequences.OnChainOutput, error) {
+			solChain, ok := chains.SolanaChains()[input.ChainSelector]
+			if !ok {
+				return sequences.OnChainOutput{}, fmt.Errorf("solana chain not found for selector %d", input.ChainSelector)
+			}
+			if len(input.FeeTokens) == 0 {
+				return sequences.OnChainOutput{}, fmt.Errorf("no fee tokens specified for chain %d", input.ChainSelector)
+			}
+
+			routerPubkey, err := a.resolveRouterPubkey(e, input.ChainSelector, input.Contracts)
+			if err != nil {
+				return sequences.OnChainOutput{}, err
+			}
+
+			ccip_router.SetProgramID(routerPubkey)
+			authority := router.GetAuthority(solChain, routerPubkey)
+
+			routerConfigPDA, _, err := state.FindConfigPDA(routerPubkey)
+			if err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("failed to derive config PDA for router %s: %w", routerPubkey, err)
+			}
+			billingSignerPDA, _, err := state.FindFeeBillingSignerPDA(routerPubkey)
+			if err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("failed to derive fee billing signer PDA for router %s: %w", routerPubkey, err)
+			}
+
+			// The router transfers to the fee aggregator recorded in its own config, so read it
+			// rather than taking it from the input -- that keeps EVM and Solana semantics aligned.
+			var cfg ccip_router.Config
+			if err := solChain.GetAccountDataBorshInto(e.GetContext(), routerConfigPDA, &cfg); err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("failed to read router config on chain %d: %w", input.ChainSelector, err)
+			}
+			feeAggregator := cfg.FeeAggregator
+			if feeAggregator.IsZero() {
+				return sequences.OnChainOutput{}, fmt.Errorf("fee aggregator is not set on router %s (chain %d); set it before withdrawing",
+					routerPubkey, input.ChainSelector)
+			}
+
+			// WithdrawBilledFunds handles one mint per instruction, so build one per fee token and
+			// submit them together.
+			ixns := make([]solana.Instruction, 0, len(input.FeeTokens))
+			for i, tok := range input.FeeTokens {
+				mint, err := solana.PublicKeyFromBase58(tok.Token)
+				if err != nil {
+					return sequences.OnChainOutput{}, fmt.Errorf("invalid fee token mint %q at feeTokens[%d] on chain %d: %w",
+						tok.Token, i, input.ChainSelector, err)
+				}
+
+				tokenProgram, err := resolveTokenProgram(e, solChain, mint)
+				if err != nil {
+					return sequences.OnChainOutput{}, err
+				}
+
+				feeTokenAccum, _, err := tokens.FindAssociatedTokenAddress(tokenProgram, mint, billingSignerPDA)
+				if err != nil {
+					return sequences.OnChainOutput{}, fmt.Errorf("failed to derive billing ATA for mint %s on chain %d: %w", mint, input.ChainSelector, err)
+				}
+				recipient, _, err := tokens.FindAssociatedTokenAddress(tokenProgram, mint, feeAggregator)
+				if err != nil {
+					return sequences.OnChainOutput{}, fmt.Errorf("failed to derive fee aggregator ATA for mint %s on chain %d: %w", mint, input.ChainSelector, err)
+				}
+
+				// The router rejects a missing recipient account with an opaque constraint error,
+				// so fail here with something an operator can act on.
+				recipientInfo, err := solChain.Client.GetAccountInfoWithOpts(e.GetContext(), recipient, &rpc.GetAccountInfoOpts{
+					Commitment: cldf_solana.SolDefaultCommitment,
+				})
+				if err != nil {
+					return sequences.OnChainOutput{}, fmt.Errorf("failed to check fee aggregator ATA %s for mint %s on chain %d: %w",
+						recipient, mint, input.ChainSelector, err)
+				}
+				if recipientInfo == nil || recipientInfo.Value == nil {
+					return sequences.OnChainOutput{}, fmt.Errorf(
+						"fee aggregator ATA %s for mint %s does not exist on chain %d; create it for fee aggregator %s before withdrawing",
+						recipient, mint, input.ChainSelector, feeAggregator)
+				}
+
+				transferAll, desiredAmount, err := withdrawAmountFor(tok)
+				if err != nil {
+					return sequences.OnChainOutput{}, fmt.Errorf("invalid amount at feeTokens[%d] on chain %d: %w", i, input.ChainSelector, err)
+				}
+
+				ixn, err := ccip_router.NewWithdrawBilledFundsInstruction(
+					transferAll,
+					desiredAmount,
+					mint,
+					feeTokenAccum,
+					recipient,
+					tokenProgram,
+					billingSignerPDA,
+					routerConfigPDA,
+					authority,
+				).ValidateAndBuild()
+				if err != nil {
+					return sequences.OnChainOutput{}, fmt.Errorf("failed to build WithdrawBilledFunds instruction for mint %s on chain %d: %w",
+						mint, input.ChainSelector, err)
+				}
+				ixns = append(ixns, ixn)
+			}
+
+			if authority != solChain.DeployerKey.PublicKey() {
+				batch, err := utils.BuildMCMSBatchOperation(
+					solChain.Selector,
+					ixns,
+					routerPubkey.String(),
+					router.ContractType.String(),
+				)
+				if err != nil {
+					return sequences.OnChainOutput{}, fmt.Errorf("failed to create MCMS batch operation: %w", err)
+				}
+				return sequences.OnChainOutput{BatchOps: []types.BatchOperation{batch}}, nil
+			}
+
+			if err := solChain.Confirm(ixns); err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("failed to confirm WithdrawBilledFunds instructions on chain %d: %w", input.ChainSelector, err)
 			}
 
 			return sequences.OnChainOutput{}, nil

--- a/deployment/fees/fee_aggregator.go
+++ b/deployment/fees/fee_aggregator.go
@@ -27,6 +27,10 @@ type feeAggregatorAdapterID string
 type FeeAggregatorAdapter interface {
 	SetFeeAggregator(e cldf.Environment) *cldf_ops.Sequence[FeeAggregatorForChain, sequences.OnChainOutput, cldf_chain.BlockChains]
 	GetFeeAggregator(e cldf.Environment, chainSelector uint64) (string, error)
+
+	// WithdrawFeeTokens sweeps accumulated fee token balances to the fee aggregator. The input
+	// carries one or more fee tokens for a single chain; the sequence handles each in turn.
+	WithdrawFeeTokens(e cldf.Environment) *cldf_ops.Sequence[WithdrawFeeTokensForChain, sequences.OnChainOutput, cldf_chain.BlockChains]
 }
 
 // FeeAggregatorAdapterRegistry maintains a registry of FeeAggregatorAdapters for different chain families and versions.

--- a/deployment/fees/withdraw_fee_tokens.go
+++ b/deployment/fees/withdraw_fee_tokens.go
@@ -1,0 +1,148 @@
+package fees
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/Masterminds/semver/v3"
+	chain_selectors "github.com/smartcontractkit/chain-selectors"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	mcms_types "github.com/smartcontractkit/mcms/types"
+
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
+)
+
+// FeeTokenWithdrawal names a single fee token to withdraw and, optionally, how much of it.
+//
+// A nil Amount withdraws the whole accumulated balance of the token. A non-nil Amount withdraws
+// exactly that many base units, and is only honoured by chain families whose withdrawal primitive
+// takes an amount. EVM's withdrawFeeTokens always sweeps the full balance, so the EVM adapters
+// reject a non-nil Amount rather than silently withdrawing more than was asked for.
+type FeeTokenWithdrawal struct {
+	Token  string   `json:"token" yaml:"token"`
+	Amount *big.Int `json:"amount,omitempty" yaml:"amount,omitempty"`
+}
+
+// WithdrawFeeTokensForChain is a fee token withdrawal for a single chain. One entry may carry many
+// fee tokens; the adapter withdraws each of them in turn.
+//
+// When Contracts is empty the adapter uses its default contract(s). When Contracts is provided the
+// adapter withdraws only from the specified contracts, using the full ref (Type + Version +
+// Qualifier) for unambiguous datastore resolution.
+type WithdrawFeeTokensForChain struct {
+	ChainSelector uint64                 `json:"chainSelector" yaml:"chainSelector"`
+	FeeTokens     []FeeTokenWithdrawal   `json:"feeTokens" yaml:"feeTokens"`
+	Contracts     []datastore.AddressRef `json:"contracts,omitempty" yaml:"contracts,omitempty"`
+}
+
+// WithdrawFeeTokensInput is the top-level input for the WithdrawFeeTokens changeset. Args may span
+// as many chains as needed; each chain is resolved to its own family adapter.
+type WithdrawFeeTokensInput struct {
+	Version *semver.Version             `json:"version" yaml:"version"`
+	Args    []WithdrawFeeTokensForChain `json:"args" yaml:"args"`
+	MCMS    mcms.Input                  `json:"mcms" yaml:"mcms"`
+}
+
+// WithdrawFeeTokens creates a changeset that withdraws accumulated fee token balances to the
+// configured fee aggregator on one or more chains.
+func WithdrawFeeTokens() cldf.ChangeSetV2[WithdrawFeeTokensInput] {
+	registry := GetFeeAggregatorRegistry()
+	mcmsRegistry := changesets.GetRegistry()
+	return cldf.CreateChangeSet(makeWithdrawFeeTokensApply(registry, mcmsRegistry), makeWithdrawFeeTokensVerify(registry))
+}
+
+func makeWithdrawFeeTokensVerify(registry *FeeAggregatorAdapterRegistry) func(cldf.Environment, WithdrawFeeTokensInput) error {
+	return func(_ cldf.Environment, cfg WithdrawFeeTokensInput) error {
+		if cfg.Version == nil {
+			return fmt.Errorf("version is required")
+		}
+		if len(cfg.Args) == 0 {
+			return fmt.Errorf("at least one chain must be specified")
+		}
+
+		seen := map[uint64]bool{}
+		for i, arg := range cfg.Args {
+			if seen[arg.ChainSelector] {
+				return fmt.Errorf("duplicate chain selector at args[%d]: %d", i, arg.ChainSelector)
+			}
+			seen[arg.ChainSelector] = true
+
+			if len(arg.FeeTokens) == 0 {
+				return fmt.Errorf("at least one fee token is required at args[%d] (chain=%d)", i, arg.ChainSelector)
+			}
+
+			// Token address formats are family specific, so only emptiness, duplicates and amount
+			// sanity are checked here; each adapter parses the addresses it understands.
+			seenTokens := map[string]bool{}
+			for j, tok := range arg.FeeTokens {
+				if tok.Token == "" {
+					return fmt.Errorf("fee token address is required at args[%d].feeTokens[%d] (chain=%d)", i, j, arg.ChainSelector)
+				}
+				if seenTokens[tok.Token] {
+					return fmt.Errorf("duplicate fee token %q at args[%d].feeTokens[%d] (chain=%d)", tok.Token, i, j, arg.ChainSelector)
+				}
+				seenTokens[tok.Token] = true
+
+				if tok.Amount != nil && tok.Amount.Sign() <= 0 {
+					return fmt.Errorf("amount must be positive at args[%d].feeTokens[%d] (chain=%d, token=%s); omit it to withdraw the full balance",
+						i, j, arg.ChainSelector, tok.Token)
+				}
+			}
+
+			family, err := chain_selectors.GetSelectorFamily(arg.ChainSelector)
+			if err != nil {
+				return fmt.Errorf("failed to get chain family for selector %d: %w", arg.ChainSelector, err)
+			}
+
+			if _, exists := registry.GetFeeAggregatorAdapter(family, cfg.Version); !exists {
+				return fmt.Errorf("no fee aggregator adapter found for chain family %s and version %s", family, cfg.Version.String())
+			}
+		}
+
+		return nil
+	}
+}
+
+func makeWithdrawFeeTokensApply(registry *FeeAggregatorAdapterRegistry, mcmsRegistry *changesets.MCMSReaderRegistry) func(cldf.Environment, WithdrawFeeTokensInput) (cldf.ChangesetOutput, error) {
+	return func(e cldf.Environment, cfg WithdrawFeeTokensInput) (cldf.ChangesetOutput, error) {
+		batchOps := make([]mcms_types.BatchOperation, 0)
+		reports := make([]cldf_ops.Report[any, any], 0)
+
+		for _, arg := range cfg.Args {
+			family, err := chain_selectors.GetSelectorFamily(arg.ChainSelector)
+			if err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("failed to get chain family for selector %d: %w", arg.ChainSelector, err)
+			}
+
+			adapter, exists := registry.GetFeeAggregatorAdapter(family, cfg.Version)
+			if !exists {
+				return cldf.ChangesetOutput{}, fmt.Errorf("no fee aggregator adapter found for chain family %s and version %s", family, cfg.Version.String())
+			}
+
+			report, err := cldf_ops.ExecuteSequence(
+				e.OperationsBundle,
+				adapter.WithdrawFeeTokens(e),
+				e.BlockChains,
+				WithdrawFeeTokensForChain{
+					ChainSelector: arg.ChainSelector,
+					FeeTokens:     arg.FeeTokens,
+					Contracts:     arg.Contracts,
+				},
+			)
+			if err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("failed to withdraw fee tokens for chain %d: %w", arg.ChainSelector, err)
+			}
+
+			batchOps = append(batchOps, report.Output.BatchOps...)
+			reports = append(reports, report.ExecutionReports...)
+		}
+
+		return changesets.NewOutputBuilder(e, mcmsRegistry).
+			WithBatchOps(batchOps).
+			WithReports(reports).
+			Build(cfg.MCMS)
+	}
+}

--- a/integration-tests/deployment/withdraw_fee_tokens_test.go
+++ b/integration-tests/deployment/withdraw_fee_tokens_test.go
@@ -191,6 +191,22 @@ func TestWithdrawFeeTokensEVM_V1_6_0(t *testing.T) {
 				"chain %d token %d: fee aggregator should have received the full balance", f.selector, i)
 		}
 	}
+
+	// The deployed 1.6.0 OnRamp rejects a zero fee aggregator in setDynamicConfig, so the adapter's
+	// zero-address guard cannot fire on this version -- the invariant is enforced on-chain. (The 2.0
+	// Proxy and OnRamp do NOT validate it, which is where that guard earns its keep.) If a future
+	// 1.6.x drops this validation, this test fails and the 1.6 guard becomes load-bearing.
+	t.Run("OnRamp itself refuses a zero fee aggregator", func(t *testing.T) {
+		_, err := fees.SetFeeAggregator().Apply(*env, fees.SetFeeAggregatorInput{
+			Version: cciputils.Version_1_6_0,
+			MCMS:    mcms.Input{},
+			Args: []fees.FeeAggregatorForChain{
+				{ChainSelector: selA, FeeAggregator: (common.Address{}).Hex()},
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "InvalidConfig")
+	})
 }
 
 func TestWithdrawFeeTokens_ValidationErrors(t *testing.T) {

--- a/integration-tests/deployment/withdraw_fee_tokens_test.go
+++ b/integration-tests/deployment/withdraw_fee_tokens_test.go
@@ -1,0 +1,493 @@
+package deployment
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/gagliardetto/solana-go"
+	chainsel "github.com/smartcontractkit/chain-selectors"
+	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
+	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf_deployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	"github.com/smartcontractkit/chainlink-deployments-framework/engine/test/environment"
+	bnmERC20Bindings "github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/burn_mint_erc20"
+	"github.com/stretchr/testify/require"
+
+	evmadaptersV1_0_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/adapters"
+	evmadaptersV1_6_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/adapters"
+	evmonrampops "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/operations/onramp"
+	evmseqV1_6_0 "github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_6_0/sequences"
+	soladaptersV1_6_0 "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_6_0/adapters"
+	solseqV1_6_0 "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_6_0/sequences"
+	solcommon "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/common"
+	solstate "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/state"
+	soltokens "github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
+	deployapi "github.com/smartcontractkit/chainlink-ccip/deployment/deploy"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/fees"
+	cciputils "github.com/smartcontractkit/chainlink-ccip/deployment/utils"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
+	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
+)
+
+// withdrawFixture is the per-chain state a withdrawal test needs: where the fees sit and where
+// they should end up.
+type withdrawFixture struct {
+	selector      uint64
+	onRamp        common.Address
+	feeAggregator common.Address
+	tokens        []*bnmERC20Bindings.BurnMintERC20
+}
+
+func onRampAddressForTest(t *testing.T, env *cldf_deployment.Environment, selector uint64) common.Address {
+	t.Helper()
+	ref, err := datastore_utils.FindAndFormatRef(
+		env.DataStore,
+		datastore.AddressRef{
+			ChainSelector: selector,
+			Type:          datastore.ContractType(evmonrampops.ContractType),
+			Version:       evmonrampops.Version,
+		},
+		selector,
+		datastore_utils.FullRef,
+	)
+	require.NoError(t, err)
+	require.True(t, common.IsHexAddress(ref.Address))
+	return common.HexToAddress(ref.Address)
+}
+
+// fundOnRampWithFeeToken deploys a fresh burn/mint token and mints `amount` of it directly to the
+// OnRamp, standing in for fees that accumulated there from ccipSend calls.
+func fundOnRampWithFeeToken(t *testing.T, env *cldf_deployment.Environment, selector uint64, onRamp common.Address, amount *big.Int) *bnmERC20Bindings.BurnMintERC20 {
+	t.Helper()
+
+	chain, ok := env.BlockChains.EVMChains()[selector]
+	require.True(t, ok)
+
+	token := DeployBurnMintTokenEVM(t, env, selector, "")
+
+	opts := *chain.DeployerKey
+	opts.Context = t.Context()
+
+	grantTx, err := token.GrantMintAndBurnRoles(&opts, chain.DeployerKey.From)
+	require.NoError(t, err)
+	_, err = chain.Confirm(grantTx)
+	require.NoError(t, err)
+
+	mintTx, err := token.Mint(&opts, onRamp, amount)
+	require.NoError(t, err)
+	_, err = chain.Confirm(mintTx)
+	require.NoError(t, err)
+
+	balance, err := token.BalanceOf(&bind.CallOpts{Context: t.Context()}, onRamp)
+	require.NoError(t, err)
+	require.Equal(t, 0, balance.Cmp(amount), "OnRamp should hold the minted fee tokens before withdrawal")
+
+	return token
+}
+
+// TestWithdrawFeeTokensEVM_V1_6_0 exercises the changeset across two chains at once, with two fee
+// tokens on each, which is the shape operators actually run: one proposal, many lanes.
+func TestWithdrawFeeTokensEVM_V1_6_0(t *testing.T) {
+	selA := chainsel.TEST_90000001.Selector
+	selB := chainsel.TEST_90000002.Selector
+
+	env, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{selA, selB}),
+	)
+	require.NoError(t, err)
+
+	evmAdapter := evmseqV1_6_0.EVMAdapter{}
+
+	deployRegistry := deployapi.GetRegistry()
+	deployRegistry.RegisterDeployer(chainsel.FamilyEVM, deployapi.MCMSVersion, &evmadaptersV1_0_0.EVMDeployer{})
+
+	mcmsRegistry := changesets.GetRegistry()
+	mcmsRegistry.RegisterMCMSReader(chainsel.FamilyEVM, &evmadaptersV1_0_0.EVMMCMSReader{})
+
+	feeAggAdapter := evmadaptersV1_6_0.NewFeeAggregatorAdapter(&evmAdapter)
+
+	SeedUltraFastCurseMCMS(t, env)
+	output, err := deployapi.DeployContracts(deployRegistry).Apply(*env, deployapi.ContractDeploymentConfig{
+		MCMS: mcms.Input{},
+		Chains: map[uint64]deployapi.ContractDeploymentConfigPerChain{
+			selA: NewDefaultDeploymentConfigForEVM(cciputils.Version_1_6_0),
+			selB: NewDefaultDeploymentConfigForEVM(cciputils.Version_1_6_0),
+		},
+	})
+	require.NoError(t, err)
+	MergeAddresses(t, env, output.DataStore)
+
+	DeployMCMS(t, env, selA, []string{cciputils.CLLQualifier})
+	DeployMCMS(t, env, selB, []string{cciputils.CLLQualifier})
+
+	// Point each chain at a fresh fee aggregator so its starting balance is unambiguously zero.
+	feeAggregators := map[uint64]common.Address{
+		selA: common.HexToAddress("0x00000000000000000000000000000000000000A1"),
+		selB: common.HexToAddress("0x00000000000000000000000000000000000000B2"),
+	}
+	_, err = fees.SetFeeAggregator().Apply(*env, fees.SetFeeAggregatorInput{
+		Version: cciputils.Version_1_6_0,
+		MCMS:    mcms.Input{},
+		Args: []fees.FeeAggregatorForChain{
+			{ChainSelector: selA, FeeAggregator: feeAggregators[selA].Hex()},
+			{ChainSelector: selB, FeeAggregator: feeAggregators[selB].Hex()},
+		},
+	})
+	require.NoError(t, err)
+
+	amount := big.NewInt(1e18)
+
+	fixtures := make([]withdrawFixture, 0, 2)
+	for _, sel := range []uint64{selA, selB} {
+		onRamp := onRampAddressForTest(t, env, sel)
+
+		onchainFeeAgg, err := feeAggAdapter.GetFeeAggregator(*env, sel)
+		require.NoError(t, err)
+		require.Equal(t, feeAggregators[sel], common.HexToAddress(onchainFeeAgg))
+
+		fixtures = append(fixtures, withdrawFixture{
+			selector:      sel,
+			onRamp:        onRamp,
+			feeAggregator: feeAggregators[sel],
+			tokens: []*bnmERC20Bindings.BurnMintERC20{
+				fundOnRampWithFeeToken(t, env, sel, onRamp, amount),
+				fundOnRampWithFeeToken(t, env, sel, onRamp, amount),
+			},
+		})
+	}
+
+	args := make([]fees.WithdrawFeeTokensForChain, 0, len(fixtures))
+	for _, f := range fixtures {
+		feeTokens := make([]fees.FeeTokenWithdrawal, 0, len(f.tokens))
+		for _, tok := range f.tokens {
+			feeTokens = append(feeTokens, fees.FeeTokenWithdrawal{Token: tok.Address().Hex()})
+		}
+		args = append(args, fees.WithdrawFeeTokensForChain{
+			ChainSelector: f.selector,
+			FeeTokens:     feeTokens,
+		})
+	}
+
+	_, err = fees.WithdrawFeeTokens().Apply(*env, fees.WithdrawFeeTokensInput{
+		Version: cciputils.Version_1_6_0,
+		MCMS:    mcms.Input{},
+		Args:    args,
+	})
+	require.NoError(t, err)
+
+	for _, f := range fixtures {
+		for i, tok := range f.tokens {
+			onRampBalance, err := tok.BalanceOf(&bind.CallOpts{Context: t.Context()}, f.onRamp)
+			require.NoError(t, err)
+			require.Equal(t, 0, onRampBalance.Cmp(big.NewInt(0)),
+				"chain %d token %d: OnRamp balance should be swept to zero", f.selector, i)
+
+			aggBalance, err := tok.BalanceOf(&bind.CallOpts{Context: t.Context()}, f.feeAggregator)
+			require.NoError(t, err)
+			require.Equal(t, 0, aggBalance.Cmp(amount),
+				"chain %d token %d: fee aggregator should have received the full balance", f.selector, i)
+		}
+	}
+}
+
+func TestWithdrawFeeTokens_ValidationErrors(t *testing.T) {
+	evmSel := chainsel.TEST_90000001.Selector
+
+	env, err := environment.New(t.Context(),
+		environment.WithEVMSimulated(t, []uint64{evmSel}),
+	)
+	require.NoError(t, err)
+
+	linkAddr := "0x779877A7B0D9E8603169DdbD7836e478b4624789"
+	cs := fees.WithdrawFeeTokens()
+
+	t.Run("nil version", func(t *testing.T) {
+		err := cs.VerifyPreconditions(*env, fees.WithdrawFeeTokensInput{
+			Version: nil,
+			Args: []fees.WithdrawFeeTokensForChain{
+				{ChainSelector: evmSel, FeeTokens: []fees.FeeTokenWithdrawal{{Token: linkAddr}}},
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "version is required")
+	})
+
+	t.Run("empty args", func(t *testing.T) {
+		err := cs.VerifyPreconditions(*env, fees.WithdrawFeeTokensInput{
+			Version: cciputils.Version_1_6_0,
+			Args:    []fees.WithdrawFeeTokensForChain{},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "at least one chain must be specified")
+	})
+
+	t.Run("no fee tokens for a chain", func(t *testing.T) {
+		err := cs.VerifyPreconditions(*env, fees.WithdrawFeeTokensInput{
+			Version: cciputils.Version_1_6_0,
+			Args: []fees.WithdrawFeeTokensForChain{
+				{ChainSelector: evmSel, FeeTokens: nil},
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "at least one fee token is required")
+	})
+
+	t.Run("empty fee token address", func(t *testing.T) {
+		err := cs.VerifyPreconditions(*env, fees.WithdrawFeeTokensInput{
+			Version: cciputils.Version_1_6_0,
+			Args: []fees.WithdrawFeeTokensForChain{
+				{ChainSelector: evmSel, FeeTokens: []fees.FeeTokenWithdrawal{{Token: ""}}},
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "fee token address is required")
+	})
+
+	t.Run("duplicate chain selector", func(t *testing.T) {
+		err := cs.VerifyPreconditions(*env, fees.WithdrawFeeTokensInput{
+			Version: cciputils.Version_1_6_0,
+			Args: []fees.WithdrawFeeTokensForChain{
+				{ChainSelector: evmSel, FeeTokens: []fees.FeeTokenWithdrawal{{Token: linkAddr}}},
+				{ChainSelector: evmSel, FeeTokens: []fees.FeeTokenWithdrawal{{Token: linkAddr}}},
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "duplicate chain selector")
+	})
+
+	t.Run("duplicate fee token within a chain", func(t *testing.T) {
+		err := cs.VerifyPreconditions(*env, fees.WithdrawFeeTokensInput{
+			Version: cciputils.Version_1_6_0,
+			Args: []fees.WithdrawFeeTokensForChain{
+				{ChainSelector: evmSel, FeeTokens: []fees.FeeTokenWithdrawal{
+					{Token: linkAddr},
+					{Token: linkAddr},
+				}},
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "duplicate fee token")
+	})
+
+	t.Run("non-positive amount", func(t *testing.T) {
+		err := cs.VerifyPreconditions(*env, fees.WithdrawFeeTokensInput{
+			Version: cciputils.Version_1_6_0,
+			Args: []fees.WithdrawFeeTokensForChain{
+				{ChainSelector: evmSel, FeeTokens: []fees.FeeTokenWithdrawal{
+					{Token: linkAddr, Amount: big.NewInt(0)},
+				}},
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "amount must be positive")
+	})
+
+	t.Run("multiple chains with multiple tokens is valid", func(t *testing.T) {
+		err := cs.VerifyPreconditions(*env, fees.WithdrawFeeTokensInput{
+			Version: cciputils.Version_1_6_0,
+			Args: []fees.WithdrawFeeTokensForChain{
+				{ChainSelector: evmSel, FeeTokens: []fees.FeeTokenWithdrawal{
+					{Token: linkAddr},
+					{Token: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"},
+				}},
+			},
+		})
+		require.NoError(t, err)
+	})
+}
+
+// solTokenBalance reads an SPL token account balance in base units.
+func solTokenBalance(t *testing.T, chain cldf_solana.Chain, account solana.PublicKey) uint64 {
+	t.Helper()
+	_, balance, err := soltokens.TokenBalance(t.Context(), chain.Client, account, cldf_solana.SolDefaultCommitment)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, balance, 0)
+	return uint64(balance)
+}
+
+// solanaFeeToken is a mint plus the two token accounts a withdrawal moves value between.
+type solanaFeeToken struct {
+	mint     solana.PublicKey
+	accumATA solana.PublicKey // owned by the router's fee billing signer PDA; where fees pile up
+	aggATA   solana.PublicKey // owned by the fee aggregator; where they should land
+}
+
+// setupSolanaFeeToken mints a fresh SPL token straight into the router's billing accumulator,
+// standing in for fees that accrued there from ccipSend calls, and creates the fee aggregator's
+// ATA so the router has somewhere to send them.
+func setupSolanaFeeToken(
+	t *testing.T,
+	chain cldf_solana.Chain,
+	billingSigner solana.PublicKey,
+	feeAggregator solana.PublicKey,
+	amount uint64,
+) solanaFeeToken {
+	t.Helper()
+
+	mintPriv, err := solana.NewRandomPrivateKey()
+	require.NoError(t, err)
+	mint := mintPriv.PublicKey()
+
+	createMintIxs, err := soltokens.CreateToken(
+		t.Context(),
+		solana.TokenProgramID,
+		mint,
+		chain.DeployerKey.PublicKey(),
+		9,
+		chain.Client,
+		cldf_solana.SolDefaultCommitment,
+	)
+	require.NoError(t, err)
+	require.NoError(t, chain.Confirm(createMintIxs, solcommon.AddSigners(mintPriv)))
+
+	accumIx, accumATA, err := soltokens.CreateAssociatedTokenAccount(
+		solana.TokenProgramID, mint, billingSigner, chain.DeployerKey.PublicKey())
+	require.NoError(t, err)
+	aggIx, aggATA, err := soltokens.CreateAssociatedTokenAccount(
+		solana.TokenProgramID, mint, feeAggregator, chain.DeployerKey.PublicKey())
+	require.NoError(t, err)
+	require.NoError(t, chain.Confirm([]solana.Instruction{accumIx, aggIx}))
+
+	mintToIx, err := soltokens.MintTo(amount, solana.TokenProgramID, mint, accumATA, chain.DeployerKey.PublicKey())
+	require.NoError(t, err)
+	require.NoError(t, chain.Confirm([]solana.Instruction{mintToIx}))
+
+	require.Equal(t, amount, solTokenBalance(t, chain, accumATA), "billing accumulator should be funded")
+	require.Equal(t, uint64(0), solTokenBalance(t, chain, aggATA), "fee aggregator should start empty")
+
+	return solanaFeeToken{mint: mint, accumATA: accumATA, aggATA: aggATA}
+}
+
+// TestWithdrawFeeTokensSolana_V1_6_0 covers the Solana path end to end, including the per-token
+// amount that only Solana can honour: a partial withdrawal first, then a full sweep of what's left.
+func TestWithdrawFeeTokensSolana_V1_6_0(t *testing.T) {
+	solSel := chainsel.SOLANA_DEVNET.Selector
+
+	programsPath, ds, err := PreloadSolanaEnvironment(t, solSel)
+	require.NoError(t, err)
+
+	env, err := environment.New(t.Context(),
+		environment.WithSolanaContainer(t, []uint64{solSel}, programsPath, solanaProgramIDs),
+	)
+	require.NoError(t, err)
+	env.DataStore = ds.Seal()
+
+	solAdapter := solseqV1_6_0.SolanaAdapter{}
+
+	deployRegistry := deployapi.GetRegistry()
+	deployRegistry.RegisterDeployer(chainsel.FamilySolana, deployapi.MCMSVersion, &solAdapter)
+
+	SeedUltraFastCurseMCMS(t, env)
+	output, err := deployapi.DeployContracts(deployRegistry).Apply(*env, deployapi.ContractDeploymentConfig{
+		MCMS: mcms.Input{},
+		Chains: map[uint64]deployapi.ContractDeploymentConfigPerChain{
+			solSel: NewDefaultDeploymentConfigForSolana(cciputils.Version_1_6_0),
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, output.DataStore.Merge(env.DataStore))
+	env.DataStore = output.DataStore.Seal()
+
+	solChain, ok := env.BlockChains.SolanaChains()[solSel]
+	require.True(t, ok)
+
+	// Point the router at a fresh fee aggregator so its ATAs start empty.
+	feeAggregator := solana.NewWallet()
+	_, err = fees.SetFeeAggregator().Apply(*env, fees.SetFeeAggregatorInput{
+		Version: cciputils.Version_1_6_0,
+		MCMS:    mcms.Input{},
+		Args: []fees.FeeAggregatorForChain{
+			{ChainSelector: solSel, FeeAggregator: feeAggregator.PublicKey().String()},
+		},
+	})
+	require.NoError(t, err)
+
+	feeAggAdapter := soladaptersV1_6_0.NewFeeAggregatorAdapter(&solAdapter)
+	onchainFeeAgg, err := feeAggAdapter.GetFeeAggregator(*env, solSel)
+	require.NoError(t, err)
+	require.Equal(t, feeAggregator.PublicKey().String(), onchainFeeAgg)
+
+	routerAddr, err := solAdapter.GetRouterAddress(env.DataStore, solSel)
+	require.NoError(t, err)
+	routerPubkey := solana.PublicKeyFromBytes(routerAddr)
+
+	billingSigner, _, err := solstate.FindFeeBillingSignerPDA(routerPubkey)
+	require.NoError(t, err)
+
+	const (
+		accumulated = uint64(1_000_000)
+		partial     = uint64(250_000)
+	)
+
+	// Two fee tokens, so the sequence has to iterate rather than handle a single mint.
+	tokenA := setupSolanaFeeToken(t, solChain, billingSigner, feeAggregator.PublicKey(), accumulated)
+	tokenB := setupSolanaFeeToken(t, solChain, billingSigner, feeAggregator.PublicKey(), accumulated)
+
+	t.Run("partial withdrawal honours the per-token amount", func(t *testing.T) {
+		_, err := fees.WithdrawFeeTokens().Apply(*env, fees.WithdrawFeeTokensInput{
+			Version: cciputils.Version_1_6_0,
+			MCMS:    mcms.Input{},
+			Args: []fees.WithdrawFeeTokensForChain{
+				{
+					ChainSelector: solSel,
+					FeeTokens: []fees.FeeTokenWithdrawal{
+						{Token: tokenA.mint.String(), Amount: new(big.Int).SetUint64(partial)},
+						{Token: tokenB.mint.String(), Amount: new(big.Int).SetUint64(partial)},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		for name, tok := range map[string]solanaFeeToken{"tokenA": tokenA, "tokenB": tokenB} {
+			require.Equal(t, accumulated-partial, solTokenBalance(t, solChain, tok.accumATA),
+				"%s: only the requested amount should leave the accumulator", name)
+			require.Equal(t, partial, solTokenBalance(t, solChain, tok.aggATA),
+				"%s: fee aggregator should have received exactly the requested amount", name)
+		}
+	})
+
+	t.Run("omitting the amount sweeps the remaining balance", func(t *testing.T) {
+		_, err := fees.WithdrawFeeTokens().Apply(*env, fees.WithdrawFeeTokensInput{
+			Version: cciputils.Version_1_6_0,
+			MCMS:    mcms.Input{},
+			Args: []fees.WithdrawFeeTokensForChain{
+				{
+					ChainSelector: solSel,
+					FeeTokens: []fees.FeeTokenWithdrawal{
+						{Token: tokenA.mint.String()},
+						{Token: tokenB.mint.String()},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		for name, tok := range map[string]solanaFeeToken{"tokenA": tokenA, "tokenB": tokenB} {
+			require.Equal(t, uint64(0), solTokenBalance(t, solChain, tok.accumATA),
+				"%s: accumulator should be fully swept", name)
+			require.Equal(t, accumulated, solTokenBalance(t, solChain, tok.aggATA),
+				"%s: fee aggregator should hold everything that accrued", name)
+		}
+	})
+
+	t.Run("unknown mint fails before any transaction is sent", func(t *testing.T) {
+		_, err := fees.WithdrawFeeTokens().Apply(*env, fees.WithdrawFeeTokensInput{
+			Version: cciputils.Version_1_6_0,
+			MCMS:    mcms.Input{},
+			Args: []fees.WithdrawFeeTokensForChain{
+				{
+					ChainSelector: solSel,
+					FeeTokens: []fees.FeeTokenWithdrawal{
+						{Token: solana.NewWallet().PublicKey().String()},
+					},
+				},
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not found")
+	})
+}

--- a/integration-tests/deployment/withdraw_fee_tokens_test.go
+++ b/integration-tests/deployment/withdraw_fee_tokens_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/rpc"
 	chainsel "github.com/smartcontractkit/chain-selectors"
 	cldf_solana "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
@@ -340,6 +341,7 @@ func setupSolanaFeeToken(
 	billingSigner solana.PublicKey,
 	feeAggregator solana.PublicKey,
 	amount uint64,
+	createAggATA bool,
 ) solanaFeeToken {
 	t.Helper()
 
@@ -362,17 +364,26 @@ func setupSolanaFeeToken(
 	accumIx, accumATA, err := soltokens.CreateAssociatedTokenAccount(
 		solana.TokenProgramID, mint, billingSigner, chain.DeployerKey.PublicKey())
 	require.NoError(t, err)
-	aggIx, aggATA, err := soltokens.CreateAssociatedTokenAccount(
-		solana.TokenProgramID, mint, feeAggregator, chain.DeployerKey.PublicKey())
+	ixs := []solana.Instruction{accumIx}
+
+	aggATA, _, err := soltokens.FindAssociatedTokenAddress(solana.TokenProgramID, mint, feeAggregator)
 	require.NoError(t, err)
-	require.NoError(t, chain.Confirm([]solana.Instruction{accumIx, aggIx}))
+	if createAggATA {
+		aggIx, _, err := soltokens.CreateAssociatedTokenAccount(
+			solana.TokenProgramID, mint, feeAggregator, chain.DeployerKey.PublicKey())
+		require.NoError(t, err)
+		ixs = append(ixs, aggIx)
+	}
+	require.NoError(t, chain.Confirm(ixs))
 
 	mintToIx, err := soltokens.MintTo(amount, solana.TokenProgramID, mint, accumATA, chain.DeployerKey.PublicKey())
 	require.NoError(t, err)
 	require.NoError(t, chain.Confirm([]solana.Instruction{mintToIx}))
 
 	require.Equal(t, amount, solTokenBalance(t, chain, accumATA), "billing accumulator should be funded")
-	require.Equal(t, uint64(0), solTokenBalance(t, chain, aggATA), "fee aggregator should start empty")
+	if createAggATA {
+		require.Equal(t, uint64(0), solTokenBalance(t, chain, aggATA), "fee aggregator should start empty")
+	}
 
 	return solanaFeeToken{mint: mint, accumATA: accumATA, aggATA: aggATA}
 }
@@ -439,8 +450,8 @@ func TestWithdrawFeeTokensSolana_V1_6_0(t *testing.T) {
 	)
 
 	// Two fee tokens, so the sequence has to iterate rather than handle a single mint.
-	tokenA := setupSolanaFeeToken(t, solChain, billingSigner, feeAggregator.PublicKey(), accumulated)
-	tokenB := setupSolanaFeeToken(t, solChain, billingSigner, feeAggregator.PublicKey(), accumulated)
+	tokenA := setupSolanaFeeToken(t, solChain, billingSigner, feeAggregator.PublicKey(), accumulated, true)
+	tokenB := setupSolanaFeeToken(t, solChain, billingSigner, feeAggregator.PublicKey(), accumulated, true)
 
 	t.Run("partial withdrawal honours the per-token amount", func(t *testing.T) {
 		_, err := fees.WithdrawFeeTokens().Apply(*env, fees.WithdrawFeeTokensInput{
@@ -488,6 +499,34 @@ func TestWithdrawFeeTokensSolana_V1_6_0(t *testing.T) {
 			require.Equal(t, accumulated, solTokenBalance(t, solChain, tok.aggATA),
 				"%s: fee aggregator should hold everything that accrued", name)
 		}
+	})
+
+	// The router will not create the recipient account, and ATA creation is permissionless, so the
+	// sequence creates it with the deployer key rather than making the operator do it beforehand.
+	t.Run("creates the fee aggregator ATA when it is missing", func(t *testing.T) {
+		tok := setupSolanaFeeToken(t, solChain, billingSigner, feeAggregator.PublicKey(), accumulated, false)
+
+		_, err := solChain.Client.GetAccountInfoWithOpts(t.Context(), tok.aggATA, &rpc.GetAccountInfoOpts{
+			Commitment: cldf_solana.SolDefaultCommitment,
+		})
+		require.ErrorIs(t, err, rpc.ErrNotFound, "fee aggregator ATA should not exist yet")
+
+		_, err = fees.WithdrawFeeTokens().Apply(*env, fees.WithdrawFeeTokensInput{
+			Version: cciputils.Version_1_6_0,
+			MCMS:    mcms.Input{},
+			Args: []fees.WithdrawFeeTokensForChain{
+				{
+					ChainSelector: solSel,
+					FeeTokens:     []fees.FeeTokenWithdrawal{{Token: tok.mint.String()}},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		require.Equal(t, uint64(0), solTokenBalance(t, solChain, tok.accumATA),
+			"accumulator should be swept")
+		require.Equal(t, accumulated, solTokenBalance(t, solChain, tok.aggATA),
+			"fee aggregator ATA should have been created and funded")
 	})
 
 	t.Run("unknown mint fails before any transaction is sent", func(t *testing.T) {


### PR DESCRIPTION
This pull request introduces a new "WithdrawFeeTokens" operation for both EVM and Solana deployments, allowing accumulated fee token balances to be withdrawn to the fee aggregator. It also refactors contract resolution logic for more consistent parameter usage and adds comprehensive tests for the new utility functions. The changes are grouped below by theme.

**New Withdraw Fee Tokens Operation**

* Added a `WithdrawFeeTokens` operation to EVM v1.6.0 and v2.0.0 adapters, enabling the withdrawal of all accumulated fee token balances to the fee aggregator in a single transaction. [[1]](diffhunk://#diff-9d1ecde81c8130a4840b32371e080a162e38d77ea391155aa341b6a1236f2e75R152-R201) [[2]](diffhunk://#diff-ebcca11928e5acc22c153c6eb0ab8dacc0216b7f0712a3bda19c5da85fd67810R267-R356)
* Implemented the corresponding contract call and operation registration for `withdrawFeeTokens` in the EVM OnRamp contract logic. [[1]](diffhunk://#diff-209bb7ef68f6ebb30cd97c38b9a1af7e9eeab01c49afeb0f4b95fcb3c739ae30R123-R126) [[2]](diffhunk://#diff-209bb7ef68f6ebb30cd97c38b9a1af7e9eeab01c49afeb0f4b95fcb3c739ae30R285-R302)
* Added the `withdrawFeeTokens` function as a public method in the deployment configuration.

**Utility and Test Enhancements**

* Introduced `EVMFeeTokenAddresses` utility to validate and convert fee token withdrawal requests, ensuring only full-balance sweeps are allowed and rejecting partial withdrawals.
* Added comprehensive unit tests for `EVMFeeTokenAddresses`, covering correct conversion, address validation, and rejection of partial withdrawals.

**Refactoring and Consistency Improvements**

* Refactored contract/address resolution logic in EVM and Solana adapters to use explicit `chainSelector` and `contracts` parameters instead of passing input structs, improving clarity and maintainability. [[1]](diffhunk://#diff-9d1ecde81c8130a4840b32371e080a162e38d77ea391155aa341b6a1236f2e75L77-R89) [[2]](diffhunk://#diff-9d1ecde81c8130a4840b32371e080a162e38d77ea391155aa341b6a1236f2e75L109-R110) [[3]](diffhunk://#diff-ebcca11928e5acc22c153c6eb0ab8dacc0216b7f0712a3bda19c5da85fd67810L92-R93) [[4]](diffhunk://#diff-ebcca11928e5acc22c153c6eb0ab8dacc0216b7f0712a3bda19c5da85fd67810L118-R146) [[5]](diffhunk://#diff-20673f908dfa1fc7aa16054a31e43ce63ec5ad8348dde9bcc04a42007704039fL60-R85) [[6]](diffhunk://#diff-20673f908dfa1fc7aa16054a31e43ce63ec5ad8348dde9bcc04a42007704039fL102-R106)
* Updated import statements and dependencies to support new operations and utility functions. [[1]](diffhunk://#diff-9d1ecde81c8130a4840b32371e080a162e38d77ea391155aa341b6a1236f2e75L14-R17) [[2]](diffhunk://#diff-ebcca11928e5acc22c153c6eb0ab8dacc0216b7f0712a3bda19c5da85fd67810R15-L19) [[3]](diffhunk://#diff-20673f908dfa1fc7aa16054a31e43ce63ec5ad8348dde9bcc04a42007704039fR8-R21)