### PR TITLE
feat: allow token mint authority to be transferred away from BnM pool signer

### DIFF
--- a/chains/solana/deployment/v1_6_0/changesets/transfer_mint_authority_changeset.go
+++ b/chains/solana/deployment/v1_6_0/changesets/transfer_mint_authority_changeset.go
@@ -1,0 +1,145 @@
+package changesets
+
+import (
+	"fmt"
+
+	"github.com/gagliardetto/solana-go"
+
+	solanautils "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/utils"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_6_0/operations/token_pools"
+	_ "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_6_0/sequences"
+	"github.com/smartcontractkit/chainlink-ccip/chains/solana/utils/tokens"
+	common_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/changesets"
+	datastore_utils "github.com/smartcontractkit/chainlink-ccip/deployment/utils/datastore"
+	"github.com/smartcontractkit/chainlink-ccip/deployment/utils/mcms"
+	cldf_datastore "github.com/smartcontractkit/chainlink-deployments-framework/datastore"
+	cldf "github.com/smartcontractkit/chainlink-deployments-framework/deployment"
+	cldf_ops "github.com/smartcontractkit/chainlink-deployments-framework/operations"
+	mcms_types "github.com/smartcontractkit/mcms/types"
+)
+
+// TokenMintAuthorityUpdate changes the mint authority of a single token to NewMintAuthority
+// (typically a token multisig). The token mint authority transfer is signed by the BnM pool
+// program's *upgrade authority* - this is the only account that's authorized to call the on
+// chain transfer instruction.
+type TokenMintAuthorityUpdate struct {
+	TokenPoolRef     cldf_datastore.AddressRef `json:"tokenPoolRef"`
+	TokenMint        solana.PublicKey          `json:"tokenMint"`
+	NewMintAuthority solana.PublicKey          `json:"newMintAuthority"`
+}
+
+// TransferMintAuthoritiesChangesetInput updates the mint authority for a batch of tokens (multiple
+// pool/mint/authority triples) in a single proposal.
+type TransferMintAuthoritiesChangesetInput struct {
+	ChainSelector uint64                     `json:"chainSelector"`
+	Updates       []TokenMintAuthorityUpdate `json:"updates"`
+	MCMS          mcms.Input                 `json:"mcms"`
+}
+
+func TransferMintAuthoritiesChangeset() cldf.ChangeSetV2[TransferMintAuthoritiesChangesetInput] {
+	return cldf.CreateChangeSet(transferMintAuthoritiesApply, transferMintAuthoritiesVerify)
+}
+
+func transferMintAuthoritiesVerify(env cldf.Environment, input TransferMintAuthoritiesChangesetInput) error {
+	if err := cldf.IsValidChainSelector(input.ChainSelector); err != nil {
+		return fmt.Errorf("invalid chain selector: %d - %w", input.ChainSelector, err)
+	}
+	if !env.BlockChains.Exists(input.ChainSelector) {
+		return fmt.Errorf("chain with selector %d does not exist", input.ChainSelector)
+	}
+	if len(input.Updates) == 0 {
+		return fmt.Errorf("at least one update is required")
+	}
+	seen := make(map[solana.PublicKey]struct{}, len(input.Updates))
+	for i, u := range input.Updates {
+		if datastore_utils.IsAddressRefEmpty(u.TokenPoolRef) {
+			return fmt.Errorf("update[%d]: tokenPoolRef must not be empty", i)
+		}
+		if u.TokenMint.IsZero() {
+			return fmt.Errorf("update[%d]: tokenMint must not be zero", i)
+		}
+		if u.NewMintAuthority.IsZero() {
+			return fmt.Errorf("update[%d]: newMintAuthority must not be zero", i)
+		}
+		fullRef, err := datastore_utils.FindAndFormatRef(env.DataStore, u.TokenPoolRef, input.ChainSelector, datastore_utils.FullRef)
+		if err != nil {
+			return fmt.Errorf("update[%d]: failed to resolve token pool ref: %w", i, err)
+		}
+		if fullRef.Type.String() != common_utils.BurnMintTokenPool.String() {
+			return fmt.Errorf("update[%d]: mint authority transfer is only supported for BurnMint token pools, but pooled ref has type '%s'", i, fullRef.Type.String())
+		}
+		if _, ok := seen[u.TokenMint]; ok {
+			return fmt.Errorf("update[%d]: duplicate tokenMint %s", i, u.TokenMint)
+		}
+		seen[u.TokenMint] = struct{}{}
+	}
+	if err := input.MCMS.Validate(); err != nil {
+		return fmt.Errorf("invalid MCMS configuration: %w", err)
+	}
+	return nil
+}
+
+func transferMintAuthoritiesApply(e cldf.Environment, input TransferMintAuthoritiesChangesetInput) (cldf.ChangesetOutput, error) {
+	chain, ok := e.BlockChains.SolanaChains()[input.ChainSelector]
+	if !ok {
+		return cldf.ChangesetOutput{}, fmt.Errorf("chain with selector %d not found", input.ChainSelector)
+	}
+
+	batchOps := make([]mcms_types.BatchOperation, 0)
+	reports := make([]cldf_ops.Report[any, any], 0)
+	ds := cldf_datastore.NewMemoryDataStore()
+	if err := ds.Merge(e.DataStore); err != nil {
+		return cldf.ChangesetOutput{}, fmt.Errorf("failed to merge environment datastore: %w", err)
+	}
+
+	// Preflight every update before executing any of them, so the deployer-authority path
+	// (which confirms each update immediately) can't partially apply a batch before a later
+	// update fails.
+	for i, u := range input.Updates {
+		poolPubkey, err := datastore_utils.FindAndFormatRef(e.DataStore, u.TokenPoolRef, input.ChainSelector, solanautils.ToAddress)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("update[%d]: failed to resolve token pool ref: %w", i, err)
+		}
+		poolSigner, _ := tokens.TokenPoolSignerAddress(u.TokenMint, poolPubkey)
+		if current := solanautils.GetTokenMintAuthority(chain, u.TokenMint); current != poolSigner && current != u.NewMintAuthority {
+			return cldf.ChangesetOutput{}, fmt.Errorf("update[%d]: current mint authority %s is neither the pool signer PDA %s nor the target %s", i, current, poolSigner, u.NewMintAuthority)
+		}
+	}
+
+	for i, u := range input.Updates {
+		poolPubkey, err := datastore_utils.FindAndFormatRef(e.DataStore, u.TokenPoolRef, input.ChainSelector, solanautils.ToAddress)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("update[%d]: failed to resolve token pool ref: %w", i, err)
+		}
+
+		tokenProg, err := solanautils.FetchTokenProgramID(e.GetContext(), chain, u.TokenMint)
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("update[%d]: failed to resolve token program for mint %s: %w", i, u.TokenMint, err)
+		}
+
+		report, err := cldf_ops.ExecuteOperation(e.OperationsBundle, token_pools.TransferMintAuthorityBurnMint, chain, token_pools.Params{
+			TokenPool:        poolPubkey,
+			TokenMint:        u.TokenMint,
+			TokenProgramID:   tokenProg,
+			NewMintAuthority: u.NewMintAuthority,
+		})
+		if err != nil {
+			return cldf.ChangesetOutput{}, fmt.Errorf("update[%d]: failed to transfer mint authority: %w", i, err)
+		}
+
+		batchOps = append(batchOps, report.Output.BatchOps...)
+		reports = append(reports, report.ToGenericReport())
+		for _, addr := range report.Output.Addresses {
+			if err := ds.Addresses().Add(addr); err != nil {
+				return cldf.ChangesetOutput{}, fmt.Errorf("update[%d]: failed to add address to datastore: %w", i, err)
+			}
+		}
+	}
+
+	return changesets.NewOutputBuilder(e, changesets.GetRegistry()).
+		WithReports(reports).
+		WithDataStore(ds).
+		WithSingleBatchOpPerChain(batchOps).
+		Build(input.MCMS)
+}

--- a/chains/solana/deployment/v1_6_0/operations/token_pools/burnmint.go
+++ b/chains/solana/deployment/v1_6_0/operations/token_pools/burnmint.go
@@ -133,21 +133,46 @@ var TransferMintAuthorityBurnMint = operations.NewOperation(
 	"Transfers the mint authority of the token pool's mint",
 	func(b operations.Bundle, chain cldf_solana.Chain, input Params) (sequences.OnChainOutput, error) {
 		burnmint_token_pool.SetProgramID(input.TokenPool)
+
+		// Idempotency guard: if the mint's authority is already the requested new
+		// authority, the transfer is a no-op (the on-chain instruction would otherwise
+		// revert with MintAuthorityAlreadySet). Skipping here lets both callers
+		// (manual registration and TransferMintAuthoritiesChangeset) re-run safely.
+		current := utils.GetTokenMintAuthority(chain, input.TokenMint)
+		if current == input.NewMintAuthority {
+			return sequences.OnChainOutput{}, nil
+		}
+
+		// NOTE: the on-chain `transferMintAuthorityToMultisig` instruction only allows the program's upgrade authority to sign the instruction - see the comment in the code for details:
+		// https://github.com/smartcontractkit/chainlink-ccip/blob/e35d9898c782fdc046920051c70ef8e34627714c/chains/solana/contracts/programs/burnmint-token-pool/src/context.rs#L144-L146.
+		// As a result, it would be incorrect to use GetAuthorityBurnMint here since that returns the *pool config owner*, which is NOT the same as the upgrade authority. The pool config
+		// owner is the PDA that owns the pool config account which is usually a different account than the program's upgrade authority. The pool config owner can be set to any arbitrary
+		// address, but the upgrade authority is the only account that can sign for the `transferMintAuthorityToMultisig` instruction. On environments where that upgrade authority IS the
+		// deployer keypair (e.g. the containerized tests) we sign directly; where it is the CCIP timelock/signer PDA, it must be executed through MCMS, which can present that PDA as the
+		// signer.
+		authority, err := utils.GetUpgradeAuthority(chain.Client, input.TokenPool)
+		if err != nil {
+			return sequences.OnChainOutput{}, err
+		}
+		if authority == (solana.PublicKey{}) {
+			return sequences.OnChainOutput{}, errors.New("burn mint token pool program is immutable (no upgrade authority); cannot transfer mint authority")
+		}
 		programData, err := utils.GetSolProgramData(chain.Client, input.TokenPool)
 		if err != nil {
 			return sequences.OnChainOutput{}, err
 		}
-		authority, err := GetAuthorityBurnMint(chain, input.TokenPool, input.TokenMint)
-		if err != nil {
-			// assume the authority is the upgrade authority if we fail to fetch the current authority, since the pool might not be initialized yet and there won't be an authority set on-chain yet (since the config account won't exist until initialization)
-			authority, err = utils.GetUpgradeAuthority(chain.Client, input.TokenPool)
-			if err != nil {
-				return sequences.OnChainOutput{}, fmt.Errorf("failed to get upgrade authority for burn mint token pool: %w", err)
-			}
-		}
+
+		// This operation assumes that the current mint authority is the pool signer PDA to keep the
+		// code simple. When the mint authority differs, the onchain code requires the old authority
+		// account to be provided in `remaining_accounts` otherwise the instruction will fail. We do
+		// an explicit check for that gap here and fail fast instead of letting it fail at execution
+		// time.
 		poolConfigPDA, _ := tokens.TokenPoolConfigAddress(input.TokenMint, input.TokenPool)
 		poolSignerPDA, _ := tokens.TokenPoolSignerAddress(input.TokenMint, input.TokenPool)
-		batches := make([]types.BatchOperation, 0)
+		if current != poolSignerPDA {
+			return sequences.OnChainOutput{}, fmt.Errorf("cannot transfer mint authority of %s: current mint authority %s is not the pool signer PDA %s", input.TokenMint, current, poolSignerPDA)
+		}
+
 		ixn, err := burnmint_token_pool.NewTransferMintAuthorityToMultisigInstruction(
 			poolConfigPDA,
 			input.TokenMint,
@@ -161,6 +186,7 @@ var TransferMintAuthorityBurnMint = operations.NewOperation(
 		if err != nil {
 			return sequences.OnChainOutput{}, err
 		}
+
 		if authority != chain.DeployerKey.PublicKey() {
 			b, err := utils.BuildMCMSBatchOperation(
 				chain.Selector,
@@ -171,8 +197,7 @@ var TransferMintAuthorityBurnMint = operations.NewOperation(
 			if err != nil {
 				return sequences.OnChainOutput{}, fmt.Errorf("failed to execute or create batch: %w", err)
 			}
-			batches = append(batches, b)
-			return sequences.OnChainOutput{BatchOps: batches}, nil
+			return sequences.OnChainOutput{BatchOps: []types.BatchOperation{b}}, nil
 		} else {
 			err = chain.Confirm([]solana.Instruction{ixn})
 			if err != nil {

--- a/chains/solana/deployment/v1_6_0/sequences/tokens.go
+++ b/chains/solana/deployment/v1_6_0/sequences/tokens.go
@@ -330,6 +330,9 @@ func (a *SolanaAdapter) ManualRegistration() *cldf_ops.Sequence[tokenapi.ManualR
 			if !ok {
 				return sequences.OnChainOutput{}, fmt.Errorf("chain with selector %d not defined", input.ChainSelector)
 			}
+			if input.SVMExtraArgs != nil && input.SVMExtraArgs.TransferMintAuthority && len(input.SVMExtraArgs.CustomerMintAuthorities) == 0 {
+				return sequences.OnChainOutput{}, errors.New("transfer mint authority is set to true but no customer mint authorities are provided")
+			}
 
 			// NOTE: we only need token metadata if we're creating a token multisig. If we
 			// don't need to create one, then we can avoid sending extraneous RPC calls to
@@ -368,6 +371,34 @@ func (a *SolanaAdapter) ManualRegistration() *cldf_ops.Sequence[tokenapi.ManualR
 				tokenMint = solana.MustPublicKeyFromBase58(tokRef.Address)
 				tokenSymb = tokRef.Qualifier
 				tokenProg = tokProgramID
+			}
+
+			// Validate a requested mint authority transfer before any side-effecting
+			// operation (registry registration, pool init/ownership, multisig creation),
+			// so an invalid request errors out without partially applying registration.
+			if input.SVMExtraArgs != nil && input.SVMExtraArgs.TransferMintAuthority {
+				poolRef, err := datastore_utils.FindAndFormatRef(input.ExistingDataStore, input.TokenPoolRef, chain.Selector, datastore_utils.FullRef)
+				if err != nil {
+					return sequences.OnChainOutput{}, fmt.Errorf("failed to find token pool address using the specified reference (%+v): %w", input.TokenPoolRef, err)
+				}
+				poolPubkey, err := solana.PublicKeyFromBase58(poolRef.Address)
+				if err != nil {
+					return sequences.OnChainOutput{}, fmt.Errorf("failed to parse token pool address '%s' as a Solana public key: %w", poolRef.Address, err)
+				}
+				if poolRef.Type.String() != common_utils.BurnMintTokenPool.String() {
+					return sequences.OnChainOutput{}, fmt.Errorf("transfer mint authority is only supported for BurnMint token pools, but got pool type '%s'", poolRef.Type.String())
+				}
+				authority, err := utils.GetUpgradeAuthority(chain.Client, poolPubkey)
+				if err != nil {
+					return sequences.OnChainOutput{}, fmt.Errorf("failed to get upgrade authority for token pool: %w", err)
+				}
+				if authority == (solana.PublicKey{}) {
+					return sequences.OnChainOutput{}, errors.New("transfer mint authority requires an upgradable BurnMint token pool, but it is immutable (no upgrade authority); cannot transfer mint authority")
+				}
+				poolSigner, _ := tokens.TokenPoolSignerAddress(tokenMint, poolPubkey)
+				if currentMintAuthority := utils.GetTokenMintAuthority(chain, tokenMint); currentMintAuthority != poolSigner {
+					return sequences.OnChainOutput{}, fmt.Errorf("transfer mint authority requires the token mint authority to be the pool signer PDA, but got %s; refusing to create an orphan multisig", currentMintAuthority)
+				}
 			}
 
 			routerAddr, err := a.GetRouterAddress(input.ExistingDataStore, chain.Selector)
@@ -458,15 +489,19 @@ func (a *SolanaAdapter) ManualRegistration() *cldf_ops.Sequence[tokenapi.ManualR
 			/////////////////////////////
 
 			if needTokenMultisig {
-				tokenPool, err := datastore_utils.FindAndFormatRef(input.ExistingDataStore, input.TokenPoolRef, chain.Selector, utils.ToAddress)
+				tokenPool, err := datastore_utils.FindAndFormatRef(input.ExistingDataStore, input.TokenPoolRef, chain.Selector, datastore_utils.FullRef)
 				if err != nil {
 					return sequences.OnChainOutput{}, fmt.Errorf("failed to find token pool address using the specified reference (%+v): %w", input.TokenPoolRef, err)
+				}
+				poolPubkey, err := solana.PublicKeyFromBase58(tokenPool.Address)
+				if err != nil {
+					return sequences.OnChainOutput{}, fmt.Errorf("failed to parse token pool address '%s' as a Solana public key: %w", tokenPool.Address, err)
 				}
 
 				// The multisig will be used as the mint authority (or owner) depending on the pool flow.
 				// We include the TokenPoolSigner PDA as one of the multisig signers so the Token Pool Program
 				// can "sign" via PDA seeds when it needs to act (PDA signing).
-				poolSigner, _ := tokens.TokenPoolSignerAddress(tokenMint, tokenPool)
+				poolSigner, _ := tokens.TokenPoolSignerAddress(tokenMint, poolPubkey)
 				signers := make([]solana.PublicKey, 0, 1+len(input.SVMExtraArgs.CustomerMintAuthorities))
 				signers = append(signers, poolSigner)
 
@@ -507,6 +542,20 @@ func (a *SolanaAdapter) ManualRegistration() *cldf_ops.Sequence[tokenapi.ManualR
 				})
 				if err != nil {
 					return sequences.OnChainOutput{}, fmt.Errorf("failed to extend token pool lookup table with multisig: %w", err)
+				}
+
+				if input.SVMExtraArgs.TransferMintAuthority {
+					transferAuthorityBurnMintReport, err := cldf_ops.ExecuteOperation(b, tokenpoolops.TransferMintAuthorityBurnMint, chain, tokenpoolops.Params{
+						TokenPool:        poolPubkey,
+						TokenMint:        tokenMint,
+						TokenProgramID:   tokenProg,
+						NewMintAuthority: msigPubkey,
+					})
+					if err != nil {
+						return sequences.OnChainOutput{}, fmt.Errorf("failed to transfer mint authority: %w", err)
+					}
+					result.Addresses = append(result.Addresses, transferAuthorityBurnMintReport.Output.Addresses...)
+					result.BatchOps = append(result.BatchOps, transferAuthorityBurnMintReport.Output.BatchOps...)
 				}
 			}
 
@@ -599,8 +648,10 @@ func (a *SolanaAdapter) SetTokenPoolRateLimits() *cldf_ops.Sequence[tokenapi.TPR
 	)
 }
 
-var _ tokenapi.TokenPoolAdminAdapter = (*SolanaAdapter)(nil)
-var _ tokenapi.RemotePoolRemover = (*SolanaAdapter)(nil)
+var (
+	_ tokenapi.TokenPoolAdminAdapter = (*SolanaAdapter)(nil)
+	_ tokenapi.RemotePoolRemover     = (*SolanaAdapter)(nil)
+)
 
 // RemoveRemotePools removes remote pool entries from a Solana 1.6 token pool. The pool address
 // is a program ID shared across mints, so the token mint comes from input.TokenRef and the pool
@@ -621,7 +672,7 @@ func (a *SolanaAdapter) RemoveRemotePools() *cldf_ops.Sequence[tokenapi.RemoveRe
 				return sequences.OnChainOutput{}, fmt.Errorf("solana chain with selector %d not defined", input.Selector)
 			}
 
-			var op = tokenpoolops.RemoveRemotePoolBurnMint
+			op := tokenpoolops.RemoveRemotePoolBurnMint
 			switch input.TokenPoolRef.Type.String() {
 			case common_utils.BurnMintTokenPool.String():
 				op = tokenpoolops.RemoveRemotePoolBurnMint
@@ -709,7 +760,7 @@ func (a *SolanaAdapter) SetTokenPoolAdmins() *cldf_ops.Sequence[tokenapi.SetToke
 				return sequences.OnChainOutput{}, fmt.Errorf("invalid rate limit admin address for chain %d: %s: %w", input.Selector, *input.RateLimitAdmin, err)
 			}
 
-			var op = tokenpoolops.UpdateRateLimitAdminBurnMint
+			op := tokenpoolops.UpdateRateLimitAdminBurnMint
 			switch input.TokenPoolRef.Type.String() {
 			case common_utils.BurnMintTokenPool.String():
 				op = tokenpoolops.UpdateRateLimitAdminBurnMint

--- a/deployment/docs/types.md
+++ b/deployment/docs/types.md
@@ -509,10 +509,15 @@ Solana-specific arguments for manual registration.
 
 ```go
 type SVMExtraArgs struct {
-    CustomerMintAuthorities []solana.PublicKey
-    SkipTokenPoolInit       bool
+    CustomerMintAuthorities []solana.PublicKey `yaml:"customerMintAuthorities,omitempty" json:"customerMintAuthorities,omitempty"`
+    TransferMintAuthority   bool               `yaml:"transferMintAuthority" json:"transferMintAuthority"`
+    SkipTokenPoolInit       bool               `yaml:"skipTokenPoolInit" json:"skipTokenPoolInit"`
 }
 ```
+
+- `CustomerMintAuthorities`: customer authorities that (together with the pool signer PDA) form the token multisig signer set.
+- `TransferMintAuthority`: when `true`, creates the token multisig *and* transfers the mint authority to it in the same proposal. Only supported for BurnMint pools and requires `CustomerMintAuthorities` to be provided.
+- `SkipTokenPoolInit`: when `true`, skips token pool initialization during manual registration.
 
 ### TPRLInput
 

--- a/deployment/tokens/manual_registration.go
+++ b/deployment/tokens/manual_registration.go
@@ -64,6 +64,7 @@ type RegisterTokenConfig struct {
 
 type SVMExtraArgs struct {
 	CustomerMintAuthorities []solana.PublicKey `yaml:"customerMintAuthorities,omitempty" json:"customerMintAuthorities,omitempty"`
+	TransferMintAuthority   bool               `yaml:"transferMintAuthority" json:"transferMintAuthority"`
 	SkipTokenPoolInit       bool               `yaml:"skipTokenPoolInit" json:"skipTokenPoolInit"`
 }
 

--- a/integration-tests/deployment/tokens_and_token_pools_test.go
+++ b/integration-tests/deployment/tokens_and_token_pools_test.go
@@ -27,6 +27,7 @@ import (
 	bnmpool "github.com/smartcontractkit/chainlink-ccip/chains/evm/gobindings/generated/v1_6_1/burn_mint_token_pool"
 	solanautils "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/utils"
 	solseqV1_6_0 "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_6_0/sequences"
+	solchangesets "github.com/smartcontractkit/chainlink-ccip/chains/solana/deployment/v1_6_0/changesets"
 	deployapi "github.com/smartcontractkit/chainlink-ccip/deployment/deploy"
 	tokensapi "github.com/smartcontractkit/chainlink-ccip/deployment/tokens"
 	cciputils "github.com/smartcontractkit/chainlink-ccip/deployment/utils"
@@ -1237,6 +1238,12 @@ func TestTokensAndTokenPools(t *testing.T) {
 				chain.Selector,
 				cciputils.CLLQualifier,
 			)
+			// After token expansion, the token's mint authority should be the pool-signer PDA
+			poolProgramID := solana.MustPublicKeyFromBase58(tokenPool.Address)
+			poolSigner, err := tokens.TokenPoolSignerAddress(tokenMint, poolProgramID)
+			require.NoError(t, err)
+			require.Equal(t, poolSigner, solanautils.GetTokenMintAuthority(chain, tokenMint),
+				"precondition: after manual registration the mint authority is the pool signer PDA")
 
 			// Verify that a new admin was proposed for the specified token
 			var tokenAdminRegistryAccountAfter ccip_common.TokenAdminRegistry
@@ -1348,7 +1355,8 @@ func TestTokensAndTokenPools(t *testing.T) {
 							Address: tokenAddr.Address,
 						},
 						SVMExtraArgs: &tokensapi.SVMExtraArgs{
-							SkipTokenPoolInit: true,
+							SkipTokenPoolInit:     true,
+							TransferMintAuthority: true,
 							CustomerMintAuthorities: []solana.PublicKey{
 								externalAdmin,
 							},
@@ -1360,6 +1368,7 @@ func TestTokensAndTokenPools(t *testing.T) {
 			MergeAddresses(t, env, output.DataStore)
 			testhelpers.ProcessTimelockProposals(t, *env, output.MCMSTimelockProposals, false)
 
+			// SPL token multisig should have been created
 			multisigRef, err := datastore_utils.FindAndFormatRef(env.DataStore, datastore.AddressRef{
 				ChainSelector: solbnm.Chain.Selector,
 				Version:       cciputils.Version_1_6_0,
@@ -1368,12 +1377,52 @@ func TestTokensAndTokenPools(t *testing.T) {
 			}, solbnm.Chain.Selector, datastore_utils.FullRef)
 			require.NoError(t, err)
 
+			// ALT should have been extended
 			lutAfter, err := solcommon.GetAddressLookupTable(t.Context(), chain.Client, tar.LookupTable)
 			require.NoError(t, err)
-
 			multisigPubkey := solana.MustPublicKeyFromBase58(multisigRef.Address)
 			require.Contains(t, lutAfter, multisigPubkey, "multisig must be present in token pool lookup table entries")
 			require.GreaterOrEqual(t, len(lutAfter), lutLenBefore+1, "token pool lookup table should include the new multisig entry")
+
+			// Token mint authority is now the token multisig
+			require.Equal(t, multisigPubkey, solanautils.GetTokenMintAuthority(chain, tokenMint),
+				"after the changeset the token multisig is the mint authority")
+
+			// Re-running the standalone remediation changeset with the multisig as the
+			// (already current) target must be an idempotent no-op: no transfer instruction
+			// is built, so no MCMS proposal is produced.
+			noopOut, err := solchangesets.TransferMintAuthoritiesChangeset().Apply(*env,
+				solchangesets.TransferMintAuthoritiesChangesetInput{
+					ChainSelector: solbnm.Chain.Selector,
+					MCMS:          NewDefaultInputForMCMS("re-run mint authority transfer (idempotent no-op)"),
+					Updates: []solchangesets.TokenMintAuthorityUpdate{{
+						TokenPoolRef:     datastore.AddressRef{Address: tokenPool.Address, Type: datastore.ContractType(solbnm.TokenPoolType)},
+						TokenMint:        tokenMint,
+						NewMintAuthority: multisigPubkey,
+					}},
+				})
+			require.NoError(t, err)
+			require.Empty(t, noopOut.MCMSTimelockProposals,
+				"re-running with the current authority as target should not schedule an MCMS proposal")
+			require.Equal(t, multisigPubkey, solanautils.GetTokenMintAuthority(chain, tokenMint),
+				"mint authority must be unchanged after the idempotent re-run")
+
+			// Transfers are only valid from the pool signer PDA, so once the authority has
+			// moved off the pool signer a follow-up transfer to a different authority must
+			// fail fast instead of scheduling an instruction that reverts at execution.
+			rejectOut, err := solchangesets.TransferMintAuthoritiesChangeset().Apply(*env,
+				solchangesets.TransferMintAuthoritiesChangesetInput{
+					ChainSelector: solbnm.Chain.Selector,
+					MCMS:          NewDefaultInputForMCMS("re-run mint authority transfer (rejected)"),
+					Updates: []solchangesets.TokenMintAuthorityUpdate{{
+						TokenPoolRef:     datastore.AddressRef{Address: tokenPool.Address, Type: datastore.ContractType(solbnm.TokenPoolType)},
+						TokenMint:        tokenMint,
+						NewMintAuthority: solana.NewWallet().PublicKey(),
+					}},
+				})
+			require.Error(t, err, "transfer away from a non-pool-signer authority must be rejected")
+			require.Contains(t, err.Error(), "neither the pool signer")
+			require.Empty(t, rejectOut.MCMSTimelockProposals)
 		})
 	})
 }


### PR DESCRIPTION
# Allow a token's mint authority to be moved to the token multisig

## What this changes

For a BurnMint solana pool, registering a token leaves the token's mint authority on the **pool signer**, so the token multisig that registration creates never actually governs minting. This PR makes the mint authority a controlled, upgradeable thing in two coordinated ways:

1. A batch changeset, `TransferMintAuthoritiesChangeset`, that moves a token's mint authority from its current authority to a new one (typically the token multisig) for any number of `(tokenPool, tokenMint, newMintAuthority)` triples in a single proposal.
2. A `transferMintAuthority` flag on solana manual registration, so a (re)deploy can create the token multisig **and** set it as the mint authority in one proposal — no separate follow-up proposal needed.

Both paths drive the existing `TransferMintAuthorityBurnMint` pool-program operation.

## Why (the intentional design)

The on-chain `transferMintAuthorityToMultisig` instruction only allows the **pool program's upgrade authority** to sign. It is not keyed on the pool config owner (which is why earlier attempts failed with `Unauthorized` on the `program_data` account).

That constraint drives the signer selection:
- The operation derives the signer from `GetUpgradeAuthority(program)`, not the config owner.
- If that upgrade authority **equals the deployer keypair** (e.g. the devnet keypair, or the container test), it signs and confirms directly.
- Otherwise (notably mainnet, where the upgrade authority is the CCIP timelock signer PDA `GoFoFfED…`), it is emitted as MCMS-batched instructions so the timelock can present that PDA as the signer.

Because Metaplex `create_metadata_accounts_v3` requires a **keypair mint authority** to sign (it cannot accept a PDA or an SPL multisig as that signer), metadata for a pooled token must be uploaded while the mint authority is still a regular keypair — i.e. before the pool takes ownership of the mint. Manual registration with `transferMintAuthority: true` then finishes the job in one proposal: create the multisig, extend the lookup table, and assign the multisig as mint authority.

## Origin (operator incident)

A customer token was self-registered via manual registration, which created a token multisig and appended it to the pool's address lookup table, but left the mint authority on the pool signer. The multisig therefore never governed minting — mint/burn authority effectively sat ungoverned on the pool-signer PDA.

We also found you could not then add token metadata to that token: the mint authority is the pool signer (a PDA, with no keypair to sign for it), and Metaplex metadata creation requires a signable mint authority; moving the authority to the multisig *address* does not help because Metaplex does not accept SPL-multisig accounts as that signer. The affected token therefore has to be redeployed (metadata uploaded first, under a keypair authority) and then re-registered with the mint authority moved to the multisig.

This PR provides both pieces needed by that remediation: a single controlled transfer (the changeset), and the option to fold the transfer into registration itself (the `transferMintAuthority` flag) so we don't add an extra proposal to an already-sequential migration.

## Remediation for already-registered tokens

Tokens whose mint authority is still the pool signer can be fixed with the standalone `TransferMintAuthoritiesChangeset` (one proposal per ChainSelector, MCMS-scheduled). It is idempotent — if the mint authority already equals the target it is a no-op, so re-runs are safe and double-transfers are avoided (the on-chain instruction would otherwise revert with `MintAuthorityAlreadySet`). All updates for a chain are coalesced into a single MCMS batch operation so the set applies atomically, and every update is validated (current authority is the pool signer or already the target) *before* any of them executes — so a partial application can't happen.

## Notes on the mechanics

- **Signer:** the operation signs as the pool program's upgrade authority; direct `chain.Confirm` when that equals the deployer, otherwise batched through MCMS.
- **Immutable programs:** if the pool program has no upgrade authority (immutable), the transfer is refused with a clear error.
- **Idempotency guard:** the operation short-circuits when the mint authority already matches the requested target.
- **Ordering:** within manual registration the multisig-create and ALT-extend execute before the transfer step, since the transfer instruction reads the multisig account. All transfer preconditions (pool type, upgrade authority, and mint ownership by the pool signer) are validated **before** those steps, so a misconfigured request fails without leaving an orphan multisig or a modified lookup table.
- **Validation:** `transferMintAuthority: true` requires `customerMintAuthorities` to be provided (they form the multisig signer set), and is only supported for BurnMint pools — non-BurnMint pools are rejected up-front. A transfer is only permitted when the mint's current authority is the pool signer PDA (to transfer) or already equals the target (idempotent no-op); any other authority is rejected.
- **Resolution:** the pool program is resolved from the datastore ref; the token program (SPL vs Token-2022) is read from the mint on-chain, so callers don't need to know the token standard.

