### PR TITLE
fix: always grant fee configs to fee quoter

### DIFF
--- a/deployment/tokens/configure_tokens_for_transfers.go
+++ b/deployment/tokens/configure_tokens_for_transfers.go
@@ -619,14 +619,29 @@ func applyTokenTransferFeeConfig(
 		return nil, nil, fmt.Errorf("token pool version is required to apply token transfer fee config for chain selector %d and remote chain selector %d", src, dst)
 	}
 
-	// NOTE: fee configs are applied differently based on the pool version:
-	//   Pre-V2 pools: apply the fee config on the fee quoter / onRamp (legacy lane).
-	//   On V2+ pools: apply the fee config on the token pool via TokenFeeAdapter.
-	if fullSrcPoolRef.Version.LessThan(utils.Version_2_0_0) {
-		return applyTokenTransferFeeConfigOnFeeQuoter(e, src, dst, fullSrcTokenRef, srcToDstFeeCfg)
+	// NOTE: fees can be configured on either the pool or fee quoter. If a v1.6 OnRamp
+	// is being used, then the FeeQuoter has precedence and the pool fees are ignored.
+	// If a v2.0 OnRamp is being used, then the pool fees have precedence, and if they
+	// are disabled, then the FeeQuoter fees are used as a fallback.
+	var batches []mcms_types.BatchOperation
+	var reports []cldf_ops.Report[any, any]
+	if fqBatches, fqReports, err := applyTokenTransferFeeConfigOnFeeQuoter(e, src, dst, fullSrcTokenRef, srcToDstFeeCfg); err != nil {
+		return nil, nil, fmt.Errorf("failed to apply token transfer fee config on fee quoter for chain selector %d and remote chain selector %d: %w", src, dst, err)
 	} else {
-		return applyTokenTransferFeeConfigOnTokenPool(e, src, dst, fullSrcPoolRef, srcToDstFeeCfg)
+		batches = append(batches, fqBatches...)
+		reports = append(reports, fqReports...)
 	}
+
+	if fullSrcPoolRef.Version.GreaterThanEqual(utils.Version_2_0_0) {
+		if poolBatches, poolReports, err := applyTokenTransferFeeConfigOnTokenPool(e, src, dst, fullSrcPoolRef, srcToDstFeeCfg); err != nil {
+			return nil, nil, fmt.Errorf("failed to apply token transfer fee config on token pool for chain selector %d and remote chain selector %d: %w", src, dst, err)
+		} else {
+			batches = append(batches, poolBatches...)
+			reports = append(reports, poolReports...)
+		}
+	}
+
+	return batches, reports, nil
 }
 
 func applyTokenTransferFeeConfigOnTokenPool(

--- a/integration-tests/deployment/configure_token_pool_test.go
+++ b/integration-tests/deployment/configure_token_pool_test.go
@@ -30,6 +30,8 @@ import (
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
 	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
 	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
+	ccvadapters "github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/adapters"
+	v2changesets "github.com/smartcontractkit/chainlink-ccip/deployment/v2_0_0/changesets"
 	solchain "github.com/smartcontractkit/chainlink-deployments-framework/chain/solana"
 	"github.com/smartcontractkit/chainlink-deployments-framework/datastore"
 	cldf_deployment "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
@@ -199,6 +201,33 @@ func setupV2PoolsForConfigureImpl(t *testing.T, tokenSymb string, useMCMS bool) 
 	DeployChainContractsV2_0_0(t, e, cumulative, selB)
 	e.DataStore = cumulative.Seal()
 
+	// Wire CCIP lanes between the test chains. ConfigureTokenPool now always applies fee configs to
+	// the FeeQuoter too, whose resolution path (ResolveFeeAdapter / FeeQuoter reads on A → B) requires
+	// a wired lane. DeployChainContracts caches proxy GetTarget reads from before SetTarget; refresh
+	// the bundle so lane configuration observes the updated on-chain executor target.
+	e.OperationsBundle = evm_testsetup.BundleWithFreshReporter(e.OperationsBundle)
+	deployer := e.BlockChains.EVMChains()[selA].DeployerKey.From.Hex()
+	laneConnectOut, err := v2changesets.ConfigureChainsForLanesFromTopology(
+		ccvadapters.GetCommitteeVerifierContractRegistry(),
+		ccvadapters.GetChainFamilyRegistry(),
+		changesets.GetRegistry(),
+	).Apply(*e, v2changesets.ConfigureChainsForLanesFromTopologyConfig{
+		Topology: NewLaneTopologyForV2(deployer, selA, selB),
+		BuildLanesCrossFamilyConfig: v2changesets.BuildLanesCrossFamilyConfig{
+			MCMS: mcms.Input{},
+			Lanes: []v2changesets.CrossFamilyLanePair{
+				{
+					ChainA:          selA,
+					ChainB:          selB,
+					ChainAOverrides: NewLaneOverridesForV2(selA),
+					ChainBOverrides: NewLaneOverridesForV2(selB),
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	MergeAddresses(t, e, laneConnectOut.DataStore)
+
 	expansionMCMS := mcms.Input{}
 	if useMCMS {
 		// Register the EVM MCMS deployer/reader (idempotent) and deploy MCMS + timelock so the
@@ -277,6 +306,10 @@ func setupV2PoolsForConfigureImpl(t *testing.T, tokenSymb string, useMCMS bool) 
 	// behavior (production RPCs return a correct estimate / apply a buffer). Same fix the
 	// SetTokenPoolRateLimits tests use via forceSimGasLimit.
 	forceSimGasLimit(e, 5_000_000)
+
+	// DeployChainContracts + token expansion cache pre-lane router reads; refresh so the fee-config
+	// apply in the test (router.getOnRamp on the wired lane) observes fresh on-chain state.
+	e.OperationsBundle = evm_testsetup.BundleWithFreshReporter(e.OperationsBundle)
 
 	return configureTestEnv{
 		env: e, selA: selA, selB: selB, poolA: poolA, poolB: poolB,


### PR DESCRIPTION
# fix: always apply fee configs to fee quoter

## What this changes

Token expansion's per-lane fee application used to branch on the source pool's version when deciding where to write the token-transfer fee: a pre-v2 pool got the fee applied on the **FeeQuoter** only, and a v2+ pool got it applied on the **token pool** only. As a result a v2 lane carried its fee solely on the pool, and the FeeQuoter's config for that (source token, destination chain) was never populated by token expansion.

This change decouples the two, so the fee is now **always** applied to the FeeQuoter (for every pool version), and additionally applied to the token pool **only** for v2+ pools. It is intentionally an overwrite of whatever fee config currently exists on each surface.

## Why (the intentional design)

Fees can live on either the pool or the fee quoter, and which one governs depends on the CCIP version of the source onRamp:

- For a v1.6 onRamp, the FeeQuoter has precedence and the pool's fee is ignored.
- For a v2.0 onRamp, the pool's fee takes precedence; if it is disabled, the FeeQuoter config is used as a fallback.

Because the FeeQuoter config is both the source of truth for v1.6 lanes and the fallback for v2 lanes, token expansion now always writes it. That way a v2 pool's fee is not stranded on the pool alone — regardless of which path governs, the lane ultimately resolves back to the FeeQuoter, so having the fee set there ensures a known (non-default) value is used as the fallback. Overwriting the existing value is intended; the FeeQuoter fee is treated as authoritative for the lane.

The decision of whether the pool is additionally configured is keyed on the **pool** version. This is a deliberate, low-cost proxy for the onRamp version: if the lane is currently on a v1.6 onRamp that later gets upgraded to v2.0, the pool fee is already in place, so debugging/remediation is one hop to the pool rather than hunting the FeeQuoter. Because the FeeQuoter is always set too, the strategy is robust even if the pool version and onRamp version disagree at any given moment.

Both application paths are idempotent: each reads the current on-chain config, resolves the desired config (merging the lane fee over the on-chain value or a sensible default), and skips writing when the desired config already matches. So running token expansion repeatedly does not produce redundant writes for either surface.

## Origin (operator incident)

This was surfaced by an operator incident on the ETH↔ARC mainnet lane: the v2 arc pool's fee (destination gas overhead) was written only to the pool, but the lane routes through a v1.6 onRamp, so the pool fee was ignored and the source FeeQuoter config (never populated by token expansion) governed instead — leaving destination execution at the default ~90k rather than the requested 200k/175k. Always writing the FeeQuoter prevents a fee from being stranded on the pool alone.

## Remediation for already-deployed lanes

This is a forward fix. Lanes that were already expanded under the old pool-only behavior need their FeeQuoter config backfilled — re-run the fee application (e.g. `set_token_transfer_fee_cross_family`) for the affected (token, source→destination) pairs. It is safe because both application paths are idempotent and the FeeQuoter fee is authoritative for v1.6 lanes.

## Notes on the mechanics

- The FeeQuoter write uses the fee quoter's fee shape (minimum-fee cents + basis points + destination overhead + max fee), mapped from the same lane fee used for the pool. The two config surfaces are structurally aligned but reside on different contracts, and each is resolved/merged independently against its own current on-chain value.
- The FeeQuoter path resolves its fee adapter by the actual on-ramp/FeeQuoter versions found on-chain (they are not guaranteed to be the same version), rather than by the pool version.
- The FeeQuoter path only writes when the resolved config is enabled and differs from the on-chain value; a lane whose fee is not enabled leaves the FeeQuoter config untouched.

This is a restructure of how the two existing application helpers are orchestrated; the underlying fee-config read/merge/write helpers are unchanged.
