### PR TITLE
feat: support token decimal for lombard remote chain adatper

### DIFF
--- a/chains/evm/deployment/v2_0_0/adapters/lombard_chain.go
+++ b/chains/evm/deployment/v2_0_0/adapters/lombard_chain.go
@@ -12,6 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	"github.com/smartcontractkit/chainlink-deployments-framework/operations"
 
+	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v1_0_0/operations/erc20"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_1_0/operations/lombard_token_pool"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_1_0/operations/lombard_verifier"
 	"github.com/smartcontractkit/chainlink-ccip/chains/evm/deployment/v2_0_0/operations/token_pool"
@@ -81,4 +82,30 @@ func (c *LombardChainAdapter) RemoteTokenPoolAddress(ds datastore.DataStore, cha
 		return nil, fmt.Errorf("failed to get token pool: %w", err)
 	}
 	return c.AddressRefToBytes(tokenPool)
+}
+
+func (c *LombardChainAdapter) RemoteTokenDecimals(bundle operations.Bundle, ds datastore.DataStore, chains chain.BlockChains, selector uint64, tokenQualifier string) (uint8, error) {
+	evmChain, ok := chains.EVMChains()[selector]
+	if !ok {
+		return 0, fmt.Errorf("EVM chain with selector %d not found", selector)
+	}
+	tokenPool, err := c.TokenPool(ds, selector, tokenQualifier)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get token pool: %w", err)
+	}
+	getTokenReport, err := operations.ExecuteOperation(bundle, token_pool.GetToken, evmChain, evm_contract.FunctionInput[struct{}]{
+		ChainSelector: selector,
+		Address:       common.HexToAddress(tokenPool.Address),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to get token address from pool: %w", err)
+	}
+	report, err := operations.ExecuteOperation(bundle, erc20.GetDecimals, evmChain, evm_contract.FunctionInput[struct{}]{
+		ChainSelector: selector,
+		Address:       getTokenReport.Output,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("failed to get token decimals: %w", err)
+	}
+	return report.Output, nil
 }

--- a/chains/evm/deployment/v2_0_0/sequences/lombard/configure_lombard_chain_for_lanes.go
+++ b/chains/evm/deployment/v2_0_0/sequences/lombard/configure_lombard_chain_for_lanes.go
@@ -120,11 +120,16 @@ var ConfigureLombardChainForLanes = cldf_ops.NewSequence(
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to get remote token address: %w", err)
 			}
+			remoteDecimals, err := dep.RemoteChains[remoteChainSelector].RemoteTokenDecimals(b, dep.DataStore, dep.BlockChains, remoteChainSelector, *tokenPoolQualifier(input.TokenQualifier))
+			if err != nil {
+				return sequences.OnChainOutput{}, fmt.Errorf("failed to get remote token decimals: %w", err)
+			}
 
 			feeCfg := (tokens_core.PartialTokenTransferFeeConfig{}).Populate(remoteChain.TokenTransferFeeConfig)
 			remoteChainConfigs[remoteChainSelector] = tokens_core.RemoteChainConfig[[]byte, string]{
 				RemotePool:             common.LeftPadBytes(remotePoolAddress, 32),
 				RemoteToken:            common.LeftPadBytes(remoteTokenAddress, 32),
+				RemoteDecimals:         remoteDecimals,
 				TokenTransferFeeConfig: &feeCfg,
 				// Lombard does not use rate limiters
 				InboundRateLimiterConfig: &tokens_core.RateLimiterConfigFloatInput{

--- a/deployment/v2_0_0/adapters/lombard.go
+++ b/deployment/v2_0_0/adapters/lombard.go
@@ -101,6 +101,9 @@ type RemoteLombardChain interface {
 	RemoteTokenAddress(bundle cldf_ops.Bundle, ds datastore.DataStore, chains cldf_chain.BlockChains, selector uint64, tokenQualifier string) ([]byte, error)
 
 	RemoteTokenPoolAddress(ds datastore.DataStore, chains cldf_chain.BlockChains, selector uint64, tokenQualifier string) ([]byte, error)
+
+	// RemoteTokenDecimals returns the decimals of the remote Lombard token on the given chain.
+	RemoteTokenDecimals(bundle cldf_ops.Bundle, ds datastore.DataStore, chains cldf_chain.BlockChains, selector uint64, tokenQualifier string) (uint8, error)
 }
 
 // LombardChainRegistry maintains a registry of Lombard chains.

--- a/deployment/v2_0_0/changesets/deploy_lombard_chains_test.go
+++ b/deployment/v2_0_0/changesets/deploy_lombard_chains_test.go
@@ -214,6 +214,9 @@ func (m *mockLombardAdapter) RemoteTokenAddress(_ cldf_ops.Bundle, _ datastore.D
 func (m *mockLombardAdapter) RemoteTokenPoolAddress(_ datastore.DataStore, _ cldf_chain.BlockChains, _ uint64, _ string) ([]byte, error) {
 	return []byte("pool"), nil
 }
+func (m *mockLombardAdapter) RemoteTokenDecimals(_ cldf_ops.Bundle, _ datastore.DataStore, _ cldf_chain.BlockChains, _ uint64, _ string) (uint8, error) {
+	return 8, nil
+}
 func (m *mockLombardAdapter) AddressRefToBytes(_ datastore.AddressRef) ([]byte, error) {
 	return []byte("bytes"), nil
 }


### PR DESCRIPTION
[Jira](https://smartcontract-it.atlassian.net/browse/NONEVM-5854?atlOrigin=eyJpIjoiYjI3OTZiNGYxNGJjNGViMWI0NGJmN2JhMjg5NmUzNmIiLCJwIjoiaiJ9): Adding tokenDecimal into RemoteLombardChain interface, and implement the EVM adatper