### PR TITLE
fix: token expansion - reduce RPC flakes and resolve edge case with reverse propagation

### DIFF
--- a/chains/evm/deployment/tokens/tokenimpl/helpers.go
+++ b/chains/evm/deployment/tokens/tokenimpl/helpers.go
@@ -1,12 +1,10 @@
 package tokenimpl
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 	"time"
 
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/burn_mint_erc20"
@@ -14,85 +12,20 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm"
 	"github.com/smartcontractkit/chainlink-deployments-framework/chain/evm/operations/contract"
 	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
-	bnm_erc20_bindings "github.com/smartcontractkit/chainlink-evm/gethwrappers/shared/generated/initial/burn_mint_erc20"
 )
 
-func revokeDefaultAdminRoleBurnMintERC20(b cldf_ops.Bundle, chain evm.Chain, token, user common.Address) ([]contract.WriteOutput, error) {
-	tokenContract, err := bnm_erc20_bindings.NewBurnMintERC20(token, chain.Client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to instantiate BurnMintERC20 contract: %w", err)
-	}
-	role, err := tokenContract.DEFAULTADMINROLE(&bind.CallOpts{Context: b.GetContext()})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get default admin role constant: %w", err)
-	}
-	report, err := cldf_ops.ExecuteOperation(b, burn_mint_erc20.RevokeAdminRole, chain, contract.FunctionInput[burn_mint_erc20.RoleAssignment]{
-		ChainSelector: chain.Selector,
-		Address:       token,
-		Args: burn_mint_erc20.RoleAssignment{
-			Role: role,
-			To:   user,
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to revoke default admin role: %w", err)
-	}
-	return []contract.WriteOutput{report.Output}, nil
-}
-
-func hasDefaultAdminRoleBurnMintERC20(ctx context.Context, chain evm.Chain, token, user common.Address) (bool, error) {
-	tokenContract, err := bnm_erc20_bindings.NewBurnMintERC20(token, chain.Client)
-	if err != nil {
-		return false, fmt.Errorf("failed to instantiate BurnMintERC20 contract: %w", err)
-	}
-	role, err := tokenContract.DEFAULTADMINROLE(&bind.CallOpts{Context: ctx})
-	if err != nil {
-		return false, fmt.Errorf("failed to get default admin role constant: %w", err)
-	}
-	hasRole, err := tokenContract.HasRole(&bind.CallOpts{Context: ctx}, role, user)
-	if err != nil {
-		return false, fmt.Errorf("failed to check default admin role for %s: %w", user.Hex(), err)
-	}
-	return hasRole, nil
-}
-
-func grantDefaultAdminRoleBurnMintERC20(b cldf_ops.Bundle, chain evm.Chain, token, user common.Address) ([]contract.WriteOutput, error) {
-	tokenContract, err := bnm_erc20_bindings.NewBurnMintERC20(token, chain.Client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to instantiate BurnMintERC20 contract: %w", err)
-	}
-	role, err := tokenContract.DEFAULTADMINROLE(&bind.CallOpts{Context: b.GetContext()})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get default admin role constant: %w", err)
-	}
-	report, err := cldf_ops.ExecuteOperation(b, burn_mint_erc20.GrantAdminRole, chain, contract.FunctionInput[burn_mint_erc20.RoleAssignment]{
-		ChainSelector: chain.Selector,
-		Address:       token,
-		Args: burn_mint_erc20.RoleAssignment{
-			Role: role,
-			To:   user,
-		},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to grant default admin role: %w", err)
-	}
-	return []contract.WriteOutput{report.Output}, nil
-}
-
-func grantMintAndBurnRolesBurnMintERC20(b cldf_ops.Bundle, chain evm.Chain, token, pool common.Address) ([]contract.WriteOutput, error) {
-	type GrantRoleArgs = contract.FunctionInput[common.Address]
-
+func getRetryConfig[T any](b cldf_ops.Bundle, chain evm.Chain, token string) cldf_ops.RetryConfig[contract.FunctionInput[T], evm.Chain] {
 	retryBuffer := 2 * time.Second
 	retryPolicy := cldf_ops.RetryPolicy{MaxAttempts: 5}
-	retryConfig := cldf_ops.RetryConfig[GrantRoleArgs, evm.Chain]{
+	retryConfig := cldf_ops.RetryConfig[contract.FunctionInput[T], evm.Chain]{
 		Enabled: true,
 		Policy:  retryPolicy,
-		InputHook: func(attempt uint, err error, in GrantRoleArgs, _ evm.Chain) GrantRoleArgs {
+		InputHook: func(attempt uint, err error, in contract.FunctionInput[T], _ evm.Chain) contract.FunctionInput[T] {
 			wait := time.Duration(attempt+1) * retryBuffer
 
 			b.Logger.Infof(
-				"Retrying GrantMintAndBurnRoles for token %s on chain %d, attempt %d/%d, waiting %s, err: %v",
-				token.Hex(), chain.Selector, attempt+1, retryPolicy.MaxAttempts, wait, err,
+				"Retrying operation for token %s on chain %d, attempt %d/%d, waiting %s, err: %v",
+				token, chain.Selector, attempt+1, retryPolicy.MaxAttempts, wait, err,
 			)
 
 			// We avoid time.Sleep since it doesn't respect context cancellation. Instead, we either wait
@@ -106,6 +39,101 @@ func grantMintAndBurnRolesBurnMintERC20(b cldf_ops.Bundle, chain evm.Chain, toke
 		},
 	}
 
+	return retryConfig
+}
+
+func revokeDefaultAdminRoleBurnMintERC20(b cldf_ops.Bundle, chain evm.Chain, token, user common.Address) ([]contract.WriteOutput, error) {
+	role, err := cldf_ops.ExecuteOperation(b, burn_mint_erc20.GetDefaultAdminRole, chain, contract.FunctionInput[struct{}]{
+		ChainSelector: chain.Selector,
+		Address:       token,
+		Args:          struct{}{},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get default admin role: %w", err)
+	}
+
+	report, err := cldf_ops.ExecuteOperation(b, burn_mint_erc20.RevokeAdminRole, chain, contract.FunctionInput[burn_mint_erc20.RoleAssignment]{
+		ChainSelector: chain.Selector,
+		Address:       token,
+		Args: burn_mint_erc20.RoleAssignment{
+			Role: role.Output,
+			To:   user,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to revoke default admin role: %w", err)
+	}
+
+	return []contract.WriteOutput{report.Output}, nil
+}
+
+func hasDefaultAdminRoleBurnMintERC20(b cldf_ops.Bundle, chain evm.Chain, token, user common.Address) (bool, error) {
+	role, err := cldf_ops.ExecuteOperation(
+		b, burn_mint_erc20.GetDefaultAdminRole, chain,
+		contract.FunctionInput[struct{}]{
+			ChainSelector: chain.Selector,
+			Address:       token,
+			Args:          struct{}{},
+		},
+		cldf_ops.WithRetryConfig(getRetryConfig[struct{}](b, chain, token.Hex())),
+	)
+	if err != nil {
+		return false, fmt.Errorf("failed to get default admin role: %w", err)
+	}
+
+	hasRole, err := cldf_ops.ExecuteOperation(
+		b, burn_mint_erc20.HasRole, chain,
+		contract.FunctionInput[burn_mint_erc20.RoleAssignment]{
+			ChainSelector: chain.Selector,
+			Address:       token,
+			Args: burn_mint_erc20.RoleAssignment{
+				Role: role.Output,
+				To:   user,
+			},
+		},
+		cldf_ops.WithRetryConfig(getRetryConfig[burn_mint_erc20.RoleAssignment](b, chain, token.Hex())),
+	)
+	if err != nil {
+		return false, fmt.Errorf("failed to check default admin role for %s: %w", user.Hex(), err)
+	}
+
+	return hasRole.Output, nil
+}
+
+func grantDefaultAdminRoleBurnMintERC20(b cldf_ops.Bundle, chain evm.Chain, token, user common.Address) ([]contract.WriteOutput, error) {
+	role, err := cldf_ops.ExecuteOperation(
+		b, burn_mint_erc20.GetDefaultAdminRole, chain,
+		contract.FunctionInput[struct{}]{
+			ChainSelector: chain.Selector,
+			Address:       token,
+			Args:          struct{}{},
+		},
+		cldf_ops.WithRetryConfig(getRetryConfig[struct{}](b, chain, token.Hex())),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get default admin role: %w", err)
+	}
+
+	report, err := cldf_ops.ExecuteOperation(
+		b, burn_mint_erc20.GrantAdminRole, chain,
+		contract.FunctionInput[burn_mint_erc20.RoleAssignment]{
+			ChainSelector: chain.Selector,
+			Address:       token,
+			Args: burn_mint_erc20.RoleAssignment{
+				Role: role.Output,
+				To:   user,
+			},
+		},
+		cldf_ops.WithRetryConfig(getRetryConfig[burn_mint_erc20.RoleAssignment](b, chain, token.Hex())),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to grant default admin role: %w", err)
+	}
+
+	return []contract.WriteOutput{report.Output}, nil
+}
+
+func grantMintAndBurnRolesBurnMintERC20(b cldf_ops.Bundle, chain evm.Chain, token, pool common.Address) ([]contract.WriteOutput, error) {
 	report, err := cldf_ops.ExecuteOperation(
 		b, burn_mint_erc20.GrantMintAndBurnRoles, chain,
 		contract.FunctionInput[common.Address]{
@@ -113,7 +141,7 @@ func grantMintAndBurnRolesBurnMintERC20(b cldf_ops.Bundle, chain evm.Chain, toke
 			Address:       token,
 			Args:          pool,
 		},
-		cldf_ops.WithRetryConfig(retryConfig),
+		cldf_ops.WithRetryConfig(getRetryConfig[common.Address](b, chain, token.Hex())),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to grant mint and burn roles: %w", err)
@@ -123,28 +151,36 @@ func grantMintAndBurnRolesBurnMintERC20(b cldf_ops.Bundle, chain evm.Chain, toke
 }
 
 func setCCIPAdminBurnMintERC20(b cldf_ops.Bundle, chain evm.Chain, token, ccipAdmin common.Address) ([]contract.WriteOutput, error) {
-	report, err := cldf_ops.ExecuteOperation(b, burn_mint_erc20.SetCCIPAdmin, chain, contract.FunctionInput[string]{
-		ChainSelector: chain.Selector,
-		Address:       token,
-		Args:          ccipAdmin.Hex(),
-	})
+	report, err := cldf_ops.ExecuteOperation(
+		b, burn_mint_erc20.SetCCIPAdmin, chain,
+		contract.FunctionInput[string]{
+			ChainSelector: chain.Selector,
+			Address:       token,
+			Args:          ccipAdmin.Hex(),
+		},
+		cldf_ops.WithRetryConfig(getRetryConfig[string](b, chain, token.Hex())),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set CCIP admin: %w", err)
 	}
+
 	return []contract.WriteOutput{report.Output}, nil
 }
 
 func transferTokensERC20(b cldf_ops.Bundle, chain evm.Chain, token, to common.Address, scaledAmount *big.Int) ([]contract.WriteOutput, error) {
-	report, err := cldf_ops.ExecuteOperation(b, erc20.Transfer, chain, contract.FunctionInput[erc20.TransferArgs]{
-		ChainSelector: chain.Selector,
-		Address:       token,
-		Args: erc20.TransferArgs{
-			Amount:   scaledAmount,
-			Receiver: to,
+	report, err := cldf_ops.ExecuteOperation(
+		b, erc20.Transfer, chain, contract.FunctionInput[erc20.TransferArgs]{
+			ChainSelector: chain.Selector,
+			Address:       token,
+			Args: erc20.TransferArgs{
+				Amount:   scaledAmount,
+				Receiver: to,
+			},
 		},
-	})
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to transfer ERC20 tokens: %w", err)
 	}
+
 	return []contract.WriteOutput{report.Output}, nil
 }

--- a/chains/evm/deployment/tokens/tokenimpl/helpers.go
+++ b/chains/evm/deployment/tokens/tokenimpl/helpers.go
@@ -43,23 +43,31 @@ func getRetryConfig[T any](b cldf_ops.Bundle, chain evm.Chain, token string) cld
 }
 
 func revokeDefaultAdminRoleBurnMintERC20(b cldf_ops.Bundle, chain evm.Chain, token, user common.Address) ([]contract.WriteOutput, error) {
-	role, err := cldf_ops.ExecuteOperation(b, burn_mint_erc20.GetDefaultAdminRole, chain, contract.FunctionInput[struct{}]{
-		ChainSelector: chain.Selector,
-		Address:       token,
-		Args:          struct{}{},
-	})
+	role, err := cldf_ops.ExecuteOperation(
+		b, burn_mint_erc20.GetDefaultAdminRole, chain,
+		contract.FunctionInput[struct{}]{
+			ChainSelector: chain.Selector,
+			Address:       token,
+			Args:          struct{}{},
+		},
+		cldf_ops.WithRetryConfig(getRetryConfig[struct{}](b, chain, token.Hex())),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get default admin role: %w", err)
 	}
 
-	report, err := cldf_ops.ExecuteOperation(b, burn_mint_erc20.RevokeAdminRole, chain, contract.FunctionInput[burn_mint_erc20.RoleAssignment]{
-		ChainSelector: chain.Selector,
-		Address:       token,
-		Args: burn_mint_erc20.RoleAssignment{
-			Role: role.Output,
-			To:   user,
+	report, err := cldf_ops.ExecuteOperation(
+		b, burn_mint_erc20.RevokeAdminRole, chain,
+		contract.FunctionInput[burn_mint_erc20.RoleAssignment]{
+			ChainSelector: chain.Selector,
+			Address:       token,
+			Args: burn_mint_erc20.RoleAssignment{
+				Role: role.Output,
+				To:   user,
+			},
 		},
-	})
+		cldf_ops.WithRetryConfig(getRetryConfig[burn_mint_erc20.RoleAssignment](b, chain, token.Hex())),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to revoke default admin role: %w", err)
 	}
@@ -167,6 +175,9 @@ func setCCIPAdminBurnMintERC20(b cldf_ops.Bundle, chain evm.Chain, token, ccipAd
 	return []contract.WriteOutput{report.Output}, nil
 }
 
+// NOTE: transferTokensERC20 is intentionally NOT retried. Transfer moves value and is not idempotent
+// by value - a retry after an unclear outcome *risks transferring twice*. The retry path is reserved
+// for idempotent role-assignment writes and reads.
 func transferTokensERC20(b cldf_ops.Bundle, chain evm.Chain, token, to common.Address, scaledAmount *big.Int) ([]contract.WriteOutput, error) {
 	report, err := cldf_ops.ExecuteOperation(
 		b, erc20.Transfer, chain, contract.FunctionInput[erc20.TransferArgs]{

--- a/chains/evm/deployment/tokens/tokenimpl/helpers.go
+++ b/chains/evm/deployment/tokens/tokenimpl/helpers.go
@@ -99,6 +99,7 @@ func hasDefaultAdminRoleBurnMintERC20(b cldf_ops.Bundle, chain evm.Chain, token,
 				To:   user,
 			},
 		},
+		cldf_ops.WithForceExecute[contract.FunctionInput[burn_mint_erc20.RoleAssignment], evm.Chain](),
 		cldf_ops.WithRetryConfig(getRetryConfig[burn_mint_erc20.RoleAssignment](b, chain, token.Hex())),
 	)
 	if err != nil {

--- a/chains/evm/deployment/tokens/tokenimpl/helpers.go
+++ b/chains/evm/deployment/tokens/tokenimpl/helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -79,14 +80,45 @@ func grantDefaultAdminRoleBurnMintERC20(b cldf_ops.Bundle, chain evm.Chain, toke
 }
 
 func grantMintAndBurnRolesBurnMintERC20(b cldf_ops.Bundle, chain evm.Chain, token, pool common.Address) ([]contract.WriteOutput, error) {
-	report, err := cldf_ops.ExecuteOperation(b, burn_mint_erc20.GrantMintAndBurnRoles, chain, contract.FunctionInput[common.Address]{
-		ChainSelector: chain.Selector,
-		Address:       token,
-		Args:          pool,
-	})
+	type GrantRoleArgs = contract.FunctionInput[common.Address]
+
+	retryBuffer := 2 * time.Second
+	retryPolicy := cldf_ops.RetryPolicy{MaxAttempts: 5}
+	retryConfig := cldf_ops.RetryConfig[GrantRoleArgs, evm.Chain]{
+		Enabled: true,
+		Policy:  retryPolicy,
+		InputHook: func(attempt uint, err error, in GrantRoleArgs, _ evm.Chain) GrantRoleArgs {
+			wait := time.Duration(attempt+1) * retryBuffer
+
+			b.Logger.Infof(
+				"Retrying GrantMintAndBurnRoles for token %s on chain %d, attempt %d/%d, waiting %s, err: %v",
+				token.Hex(), chain.Selector, attempt+1, retryPolicy.MaxAttempts, wait, err,
+			)
+
+			// We avoid time.Sleep since it doesn't respect context cancellation. Instead, we either wait
+			// for the entire backoff duration or for the context to be cancelled, whichever comes first.
+			select {
+			case <-b.GetContext().Done():
+			case <-time.After(wait):
+			}
+
+			return in
+		},
+	}
+
+	report, err := cldf_ops.ExecuteOperation(
+		b, burn_mint_erc20.GrantMintAndBurnRoles, chain,
+		contract.FunctionInput[common.Address]{
+			ChainSelector: chain.Selector,
+			Address:       token,
+			Args:          pool,
+		},
+		cldf_ops.WithRetryConfig(retryConfig),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to grant mint and burn roles: %w", err)
 	}
+
 	return []contract.WriteOutput{report.Output}, nil
 }
 

--- a/chains/evm/deployment/tokens/tokenimpl/impl.go
+++ b/chains/evm/deployment/tokens/tokenimpl/impl.go
@@ -1,7 +1,6 @@
 package tokenimpl
 
 import (
-	"context"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -50,7 +49,7 @@ type Token interface {
 	// HasAdminRole checks whether user has the default-admin or contract-specific
 	// admin role. Returns an error for token types whose Capabilities.SupportsAdminRole
 	// is false; callers should consult that flag first.
-	HasAdminRole(ctx context.Context, chain evm.Chain, token, user common.Address) (bool, error)
+	HasAdminRole(b cldf_ops.Bundle, chain evm.Chain, token, user common.Address) (bool, error)
 
 	// GrantAdminRole grants the default-admin or contract-specific
 	// admin role to user. Returns an error for token types whose

--- a/chains/evm/deployment/tokens/tokenimpl/token_burn_mint_erc20.go
+++ b/chains/evm/deployment/tokens/tokenimpl/token_burn_mint_erc20.go
@@ -1,7 +1,6 @@
 package tokenimpl
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 
@@ -36,8 +35,8 @@ func (tokenBurnMintERC20) RevokeAdminRole(b operations.Bundle, chain evm.Chain, 
 	return revokeDefaultAdminRoleBurnMintERC20(b, chain, token, user)
 }
 
-func (tokenBurnMintERC20) HasAdminRole(ctx context.Context, chain evm.Chain, token, user common.Address) (bool, error) {
-	return hasDefaultAdminRoleBurnMintERC20(ctx, chain, token, user)
+func (tokenBurnMintERC20) HasAdminRole(b operations.Bundle, chain evm.Chain, token, user common.Address) (bool, error) {
+	return hasDefaultAdminRoleBurnMintERC20(b, chain, token, user)
 }
 
 func (tokenBurnMintERC20) GrantAdminRole(b operations.Bundle, chain evm.Chain, token, externalAdmin common.Address) ([]contract.WriteOutput, error) {

--- a/chains/evm/deployment/tokens/tokenimpl/token_burn_mint_erc20_with_drip_v1_0_0.go
+++ b/chains/evm/deployment/tokens/tokenimpl/token_burn_mint_erc20_with_drip_v1_0_0.go
@@ -1,7 +1,6 @@
 package tokenimpl
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 
@@ -39,8 +38,8 @@ func (tokenBurnMintERC20WithDripV1_0_0) RevokeAdminRole(b operations.Bundle, cha
 	return revokeDefaultAdminRoleBurnMintERC20(b, chain, token, externalAdmin)
 }
 
-func (tokenBurnMintERC20WithDripV1_0_0) HasAdminRole(ctx context.Context, chain evm.Chain, token, user common.Address) (bool, error) {
-	return hasDefaultAdminRoleBurnMintERC20(ctx, chain, token, user)
+func (tokenBurnMintERC20WithDripV1_0_0) HasAdminRole(b operations.Bundle, chain evm.Chain, token, user common.Address) (bool, error) {
+	return hasDefaultAdminRoleBurnMintERC20(b, chain, token, user)
 }
 
 func (tokenBurnMintERC20WithDripV1_0_0) GrantAdminRole(b operations.Bundle, chain evm.Chain, token, externalAdmin common.Address) ([]contract.WriteOutput, error) {

--- a/chains/evm/deployment/tokens/tokenimpl/token_burn_mint_erc20_with_drip_v1_5_0.go
+++ b/chains/evm/deployment/tokens/tokenimpl/token_burn_mint_erc20_with_drip_v1_5_0.go
@@ -1,7 +1,6 @@
 package tokenimpl
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 
@@ -35,8 +34,8 @@ func (tokenBurnMintERC20WithDripV1_5_0) RevokeAdminRole(b operations.Bundle, cha
 	return revokeDefaultAdminRoleBurnMintERC20(b, chain, token, externalAdmin)
 }
 
-func (tokenBurnMintERC20WithDripV1_5_0) HasAdminRole(ctx context.Context, chain evm.Chain, token, user common.Address) (bool, error) {
-	return hasDefaultAdminRoleBurnMintERC20(ctx, chain, token, user)
+func (tokenBurnMintERC20WithDripV1_5_0) HasAdminRole(b operations.Bundle, chain evm.Chain, token, user common.Address) (bool, error) {
+	return hasDefaultAdminRoleBurnMintERC20(b, chain, token, user)
 }
 
 func (tokenBurnMintERC20WithDripV1_5_0) GrantAdminRole(b operations.Bundle, chain evm.Chain, token, externalAdmin common.Address) ([]contract.WriteOutput, error) {

--- a/chains/evm/deployment/tokens/tokenimpl/token_burn_mint_erc677.go
+++ b/chains/evm/deployment/tokens/tokenimpl/token_burn_mint_erc677.go
@@ -1,7 +1,6 @@
 package tokenimpl
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 
@@ -38,7 +37,7 @@ func (tokenBurnMintERC677) RevokeAdminRole(_ operations.Bundle, _ evm.Chain, _, 
 	return nil, fmt.Errorf("admin role revoke not supported for BurnMintERC677 token type")
 }
 
-func (tokenBurnMintERC677) HasAdminRole(_ context.Context, _ evm.Chain, _, _ common.Address) (bool, error) {
+func (tokenBurnMintERC677) HasAdminRole(_ operations.Bundle, _ evm.Chain, _, _ common.Address) (bool, error) {
 	return false, fmt.Errorf("admin role checks not supported for BurnMintERC677 token type")
 }
 

--- a/chains/evm/deployment/tokens/tokenimpl/token_erc20.go
+++ b/chains/evm/deployment/tokens/tokenimpl/token_erc20.go
@@ -1,7 +1,6 @@
 package tokenimpl
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 
@@ -36,7 +35,7 @@ func (tokenERC20) RevokeAdminRole(_ operations.Bundle, _ evm.Chain, _, _ common.
 	return nil, fmt.Errorf("admin role not supported for plain ERC20 token")
 }
 
-func (tokenERC20) HasAdminRole(_ context.Context, _ evm.Chain, _, _ common.Address) (bool, error) {
+func (tokenERC20) HasAdminRole(_ operations.Bundle, _ evm.Chain, _, _ common.Address) (bool, error) {
 	return false, fmt.Errorf("admin role checks not supported for plain ERC20 token")
 }
 

--- a/chains/evm/deployment/tokens/tokenimpl/token_tip20.go
+++ b/chains/evm/deployment/tokens/tokenimpl/token_tip20.go
@@ -1,7 +1,6 @@
 package tokenimpl
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 
@@ -44,12 +43,12 @@ func (tokenTIP20) RevokeAdminRole(b operations.Bundle, chain evm.Chain, token, u
 	return []contract.WriteOutput{report.Output}, nil
 }
 
-func (tokenTIP20) HasAdminRole(ctx context.Context, chain evm.Chain, token, user common.Address) (bool, error) {
+func (tokenTIP20) HasAdminRole(b operations.Bundle, chain evm.Chain, token, user common.Address) (bool, error) {
 	tokenContract, err := tip20.NewTIP20Token(token, chain.Client)
 	if err != nil {
 		return false, fmt.Errorf("failed to instantiate TIP-20 token contract: %w", err)
 	}
-	hasRole, err := tokenContract.HasRole(&bind.CallOpts{Context: ctx}, user, tip20.DefaultAdminRole)
+	hasRole, err := tokenContract.HasRole(&bind.CallOpts{Context: b.GetContext()}, user, tip20.DefaultAdminRole)
 	if err != nil {
 		return false, fmt.Errorf("failed to check TIP-20 admin role for %s: %w", user.Hex(), err)
 	}

--- a/chains/evm/deployment/v1_0_0/operations/burn_mint_erc20/burn_mint_erc20.go
+++ b/chains/evm/deployment/v1_0_0/operations/burn_mint_erc20/burn_mint_erc20.go
@@ -154,3 +154,14 @@ var GrantMintAndBurnRoles = contract.NewWrite(contract.WriteParams[common.Addres
 		return token.GrantMintAndBurnRoles(opts, input)
 	},
 })
+
+var HasRole = contract.NewRead(contract.ReadParams[RoleAssignment, bool, *burn_mint_erc20.BurnMintERC20]{
+	Name:         "burn_mint_erc20:has-role",
+	Version:      utils.Version_1_0_0,
+	Description:  "Checks if an address has a specific role on BurnMintERC20 token contract",
+	ContractType: ContractType,
+	NewContract:  burn_mint_erc20.NewBurnMintERC20,
+	CallContract: func(token *burn_mint_erc20.BurnMintERC20, opts *bind.CallOpts, input RoleAssignment) (bool, error) {
+		return token.HasRole(opts, input.Role, input.To)
+	},
+})

--- a/chains/evm/deployment/v1_0_0/sequences/grant_token_admin_role.go
+++ b/chains/evm/deployment/v1_0_0/sequences/grant_token_admin_role.go
@@ -65,7 +65,7 @@ var GrantTokenAdminRole = cldf_ops.NewSequence(
 
 		timelockHasAdminRole := false
 		if timelockAddress != (common.Address{}) {
-			if hasRole, err := tokenImpl.HasAdminRole(b.GetContext(), chain, tokenAddress, timelockAddress); err != nil {
+			if hasRole, err := tokenImpl.HasAdminRole(b, chain, tokenAddress, timelockAddress); err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to check admin role for timelock %s on token %s: %w", timelockAddress.Hex(), tokenAddress.Hex(), err)
 			} else {
 				timelockHasAdminRole = hasRole
@@ -73,7 +73,7 @@ var GrantTokenAdminRole = cldf_ops.NewSequence(
 		}
 		deployerHasAdminRole := false
 		if chain.DeployerKey.From != (common.Address{}) {
-			if hasRole, err := tokenImpl.HasAdminRole(b.GetContext(), chain, tokenAddress, chain.DeployerKey.From); err != nil {
+			if hasRole, err := tokenImpl.HasAdminRole(b, chain, tokenAddress, chain.DeployerKey.From); err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to check admin role for deployer %s on token %s: %w", chain.DeployerKey.From.Hex(), tokenAddress.Hex(), err)
 			} else {
 				deployerHasAdminRole = hasRole
@@ -84,7 +84,7 @@ var GrantTokenAdminRole = cldf_ops.NewSequence(
 			return sequences.OnChainOutput{}, nil
 		}
 
-		targetHasAdminRole, err := tokenImpl.HasAdminRole(b.GetContext(), chain, tokenAddress, grantAddress)
+		targetHasAdminRole, err := tokenImpl.HasAdminRole(b, chain, tokenAddress, grantAddress)
 		if err != nil {
 			return sequences.OnChainOutput{}, fmt.Errorf("failed to check admin role for target %s on token %s: %w", grantAddress.Hex(), tokenAddress.Hex(), err)
 		}

--- a/chains/evm/deployment/v1_0_0/sequences/revoke_token_admin_role.go
+++ b/chains/evm/deployment/v1_0_0/sequences/revoke_token_admin_role.go
@@ -75,7 +75,7 @@ var RevokeTokenAdminRole = cldf_ops.NewSequence(
 		// not the case, then we return no operations and log a warning instead of returning an error.
 		timelockHasAdminRole := false
 		if timelockAddress != (common.Address{}) {
-			if hasRole, err := tokenImpl.HasAdminRole(b.GetContext(), chain, tokenAddress, timelockAddress); err != nil {
+			if hasRole, err := tokenImpl.HasAdminRole(b, chain, tokenAddress, timelockAddress); err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to check admin role for timelock %s on token %s: %w", timelockAddress.Hex(), tokenAddress.Hex(), err)
 			} else {
 				timelockHasAdminRole = hasRole
@@ -83,7 +83,7 @@ var RevokeTokenAdminRole = cldf_ops.NewSequence(
 		}
 		deployerHasAdminRole := false
 		if chain.DeployerKey.From != (common.Address{}) {
-			if hasRole, err := tokenImpl.HasAdminRole(b.GetContext(), chain, tokenAddress, chain.DeployerKey.From); err != nil {
+			if hasRole, err := tokenImpl.HasAdminRole(b, chain, tokenAddress, chain.DeployerKey.From); err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to check admin role for deployer %s on token %s: %w", chain.DeployerKey.From.Hex(), tokenAddress.Hex(), err)
 			} else {
 				deployerHasAdminRole = hasRole
@@ -117,7 +117,7 @@ var RevokeTokenAdminRole = cldf_ops.NewSequence(
 		// that ensures there's at least one account with the admin role on the token contract
 		var writes []evm_contract.WriteOutput
 		if fallbackAddress != (common.Address{}) && fallbackAddress != revokeAddress {
-			fallbackAccountHasAdminRole, err := tokenImpl.HasAdminRole(b.GetContext(), chain, tokenAddress, fallbackAddress)
+			fallbackAccountHasAdminRole, err := tokenImpl.HasAdminRole(b, chain, tokenAddress, fallbackAddress)
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to check admin role for fallback address %s on token %s: %w", fallbackAddress.Hex(), tokenAddress.Hex(), err)
 			}
@@ -136,7 +136,7 @@ var RevokeTokenAdminRole = cldf_ops.NewSequence(
 
 		// If the account that we want to revoke admin access from does NOT have the admin role
 		// then we skip the revocation to save gas and avoid unnecessary transactions.
-		revokeAccountHasAdminRole, err := tokenImpl.HasAdminRole(b.GetContext(), chain, tokenAddress, revokeAddress)
+		revokeAccountHasAdminRole, err := tokenImpl.HasAdminRole(b, chain, tokenAddress, revokeAddress)
 		if err != nil {
 			return sequences.OnChainOutput{}, fmt.Errorf("failed to check admin role for %s on token %s: %w", revokeAddress.Hex(), tokenAddress.Hex(), err)
 		}

--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -500,13 +500,26 @@ func processTokenConfigForChain(e cldf.Environment, cfg map[uint64]TokenTransfer
 				// it is being migrated to in this changeset. If they differ, or it has no current pool then it's
 				// getting a new pool and we leave it alone. If they are the same, then it keeps its current pool
 				// and should be told about the new pool.
-				if _, alsoMigrating := cfg[ru.remoteSelector]; alsoMigrating {
+				if peerCfg, alsoMigrating := cfg[ru.remoteSelector]; alsoMigrating {
 					targetBytes, err := ru.remoteNormalizer.StringToBytes(ru.remotePoolRef.Address)
 					if err != nil {
 						return nil, nil, nil, fmt.Errorf("failed to convert remote pool ref to bytes for chain selector %d: %w", ru.remoteSelector, err)
 					}
+
+					// A peer that's being replaced this batch gets a brand-new pool that isn't live yet so reverse
+					// propagation into it would prematurely activate it and break its own migration - instead, its
+					// forward config wires the web instead.
 					activeBytes := activePoolsSnapshot[ru.remoteSelector]
 					if len(activeBytes) == 0 || !bytes.Equal(activeBytes, targetBytes) {
+						continue
+					}
+
+					// If the peer is configured to connect to the migrating chain (selector), then its own forward
+					// config in this batch already adds this migration's pool as an additional remote, so reverse-
+					// propagation would add it a second time and revert with PoolAlreadyAdded. For these cases, we
+					// need to skip reverse propagation into that peer.
+					_, peerConnectsToMigratingChain := peerCfg.RemoteChains[selector]
+					if peerConnectsToMigratingChain {
 						continue
 					}
 				}


### PR DESCRIPTION
Two related fixes to the EVM token-pool setup tooling.

# Reduce RPC flakes (token role helpers)

## Purpose

The grant/revoke/has-admin helpers on BurnMintERC20 previously talked to the token contract through the raw go-ethereum bindings (`bind.CallOpts` + a bare `context.Context`), which bypassed the deployment framework's operation layer. That made reads and writes vulnerable to transient RPC failures (connection resets, skewed estimate views after a prior op in the same sequence, etc.), surfacing as hard errors instead of being retried. This routes them through the cldf operations framework with bounded retry so flakiness is absorbed by backoff rather than failing the changeset.

## What it adds

- `HasAdminRole` on the `Token` interface now takes `cldf_ops.Bundle` instead of `context.Context`, so token types issue reads/writes through the operations framework. All implementations (BurnMint, both WithDrip variants, ERC677, ERC20, TIP-20) are updated; TIP-20 keeps its direct binding call (no cldf operation exists for it) but sources its context from the Bundle.
- A `HasRole` read operation for BurnMintERC20 (`burn_mint_erc20:has-role`), so `hasDefaultAdminRoleBurnMintERC20` is a framework read rather than a raw binding call.
- A small generic `getRetryConfig[T]` helper that builds the retry config once and wires it into the operations it's used with, rather than duplicating the retry block per helper.

## Intentional design choices

- **Retry is bounded and scales with attempt.** Five attempts with backoff of `(attempt+1) × 2s` — a short, block-scale wait that lets the RPC node's view catch up when a change made earlier in the same sequence isn't yet visible to the estimate view.
- **Backoff is context-cancellation-aware.** The wait is a `select` between the bundle's context and `time.After`, deliberately avoiding `time.Sleep`, so a cancelled run unblocks immediately.
- **Retry applies only to operations that are idempotent by value.** Role grants/revokes and reads are safe to re-prepare. `transferTokensERC20` is intentionally left unwrapped — a transfer moves value and is not idempotent by value, so retrying after an unclear outcome risks a double transfer. That omission is documented at the call site.
- **The mutable `HasRole` read is force-executed to stay fresh.** The framework reuses previous successful reports within a bundle by default; the `HasRole` check bypasses that (`WithForceExecute`) because role membership can change and it gates an idempotency decision. The `GetDefaultAdminRole` read is constant, so it keeps the cache. Both still get the retry config.
- **Writes and permission checks share one execution path.** Threading the `Bundle` through `HasAdminRole` means the grant/revoke sequences and their role reads use the same execution and retry semantics as the rest of the deployment framework.

# Correct batched reverse-propagation skip

## Purpose

During an `AutoMigrateRemoteChains` batch, a migrated pool reverse-propagates its new pool into every counterpart so the web stays reachable in both directions. Reverse-propagation must not run at all into a counterpart in two cases; previously only one was handled, and the other caused the MCMS proposal to revert at execution.

## The two skip cases

1. **The counterpart is being replaced this batch** — its brand-new pool isn't live yet, so reverse-propagating would prematurely activate it and break that counterpart's own migration; its forward config wires its web instead. Skipped when the counterpart's target pool differs from its pre-batch active pool (or it has no active pool).
2. **The counterpart's own forward config already adds this migration's pool** — the peer is configured to connect to the migrating chain in this same batch, so its forward configuration adds the new pool on its side; reverse-propagating then adds it a second time and the on-chain `addRemotePool` reverts with `PoolAlreadyAdded`. Skipped when the migrating chain selector appears in the peer's `RemoteChains`.

Only the first was previously handled. The missed second case happened with a reusing peer that was itself forward-configured in the same batch (both sides of a connection end up in the changeset): the new pool was added twice — once by the peer's own forward config, once by this migration's reverse-propagation — and the batch reverted at execution.

Both decisions are driven by on-chain pool state and the peer's own configuration rather than any version- or family-specific interface, so they stay correct across EVM versions and Solana.
