### PR TITLE
CCTP 2.0 lane mechanism and configure lane support for Solana

### DIFF
--- a/chains/evm/deployment/v2_0_0/sequences/cctp/configure_cctp_chain_for_lanes.go
+++ b/chains/evm/deployment/v2_0_0/sequences/cctp/configure_cctp_chain_for_lanes.go
@@ -268,15 +268,9 @@ var ConfigureCCTPChainForLanes = cldf_ops.NewSequence(
 		// Proactively configure the CCTP-through-CCV pool for all CCTP-capable remotes.
 		// This excludes lock-release lanes, but includes V1/V2 remotes so the CCV pool
 		// is ready before proxy routing is switched to CCTP_V2_WITH_CCV.
-		// Non-EVM remotes (e.g. Solana) are excluded: CCIP 2.0 does not support them, so
-		// CCTP_V2_WITH_CCV will never be enabled for them and preconfiguring the CCV pool
-		// would be wasted state.
 		cctpThroughCCVRemoteChainConfigs := make(map[uint64]tokens_core.RemoteChainConfig[[]byte, string])
 		for remoteChainSelector, remoteChainConfig := range remoteChainConfigs {
 			if input.RemoteChains[remoteChainSelector].LockOrBurnMechanism == MechanismLockRelease {
-				continue
-			}
-			if !isEVMRemote(remoteChainSelector) {
 				continue
 			}
 			cctpThroughCCVRemoteChainConfigs[remoteChainSelector] = remoteChainConfig
@@ -528,25 +522,12 @@ func buildVerifierResolverOutboundArgs(input adapters.ConfigureCCTPChainForLanes
 		if remoteChain.LockOrBurnMechanism == MechanismLockRelease {
 			continue
 		}
-		if !isEVMRemote(remoteChainSelector) {
-			continue
-		}
 		out = append(out, versioned_verifier_resolver.OutboundImplementationArgs{
 			DestChainSelector: remoteChainSelector,
 			Verifier:          cctpVerifierAddress,
 		})
 	}
 	return out
-}
-
-// isEVMRemote reports whether a remote chain selector belongs to the EVM family.
-// Selectors that fail to resolve are treated as non-EVM (skipped by callers).
-func isEVMRemote(remoteChainSelector uint64) bool {
-	family, err := chain_selectors.GetSelectorFamily(remoteChainSelector)
-	if err != nil {
-		return false
-	}
-	return family == chain_selectors.FamilyEVM
 }
 
 // buildUSDCTokenPoolProxyMechanismArgs builds remote chain selectors and lock/burn mechanisms for the USDCTokenPoolProxy.
@@ -572,10 +553,6 @@ func buildCCTPVerifierArgs(dep adapters.ConfigureCCTPChainForLanesDeps, input ad
 	for remoteChainSelector, remoteChain := range input.RemoteChains {
 		if dep.RemoteChains[remoteChainSelector].USDCType() == adapters.NonCanonical {
 			// Non-canonical USDC chains do not support CCTP, so we don't need to perform any CCTP-specific operations.
-			continue
-		}
-		if !isEVMRemote(remoteChainSelector) {
-			// Non-EVM remotes (e.g. Solana) are not supported by CCIP 2.0 yet, so we don't configure it yet.
 			continue
 		}
 		allowedCallerOnDest, err := dep.RemoteChains[remoteChainSelector].CCTPV2AllowedCallerOnDest(dep.DataStore, dep.BlockChains, remoteChainSelector)

--- a/chains/evm/deployment/v2_0_0/sequences/cctp/configure_cctp_chain_for_lanes.go
+++ b/chains/evm/deployment/v2_0_0/sequences/cctp/configure_cctp_chain_for_lanes.go
@@ -512,10 +512,9 @@ func buildRemoteChainConfigs(dep adapters.ConfigureCCTPChainForLanesDeps, input 
 }
 
 // buildVerifierResolverOutboundArgs builds outbound implementation args for the CCTPVerifierResolver.
-// Includes every CCTP-capable EVM remote (V1, V2, V2_WITH_CCV) and excludes lock-release lanes, matching the
+// Includes every CCTP-capable remote (V1, V2, V2_WITH_CCV) and excludes lock-release lanes, matching the
 // set of chains preconfigured on the CCTP-through-CCV pool. This keeps CCTPThroughCCVTokenPool.getTokenTransferFeeConfig
 // from reverting on V1 remotes before proxy routing is switched to CCTP_V2_WITH_CCV.
-// Non-EVM remotes (e.g. Solana) are skipped: CCIP 2.0 does not support them, so the CCV pool will never be used for them.
 func buildVerifierResolverOutboundArgs(input adapters.ConfigureCCTPChainForLanesInput, cctpVerifierAddress common.Address) []versioned_verifier_resolver.OutboundImplementationArgs {
 	out := make([]versioned_verifier_resolver.OutboundImplementationArgs, 0, len(input.RemoteChains))
 	for remoteChainSelector, remoteChain := range input.RemoteChains {

--- a/deployment/v2_0_0/changesets/deploy_cctp_chains.go
+++ b/deployment/v2_0_0/changesets/deploy_cctp_chains.go
@@ -92,22 +92,12 @@ func makeVerifyDeployCCTPChains(_ *adapters.CCTPChainRegistry, _ *changesets.MCM
 				}
 			}
 			for remoteChainSelector := range chainCfg.RemoteChains {
-				remoteFamily, err := chain_selectors.GetSelectorFamily(remoteChainSelector)
-				if err != nil {
-					return err
-				}
 				remoteChainCfg, ok := cfg.Chains[remoteChainSelector]
 				if !ok {
 					return fmt.Errorf("remote chain selector %d not found in chains", remoteChainSelector)
 				}
-				if _, ok := remoteChainCfg.RemoteChains[chainSel]; !ok {
+				if _, ok = remoteChainCfg.RemoteChains[chainSel]; !ok {
 					return fmt.Errorf("chain %d has remote %d but chain %d does not define a remote chain config for %d (each remote must point back to the current chain)", chainSel, remoteChainSelector, remoteChainSelector, chainSel)
-				}
-				if family == chain_selectors.FamilySolana || remoteFamily == chain_selectors.FamilySolana {
-					mechanism := chainCfg.RemoteChains[remoteChainSelector].LockOrBurnMechanism
-					if mechanism != "CCTP_V1" {
-						return fmt.Errorf("solana lanes only support CCTP_V1, got %q for chain %d -> %d", mechanism, chainSel, remoteChainSelector)
-					}
 				}
 			}
 		}

--- a/deployment/v2_0_0/changesets/deploy_cctp_chains_test.go
+++ b/deployment/v2_0_0/changesets/deploy_cctp_chains_test.go
@@ -520,6 +520,31 @@ func TestDeployCCTPChains_VerifyPreconditions(t *testing.T) {
 			},
 		},
 		{
+			desc: "success - solana lane with CCTP_V2_WITH_CCV",
+			cfg: v2_0_0_changesets.DeployCCTPChainsConfig{
+				Chains: map[uint64]v2_0_0_changesets.CCTPChainConfig{
+					5009297550715157269: {
+						USDCType:         adapters.Canonical,
+						TokenMessengerV2: "0x8888888888888888888888888888888888888888",
+						RemoteChains: map[uint64]adapters.RemoteCCTPChainConfig{
+							chain_selectors.SOLANA_DEVNET.Selector: {
+								LockOrBurnMechanism: "CCTP_V2_WITH_CCV",
+							},
+						},
+					},
+					chain_selectors.SOLANA_DEVNET.Selector: {
+						USDCType:  adapters.Canonical,
+						USDCToken: "11111111111111111111111111111111",
+						RemoteChains: map[uint64]adapters.RemoteCCTPChainConfig{
+							5009297550715157269: {
+								LockOrBurnMechanism: "CCTP_V2_WITH_CCV",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			desc: "success - empty CCTP v1 token messenger with CCTP_V1 lane in config",
 			cfg: v2_0_0_changesets.DeployCCTPChainsConfig{
 				Chains: map[uint64]v2_0_0_changesets.CCTPChainConfig{
@@ -542,32 +567,6 @@ func TestDeployCCTPChains_VerifyPreconditions(t *testing.T) {
 					},
 				},
 			},
-		},
-		{
-			desc: "failure - solana lanes require CCTP_V1",
-			cfg: v2_0_0_changesets.DeployCCTPChainsConfig{
-				Chains: map[uint64]v2_0_0_changesets.CCTPChainConfig{
-					5009297550715157269: {
-						USDCType:         adapters.Canonical,
-						TokenMessengerV2: "0x8888888888888888888888888888888888888888",
-						RemoteChains: map[uint64]adapters.RemoteCCTPChainConfig{
-							chain_selectors.SOLANA_DEVNET.Selector: {
-								LockOrBurnMechanism: "CCTP_V2_WITH_CCV",
-							},
-						},
-					},
-					chain_selectors.SOLANA_DEVNET.Selector: {
-						USDCType:  adapters.Canonical,
-						USDCToken: "11111111111111111111111111111111",
-						RemoteChains: map[uint64]adapters.RemoteCCTPChainConfig{
-							5009297550715157269: {
-								LockOrBurnMechanism: "CCTP_V1",
-							},
-						},
-					},
-				},
-			},
-			expectedError: "solana lanes only support CCTP_V1",
 		},
 		{
 			desc: "failure - invalid CCTP type",
@@ -618,7 +617,7 @@ func TestDeployCCTPChains_VerifyPreconditions(t *testing.T) {
 			expectedError: "unknown chain selector",
 		},
 		{
-			desc: "failure - unknown remote chain selector",
+			desc: "failure - remote chain not in chains",
 			cfg: v2_0_0_changesets.DeployCCTPChainsConfig{
 				Chains: map[uint64]v2_0_0_changesets.CCTPChainConfig{
 					5009297550715157269: {
@@ -631,7 +630,7 @@ func TestDeployCCTPChains_VerifyPreconditions(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "unknown chain selector",
+			expectedError: "not found in chains",
 		},
 		{
 			desc: "failure - invalid MCMS timelock action",
@@ -664,7 +663,7 @@ func TestDeployCCTPChains_VerifyPreconditions(t *testing.T) {
 			expectedError: "failed to validate MCMS input",
 		},
 		{
-			desc: "failure - multiple remote chains with one having unknown selector",
+			desc: "failure - multiple remote chains with one not pointing back",
 			cfg: v2_0_0_changesets.DeployCCTPChainsConfig{
 				Chains: map[uint64]v2_0_0_changesets.CCTPChainConfig{
 					5009297550715157269: {
@@ -673,7 +672,7 @@ func TestDeployCCTPChains_VerifyPreconditions(t *testing.T) {
 						TokenMessengerV2: "0x8888888888888888888888888888888888888888",
 						RemoteChains: map[uint64]adapters.RemoteCCTPChainConfig{
 							15971525489660198786: {},
-							0:                    {}, // Invalid remote chain selector
+							3478487238524512106:  {}, // No back-reference from this chain
 						},
 					},
 					15971525489660198786: {
@@ -684,9 +683,13 @@ func TestDeployCCTPChains_VerifyPreconditions(t *testing.T) {
 							5009297550715157269: {},
 						},
 					},
+					3478487238524512106: {
+						USDCType:         adapters.Canonical,
+						TokenMessengerV2: "0x5555555555555555555555555555555555555555",
+					},
 				},
 			},
-			expectedError: "unknown chain selector",
+			expectedError: "does not define a remote chain config for",
 		},
 	}
 


### PR DESCRIPTION
Enable Solana lane mechanism CCTP_V2_WITH_CCV and remove EVM-only check in CCTP lane configuration